### PR TITLE
feat: runner:script playbooks + token-intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,34 @@ Run `ceo playbook scan` after editing any playbook to refresh `registry.json` an
 
 To disable a playbook without deleting it: change `status: active` → `status: inactive` and rescan.
 
+### Shell-only playbooks (`runner: script`)
+
+A playbook can declare `runner: script` to dispatch a shell script directly, skipping the LLM call. Use this for deterministic intakes — token reports, status snapshots, scheduled file moves — where an AI summary would just be wasted tokens.
+
+```yaml
+---
+name: token-intake
+trigger: cron
+schedule: "45 8 * * 1-5"
+preflight: none
+tier: read
+status: active
+runner: script
+script: ceo-token-intake.sh   # resolved against scripts/ in the plugin clone
+---
+```
+
+The script receives `CEO_VAULT`, `CEO_DIR`, `LOG_DIR`, `TODAY`, `NOW`, and `TRIGGER` as exported environment variables. It is responsible for whatever output it produces — the dispatcher does not parse stdout or write to the daily report. Exit code 0 = success; non-zero is logged to `cron-skips.log`.
+
+The default runner is `claude` — every existing playbook is unaffected.
+
+A starter shell-only playbook ships at `docs/playbooks/token-intake.md`. Copy it into the vault to enable:
+
+```bash
+cp docs/playbooks/token-intake.md "$CEO_VAULT/CEO/playbooks/"
+ceo playbook scan
+```
+
 ## Authority tiers
 
 | Tier | Actions | Execution path | Approval |
@@ -266,6 +294,13 @@ jq '.playbooks[] | select(.name == "<name>")' ~/Documents/Obsidian/CEO/registry.
 If the playbook frontmatter changed but `registry.json` is stale: `ceo playbook scan`.
 If `status: inactive` in `registry.json`: flip frontmatter and rescan.
 If preflight is gating the run: `ceo preflight <name>` to see why.
+
+### Script-runner playbook not firing
+
+1. Run `ceo playbook info <name>` and confirm `runner: script` and `script: <filename>`.
+2. Confirm the file exists and is executable: `ls -l scripts/<filename>`.
+3. Check `CEO/log/cron-skips.log` for `ERROR — Script not found` or `Script not executable`.
+4. If the cron tick fired but nothing happened, run the script manually with `CEO_VAULT` set: `CEO_VAULT="$HOME/Documents/Obsidian" bash scripts/<filename>`.
 
 ### count-blessings produces no Personal section in the brief
 

