### PR TITLE
feat(ceo): centralize cron PATH augmentation in ceo_augment_path()

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -91,6 +91,16 @@ ceo_load_config() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_augment_path — prepend common user-tool prefixes to PATH so cron-invoked
+# scripts can find Homebrew binaries, bun-installed CLIs, and ~/.local/bin
+# symlinks. Cron starts with PATH=/usr/bin:/bin; this is the single source of
+# truth for the prefix list across ceo-cron.sh and any runner:script playbook.
+# ---------------------------------------------------------------------------
+ceo_augment_path() {
+  export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+}
+
+# ---------------------------------------------------------------------------
 # ceo_validate_vault — verify the vault is ready (CEO/inbox.md must exist).
 # Call after ceo_load_config.
 #

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -93,8 +93,7 @@ ceo_load_config() {
 # ---------------------------------------------------------------------------
 # ceo_augment_path — prepend common user-tool prefixes to PATH so cron-invoked
 # scripts can find Homebrew binaries, bun-installed CLIs, and ~/.local/bin
-# symlinks. Cron starts with PATH=/usr/bin:/bin; this is the single source of
-# truth for the prefix list across ceo-cron.sh and any runner:script playbook.
+# symlinks. Cron starts with PATH=/usr/bin:/bin.
 # ---------------------------------------------------------------------------
 ceo_augment_path() {
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -96,7 +96,10 @@ ceo_load_config() {
 # symlinks. Cron starts with PATH=/usr/bin:/bin.
 # ---------------------------------------------------------------------------
 ceo_augment_path() {
+  [ -n "${_CEO_PATH_AUGMENTED:-}" ] && return 0
+  : "${HOME:?HOME must be set before ceo_augment_path}"
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+  export _CEO_PATH_AUGMENTED=1
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/ceo-config.sh"
 
 # Vault resolution delegated to ceo-config.sh
 ceo_load_config || { echo "FATAL — CEO config not found. Set CEO_VAULT or run: ceo setup" >&2; exit 1; }
+ceo_augment_path
 VAULT="$CEO_VAULT"
 
 CEO_DIR="$VAULT/CEO"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -441,9 +441,6 @@ PB
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {
-  # Regression guard for #9: the helper is the single source of truth for
-  # cron PATH augmentation. ceo-cron.sh and runner:script playbooks rely on
-  # it; if the prefix list drifts here, every consumer drifts.
   local out
   out=$(env HOME=/fake bash -c '
     set -uo pipefail
@@ -458,7 +455,6 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
 }
-
 
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -484,6 +484,27 @@ test_ceo_augment_path_empty_home_aborts() {
   fi
 }
 
+test_ceo_cron_invokes_ceo_augment_path_at_dispatch() {
+  cat > "$CEO_DIR/playbooks/path-strip.md" << 'PB'
+---
+name: path-strip
+description: stripped-PATH wiring guard
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local rc=0
+  PATH=/usr/bin:/bin bash "$CRON" path-strip >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ceo-cron must invoke ceo_augment_path so dispatcher resolves binaries under stripped PATH"
+  assert_file_exists "$HOME/claude-invoked.txt" "claude stub must fire (proves PATH augmentation reached dispatcher)"
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -454,6 +454,9 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/usr/local/bin"   "PATH must include /usr/local/bin"
   assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
+
+  local first_segment="${out%%:*}"
+  assert_eq "$first_segment" "/fake/.bun/bin" "augmented prefix must be FIRST on PATH"
 }
 
 test_ceo_augment_path_idempotent() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -50,8 +50,8 @@ setup() {
   : > "$CEO_DIR/inbox.md"
 
   # Stub crontab so playbook scan's cron install can't touch the user's real crontab.
-  mkdir -p "$TEST_HOME/bin"
-  cat > "$TEST_HOME/bin/crontab" << 'STUB'
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/crontab" << 'STUB'
 #!/bin/bash
 # no-op stub for tests
 if [ "${1:-}" = "-l" ]; then
@@ -60,30 +60,30 @@ if [ "${1:-}" = "-l" ]; then
 fi
 cat > "$HOME/.fake-crontab"
 STUB
-  chmod +x "$TEST_HOME/bin/crontab"
+  chmod +x "$TEST_HOME/.bun/bin/crontab"
   : > "$HOME/.fake-crontab"
 
   # Stub claude on PATH so dispatcher invocations are detectable. Default behavior
-  # is success — individual tests override $TEST_HOME/bin/claude to simulate failure.
-  cat > "$TEST_HOME/bin/claude" << 'STUB'
+  # is success — individual tests override $TEST_HOME/.bun/bin/claude to simulate failure.
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash
 echo "claude-fired" > "$HOME/claude-invoked.txt"
 echo "ACTION: 1 | read | noop | n/a"
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   # macOS lacks `timeout` from GNU coreutils; the dispatcher uses
   # `timeout N claude ...`. Stub it as a transparent passthrough.
   if ! command -v timeout >/dev/null 2>&1; then
-    cat > "$TEST_HOME/bin/timeout" << 'STUB'
+    cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
 #!/bin/bash
 shift  # discard the duration arg
 exec "$@"
 STUB
-    chmod +x "$TEST_HOME/bin/timeout"
+    chmod +x "$TEST_HOME/.bun/bin/timeout"
   fi
 
-  export PATH="$TEST_HOME/bin:$PATH"
+  export PATH="$TEST_HOME/.bun/bin:$PATH"
 }
 
 teardown() {
@@ -306,12 +306,12 @@ SH
 }
 
 test_read_tier_failure_increments_fail_count() {
-  cat > "$TEST_HOME/bin/claude" << 'STUB'
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash
 echo "synthetic stderr from claude stub" >&2
 exit 2
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   cat > "$CEO_DIR/playbooks/read-tier-fail.md" << 'PB'
 ---
@@ -344,7 +344,7 @@ PB
 test_phase3_failure_does_not_log_completed() {
   # Stateful stub: succeeds on Phase-1 (with ACTION line low-stakes-write),
   # fails on Phase-3.
-  cat > "$TEST_HOME/bin/claude" << STUB
+  cat > "$TEST_HOME/.bun/bin/claude" << STUB
 #!/bin/bash
 COUNT_FILE="$TEST_HOME/.claude-call-count"
 n=\$(cat "\$COUNT_FILE" 2>/dev/null || echo 0)
@@ -357,7 +357,7 @@ fi
 echo "synthetic phase-3 failure" >&2
 exit 3
 STUB
-  chmod +x "$TEST_HOME/bin/claude"
+  chmod +x "$TEST_HOME/.bun/bin/claude"
 
   cat > "$CEO_DIR/playbooks/phase3-fail.md" << 'PB'
 ---
@@ -439,6 +439,26 @@ PB
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Unknown runner 'scrpt'" "skips log must record unknown-runner rejection"
 }
+
+test_ceo_augment_path_prepends_user_tool_prefixes() {
+  # Regression guard for #9: the helper is the single source of truth for
+  # cron PATH augmentation. ceo-cron.sh and runner:script playbooks rely on
+  # it; if the prefix list drifts here, every consumer drifts.
+  local out
+  out=$(env HOME=/fake bash -c '
+    set -uo pipefail
+    PATH=/usr/bin:/bin
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path
+    echo "$PATH"
+  ')
+  assert_contains "$out" "/fake/.bun/bin"  "PATH must include ~/.bun/bin"
+  assert_contains "$out" "/opt/homebrew/bin" "PATH must include Homebrew prefix"
+  assert_contains "$out" "/usr/local/bin"   "PATH must include /usr/local/bin"
+  assert_contains "$out" "/fake/.local/bin"  "PATH must include ~/.local/bin"
+  assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
+}
+
 
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -456,6 +456,31 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
   assert_contains "$out" "/usr/bin"         "original PATH must be preserved"
 }
 
+test_ceo_augment_path_idempotent() {
+  local out
+  out=$(env HOME=/fake bash -c '
+    set -uo pipefail
+    PATH=/usr/bin:/bin
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path; first="$PATH"
+    ceo_augment_path; second="$PATH"
+    [ "$first" = "$second" ] && echo idempotent || echo diverged
+  ')
+  assert_eq "$out" "idempotent" "ceo_augment_path must not drift PATH on repeated calls"
+}
+
+test_ceo_augment_path_empty_home_aborts() {
+  local rc=0
+  HOME="" bash -c '
+    source '"$SCRIPT_DIR"'/ceo-config.sh
+    ceo_augment_path
+  ' >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] expected non-zero rc with HOME="", got 0\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+ceo_augment_path
 
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
@@ -21,9 +22,6 @@ TOKEN_DIR="$CEO_DIR/reports/token"
 TODAY=$(date +%Y-%m-%d)
 REPORT_FILE="$TOKEN_DIR/$TODAY.md"
 INBOX_LINE="- [ ] Review daily token report [[CEO/reports/token/$TODAY]]"
-
-# bun lives in ~/.bun/bin; homebrew in /opt/homebrew/bin (Mac) or /usr/local/bin (Linux/WSL)
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 mkdir -p "$TOKEN_DIR"
 

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -44,17 +44,17 @@ setup() {
   mkdir -p "$CEO_DIR/reports/token"
   : > "$CEO_DIR/inbox.md"
 
-  mkdir -p "$TEST_HOME/bin"
-  cat > "$TEST_HOME/bin/rtk" << 'STUB'
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/rtk" << 'STUB'
 #!/bin/bash
 echo "rtk-stub: $*"
 STUB
-  cat > "$TEST_HOME/bin/token-scope" << 'STUB'
+  cat > "$TEST_HOME/.bun/bin/token-scope" << 'STUB'
 #!/bin/bash
 echo "token-scope-stub: $*"
 STUB
-  chmod +x "$TEST_HOME/bin/rtk" "$TEST_HOME/bin/token-scope"
-  export PATH="$TEST_HOME/bin:$PATH"
+  chmod +x "$TEST_HOME/.bun/bin/rtk" "$TEST_HOME/.bun/bin/token-scope"
+  export PATH="$TEST_HOME/.bun/bin:$PATH"
 }
 
 teardown() {
@@ -95,6 +95,16 @@ test_does_not_re_append_after_inbox_checkoff() {
   local count
   count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
   assert_eq "$count" "1" "checked-off line must not trigger re-append"
+}
+
+test_invokes_ceo_augment_path() {
+  PATH=/usr/bin:/bin bash "$INTAKE" >/dev/null 2>&1
+  local today report body
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today.md"
+  assert_file_exists "$report" "report file must exist"
+  body=$(cat "$report")
+  assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
 }
 
 test_aborts_on_unwritable_report_dir() {


### PR DESCRIPTION
Closes #9

## Description (Issue Fixed & New Behavior)

Cron starts with `PATH=/usr/bin:/bin`; Homebrew, bun-installed CLIs (e.g. `token-scope`), and `~/.local/bin` symlinks aren't reachable. `ceo-token-intake.sh` (PR #4) hardcoded a prefix list inline; future `runner: script` playbooks would copy/paste the same block and drift over time.

This PR adds `ceo_augment_path()` to `ceo-config.sh` as the single source of truth for the prefix list:

```
$HOME/.bun/bin : /opt/homebrew/bin : /usr/local/bin : $HOME/.local/bin : $PATH
```

Wired in two places:
- `ceo-cron.sh` calls it before the `jq` / `yq` checks, so the dispatcher can resolve those binaries under cron's stripped PATH.
- `ceo-token-intake.sh` calls it in place of the inline `export PATH="..."` line.

Test stubs in `ceo-cron.test.sh` move from `$TEST_HOME/bin` to `$TEST_HOME/.bun/bin` so they remain first in the augmented PATH.

## Stacked on PR #4

This PR targets `nh/feature/runner-script-and-token-intake` (PR #4) as its base because it modifies `ceo-token-intake.sh`, which only exists on that branch. When PR #4 merges, GitHub will auto-retarget this PR to `main`. Diff against the base shows only this PR's changes.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-cron.test.sh` — 13 tests pass, including the new `test_ceo_augment_path_prepends_user_tool_prefixes`.
3. Verify the regression guard: `git stash push scripts/ceo-config.sh && bash scripts/ceo-cron.test.sh` — `test_ceo_augment_path_prepends_user_tool_prefixes` fails with `command not found: ceo_augment_path`. Restore with `git stash pop`.
4. Smoke test against the live vault: `unset PATH; export PATH=/usr/bin:/bin; export CEO_VAULT="$HOME/Documents/Obsidian"; bash scripts/ceo-token-intake.sh` — token-intake runs and finds `rtk` / `token-scope`.

## Additional Notes / HelpScout Tickets

Surfaced by the n=8 panel review on PR #4. Sibling fix #8 (`ceo_load_config` dead-guard) is in PR #10.

N/A