### PR TITLE
fix(ceo): make ceo_load_config return non-zero when unresolved

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -21,10 +21,10 @@ if [ "$INSTALL_DIR" = "/" ]; then
   INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
 fi
 
-# Vault discovery handled by ceo-config.sh (ceo_load_config called above).
-VAULT="$CEO_VAULT"
-
-CEO_DIR="$VAULT/CEO"
+# Vault may be unset on a fresh host; help/setup/doctor/next must remain reachable.
+# Vault-requiring subcommands call ceo_require_vault in the dispatcher below.
+VAULT="${CEO_VAULT:-}"
+CEO_DIR="${VAULT:+$VAULT/CEO}"
 CEO_CRON="$SCRIPT_DIR/ceo-cron.sh"
 
 cmd_help() {
@@ -745,16 +745,19 @@ $YESTERDAY_REPORT"
   cd "$VAULT" && claude --model "$model" --system-prompt "$sys_prompt"
 }
 
+# Bind vault globals after ceo_require_vault has set CEO_VAULT.
+_bind_vault() { VAULT="$CEO_VAULT"; CEO_DIR="$VAULT/CEO"; }
+
 # Dispatch
 case "${1:-help}" in
   setup)    cmd_setup ;;
   next)     cmd_next ;;
   doctor)   cmd_doctor ;;
-  preflight) cmd_preflight ;;
-  test)     cmd_test ;;
-  chat)     shift; cmd_chat "$@" ;;
-  cron)     shift; cmd_cron "$@" ;;
-  playbook) shift; cmd_playbook "$@" ;;
+  preflight) ceo_require_vault; _bind_vault; cmd_preflight ;;
+  test)     ceo_require_vault; _bind_vault; cmd_test ;;
+  chat)     ceo_require_vault; _bind_vault; shift; cmd_chat "$@" ;;
+  cron)     ceo_require_vault; _bind_vault; shift; cmd_cron "$@" ;;
+  playbook) ceo_require_vault; _bind_vault; shift; cmd_playbook "$@" ;;
   help|-h|--help) cmd_help ;;
   *)
     echo "Unknown command: $1"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -83,9 +83,7 @@ ceo_load_config() {
     fi
   done
 
-  # No source resolved CEO_VAULT — return non-zero so callers' `|| exit 1`
-  # guards actually fire instead of silently provisioning under
-  # $HOME/Documents/Obsidian on a misconfigured host.
+  # Postcondition: CEO_VAULT remains unset on rc=1; ceo_require_vault() turns this into exit 1.
   return 1
 }
 

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -6,13 +6,14 @@
 #   ceo_detect_os()      — prints: wsl | linux | macos | unknown
 #   ceo_config_path()    — prints path to ~/.ceo/config
 #   ceo_load_config()    — resolves CEO_VAULT; returns 0 on success, 1 if empty
+#   ceo_require_vault()  — load config; exit 1 with operator guidance if unresolved
 #   ceo_validate_vault() — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
 #
 # Resolution order in ceo_load_config():
 #   1. CEO_VAULT already set in environment → use it as-is, return 0 (bypass mode)
 #   2. ~/.ceo/config exists → source it, CEO_VAULT from that file
 #   3. Legacy discovery loop (fallback — remove after 2026-05-26)
-#   4. Hard fallback: $HOME/Documents/Obsidian
+# Returns 1 if none of the above resolved CEO_VAULT.
 #
 # Idempotency guard — safe to source multiple times.
 [ -n "${_CEO_CONFIG_LOADED:-}" ] && return 0