--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -1,0 +1,45 @@
+---
+name: token-intake
+description: Daily RTK + token-scope spend intake — drops one inbox item linking to today's report
+trigger: cron
+schedule: "45 8 * * 1-5"
+preflight: none
+tier: read
+status: active
+runner: script
+script: ceo-token-intake.sh
+---
+
+# Token Intake
+
+Shell-only playbook. The dispatcher invokes `scripts/ceo-token-intake.sh` directly — no LLM call.
+
+## What it does
+
+Captures four command outputs into `CEO/reports/token/<TODAY>.md`:
+
+- `rtk gain` — global RTK savings
+- `rtk gain -p` — RTK savings scoped to current project
+- `rtk cc-economics` — ccusage spend vs RTK savings
+- `token-scope --since 1d` — Claude Code spend for the last 24h
+
+Then idempotently appends one line to `CEO/inbox.md`:
+
+```
+- [ ] Review daily token report [[CEO/reports/token/<TODAY>]]
+```
+
+The chat-triggered `inbox` playbook picks the line up next time `ceo chat inbox` runs.
+
+## Install
+
+Copy this file into the vault, then re-scan:
+
+```
+cp docs/playbooks/token-intake.md "$CEO_VAULT/CEO/playbooks/"
+ceo playbook scan
+```
+
+## Disable
+
+Set `status: inactive` and re-scan.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -275,7 +275,7 @@ cmd_preflight() {
   # Define preflights inline (can't source from ceo-cron.sh mid-script)
   preflight_none() { return 0; }
   preflight_has_unchecked_inbox() {
-    [ -f "$CEO_DIR/inbox.md" ] && grep -q "^- \[ \]" "$CEO_DIR/inbox.md"
+    ceo_inbox_has_unchecked
   }
   preflight_has_prs_to_review() {
     [ "${PR_REVIEW_COUNT:-0}" -gt 0 ]

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -381,7 +381,11 @@ cmd_playbook_scan() {
     old_registry=$(cat "$registry_file")
   fi
 
-  local new_registry='{"generated":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","playbooks":[]}'
+  local new_registry
+  new_registry=$(jq -n \
+    --argjson v "$CEO_REGISTRY_SCHEMA_VERSION" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{schema_version: $v, generated: $ts, playbooks: []}')
   local found=0
   local skipped=0
 
@@ -571,10 +575,12 @@ $marker_end"
 
 cmd_playbook_list() {
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
+    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
+  esac
 
   printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
   printf "%-16s %-10s %-20s %-10s %-8s\n" "----" "-------" "--------" "-----" "------"
@@ -600,10 +606,12 @@ cmd_playbook_info() {
   fi
 
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
+    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
+  esac
 
   local entry
   entry=$(jq -r --arg n "$target" '.playbooks[] | select(.name==$n)' "$registry_file")

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -390,7 +390,7 @@ cmd_playbook_scan() {
     local basename
     basename=$(basename "$f")
 
-    local name description trigger schedule model preflight tier status bin
+    local name description trigger schedule model preflight tier status bin runner script
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -406,6 +406,8 @@ cmd_playbook_scan() {
     tier=$(yq --front-matter=extract '.tier // ""' "$f" 2>/dev/null || echo "")
     status=$(yq --front-matter=extract '.status // ""' "$f" 2>/dev/null || echo "")
     bin=$(yq --front-matter=extract '.bin // ""' "$f" 2>/dev/null || echo "")
+    runner=$(yq --front-matter=extract '.runner // ""' "$f" 2>/dev/null || echo "")
+    script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
 
     local entry
     entry=$(jq -n \
@@ -418,8 +420,10 @@ cmd_playbook_scan() {
       --arg tier "$tier" \
       --arg status "$status" \
       --arg bin "$bin" \
+      --arg runner "$runner" \
+      --arg script "$script" \
       --arg file "playbooks/$basename" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -368,6 +368,24 @@ cmd_playbook_scan() {
 
   ceo_validate_vault || exit 1
 
+  # Primary-host write gate: registry.json is Syncthing-shared, so only one
+  # host may rewrite it. Peers running an older binary would silently drop
+  # newer fields. Configure via settings.json: {"primary_host": "<host>"}.
+  # Unset → backward-compatible (any host may scan).
+  local settings_file="$CEO_DIR/settings.json"
+  if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
+    local primary_host
+    primary_host=$(jq -r '.primary_host // ""' "$settings_file" 2>/dev/null)
+    if [ -n "$primary_host" ]; then
+      local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
+      if [ "$this_host" != "$primary_host" ]; then
+        echo "ERROR: 'ceo playbook scan' must run on the primary host ($primary_host); this host is '$this_host'." >&2
+        echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
+        exit 1
+      fi
+    fi
+  fi
+
   local playbook_dir="$CEO_DIR/playbooks"
   local registry_file="$CEO_DIR/registry.json"
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -409,6 +409,14 @@ cmd_playbook_scan() {
     runner=$(yq --front-matter=extract '.runner // ""' "$f" 2>/dev/null || echo "")
     script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
 
+    case "$runner" in
+      ""|claude|script) ;;
+      *)
+        echo "  SKIP  $basename (unknown runner: '$runner', expected: claude|script)"
+        skipped=$((skipped + 1))
+        continue ;;
+    esac
+
     local entry
     entry=$(jq -n \
       --arg name "$name" \

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -367,24 +367,7 @@ cmd_playbook_scan() {
   fi
 
   ceo_validate_vault || exit 1
-
-  # Primary-host write gate: registry.json is Syncthing-shared, so only one
-  # host may rewrite it. Peers running an older binary would silently drop
-  # newer fields. Configure via settings.json: {"primary_host": "<host>"}.
-  # Unset → backward-compatible (any host may scan).
-  local settings_file="$CEO_DIR/settings.json"
-  if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
-    local primary_host
-    primary_host=$(jq -r '.primary_host // ""' "$settings_file" 2>/dev/null)
-    if [ -n "$primary_host" ]; then
-      local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
-      if [ "$this_host" != "$primary_host" ]; then
-        echo "ERROR: 'ceo playbook scan' must run on the primary host ($primary_host); this host is '$this_host'." >&2
-        echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
-        exit 1
-      fi
-    fi
-  fi
+  ceo_assert_primary_host || exit 1
 
   local playbook_dir="$CEO_DIR/playbooks"
   local registry_file="$CEO_DIR/registry.json"

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -27,6 +27,25 @@ VAULT="${CEO_VAULT:-}"
 CEO_DIR="${VAULT:+$VAULT/CEO}"
 CEO_CRON="$SCRIPT_DIR/ceo-cron.sh"
 
+_registry_schema_error() {
+  local rc="$1"
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan" ;;
+    2) echo "Registry schema_version missing, malformed, or below $CEO_REGISTRY_SCHEMA_VERSION. Run: ceo playbook scan" ;;
+    *) echo "Registry validation failed (rc=$rc)" ;;
+  esac
+}
+
+_require_registry_current() {
+  local registry_file="$1"
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  if [ "$rc" != "0" ]; then
+    _registry_schema_error "$rc"
+    exit 1
+  fi
+}
+
 cmd_help() {
   cat <<'USAGE'
 Usage: ceo <command>
@@ -193,23 +212,30 @@ cmd_doctor() {
   # bin symlinks for playbooks
   local registry_file="$CEO_DIR/registry.json"
   if [ -f "$registry_file" ] && command -v jq &>/dev/null; then
-    local missing_bins=0 bin_total=0
-    while IFS= read -r row; do
-      local p_name p_bin
-      p_name=$(echo "$row" | jq -r '.name')
-      p_bin=$(echo "$row" | jq -r '.bin // ""')
-      [ -z "$p_bin" ] && continue
-      bin_total=$((bin_total + 1))
-      local link_name="${p_bin%.sh}"
-      if [ ! -L "$HOME/.local/bin/$link_name" ]; then
-        echo "  ! Missing bin symlink: ~/.local/bin/$link_name (playbook: $p_name) — run: ceo playbook scan"
-        missing_bins=$((missing_bins + 1))
-        warn=$((warn + 1))
+    local registry_rc=0
+    ceo_registry_validate "$registry_file" || registry_rc=$?
+    if [ "$registry_rc" != "0" ]; then
+      echo "  ✗ $(_registry_schema_error "$registry_rc")"
+      fail=$((fail + 1))
+    else
+      local missing_bins=0 bin_total=0
+      while IFS= read -r row; do
+        local p_name p_bin
+        p_name=$(echo "$row" | jq -r '.name')
+        p_bin=$(echo "$row" | jq -r '.bin // ""')
+        [ -z "$p_bin" ] && continue
+        bin_total=$((bin_total + 1))
+        local link_name="${p_bin%.sh}"
+        if [ ! -L "$HOME/.local/bin/$link_name" ]; then
+          echo "  ! Missing bin symlink: ~/.local/bin/$link_name (playbook: $p_name) — run: ceo playbook scan"
+          missing_bins=$((missing_bins + 1))
+          warn=$((warn + 1))
+        fi
+      done < <(jq -c '.playbooks[] | select(.status=="active")' "$registry_file" 2>/dev/null)
+      if [ "$bin_total" -gt 0 ] && [ "$missing_bins" -eq 0 ]; then
+        echo "  ✓ Playbook bin symlinks present ($bin_total)"
+        ok=$((ok + 1))
       fi
-    done < <(jq -c '.playbooks[] | select(.status=="active")' "$registry_file" 2>/dev/null)
-    if [ "$bin_total" -gt 0 ] && [ "$missing_bins" -eq 0 ]; then
-      echo "  ✓ Playbook bin symlinks present ($bin_total)"
-      ok=$((ok + 1))
     fi
   fi
 
@@ -299,10 +325,7 @@ cmd_preflight() {
   }
 
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  _require_registry_current "$registry_file"
 
   local would_run=0
   local would_skip=0
@@ -378,6 +401,24 @@ cmd_playbook_scan() {
 
   local old_registry='{"playbooks":[]}'
   if [ -f "$registry_file" ]; then
+    if ! jq -e 'type == "object"' "$registry_file" >/dev/null 2>&1; then
+      echo "ERROR: refusing to overwrite unparseable registry: $registry_file"
+      exit 1
+    fi
+    if jq -e 'has("schema_version")' "$registry_file" >/dev/null 2>&1; then
+      local existing_v
+      existing_v=$(ceo_registry_version "$registry_file")
+      if [ -z "$existing_v" ]; then
+        echo "ERROR: refusing to overwrite registry with malformed schema_version."
+        echo "Fix or remove $registry_file, then rerun ceo playbook scan."
+        exit 1
+      fi
+      if [ "$existing_v" -gt "$CEO_REGISTRY_SCHEMA_VERSION" ]; then
+        echo "ERROR: refusing to downgrade registry (on-disk schema_version=$existing_v, this binary writes $CEO_REGISTRY_SCHEMA_VERSION)."
+        echo "Update this host's claude-ceo binary first."
+        exit 1
+      fi
+    fi
     old_registry=$(cat "$registry_file")
   fi
 
@@ -473,7 +514,9 @@ cmd_playbook_scan() {
     fi
   done <<< "$old_names"
 
-  echo "$new_registry" | jq '.' > "$registry_file"
+  local registry_tmp="$registry_file.tmp"
+  echo "$new_registry" | jq '.' > "$registry_tmp"
+  mv "$registry_tmp" "$registry_file"
 
   echo ""
   echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped)"
@@ -575,12 +618,7 @@ $marker_end"
 
 cmd_playbook_list() {
   local registry_file="$CEO_DIR/registry.json"
-  local rc=0
-  ceo_registry_validate "$registry_file" || rc=$?
-  case "$rc" in
-    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
-    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
-  esac
+  _require_registry_current "$registry_file"
 
   printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
   printf "%-16s %-10s %-20s %-10s %-8s\n" "----" "-------" "--------" "-----" "------"
@@ -606,12 +644,7 @@ cmd_playbook_info() {
   fi
 
   local registry_file="$CEO_DIR/registry.json"
-  local rc=0
-  ceo_registry_validate "$registry_file" || rc=$?
-  case "$rc" in
-    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
-    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
-  esac
+  _require_registry_current "$registry_file"
 
   local entry
   entry=$(jq -r --arg n "$target" '.playbooks[] | select(.name==$n)' "$registry_file")
@@ -664,10 +697,7 @@ cmd_chat() {
   ceo_validate_vault || exit 1
   local registry_file="$CEO_DIR/registry.json"
 
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  _require_registry_current "$registry_file"
 
   local model="sonnet"
   local playbook_content=""

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -91,6 +91,16 @@ ceo_load_config() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_augment_path — prepend common user-tool prefixes to PATH so cron-invoked
+# scripts can find Homebrew binaries, bun-installed CLIs, and ~/.local/bin
+# symlinks. Cron starts with PATH=/usr/bin:/bin; this is the single source of
+# truth for the prefix list across ceo-cron.sh and any runner:script playbook.
+# ---------------------------------------------------------------------------
+ceo_augment_path() {
+  export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+}
+
+# ---------------------------------------------------------------------------
 # ceo_validate_vault — verify the vault is ready (CEO/inbox.md must exist).
 # Call after ceo_load_config.
 #

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -93,8 +93,7 @@ ceo_load_config() {
 # ---------------------------------------------------------------------------
 # ceo_augment_path — prepend common user-tool prefixes to PATH so cron-invoked
 # scripts can find Homebrew binaries, bun-installed CLIs, and ~/.local/bin
-# symlinks. Cron starts with PATH=/usr/bin:/bin; this is the single source of
-# truth for the prefix list across ceo-cron.sh and any runner:script playbook.
+# symlinks. Cron starts with PATH=/usr/bin:/bin.
 # ---------------------------------------------------------------------------
 ceo_augment_path() {
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -161,3 +161,72 @@ ceo_inbox_has_unchecked() {
   fi
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# ceo_assert_primary_host — gate writes to Syncthing-shared state behind the
+# host configured as primary in CEO/settings.json.
+#
+# The invariant: only the primary host overwrites Syncthing-shared registry
+# state. The gate is opt-in — settings.json absent means no gate.
+#
+# Returns 0 (host is allowed to proceed) when:
+#   - CEO/settings.json is absent (backward-compatible, no gate configured)
+#   - settings.json is present, parseable, and primary_host is empty
+#   - settings.json is present, parseable, and primary_host == this host
+#
+# Returns 1 (host MUST NOT proceed) when:
+#   - settings.json is present but jq is not installed (cannot evaluate gate)
+#   - settings.json is present but malformed JSON
+#   - this host cannot be resolved (CEO_HOSTNAME unset and `hostname -s` empty)
+#   - primary_host is set and does not match this host
+#
+# Unknown top-level keys in settings.json emit a warning to stderr (typo
+# defense — see ~/.claude/rules/enum-config-typo-fallback.md). Failing-open
+# on a typo is the silent-regression shape this helper exists to prevent.
+# ---------------------------------------------------------------------------
+ceo_assert_primary_host() {
+  : "${CEO_DIR:?CEO_DIR must be set before ceo_assert_primary_host}"
+  local settings_file="$CEO_DIR/settings.json"
+  local jq_bin="${CEO_JQ_BIN:-jq}"
+
+  [ -f "$settings_file" ] || return 0
+
+  if ! command -v "$jq_bin" &>/dev/null; then
+    echo "ERROR: $settings_file exists but jq is not installed; cannot evaluate primary_host gate." >&2
+    echo "  Install jq (brew install jq | sudo apt install jq) or remove $settings_file." >&2
+    return 1
+  fi
+
+  if ! "$jq_bin" empty "$settings_file" 2>/dev/null; then
+    echo "ERROR: $settings_file is not valid JSON; refusing to evaluate primary_host gate." >&2
+    return 1
+  fi
+
+  local known_keys=" primary_host "
+  local k
+  while IFS= read -r k; do
+    [ -n "$k" ] || continue
+    case "$known_keys" in
+      *" $k "*) ;;
+      *) echo "WARNING: $settings_file contains unknown key '$k' — ignored. Known keys: primary_host" >&2 ;;
+    esac
+  done < <("$jq_bin" -r 'keys[]' "$settings_file" 2>/dev/null || true)
+
+  local primary_host
+  primary_host=$("$jq_bin" -r '.primary_host // ""' "$settings_file" 2>/dev/null || echo "")
+  [ -n "$primary_host" ] || return 0
+
+  local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
+  if [ -z "$this_host" ]; then
+    echo "ERROR: cannot determine this host (CEO_HOSTNAME unset and 'hostname -s' returned empty)." >&2
+    return 1
+  fi
+
+  if [ "$this_host" != "$primary_host" ]; then
+    echo "ERROR: this operation must run on the primary host ($primary_host); this host is '$this_host'." >&2
+    echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
+    return 1
+  fi
+
+  return 0
+}

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -96,7 +96,10 @@ ceo_load_config() {
 # symlinks. Cron starts with PATH=/usr/bin:/bin.
 # ---------------------------------------------------------------------------
 ceo_augment_path() {
+  [ -n "${_CEO_PATH_AUGMENTED:-}" ] && return 0
+  : "${HOME:?HOME must be set before ceo_augment_path}"
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+  export _CEO_PATH_AUGMENTED=1
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -3,11 +3,12 @@
 # Source this file; do not execute it directly.
 #
 # Provides:
-#   ceo_detect_os()      — prints: wsl | linux | macos | unknown
-#   ceo_config_path()    — prints path to ~/.ceo/config
-#   ceo_load_config()    — resolves CEO_VAULT; returns 0 on success, 1 if empty
-#   ceo_require_vault()  — load config; exit 1 with operator guidance if unresolved
-#   ceo_validate_vault() — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_detect_os()         — prints: wsl | linux | macos | unknown
+#   ceo_config_path()       — prints path to ~/.ceo/config
+#   ceo_load_config()       — resolves CEO_VAULT; returns 0 on success, 1 if empty
+#   ceo_require_vault()     — load config; exit 1 with operator guidance if unresolved
+#   ceo_validate_vault()    — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_registry_validate() — verifies registry.json schema_version; returns 0/1/2
 #
 # Resolution order in ceo_load_config():
 #   1. CEO_VAULT already set in environment → use it as-is, return 0 (bypass mode)
@@ -108,6 +109,36 @@ ceo_augment_path() {
   : "${HOME:?HOME must be set before ceo_augment_path}"
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
   export _CEO_PATH_AUGMENTED=1
+}
+
+# ---------------------------------------------------------------------------
+# Registry schema. Bump CEO_REGISTRY_SCHEMA_VERSION whenever the on-disk
+# shape of registry.json changes — a peer host running an older binary will
+# then refuse to dispatch instead of silently downgrading the registry on
+# the next `ceo playbook scan`.
+#
+# Version history:
+#   2 — adds runner, script fields (PR #4)
+#   1 — implicit (pre-runner-script registry; missing field treated as <2)
+# ---------------------------------------------------------------------------
+CEO_REGISTRY_SCHEMA_VERSION=2
+
+# ceo_registry_validate <registry_file>
+#   0 — schema_version >= CEO_REGISTRY_SCHEMA_VERSION
+#   1 — registry file does not exist
+#   2 — schema_version missing or below current
+ceo_registry_validate() {
+  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  if [ ! -f "$registry_file" ]; then
+    return 1
+  fi
+  local v
+  v=$(jq -r '.schema_version // 0 | tonumber? // 0' "$registry_file" 2>/dev/null)
+  [ -z "$v" ] && v=0
+  if [ "$v" -lt "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
+    return 2
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -130,3 +130,34 @@ ceo_validate_vault() {
   fi
   return 0
 }
+
+# ---------------------------------------------------------------------------
+# ceo_inbox_has_unchecked — scan legacy CEO/inbox.md and per-host
+# CEO/inbox/<host>.md shadow files for any unchecked todo line.
+#
+# Per-host shadow files exist because Syncthing peers cannot safely share a
+# single inbox.md writer; see issue #5. The legacy inbox.md remains supported
+# for user-curated entries.
+#
+# Reads CEO_DIR from the environment (callers already have it set).
+#
+# Returns:
+#   0  at least one "- [ ]" line exists in any inbox source
+#   1  no unchecked items, or no inbox sources present
+# ---------------------------------------------------------------------------
+ceo_inbox_has_unchecked() {
+  local dir="${CEO_DIR:?CEO_DIR must be set before ceo_inbox_has_unchecked}"
+  if [ -f "$dir/inbox.md" ] && grep -q "^- \[ \]" "$dir/inbox.md" 2>/dev/null; then
+    return 0
+  fi
+  if [ -d "$dir/inbox" ]; then
+    local f
+    for f in "$dir/inbox/"*.md; do
+      [ -f "$f" ] || continue
+      if grep -q "^- \[ \]" "$f" 2>/dev/null; then
+        return 0
+      fi
+    done
+  fi
+  return 1
+}

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -123,19 +123,32 @@ ceo_augment_path() {
 # ---------------------------------------------------------------------------
 CEO_REGISTRY_SCHEMA_VERSION=2
 
+# ceo_registry_version <registry_file>
+#   Prints the integer schema_version, or nothing if missing/malformed.
+ceo_registry_version() {
+  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  jq -r '
+    if has("schema_version")
+      and (.schema_version | type) == "number"
+      and (.schema_version | floor == .)
+    then .schema_version
+    else empty
+    end
+  ' "$registry_file" 2>/dev/null
+}
+
 # ceo_registry_validate <registry_file>
-#   0 — schema_version >= CEO_REGISTRY_SCHEMA_VERSION
+#   0 — schema_version is an integer >= CEO_REGISTRY_SCHEMA_VERSION
 #   1 — registry file does not exist
-#   2 — schema_version missing or below current
+#   2 — schema_version missing, malformed, or below current
 ceo_registry_validate() {
   local registry_file="${1:-${CEO_DIR:-}/registry.json}"
   if [ ! -f "$registry_file" ]; then
     return 1
   fi
   local v
-  v=$(jq -r '.schema_version // 0 | tonumber? // 0' "$registry_file" 2>/dev/null)
-  [ -z "$v" ] && v=0
-  if [ "$v" -lt "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
+  v=$(ceo_registry_version "$registry_file")
+  if ! [ "$v" -ge "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
     return 2
   fi
   return 0

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -101,6 +101,68 @@ test_ceo_help_works_on_fresh_host() {
   assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
 }
 
+# ceo_inbox_has_unchecked — preflight helper that scans both the legacy
+# CEO/inbox.md (user-curated) and per-host CEO/inbox/<host>.md shadow files.
+# Used by morning-brief and inbox cron preflights.
+
+_inbox_check() {
+  local ceo_dir="$1"
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    CEO_DIR='$ceo_dir' ceo_inbox_has_unchecked
+  " >/dev/null 2>&1
+}
+
+test_inbox_has_unchecked_returns_nonzero_when_no_files_exist() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "no inbox files anywhere → nothing to do"
+}
+
+test_inbox_has_unchecked_finds_legacy_inbox_md() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  printf -- '- [ ] something\n' > "$TEST_HOME/CEO/inbox.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "unchecked item in legacy inbox.md must trigger preflight"
+}
+
+test_inbox_has_unchecked_skips_legacy_when_all_checked() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  printf -- '- [x] done\n' > "$TEST_HOME/CEO/inbox.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "all-checked legacy inbox.md must not trigger preflight"
+}
+
+test_inbox_has_unchecked_finds_per_host_shadow_file() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [ ] from-mac\n' > "$TEST_HOME/CEO/inbox/mac-mini.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "unchecked item in per-host shadow must trigger preflight"
+}
+
+test_inbox_has_unchecked_skips_per_host_when_all_checked() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [x] done-on-mac\n' > "$TEST_HOME/CEO/inbox/mac-mini.md"
+  printf -- '- [x] done-on-wsl\n' > "$TEST_HOME/CEO/inbox/wsl-host.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "all-checked per-host shadow files must not trigger preflight"
+}
+
+test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [x] legacy-done\n' > "$TEST_HOME/CEO/inbox.md"
+  printf -- '- [ ] shadow-pending\n' > "$TEST_HOME/CEO/inbox/host-b.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "must find unchecked items even when legacy is clean"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -101,6 +101,45 @@ test_ceo_help_works_on_fresh_host() {
   assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
 }
 
+test_registry_validate_accepts_integer_current_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":2,"playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "integer schema_version at current version must validate"
+}
+
+test_registry_validate_rejects_non_integer_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":1.5,"playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "float schema_version must reject instead of falling through"
+}
+
+test_registry_validate_rejects_string_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":"2","playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "string schema_version must reject instead of coercing"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -180,6 +180,9 @@ PREFLIGHT=$(echo "$ENTRY" | jq -r '.preflight // "none"')
 STATUS=$(echo "$ENTRY" | jq -r '.status // "active"')
 TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
 TIER=$(echo "$ENTRY" | jq -r '.tier // "read"')
+RUNNER=$(echo "$ENTRY" | jq -r '.runner // ""')
+[ -z "$RUNNER" ] && RUNNER="claude"
+SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
 
 # Chat-only playbooks cannot run via cron
 if [ "$TRIGGER_TYPE" = "chat" ]; then
@@ -214,6 +217,36 @@ if type "$PREFLIGHT_FN" &>/dev/null; then
   _v "Preflight '$PREFLIGHT' passed"
 else
   _v "WARNING: Unknown preflight '$PREFLIGHT' — running anyway"
+fi
+
+# --- Script-runner branch: exec named script, skip claude --print ---
+if [ "$RUNNER" = "script" ]; then
+  if [ -z "$SCRIPT_PATH" ]; then
+    echo "$(date): ERROR — Playbook '$TRIGGER' has runner:script but no script field" >> "$LOG_DIR/cron-skips.log"
+    _v "ERROR: runner:script requires a script field"
+    exit 1
+  fi
+  SCRIPT_FULL="$SCRIPT_DIR/$SCRIPT_PATH"
+  if [ ! -f "$SCRIPT_FULL" ]; then
+    echo "$(date): ERROR — Script not found: $SCRIPT_FULL (playbook: $TRIGGER)" >> "$LOG_DIR/cron-skips.log"
+    _v "ERROR: Script not found at $SCRIPT_FULL"
+    exit 1
+  fi
+  if [ ! -x "$SCRIPT_FULL" ]; then
+    echo "$(date): ERROR — Script not executable: $SCRIPT_FULL (playbook: $TRIGGER)" >> "$LOG_DIR/cron-skips.log"
+    _v "ERROR: Script not executable at $SCRIPT_FULL"
+    exit 1
+  fi
+  _v "Runner: script — exec $SCRIPT_PATH"
+  export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
+  SCRIPT_EXIT=0
+  "$SCRIPT_FULL" || SCRIPT_EXIT=$?
+  if [ "$SCRIPT_EXIT" -ne 0 ]; then
+    _v "FAILED (exit: $SCRIPT_EXIT)"
+    echo "$(date): Script exited $SCRIPT_EXIT for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
+  fi
+  date +%s > "$LAST_RUN_FILE"
+  exit "$SCRIPT_EXIT"
 fi
 
 # --- Read context files (with size limits for injection safety) ---

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/ceo-config.sh"
 
 # Vault resolution delegated to ceo-config.sh
 ceo_load_config || { echo "FATAL — CEO config not found. Set CEO_VAULT or run: ceo setup" >&2; exit 1; }
+ceo_augment_path
 VAULT="$CEO_VAULT"
 
 CEO_DIR="$VAULT/CEO"

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -214,6 +214,12 @@ TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
 TIER=$(echo "$ENTRY" | jq -r '.tier // "read"')
 RUNNER=$(echo "$ENTRY" | jq -r '.runner // ""')
 [ -z "$RUNNER" ] && RUNNER="claude"
+case "$RUNNER" in
+  claude|script) ;;
+  *)
+    _record_failure "Unknown runner '$RUNNER' for $TRIGGER (expected: claude|script)"
+    exit 1 ;;
+esac
 SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
 
 # Chat-only playbooks cannot run via cron

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -35,6 +35,38 @@ FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
 # --- Verbose mode (set CEO_VERBOSE=1 for stdout progress) ---
 _v() { [ "${CEO_VERBOSE:-}" = "1" ] && echo "  $*" || true; }
 
+# Single source of truth for terminal-exit bookkeeping. Every success path
+# calls _record_success; every failure path calls _record_failure. Deferral
+# paths (chat-only, status-not-active, missing playbook, preflight no-work)
+# are not failures and exit directly without invoking either helper.
+_record_success() {
+  echo 0 > "$FAIL_COUNT_FILE"
+  date +%s > "$LAST_RUN_FILE"
+  [ "$TRIGGER" = "morning-scan" ] && touch "$LOG_DIR/.last-scan"
+  echo "$(date): $TRIGGER completed" >> "$LOG_DIR/cron-runs.log"
+}
+
+_record_failure() {
+  local reason="$1"
+  echo "$(date): ERROR — $reason" >> "$LOG_DIR/cron-skips.log"
+  local fails
+  fails=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
+  fails=$((fails + 1))
+  echo "$fails" > "$FAIL_COUNT_FILE"
+  if [ "$fails" -ge 3 ]; then
+    cat >> "$CEO_DIR/approvals/pending.md" << ALERTEOF
+
+## $TODAY $NOW — ALERT
+
+- [ ] **CEO cron failing repeatedly** — $fails consecutive failures
+  - trigger: $TRIGGER
+  - last error: $reason
+  - action needed: check cron-raw.log and cron-skips.log
+ALERTEOF
+  fi
+  date +%s > "$LAST_RUN_FILE"
+}
+
 # --- Require jq ---
 if ! command -v jq &>/dev/null; then
   echo "$(date): FATAL — jq not installed. Run: sudo apt install jq" >&2
@@ -243,10 +275,11 @@ if [ "$RUNNER" = "script" ]; then
   "$SCRIPT_FULL" || SCRIPT_EXIT=$?
   if [ "$SCRIPT_EXIT" -ne 0 ]; then
     _v "FAILED (exit: $SCRIPT_EXIT)"
-    echo "$(date): Script exited $SCRIPT_EXIT for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
+    _record_failure "Script exited $SCRIPT_EXIT for $TRIGGER"
+    exit "$SCRIPT_EXIT"
   fi
-  date +%s > "$LAST_RUN_FILE"
-  exit "$SCRIPT_EXIT"
+  _record_success
+  exit 0
 fi
 
 # --- Read context files (with size limits for injection safety) ---
@@ -380,31 +413,29 @@ END_LOG_ENTRY"
     echo "$(date) [$TRIGGER] Single-call output:" >> "$LOG_DIR/cron-raw.log"
     echo "$SINGLE_OUTPUT" >> "$LOG_DIR/cron-raw.log"
     echo "---" >> "$LOG_DIR/cron-raw.log"
-  else
-    LOG_ENTRY=$(echo "$SINGLE_OUTPUT" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
-    if [ -n "$LOG_ENTRY" ]; then
-      _v ""
-      _v "--- Output ---"
-      [ "${CEO_VERBOSE:-}" = "1" ] && echo "$LOG_ENTRY"
-      _v "--- End ---"
-      _v ""
-      "$SCRIPT_DIR/ceo-report.sh" intake "$TRIGGER" "$LOG_ENTRY"
-    else
-      _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
-      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** completed (unparseable output)
-**Playbook:** $PLAYBOOK_REL
-**Note:** Execution succeeded but log format could not be parsed."
-      echo "$(date) [$TRIGGER] Unparseable output:" >> "$LOG_DIR/cron-raw.log"
-      echo "$SINGLE_OUTPUT" >> "$LOG_DIR/cron-raw.log"
-      echo "---" >> "$LOG_DIR/cron-raw.log"
-    fi
+    _record_failure "Single-call execution failed for $TRIGGER (exit: $SINGLE_EXIT)"
+    exit "$SINGLE_EXIT"
   fi
 
-  # Update timestamps and exit
-  echo 0 > "$FAIL_COUNT_FILE"
-  date +%s > "$LAST_RUN_FILE"
-  [ "$TRIGGER" = "morning-scan" ] && touch "$LOG_DIR/.last-scan"
-  echo "$(date): $TRIGGER completed" >> "$LOG_DIR/cron-runs.log"
+  LOG_ENTRY=$(echo "$SINGLE_OUTPUT" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
+  if [ -n "$LOG_ENTRY" ]; then
+    _v ""
+    _v "--- Output ---"
+    [ "${CEO_VERBOSE:-}" = "1" ] && echo "$LOG_ENTRY"
+    _v "--- End ---"
+    _v ""
+    "$SCRIPT_DIR/ceo-report.sh" intake "$TRIGGER" "$LOG_ENTRY"
+  else
+    _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
+    "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** completed (unparseable output)
+**Playbook:** $PLAYBOOK_REL
+**Note:** Execution succeeded but log format could not be parsed."
+    echo "$(date) [$TRIGGER] Unparseable output:" >> "$LOG_DIR/cron-raw.log"
+    echo "$SINGLE_OUTPUT" >> "$LOG_DIR/cron-raw.log"
+    echo "---" >> "$LOG_DIR/cron-raw.log"
+  fi
+
+  _record_success
   exit 0
 fi
 
@@ -461,32 +492,12 @@ PLAN_OUTPUT=$(cd "$VAULT" && echo "$PLAN_PROMPT" | timeout 300 claude --print --
 
 if [ $PLAN_EXIT -ne 0 ]; then
   _v "Phase 1 FAILED (exit: $PLAN_EXIT)"
-  echo "$(date): ERROR — Phase 1 (plan) failed for $TRIGGER (exit: $PLAN_EXIT)" >> "$LOG_DIR/cron-skips.log"
   echo "$(date) [$TRIGGER] Plan output:" >> "$LOG_DIR/cron-raw.log"
   echo "$PLAN_OUTPUT" >> "$LOG_DIR/cron-raw.log"
   echo "---" >> "$LOG_DIR/cron-raw.log"
-
-  # Track consecutive failures
-  FAILS=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
-  FAILS=$((FAILS + 1))
-  echo "$FAILS" > "$FAIL_COUNT_FILE"
-  if [ "$FAILS" -ge 3 ]; then
-    PENDING="$CEO_DIR/approvals/pending.md"
-    cat >> "$PENDING" << ALERTEOF
-
-## $TODAY $NOW — ALERT
-
-- [ ] **CEO cron failing repeatedly** — $FAILS consecutive failures
-  - trigger: $TRIGGER
-  - last error: exit code $PLAN_EXIT
-  - action needed: check cron-raw.log and cron-skips.log
-ALERTEOF
-  fi
+  _record_failure "Phase 1 (plan) failed for $TRIGGER (exit: $PLAN_EXIT)"
   exit 1
 fi
-
-# Reset fail count on success
-echo 0 > "$FAIL_COUNT_FILE"
 
 # --- Phase 2: FILTER (shell strips high-stakes actions) ---
 _v "Phase 1 done. Filtering actions..."
@@ -581,6 +592,8 @@ END_LOG_ENTRY"
     echo "$(date) [$TRIGGER] Exec output:" >> "$LOG_DIR/cron-raw.log"
     echo "$EXEC_OUTPUT" >> "$LOG_DIR/cron-raw.log"
     echo "---" >> "$LOG_DIR/cron-raw.log"
+    _record_failure "Phase 3 (exec) failed for $TRIGGER (exit: $EXEC_EXIT)"
+    exit "$EXEC_EXIT"
   else
     # Extract structured log entry
     LOG_ENTRY=$(echo "$EXEC_OUTPUT" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
@@ -604,11 +617,4 @@ END_LOG_ENTRY"
   fi
 fi
 
-# --- Update per-trigger last-run timestamp ---
-date +%s > "$LAST_RUN_FILE"
-
-if [ "$TRIGGER" = "morning-scan" ]; then
-  touch "$LOG_DIR/.last-scan"
-fi
-
-echo "$(date): $TRIGGER completed" >> "$LOG_DIR/cron-runs.log"
+_record_success

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -33,7 +33,7 @@ LAST_RUN_FILE="$LOG_DIR/.last-run-${TRIGGER}"
 FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
 
 # --- Verbose mode (set CEO_VERBOSE=1 for stdout progress) ---
-_v() { [ "${CEO_VERBOSE:-}" = "1" ] && echo "  $*"; }
+_v() { [ "${CEO_VERBOSE:-}" = "1" ] && echo "  $*" || true; }
 
 # --- Require jq ---
 if ! command -v jq &>/dev/null; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -204,6 +204,7 @@ case "$REGISTRY_RC" in
     exit 1 ;;
   2)
     echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _record_failure "registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?)"
     _v "FATAL: registry.json schema_version too old. Run: ceo playbook scan"
     exit 1 ;;
 esac

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -194,11 +194,19 @@ preflight_has_auto_review_prs() {
 
 # --- Look up trigger in registry ---
 REGISTRY_FILE="$CEO_DIR/registry.json"
-if [ ! -f "$REGISTRY_FILE" ]; then
-  echo "$(date): FATAL — registry.json not found. Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
-  _v "FATAL: registry.json not found. Run: ceo playbook scan"
-  exit 1
-fi
+REGISTRY_RC=0
+ceo_registry_validate "$REGISTRY_FILE" || REGISTRY_RC=$?
+case "$REGISTRY_RC" in
+  0) ;;
+  1)
+    echo "$(date): FATAL — registry.json not found. Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _v "FATAL: registry.json not found. Run: ceo playbook scan"
+    exit 1 ;;
+  2)
+    echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _v "FATAL: registry.json schema_version too old. Run: ceo playbook scan"
+    exit 1 ;;
+esac
 
 ENTRY=$(jq -r --arg t "$TRIGGER" '.playbooks[] | select(.name == $t)' "$REGISTRY_FILE" 2>/dev/null)
 if [ -z "$ENTRY" ]; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -153,7 +153,7 @@ BRANCH_PREFIX=$(_cfg '.branch_prefix' 'ceo/')
 preflight_none() { return 0; }
 
 preflight_has_unchecked_inbox() {
-  [ -f "$CEO_DIR/inbox.md" ] && grep -q "^- \[ \]" "$CEO_DIR/inbox.md"
+  ceo_inbox_has_unchecked
 }
 
 preflight_has_prs_to_review() {

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -272,7 +272,7 @@ if [ "$RUNNER" = "script" ]; then
   _v "Runner: script — exec $SCRIPT_PATH"
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
   SCRIPT_EXIT=0
-  "$SCRIPT_FULL" || SCRIPT_EXIT=$?
+  "$SCRIPT_FULL" 2>>"$LOG_DIR/cron-stderr.log" || SCRIPT_EXIT=$?
   if [ "$SCRIPT_EXIT" -ne 0 ]; then
     _v "FAILED (exit: $SCRIPT_EXIT)"
     _record_failure "Script exited $SCRIPT_EXIT for $TRIGGER"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -530,6 +530,73 @@ PB
   assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"
 }
 
+test_playbook_scan_blocks_non_primary_host() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "non-primary host must be refused"
+  assert_contains "$out" "primary host" "error must mention primary host gating"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] non-primary host wrote registry.json (must not)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_scan_succeeds_on_primary_host() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0
+  CEO_HOSTNAME=alpha bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "primary host must be allowed to scan"
+  assert_file_exists "$CEO_DIR/registry.json" "registry must be written by primary host"
+}
+
+test_playbook_scan_unrestricted_when_primary_host_unset() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0
+  CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "no primary_host setting → backward-compatible (any host can scan)"
+  assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -72,6 +72,17 @@ echo "ACTION: 1 | read | noop | n/a"
 STUB
   chmod +x "$TEST_HOME/bin/claude"
 
+  # macOS lacks `timeout` from GNU coreutils; the dispatcher uses
+  # `timeout N claude ...`. Stub it as a transparent passthrough.
+  if ! command -v timeout >/dev/null 2>&1; then
+    cat > "$TEST_HOME/bin/timeout" << 'STUB'
+#!/bin/bash
+shift  # discard the duration arg
+exec "$@"
+STUB
+    chmod +x "$TEST_HOME/bin/timeout"
+  fi
+
   export PATH="$TEST_HOME/bin:$PATH"
 }
 
@@ -107,15 +118,20 @@ SH
 
   CEO_VERBOSE=1 bash "$CRON" fake-intake >/dev/null 2>&1
   assert_file_exists "$TEST_HOME/script-fired.txt" "script must have executed"
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude was invoked but the script-runner branch must skip it\n' \
+      "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
 
   rm -f "$SCRIPT_DIR/fake-intake.sh"
 }
 
-test_runner_default_claude_unchanged() {
+test_runner_default_invokes_claude() {
   cat > "$CEO_DIR/playbooks/fake-claude.md" << 'PB'
 ---
 name: fake-claude
-description: Existing-shape playbook
+description: Default-runner playbook
 trigger: cron
 schedule: "0 9 * * *"
 model: haiku
@@ -127,13 +143,39 @@ status: active
 PB
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local entry runner
-  entry=$(jq -r '.playbooks[] | select(.name=="fake-claude")' "$CEO_DIR/registry.json")
-  runner=$(echo "$entry" | jq -r '.runner // ""')
-  # Empty string means "use default" — dispatcher treats unset and empty identically.
-  if [ -n "$runner" ] && [ "$runner" != "claude" ]; then
-    assert_eq "$runner" "claude" "default runner must be claude or empty"
-  fi
+  CEO_VERBOSE=1 bash "$CRON" fake-claude >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "default runner must invoke claude"
+}
+
+test_v_safe_under_set_e() {
+  cat > "$CEO_DIR/playbooks/v-test.md" << 'PB'
+---
+name: v-test
+description: Exercises _v under set -e with CEO_VERBOSE unset
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: v-test.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/v-test.sh" << SH
+#!/bin/bash
+echo "ran" > "$TEST_HOME/v-test-fired.txt"
+SH
+  chmod +x "$SCRIPT_DIR/v-test.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  unset CEO_VERBOSE
+  bash "$CRON" v-test >/dev/null 2>&1
+  assert_file_exists "$TEST_HOME/v-test-fired.txt" \
+    "script must run end-to-end with CEO_VERBOSE unset (regression guard for a528fde)"
+
+  rm -f "$SCRIPT_DIR/v-test.sh"
 }
 
 test_script_stderr_redirected_to_log() {
@@ -414,7 +456,10 @@ PB
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
-  CEO_VERBOSE=1 bash "$CRON" bad-intake >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" bad-intake >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "missing-script field must exit 1"
+
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -136,6 +136,39 @@ PB
   fi
 }
 
+test_script_stderr_redirected_to_log() {
+  cat > "$CEO_DIR/playbooks/stderr-intake.md" << 'PB'
+---
+name: stderr-intake
+description: Test playbook to verify script stderr is captured
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: stderr-intake.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/stderr-intake.sh" << 'SH'
+#!/bin/bash
+echo "synthetic-script-stderr-sentinel" >&2
+exit 4
+SH
+  chmod +x "$SCRIPT_DIR/stderr-intake.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" stderr-intake >/dev/null 2>&1 || true
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "synthetic-script-stderr-sentinel" \
+    "script stderr must be appended to cron-stderr.log"
+
+  rm -f "$SCRIPT_DIR/stderr-intake.sh"
+}
+
 test_script_failure_increments_fail_count() {
   cat > "$CEO_DIR/playbooks/fail-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -505,6 +505,85 @@ PB
   assert_file_exists "$HOME/claude-invoked.txt" "claude stub must fire (proves PATH augmentation reached dispatcher)"
 }
 
+test_playbook_scan_writes_schema_version_2() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: schema-version regression seed
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local v
+  v=$(jq -r '.schema_version // "missing"' "$CEO_DIR/registry.json")
+  assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
+}
+
+test_cron_skips_on_missing_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  jq 'del(.schema_version)' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CRON" example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit 1 when registry has no schema_version"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_cron_skips_on_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CRON" example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit 1 when registry schema_version is below current"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -62,6 +62,16 @@ cat > "$HOME/.fake-crontab"
 STUB
   chmod +x "$TEST_HOME/bin/crontab"
   : > "$HOME/.fake-crontab"
+
+  # Stub claude on PATH so dispatcher invocations are detectable. Default behavior
+  # is success — individual tests override $TEST_HOME/bin/claude to simulate failure.
+  cat > "$TEST_HOME/bin/claude" << 'STUB'
+#!/bin/bash
+echo "claude-fired" > "$HOME/claude-invoked.txt"
+echo "ACTION: 1 | read | noop | n/a"
+STUB
+  chmod +x "$TEST_HOME/bin/claude"
+
   export PATH="$TEST_HOME/bin:$PATH"
 }
 
@@ -123,6 +133,182 @@ PB
   # Empty string means "use default" — dispatcher treats unset and empty identically.
   if [ -n "$runner" ] && [ "$runner" != "claude" ]; then
     assert_eq "$runner" "claude" "default runner must be claude or empty"
+  fi
+}
+
+test_script_failure_increments_fail_count() {
+  cat > "$CEO_DIR/playbooks/fail-intake.md" << 'PB'
+---
+name: fail-intake
+description: Test playbook for runner:script failure
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: fail-intake.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/fail-intake.sh" << 'SH'
+#!/bin/bash
+exit 7
+SH
+  chmod +x "$SCRIPT_DIR/fail-intake.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" fail-intake >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after one script failure"
+
+  rm -f "$SCRIPT_DIR/fail-intake.sh"
+}
+
+test_script_success_resets_fail_count() {
+  cat > "$CEO_DIR/playbooks/ok-intake.md" << 'PB'
+---
+name: ok-intake
+description: Test playbook for runner:script success
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: ok-intake.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/ok-intake.sh" << 'SH'
+#!/bin/bash
+exit 0
+SH
+  chmod +x "$SCRIPT_DIR/ok-intake.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  echo 2 > "$CEO_DIR/log/.fail-count"
+  CEO_VERBOSE=1 bash "$CRON" ok-intake >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "0" "FAIL_COUNT_FILE must be 0 after a successful script run"
+
+  rm -f "$SCRIPT_DIR/ok-intake.sh"
+}
+
+test_script_success_appends_runs_log() {
+  cat > "$CEO_DIR/playbooks/log-intake.md" << 'PB'
+---
+name: log-intake
+description: Test playbook to verify cron-runs.log entry
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: log-intake.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/log-intake.sh" << 'SH'
+#!/bin/bash
+exit 0
+SH
+  chmod +x "$SCRIPT_DIR/log-intake.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" log-intake >/dev/null 2>&1 || true
+
+  local runs_log
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  assert_contains "$runs_log" "log-intake completed" "cron-runs.log must record successful script run"
+
+  rm -f "$SCRIPT_DIR/log-intake.sh"
+}
+
+test_read_tier_failure_increments_fail_count() {
+  cat > "$TEST_HOME/bin/claude" << 'STUB'
+#!/bin/bash
+echo "synthetic stderr from claude stub" >&2
+exit 2
+STUB
+  chmod +x "$TEST_HOME/bin/claude"
+
+  cat > "$CEO_DIR/playbooks/read-tier-fail.md" << 'PB'
+---
+name: read-tier-fail
+description: Read-tier playbook used to exercise claude failure path
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+# Body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" read-tier-fail >/dev/null 2>&1 || true
+
+  local fails runs_log
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after a read-tier failure"
+  if [[ "$runs_log" == *"read-tier-fail completed"* ]]; then
+    printf '  FAIL [%s] read-tier failure must NOT log completed\n    runs_log: %q\n' \
+      "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_phase3_failure_does_not_log_completed() {
+  # Stateful stub: succeeds on Phase-1 (with ACTION line low-stakes-write),
+  # fails on Phase-3.
+  cat > "$TEST_HOME/bin/claude" << STUB
+#!/bin/bash
+COUNT_FILE="$TEST_HOME/.claude-call-count"
+n=\$(cat "\$COUNT_FILE" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$COUNT_FILE"
+if [ "\$n" = "1" ]; then
+  echo "ACTION: 1 | low-stakes-write | noop | echo ok"
+  exit 0
+fi
+echo "synthetic phase-3 failure" >&2
+exit 3
+STUB
+  chmod +x "$TEST_HOME/bin/claude"
+
+  cat > "$CEO_DIR/playbooks/phase3-fail.md" << 'PB'
+---
+name: phase3-fail
+description: Low-stakes-write playbook to exercise Phase-3 failure
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: low-stakes-write
+status: active
+---
+# Body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" phase3-fail >/dev/null 2>&1 || true
+
+  local fails runs_log
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after Phase-3 failure"
+  if [[ "$runs_log" == *"phase3-fail completed"* ]]; then
+    printf '  FAIL [%s] Phase-3 failure must NOT log completed\n    runs_log: %q\n' \
+      "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
   fi
 }
 

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -441,9 +441,6 @@ PB
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {
-  # Regression guard for #9: the helper is the single source of truth for
-  # cron PATH augmentation. ceo-cron.sh and runner:script playbooks rely on
-  # it; if the prefix list drifts here, every consumer drifts.
   local out
   out=$(env HOME=/fake bash -c '
     set -uo pipefail
@@ -458,7 +455,6 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
 }
-
 
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -484,6 +484,27 @@ test_ceo_augment_path_empty_home_aborts() {
   fi
 }
 
+test_ceo_cron_invokes_ceo_augment_path_at_dispatch() {
+  cat > "$CEO_DIR/playbooks/path-strip.md" << 'PB'
+---
+name: path-strip
+description: stripped-PATH wiring guard
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local rc=0
+  PATH=/usr/bin:/bin bash "$CRON" path-strip >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ceo-cron must invoke ceo_augment_path so dispatcher resolves binaries under stripped PATH"
+  assert_file_exists "$HOME/claude-invoked.txt" "claude stub must fire (proves PATH augmentation reached dispatcher)"
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -525,6 +525,33 @@ PB
   assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
 }
 
+test_playbook_scan_refuses_newer_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: schema-version downgrade guard
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  printf '{"schema_version":99,"future_field":"must-stay","playbooks":[]}\n' \
+    > "$CEO_DIR/registry.json"
+  local before
+  before=$(cat "$CEO_DIR/registry.json")
+
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook scan must refuse to overwrite newer registry schema"
+
+  local after
+  after=$(cat "$CEO_DIR/registry.json")
+  assert_eq "$after" "$before" "newer registry content must remain unchanged"
+}
+
 test_cron_skips_on_missing_schema_version() {
   cat > "$CEO_DIR/playbooks/example.md" << 'PB'
 ---
@@ -550,6 +577,10 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/claude-invoked.txt" ]; then
     printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
@@ -582,6 +613,59 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
+
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_list_rejects_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CEO_CLI" playbook list >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook list must reject old registry schema"
+}
+
+test_playbook_info_rejects_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CEO_CLI" playbook info example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook info must reject old registry schema"
 }
 
 test_runner_script_missing_script_field_fails() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -95,7 +95,7 @@ SH
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
-  CEO_VERBOSE=0 bash "$CRON" fake-intake >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" fake-intake >/dev/null 2>&1
   assert_file_exists "$TEST_HOME/script-fired.txt" "script must have executed"
 
   rm -f "$SCRIPT_DIR/fake-intake.sh"
@@ -142,7 +142,7 @@ PB
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
-  CEO_VERBOSE=0 bash "$CRON" bad-intake >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" bad-intake >/dev/null 2>&1
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -454,6 +454,9 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/usr/local/bin"   "PATH must include /usr/local/bin"
   assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
+
+  local first_segment="${out%%:*}"
+  assert_eq "$first_segment" "/fake/.bun/bin" "augmented prefix must be FIRST on PATH"
 }
 
 test_ceo_augment_path_idempotent() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -50,8 +50,8 @@ setup() {
   : > "$CEO_DIR/inbox.md"
 
   # Stub crontab so playbook scan's cron install can't touch the user's real crontab.
-  mkdir -p "$TEST_HOME/bin"
-  cat > "$TEST_HOME/bin/crontab" << 'STUB'
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/crontab" << 'STUB'
 #!/bin/bash
 # no-op stub for tests
 if [ "${1:-}" = "-l" ]; then
@@ -60,30 +60,30 @@ if [ "${1:-}" = "-l" ]; then
 fi
 cat > "$HOME/.fake-crontab"
 STUB
-  chmod +x "$TEST_HOME/bin/crontab"
+  chmod +x "$TEST_HOME/.bun/bin/crontab"
   : > "$HOME/.fake-crontab"
 
   # Stub claude on PATH so dispatcher invocations are detectable. Default behavior
-  # is success — individual tests override $TEST_HOME/bin/claude to simulate failure.
-  cat > "$TEST_HOME/bin/claude" << 'STUB'
+  # is success — individual tests override $TEST_HOME/.bun/bin/claude to simulate failure.
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash
 echo "claude-fired" > "$HOME/claude-invoked.txt"
 echo "ACTION: 1 | read | noop | n/a"
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   # macOS lacks `timeout` from GNU coreutils; the dispatcher uses
   # `timeout N claude ...`. Stub it as a transparent passthrough.
   if ! command -v timeout >/dev/null 2>&1; then
-    cat > "$TEST_HOME/bin/timeout" << 'STUB'
+    cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
 #!/bin/bash
 shift  # discard the duration arg
 exec "$@"
 STUB
-    chmod +x "$TEST_HOME/bin/timeout"
+    chmod +x "$TEST_HOME/.bun/bin/timeout"
   fi
 
-  export PATH="$TEST_HOME/bin:$PATH"
+  export PATH="$TEST_HOME/.bun/bin:$PATH"
 }
 
 teardown() {
@@ -306,12 +306,12 @@ SH
 }
 
 test_read_tier_failure_increments_fail_count() {
-  cat > "$TEST_HOME/bin/claude" << 'STUB'
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash
 echo "synthetic stderr from claude stub" >&2
 exit 2
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   cat > "$CEO_DIR/playbooks/read-tier-fail.md" << 'PB'
 ---
@@ -344,7 +344,7 @@ PB
 test_phase3_failure_does_not_log_completed() {
   # Stateful stub: succeeds on Phase-1 (with ACTION line low-stakes-write),
   # fails on Phase-3.
-  cat > "$TEST_HOME/bin/claude" << STUB
+  cat > "$TEST_HOME/.bun/bin/claude" << STUB
 #!/bin/bash
 COUNT_FILE="$TEST_HOME/.claude-call-count"
 n=\$(cat "\$COUNT_FILE" 2>/dev/null || echo 0)
@@ -357,7 +357,7 @@ fi
 echo "synthetic phase-3 failure" >&2
 exit 3
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   cat > "$CEO_DIR/playbooks/phase3-fail.md" << 'PB'
 ---
@@ -439,6 +439,26 @@ PB
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Unknown runner 'scrpt'" "skips log must record unknown-runner rejection"
 }
+
+test_ceo_augment_path_prepends_user_tool_prefixes() {
+  # Regression guard for #9: the helper is the single source of truth for
+  # cron PATH augmentation. ceo-cron.sh and runner:script playbooks rely on
+  # it; if the prefix list drifts here, every consumer drifts.
+  local out
+  out=$(env HOME=/fake bash -c '
+    set -uo pipefail
+    PATH=/usr/bin:/bin
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path
+    echo "$PATH"
+  ')
+  assert_contains "$out" "/fake/.bun/bin"  "PATH must include ~/.bun/bin"
+  assert_contains "$out" "/opt/homebrew/bin" "PATH must include Homebrew prefix"
+  assert_contains "$out" "/usr/local/bin"   "PATH must include /usr/local/bin"
+  assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
+  assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
+}
+
 
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -456,6 +456,31 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
 }
 
+test_ceo_augment_path_idempotent() {
+  local out
+  out=$(env HOME=/fake bash -c '
+    set -uo pipefail
+    PATH=/usr/bin:/bin
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path; first="$PATH"
+    ceo_augment_path; second="$PATH"
+    [ "$first" = "$second" ] && echo idempotent || echo diverged
+  ')
+  assert_eq "$out" "idempotent" "ceo_augment_path must not drift PATH on repeated calls"
+}
+
+test_ceo_augment_path_empty_home_aborts() {
+  local rc=0
+  HOME="" bash -c '
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path
+  ' >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] expected non-zero rc with HOME="", got 0\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Self-contained test harness for the ceo-cron.sh script-runner branch.
+# Mirrors the count-blessings.test.sh shape — portable across BSD and GNU userlands.
+
+set -uo pipefail  # no -e — tests handle their own failures
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+CRON="$SCRIPT_DIR/ceo-cron.sh"
+
+FAILS=0
+CURRENT_TEST=""
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1" msg="${2:-}"
+  if [[ ! -f "$path" ]]; then
+    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports"
+  : > "$CEO_DIR/AGENTS.md"
+  : > "$CEO_DIR/IDENTITY.md"
+  : > "$CEO_DIR/TRAINING.md"
+  : > "$CEO_DIR/inbox.md"
+
+  # Stub crontab so playbook scan's cron install can't touch the user's real crontab.
+  mkdir -p "$TEST_HOME/bin"
+  cat > "$TEST_HOME/bin/crontab" << 'STUB'
+#!/bin/bash
+# no-op stub for tests
+if [ "${1:-}" = "-l" ]; then
+  cat "$HOME/.fake-crontab" 2>/dev/null || true
+  exit 0
+fi
+cat > "$HOME/.fake-crontab"
+STUB
+  chmod +x "$TEST_HOME/bin/crontab"
+  : > "$HOME/.fake-crontab"
+  export PATH="$TEST_HOME/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+}
+
+test_runner_script_execs_named_script_and_skips_claude() {
+  cat > "$CEO_DIR/playbooks/fake-intake.md" << 'PB'
+---
+name: fake-intake
+description: Test playbook for runner:script
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: fake-intake.sh
+---
+PB
+
+  cat > "$SCRIPT_DIR/fake-intake.sh" << SH
+#!/bin/bash
+echo "ran" > "$TEST_HOME/script-fired.txt"
+SH
+  chmod +x "$SCRIPT_DIR/fake-intake.sh"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  CEO_VERBOSE=0 bash "$CRON" fake-intake >/dev/null 2>&1
+  assert_file_exists "$TEST_HOME/script-fired.txt" "script must have executed"
+
+  rm -f "$SCRIPT_DIR/fake-intake.sh"
+}
+
+test_runner_default_claude_unchanged() {
+  cat > "$CEO_DIR/playbooks/fake-claude.md" << 'PB'
+---
+name: fake-claude
+description: Existing-shape playbook
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+# Body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local entry runner
+  entry=$(jq -r '.playbooks[] | select(.name=="fake-claude")' "$CEO_DIR/registry.json")
+  runner=$(echo "$entry" | jq -r '.runner // "claude"')
+  assert_eq "$runner" "claude" "default runner must remain claude"
+}
+
+test_runner_script_missing_script_field_fails() {
+  cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
+---
+name: bad-intake
+description: runner:script without script field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+---
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  CEO_VERBOSE=0 bash "$CRON" bad-intake >/dev/null 2>&1
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"
+}
+
+run_tests() {
+  local count=0
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    CURRENT_TEST="$fn"
+    setup
+    "$fn"
+    teardown
+    count=$((count + 1))
+  done
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}
+
+run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -119,8 +119,11 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local entry runner
   entry=$(jq -r '.playbooks[] | select(.name=="fake-claude")' "$CEO_DIR/registry.json")
-  runner=$(echo "$entry" | jq -r '.runner // "claude"')
-  assert_eq "$runner" "claude" "default runner must remain claude"
+  runner=$(echo "$entry" | jq -r '.runner // ""')
+  # Empty string means "use default" — dispatcher treats unset and empty identically.
+  if [ -n "$runner" ] && [ "$runner" != "claude" ]; then
+    assert_eq "$runner" "claude" "default runner must be claude or empty"
+  fi
 }
 
 test_runner_script_missing_script_field_fails() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -597,6 +597,79 @@ PB
   assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
 }
 
+test_playbook_scan_typoed_primary_host_field_emits_warning() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"promary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "0" "typo'd key falls through to no-gate (backward-compat) but must warn"
+  assert_contains "$out" "unknown key 'promary_host'" "typo'd key must surface a warning so operator notices"
+  assert_file_exists "$CEO_DIR/registry.json" "scan continues despite typo (gate is not configured from parser's view)"
+}
+
+test_playbook_scan_malformed_settings_json_fails_loud() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf 'not valid json\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "malformed settings.json must fail loud, not silently fall through"
+  assert_contains "$out" "not valid JSON" "error must name the JSON parse failure"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] registry written despite malformed settings.json\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_scan_missing_jq_with_settings_fails_loud() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_JQ_BIN=jq-deliberately-missing-for-test CEO_HOSTNAME=anyhost \
+        bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "missing jq with settings.json must fail loud"
+  assert_contains "$out" "jq is not installed" "error must name the missing dependency"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] registry written despite missing-jq error\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -345,6 +345,59 @@ PB
   fi
 }
 
+test_runner_unknown_value_skipped_at_scan() {
+  cat > "$CEO_DIR/playbooks/typo-runner.md" << 'PB'
+---
+name: typo-runner
+description: Playbook with a typo in the runner field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: scrpt
+script: typo-runner.sh
+---
+PB
+
+  local scan_out
+  scan_out=$(bash "$CEO_CLI" playbook scan 2>&1 || true)
+  assert_contains "$scan_out" "unknown runner: 'scrpt'" "scan must skip unknown runner with diagnostic"
+
+  local entry
+  entry=$(jq -r '.playbooks[] | select(.name=="typo-runner")' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  assert_eq "$entry" "" "skipped playbook must not appear in registry.json"
+}
+
+test_runner_unknown_value_rejected_at_dispatch() {
+  cat > "$CEO_DIR/playbooks/forced-typo.md" << 'PB'
+---
+name: forced-typo
+description: Valid playbook
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# Body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  jq '(.playbooks[] | select(.name=="forced-typo") | .runner) |= "scrpt"' \
+    "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" forced-typo >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "dispatcher must reject unknown runner with exit 1"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "Unknown runner 'scrpt'" "skips log must record unknown-runner rejection"
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+ceo_augment_path
 
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
@@ -21,9 +22,6 @@ TOKEN_DIR="$CEO_DIR/reports/token"
 TODAY=$(date +%Y-%m-%d)
 REPORT_FILE="$TOKEN_DIR/$TODAY.md"
 INBOX_LINE="- [ ] Review daily token report [[CEO/reports/token/$TODAY]]"
-
-# bun lives in ~/.bun/bin; homebrew in /opt/homebrew/bin (Mac) or /usr/local/bin (Linux/WSL)
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 mkdir -p "$TOKEN_DIR"
 

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# ceo-token-intake.sh — Daily RTK + token-scope spend intake.
+# Captures four command outputs to CEO/reports/token/<TODAY>.md and idempotently
+# appends one inbox line linking to it. The chat-triggered inbox playbook
+# surfaces the line for morning discussion via `ceo chat inbox`.
+#
+# Invoked by ceo-cron.sh when the token-intake playbook (runner:script) fires.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+INBOX_FILE="$CEO_DIR/inbox.md"
+TOKEN_DIR="$CEO_DIR/reports/token"
+TODAY=$(date +%Y-%m-%d)
+REPORT_FILE="$TOKEN_DIR/$TODAY.md"
+INBOX_LINE="- [ ] Review daily token report [[CEO/reports/token/$TODAY]]"
+
+# bun lives in ~/.bun/bin; homebrew in /opt/homebrew/bin (Mac) or /usr/local/bin (Linux/WSL)
+export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+mkdir -p "$TOKEN_DIR"
+
+# capture <label> <cmd> [args...] — run a command and wrap its output in a fenced block.
+# Falls back to "<cmd> unavailable" so the inbox link always resolves to readable content.
+capture() {
+  local label="$1"; shift
+  printf '\n## %s\n\n```\n' "$label"
+  if command -v "$1" >/dev/null 2>&1; then
+    "$@" 2>&1 || printf '\n[command exited non-zero]\n'
+  else
+    printf '%s unavailable on $PATH\n' "$1"
+  fi
+  printf '```\n'
+}
+
+{
+  printf -- '---\ndate: %s\ntype: ceo-token-intake\n---\n\n' "$TODAY"
+  printf '# Token Report — %s\n' "$TODAY"
+  capture "RTK — global savings" rtk gain
+  capture "RTK — current project" rtk gain -p
+  capture "RTK — Claude Code economics" rtk cc-economics
+  capture "token-scope — last 24h" token-scope --since 1d
+} > "$REPORT_FILE"
+
+# Idempotently append the inbox line.
+# `--` guards against the leading `-` in the pattern being parsed as an option flag.
+touch "$INBOX_FILE"
+if ! grep -qF -- "$INBOX_LINE" "$INBOX_FILE"; then
+  printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
+fi
+
+exit 0

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # ceo-token-intake.sh — Daily RTK + token-scope spend intake.
-# Captures four command outputs to CEO/reports/token/<TODAY>.md and idempotently
-# appends one inbox line linking to it. The chat-triggered inbox playbook
-# surfaces the line for morning discussion via `ceo chat inbox`.
+# Captures four command outputs to CEO/reports/token/<TODAY>-<host>.md and
+# idempotently appends one inbox line to CEO/inbox/<host>.md linking to it.
+# Per-host filenames keep two Syncthing peers from racing on the same path.
+# The chat-triggered inbox playbook surfaces the line via `ceo chat inbox`.
 #
 # Invoked by ceo-cron.sh when the token-intake playbook (runner:script) fires.
 
@@ -17,13 +18,17 @@ ceo_augment_path
 
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
-INBOX_FILE="$CEO_DIR/inbox.md"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+INBOX_DIR="$CEO_DIR/inbox"
+INBOX_FILE="$INBOX_DIR/$HOST.md"
 TOKEN_DIR="$CEO_DIR/reports/token"
 TODAY=$(date +%Y-%m-%d)
-REPORT_FILE="$TOKEN_DIR/$TODAY.md"
-INBOX_LINE="- [ ] Review daily token report [[CEO/reports/token/$TODAY]]"
+REPORT_FILE="$TOKEN_DIR/$TODAY-$HOST.md"
+WIKILINK="[[CEO/reports/token/$TODAY-$HOST]]"
+INBOX_LINE="- [ ] Review daily token report $WIKILINK"
 
-mkdir -p "$TOKEN_DIR"
+mkdir -p "$TOKEN_DIR" "$INBOX_DIR"
 
 # capture <label> <cmd> [args...] — run a command and wrap its output in a fenced block.
 # Falls back to "<cmd> unavailable" so the inbox link always resolves to readable content.
@@ -55,7 +60,6 @@ fi
 # rather than the full line so a `[x]` checkoff doesn't re-trigger the
 # append.
 touch "$INBOX_FILE"
-WIKILINK="[[CEO/reports/token/$TODAY]]"
 if ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then
   printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
 fi

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -6,7 +6,7 @@
 #
 # Invoked by ceo-cron.sh when the token-intake playbook (runner:script) fires.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=ceo-config.sh
@@ -35,24 +35,30 @@ capture() {
   if command -v "$1" >/dev/null 2>&1; then
     "$@" 2>&1 || printf '\n[command exited non-zero]\n'
   else
-    printf '%s unavailable on $PATH\n' "$1"
+    printf '%s unavailable on PATH=%s\n' "$1" "$PATH"
   fi
   printf '```\n'
 }
 
-{
+if ! {
   printf -- '---\ndate: %s\ntype: ceo-token-intake\n---\n\n' "$TODAY"
   printf '# Token Report — %s\n' "$TODAY"
   capture "RTK — global savings" rtk gain
   capture "RTK — current project" rtk gain -p
   capture "RTK — Claude Code economics" rtk cc-economics
   capture "token-scope — last 24h" token-scope --since 1d
-} > "$REPORT_FILE"
+} > "$REPORT_FILE"; then
+  echo "ERROR: failed to write $REPORT_FILE" >&2
+  exit 1
+fi
+[ -s "$REPORT_FILE" ] || { echo "ERROR: empty report $REPORT_FILE" >&2; exit 1; }
 
-# Idempotently append the inbox line.
-# `--` guards against the leading `-` in the pattern being parsed as an option flag.
+# Idempotently append the inbox line. Dedupe on the wikilink target
+# rather than the full line so a `[x]` checkoff doesn't re-trigger the
+# append.
 touch "$INBOX_FILE"
-if ! grep -qF -- "$INBOX_LINE" "$INBOX_FILE"; then
+WIKILINK="[[CEO/reports/token/$TODAY]]"
+if ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then
   printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
 fi
 

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -41,8 +41,8 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="testhost"
   mkdir -p "$CEO_DIR/reports/token"
-  : > "$CEO_DIR/inbox.md"
 
   mkdir -p "$TEST_HOME/.bun/bin"
   cat > "$TEST_HOME/.bun/bin/rtk" << 'STUB'
@@ -61,47 +61,75 @@ teardown() {
   rm -rf "$TEST_HOME"
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+  unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP
 }
 
-test_creates_report_and_appends_inbox_line() {
+test_creates_host_suffixed_report_and_appends_per_host_inbox_line() {
   bash "$INTAKE" >/dev/null 2>&1
-  local today report
+  local today report inbox
   today=$(date +%Y-%m-%d)
-  report="$CEO_DIR/reports/token/$today.md"
-  assert_file_exists "$report" "report file must exist after intake"
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_file_exists "$report" "report path must include hostname suffix"
+  assert_file_exists "$inbox" "per-host inbox shadow file must be created"
   local count
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
-  assert_eq "$count" "1" "inbox must contain exactly one wikilink to today's report"
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
+  assert_eq "$count" "1" "per-host inbox must contain wikilink to host-suffixed report"
+}
+
+test_does_not_write_to_shared_inbox_md() {
+  bash "$INTAKE" >/dev/null 2>&1
+  if [ -f "$CEO_DIR/inbox.md" ] && [ -s "$CEO_DIR/inbox.md" ]; then
+    printf '  FAIL [%s] writer must not touch shared CEO/inbox.md\n    contents: %q\n' \
+      "$CURRENT_TEST" "$(cat "$CEO_DIR/inbox.md")"
+    FAILS=$((FAILS + 1))
+  fi
 }
 
 test_idempotent_same_day() {
   bash "$INTAKE" >/dev/null 2>&1
   bash "$INTAKE" >/dev/null 2>&1
-  local today count
+  local today inbox count
   today=$(date +%Y-%m-%d)
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "two runs must leave exactly one inbox line"
 }
 
 test_does_not_re_append_after_inbox_checkoff() {
   bash "$INTAKE" >/dev/null 2>&1
-  local today
+  local today inbox
   today=$(date +%Y-%m-%d)
-  sed -i.bak "s|- \[ \] Review daily token report \[\[CEO/reports/token/$today\]\]|- [x] Review daily token report [[CEO/reports/token/$today]]|" "$CEO_DIR/inbox.md"
-  rm -f "$CEO_DIR/inbox.md.bak"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  sed -i.bak "s|^- \[ \]|- [x]|" "$inbox"
+  rm -f "$inbox.bak"
 
   bash "$INTAKE" >/dev/null 2>&1
   local count
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "checked-off line must not trigger re-append"
+}
+
+test_two_hosts_write_disjoint_files() {
+  CEO_HOSTNAME="alpha" bash "$INTAKE" >/dev/null 2>&1
+  CEO_HOSTNAME="beta"  bash "$INTAKE" >/dev/null 2>&1
+  local today
+  today=$(date +%Y-%m-%d)
+  assert_file_exists "$CEO_DIR/reports/token/$today-alpha.md" "alpha report"
+  assert_file_exists "$CEO_DIR/reports/token/$today-beta.md"  "beta report"
+  assert_file_exists "$CEO_DIR/inbox/alpha.md" "alpha inbox shadow"
+  assert_file_exists "$CEO_DIR/inbox/beta.md"  "beta inbox shadow"
+  if [ -f "$CEO_DIR/inbox/beta.md" ] && grep -qF "alpha" "$CEO_DIR/inbox/beta.md"; then
+    printf '  FAIL [%s] beta inbox shadow must not reference alpha\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
 }
 
 test_invokes_ceo_augment_path() {
   PATH=/usr/bin:/bin bash "$INTAKE" >/dev/null 2>&1
   local today report body
   today=$(date +%Y-%m-%d)
-  report="$CEO_DIR/reports/token/$today.md"
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
   assert_file_exists "$report" "report file must exist"
   body=$(cat "$report")
   assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
@@ -109,7 +137,7 @@ test_invokes_ceo_augment_path() {
 
 test_aborts_on_unwritable_report_dir() {
   if [ "$(id -u)" = "0" ]; then
-    return 0  # chmod doesn't apply to root
+    return 0
   fi
   chmod 0500 "$CEO_DIR/reports/token"
   local rc=0
@@ -119,11 +147,8 @@ test_aborts_on_unwritable_report_dir() {
     printf '  FAIL [%s] script must exit non-zero on unwritable report dir (got rc=0)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
-  local inbox
-  inbox=$(cat "$CEO_DIR/inbox.md")
-  if [[ "$inbox" == *"[[CEO/reports/token/"* ]]; then
-    printf '  FAIL [%s] inbox must NOT have an inbox line when the report write failed\n    inbox: %q\n' \
-      "$CURRENT_TEST" "$inbox"
+  if [ -f "$CEO_DIR/inbox/$CEO_HOSTNAME.md" ] && grep -qF "[[CEO/reports/token/" "$CEO_DIR/inbox/$CEO_HOSTNAME.md"; then
+    printf '  FAIL [%s] per-host inbox must NOT have an inbox line when the report write failed\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
 }

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -44,17 +44,17 @@ setup() {
   mkdir -p "$CEO_DIR/reports/token"
   : > "$CEO_DIR/inbox.md"
 
-  mkdir -p "$TEST_HOME/bin"
-  cat > "$TEST_HOME/bin/rtk" << 'STUB'
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/rtk" << 'STUB'
 #!/bin/bash
 echo "rtk-stub: $*"
 STUB
-  cat > "$TEST_HOME/bin/token-scope" << 'STUB'
+  cat > "$TEST_HOME/.bun/bin/token-scope" << 'STUB'
 #!/bin/bash
 echo "token-scope-stub: $*"
 STUB
-  chmod +x "$TEST_HOME/bin/rtk" "$TEST_HOME/bin/token-scope"
-  export PATH="$TEST_HOME/bin:$PATH"
+  chmod +x "$TEST_HOME/.bun/bin/rtk" "$TEST_HOME/.bun/bin/token-scope"
+  export PATH="$TEST_HOME/.bun/bin:$PATH"
 }
 
 teardown() {
@@ -95,6 +95,16 @@ test_does_not_re_append_after_inbox_checkoff() {
   local count
   count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
   assert_eq "$count" "1" "checked-off line must not trigger re-append"
+}
+
+test_invokes_ceo_augment_path() {
+  PATH=/usr/bin:/bin bash "$INTAKE" >/dev/null 2>&1
+  local today report body
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today.md"
+  assert_file_exists "$report" "report file must exist"
+  body=$(cat "$report")
+  assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
 }
 
 test_aborts_on_unwritable_report_dir() {

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Self-contained test harness for ceo-token-intake.sh — verifies the report
+# write, idempotency, and write-failure invariants the script claims.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTAKE="$SCRIPT_DIR/ceo-token-intake.sh"
+
+FAILS=0
+CURRENT_TEST=""
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1" msg="${2:-}"
+  if [[ ! -f "$path" ]]; then
+    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  mkdir -p "$CEO_DIR/reports/token"
+  : > "$CEO_DIR/inbox.md"
+
+  mkdir -p "$TEST_HOME/bin"
+  cat > "$TEST_HOME/bin/rtk" << 'STUB'
+#!/bin/bash
+echo "rtk-stub: $*"
+STUB
+  cat > "$TEST_HOME/bin/token-scope" << 'STUB'
+#!/bin/bash
+echo "token-scope-stub: $*"
+STUB
+  chmod +x "$TEST_HOME/bin/rtk" "$TEST_HOME/bin/token-scope"
+  export PATH="$TEST_HOME/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+}
+
+test_creates_report_and_appends_inbox_line() {
+  bash "$INTAKE" >/dev/null 2>&1
+  local today report
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today.md"
+  assert_file_exists "$report" "report file must exist after intake"
+  local count
+  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  assert_eq "$count" "1" "inbox must contain exactly one wikilink to today's report"
+}
+
+test_idempotent_same_day() {
+  bash "$INTAKE" >/dev/null 2>&1
+  bash "$INTAKE" >/dev/null 2>&1
+  local today count
+  today=$(date +%Y-%m-%d)
+  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  assert_eq "$count" "1" "two runs must leave exactly one inbox line"
+}
+
+test_does_not_re_append_after_inbox_checkoff() {
+  bash "$INTAKE" >/dev/null 2>&1
+  local today
+  today=$(date +%Y-%m-%d)
+  sed -i.bak "s|- \[ \] Review daily token report \[\[CEO/reports/token/$today\]\]|- [x] Review daily token report [[CEO/reports/token/$today]]|" "$CEO_DIR/inbox.md"
+  rm -f "$CEO_DIR/inbox.md.bak"
+
+  bash "$INTAKE" >/dev/null 2>&1
+  local count
+  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  assert_eq "$count" "1" "checked-off line must not trigger re-append"
+}
+
+test_aborts_on_unwritable_report_dir() {
+  if [ "$(id -u)" = "0" ]; then
+    return 0  # chmod doesn't apply to root
+  fi
+  chmod 0500 "$CEO_DIR/reports/token"
+  local rc=0
+  bash "$INTAKE" >/dev/null 2>&1 || rc=$?
+  chmod 0700 "$CEO_DIR/reports/token"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] script must exit non-zero on unwritable report dir (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  local inbox
+  inbox=$(cat "$CEO_DIR/inbox.md")
+  if [[ "$inbox" == *"[[CEO/reports/token/"* ]]; then
+    printf '  FAIL [%s] inbox must NOT have an inbox line when the report write failed\n    inbox: %q\n' \
+      "$CURRENT_TEST" "$inbox"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+run_tests() {
+  local count=0
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    CURRENT_TEST="$fn"
+    setup
+    "$fn"
+    teardown
+    count=$((count + 1))
+  done
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}
+
+run_tests


### PR DESCRIPTION
Closes #6

## Description (Issue Fixed & New Behavior)

Adds an optional `runner: script` field to playbook frontmatter. When set, `ceo-cron.sh` execs the named script (resolved against `scripts/`) instead of building a context payload and calling `claude --print`. Default runner stays `claude` — every existing playbook is unaffected.

First user is `token-intake` (template at `docs/playbooks/token-intake.md`), a daily shell-only playbook that captures `rtk gain`, `rtk gain -p`, `rtk cc-economics`, and `token-scope --since 1d` to `CEO/reports/token/<TODAY>.md` and idempotently appends one inbox line linking to it. The chat-triggered `inbox` playbook then surfaces the item for morning discussion via `ceo chat inbox`.

Also includes:
- `ceo-cron.test.sh` — 3 self-contained tests covering the new dispatcher branch, the missing-script error path, and the assertion that an unmodified playbook keeps the default (claude) runner. Mirrors the `count-blessings.test.sh` shape: portable across BSD/GNU, ``mktemp -d`` per test, ``crontab`` stubbed via PATH so tests can't pollute the user's real crontab.
- ``fix(ceo): make _v safe under set -e in non-verbose mode`` — pre-existing bug. ``_v()`` was ``[ ... = \"1\" ] && echo`` which returns exit 1 when ``CEO_VERBOSE`` isn't ``\"1\"``. Under ``set -euo pipefail``, the first ``_v`` call after registry lookup aborted the script. Cron-installed playbooks (which don't set ``CEO_VERBOSE``) all hit this on the first ``_v`` after preflight; only ``ceo test`` and ``ceo morning-brief`` worked because the CLI sets ``CEO_VERBOSE=1`` explicitly. Adding ``|| true`` keeps ``_v`` exit at 0 regardless of verbosity, restoring cron execution.

``cmd_playbook_info`` displays ``runner`` and ``script`` automatically — no change needed because it already iterates registry fields generically.

## Testing Procedure

1. Check out this branch.
2. Run ``bash scripts/ceo-cron.test.sh`` — all 3 tests pass.
3. Run ``bash scripts/count-blessings.test.sh`` — existing harness still passes.
4. Copy ``docs/playbooks/token-intake.md`` into ``\$CEO_VAULT/CEO/playbooks/``, run ``ceo playbook scan``.
5. Confirm a cron line for ``token-intake`` appears between the ``# CEO Agent START``/``END`` markers in ``crontab -l``.
6. Run ``bash scripts/ceo-token-intake.sh`` manually — verify ``\$CEO_VAULT/CEO/reports/token/<TODAY>.md`` is created with all four command outputs and ``\$CEO_VAULT/CEO/inbox.md`` gains exactly one new ``- [ ] Review daily token report …`` line.
7. Run the script a second time — inbox line is NOT duplicated (verified via ``grep -cF -- \"Review daily token report\" \$CEO_VAULT/CEO/inbox.md``).
8. Verify cron-style invocation: ``bash scripts/ceo-cron.sh token-intake`` (no ``CEO_VERBOSE``) — exits 0 and writes the report.
9. Run ``ceo chat inbox`` — confirm the new line is read and processed.

## Additional Notes / HelpScout Tickets

N/A