@@ -44,7 +45,7 @@ ceo_config_path() {
 # ceo_load_config — resolve CEO_VAULT and export it.
 #
 # Returns:
-#   0  CEO_VAULT is set (env bypass, config file, discovery, or hard fallback)
+#   0  CEO_VAULT is set (env bypass, config file, or legacy discovery)
 #   1  CEO_VAULT is still empty after all resolution steps
 # ---------------------------------------------------------------------------
 ceo_load_config() {

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -89,6 +89,17 @@ ceo_load_config() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_require_vault — load config; exit 1 with operator guidance if unresolved.
+# For executed scripts only. Sourced scripts must call ceo_load_config and
+# `return 1` on failure (exit would kill the caller's shell).
+# ---------------------------------------------------------------------------
+ceo_require_vault() {
+  ceo_load_config && return 0
+  echo "FATAL — CEO_VAULT unresolved. Run 'ceo setup' to initialize." >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
 # ceo_validate_vault — verify the vault is ready (CEO/inbox.md must exist).
 # Call after ceo_load_config.
 #

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -78,16 +78,14 @@ ceo_load_config() {
   do
     if [ -d "$_candidate/CEO" ]; then
       export CEO_VAULT="$_candidate"
-      break
+      return 0
     fi
   done
 
-  # Step 4: Hard fallback — CEO_VAULT always ends up set.
-  if [ -z "${CEO_VAULT:-}" ]; then
-    export CEO_VAULT="$HOME/Documents/Obsidian"
-  fi
-
-  [ -n "${CEO_VAULT:-}" ]
+  # No source resolved CEO_VAULT — return non-zero so callers' `|| exit 1`
+  # guards actually fire instead of silently provisioning under
+  # $HOME/Documents/Obsidian on a misconfigured host.
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -61,6 +61,46 @@ test_load_config_finds_legacy_candidate() {
   assert_eq "$vault_path" "$TEST_HOME/Documents/Obsidian" "must export the discovered vault path"
 }
 
+test_require_vault_exits_when_unresolved() {
+  local rc=0
+  env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_require_vault
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "ceo_require_vault must exit 1 when no source resolves CEO_VAULT"
+}
+
+test_require_vault_returns_zero_when_resolved() {
+  local rc=0
+  env -i HOME="$TEST_HOME/empty" CEO_VAULT="$TEST_HOME/explicit" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_require_vault
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ceo_require_vault must return 0 when CEO_VAULT resolves"
+}
+
+test_ceo_report_fails_loud_on_unresolved_vault() {
+  local rc=0 out
+  out=$(env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/ceo-report.sh" intake test-trigger "content" 2>&1) || rc=$?
+  assert_eq "$rc" "1" "ceo-report.sh must exit 1 when no vault resolves"
+  case "$out" in
+    *FATAL*) ;;
+    *) printf '  FAIL [%s] stderr missing FATAL\n    got: %q\n' "$CURRENT_TEST" "$out"; FAILS=$((FAILS + 1)) ;;
+  esac
+  if [ -d "$TEST_HOME/empty/Documents/Obsidian/CEO" ]; then
+    printf '  FAIL [%s] silent provision under default path\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_ceo_help_works_on_fresh_host() {
+  local rc=0
+  env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/ceo" help >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Self-contained test harness for ceo-config.sh.
+# Mirrors the count-blessings.test.sh shape — portable across BSD and GNU userlands.
+
+set -uo pipefail  # no -e — tests handle their own failures
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/ceo-config.sh"
+
+FAILS=0
+CURRENT_TEST=""
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME
+}
+
+test_load_config_returns_nonzero_when_unresolved() {
+  local rc=0
+  env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_load_config
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "ceo_load_config must return 1 when no source resolves CEO_VAULT"
+}
+
+test_load_config_honors_env_bypass() {
+  local rc=0
+  env -i HOME="$TEST_HOME/empty" CEO_VAULT="$TEST_HOME/explicit" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_load_config
+    [ \"\$CEO_VAULT\" = \"$TEST_HOME/explicit\" ]
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "explicit CEO_VAULT in env must short-circuit discovery"
+}
+
+test_load_config_finds_legacy_candidate() {
+  local rc=0 vault_path
+  mkdir -p "$TEST_HOME/Documents/Obsidian/CEO"
+  vault_path=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_load_config
+    echo \"\$CEO_VAULT\"
+  " 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "ceo_load_config must succeed when a candidate vault exists"
+  assert_eq "$vault_path" "$TEST_HOME/Documents/Obsidian" "must export the discovered vault path"
+}
+
+run_tests() {
+  local count=0
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    CURRENT_TEST="$fn"
+    setup
+    "$fn"
+    teardown
+    count=$((count + 1))
+  done
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}
+
+run_tests

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 
 # Vault resolution delegated to ceo-config.sh
-ceo_load_config || { echo "FATAL — CEO config not found. Set CEO_VAULT or run: ceo setup" >&2; exit 1; }
+ceo_require_vault
 VAULT="$CEO_VAULT"
 
 CEO_DIR="$VAULT/CEO"

--- a/scripts/ceo-report.sh
+++ b/scripts/ceo-report.sh
@@ -26,9 +26,9 @@ if [ -z "$CONTENT" ]; then
   exit 1
 fi
 
-# Resolve vault
-ceo_load_config || true
-VAULT="${CEO_VAULT:-$HOME/Documents/Obsidian}"
+# Resolve vault — fail loud if unset (no silent provision under default).
+ceo_require_vault
+VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 REPORT_DIR="$CEO_DIR/reports"
 TODAY=$(date +%Y-%m-%d)


### PR DESCRIPTION
Closes #8

## Description (Issue Fixed & New Behavior)

`ceo_load_config()` previously fell through to a hard `$HOME/Documents/Obsidian` default and always returned 0, making every caller's `|| exit 1` guard dead code. On a misconfigured host — `CEO_VAULT` unset, no `~/.ceo/config`, no candidate vault under `HOME` — cron silently provisioned reports under the wrong path with no error or fail-count increment.

This PR removes the hard fallback. The legacy discovery loop now returns 0 only when a candidate vault was actually found; otherwise the function returns 1, so each caller's guard fires.

Pre-existing concern surfaced by the n=8 panel review on PR #4. Per `~/.claude/rules/safety-invariant-scope.md`: gate the invariant at the function so callers can't opt out.

Affected guards (all currently dead code):
- `scripts/ceo-cron.sh:23` — `|| { echo FATAL; exit 1; }`
- `scripts/ceo-gather.sh:25` — `|| { echo ERROR; return 1; }`
- `scripts/ceo-token-intake.sh:15` — `|| { echo ERROR; exit 1; }` (lives on PR #4 branch)
- `scripts/ceo:12` — `|| true` (intentional; CLI re-validates per subcommand)

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-config.test.sh` — 3 tests pass:
   - `test_load_config_returns_nonzero_when_unresolved` — empty HOME / no env / no config returns 1
   - `test_load_config_honors_env_bypass` — explicit `CEO_VAULT` short-circuits discovery
   - `test_load_config_finds_legacy_candidate` — `~/Documents/Obsidian/CEO` discovered via the legacy loop
3. Verify the regression guard: `git stash push scripts/ceo-config.sh && bash scripts/ceo-config.test.sh` — `test_load_config_returns_nonzero_when_unresolved` fails. Restore with `git stash pop`.
4. Run `bash scripts/count-blessings.test.sh` — existing harness still passes (no regressions).

## Additional Notes / HelpScout Tickets

The legacy discovery loop block has a `TODO: Remove this block after 2026-05-26` marker. This PR doesn't touch that — only the unconditional fallback after the loop.

N/A