### PR TITLE
feat(config): registry schema_version + cross-host downgrade guard

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -381,7 +381,11 @@ cmd_playbook_scan() {
     old_registry=$(cat "$registry_file")
   fi
 
-  local new_registry='{"generated":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","playbooks":[]}'
+  local new_registry
+  new_registry=$(jq -n \
+    --argjson v "$CEO_REGISTRY_SCHEMA_VERSION" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{schema_version: $v, generated: $ts, playbooks: []}')
   local found=0
   local skipped=0
 
@@ -571,10 +575,12 @@ $marker_end"
 
 cmd_playbook_list() {
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
+    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
+  esac
 
   printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
   printf "%-16s %-10s %-20s %-10s %-8s\n" "----" "-------" "--------" "-----" "------"
@@ -600,10 +606,12 @@ cmd_playbook_info() {
   fi
 
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
+    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
+  esac
 
   local entry
   entry=$(jq -r --arg n "$target" '.playbooks[] | select(.name==$n)' "$registry_file")

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -27,6 +27,25 @@ VAULT="${CEO_VAULT:-}"
 CEO_DIR="${VAULT:+$VAULT/CEO}"
 CEO_CRON="$SCRIPT_DIR/ceo-cron.sh"
 
+_registry_schema_error() {
+  local rc="$1"
+  case "$rc" in
+    1) echo "No registry found. Run: ceo playbook scan" ;;
+    2) echo "Registry schema_version missing, malformed, or below $CEO_REGISTRY_SCHEMA_VERSION. Run: ceo playbook scan" ;;
+    *) echo "Registry validation failed (rc=$rc)" ;;
+  esac
+}
+
+_require_registry_current() {
+  local registry_file="$1"
+  local rc=0
+  ceo_registry_validate "$registry_file" || rc=$?
+  if [ "$rc" != "0" ]; then
+    _registry_schema_error "$rc"
+    exit 1
+  fi
+}
+
 cmd_help() {
   cat <<'USAGE'
 Usage: ceo <command>
@@ -193,23 +212,30 @@ cmd_doctor() {
   # bin symlinks for playbooks
   local registry_file="$CEO_DIR/registry.json"
   if [ -f "$registry_file" ] && command -v jq &>/dev/null; then
-    local missing_bins=0 bin_total=0
-    while IFS= read -r row; do
-      local p_name p_bin
-      p_name=$(echo "$row" | jq -r '.name')
-      p_bin=$(echo "$row" | jq -r '.bin // ""')
-      [ -z "$p_bin" ] && continue
-      bin_total=$((bin_total + 1))
-      local link_name="${p_bin%.sh}"
-      if [ ! -L "$HOME/.local/bin/$link_name" ]; then
-        echo "  ! Missing bin symlink: ~/.local/bin/$link_name (playbook: $p_name) — run: ceo playbook scan"
-        missing_bins=$((missing_bins + 1))
-        warn=$((warn + 1))
+    local registry_rc=0
+    ceo_registry_validate "$registry_file" || registry_rc=$?
+    if [ "$registry_rc" != "0" ]; then
+      echo "  ✗ $(_registry_schema_error "$registry_rc")"
+      fail=$((fail + 1))
+    else
+      local missing_bins=0 bin_total=0
+      while IFS= read -r row; do
+        local p_name p_bin
+        p_name=$(echo "$row" | jq -r '.name')
+        p_bin=$(echo "$row" | jq -r '.bin // ""')
+        [ -z "$p_bin" ] && continue
+        bin_total=$((bin_total + 1))
+        local link_name="${p_bin%.sh}"
+        if [ ! -L "$HOME/.local/bin/$link_name" ]; then
+          echo "  ! Missing bin symlink: ~/.local/bin/$link_name (playbook: $p_name) — run: ceo playbook scan"
+          missing_bins=$((missing_bins + 1))
+          warn=$((warn + 1))
+        fi
+      done < <(jq -c '.playbooks[] | select(.status=="active")' "$registry_file" 2>/dev/null)
+      if [ "$bin_total" -gt 0 ] && [ "$missing_bins" -eq 0 ]; then
+        echo "  ✓ Playbook bin symlinks present ($bin_total)"
+        ok=$((ok + 1))
       fi
-    done < <(jq -c '.playbooks[] | select(.status=="active")' "$registry_file" 2>/dev/null)
-    if [ "$bin_total" -gt 0 ] && [ "$missing_bins" -eq 0 ]; then
-      echo "  ✓ Playbook bin symlinks present ($bin_total)"
-      ok=$((ok + 1))
     fi
   fi
 
@@ -299,10 +325,7 @@ cmd_preflight() {
   }
 
   local registry_file="$CEO_DIR/registry.json"
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  _require_registry_current "$registry_file"
 
   local would_run=0
   local would_skip=0
@@ -378,6 +401,24 @@ cmd_playbook_scan() {
 
   local old_registry='{"playbooks":[]}'
   if [ -f "$registry_file" ]; then
+    if ! jq -e 'type == "object"' "$registry_file" >/dev/null 2>&1; then
+      echo "ERROR: refusing to overwrite unparseable registry: $registry_file"
+      exit 1
+    fi
+    if jq -e 'has("schema_version")' "$registry_file" >/dev/null 2>&1; then
+      local existing_v
+      existing_v=$(ceo_registry_version "$registry_file")
+      if [ -z "$existing_v" ]; then
+        echo "ERROR: refusing to overwrite registry with malformed schema_version."
+        echo "Fix or remove $registry_file, then rerun ceo playbook scan."
+        exit 1
+      fi
+      if [ "$existing_v" -gt "$CEO_REGISTRY_SCHEMA_VERSION" ]; then
+        echo "ERROR: refusing to downgrade registry (on-disk schema_version=$existing_v, this binary writes $CEO_REGISTRY_SCHEMA_VERSION)."
+        echo "Update this host's claude-ceo binary first."
+        exit 1
+      fi
+    fi
     old_registry=$(cat "$registry_file")
   fi
 
@@ -473,7 +514,9 @@ cmd_playbook_scan() {
     fi
   done <<< "$old_names"
 
-  echo "$new_registry" | jq '.' > "$registry_file"
+  local registry_tmp="$registry_file.tmp"
+  echo "$new_registry" | jq '.' > "$registry_tmp"
+  mv "$registry_tmp" "$registry_file"
 
   echo ""
   echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped)"
@@ -575,12 +618,7 @@ $marker_end"
 
 cmd_playbook_list() {
   local registry_file="$CEO_DIR/registry.json"
-  local rc=0
-  ceo_registry_validate "$registry_file" || rc=$?
-  case "$rc" in
-    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
-    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
-  esac
+  _require_registry_current "$registry_file"
 
   printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
   printf "%-16s %-10s %-20s %-10s %-8s\n" "----" "-------" "--------" "-----" "------"
@@ -606,12 +644,7 @@ cmd_playbook_info() {
   fi
 
   local registry_file="$CEO_DIR/registry.json"
-  local rc=0
-  ceo_registry_validate "$registry_file" || rc=$?
-  case "$rc" in
-    1) echo "No registry found. Run: ceo playbook scan"; exit 1 ;;
-    2) echo "Registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan"; exit 1 ;;
-  esac
+  _require_registry_current "$registry_file"
 
   local entry
   entry=$(jq -r --arg n "$target" '.playbooks[] | select(.name==$n)' "$registry_file")
@@ -664,10 +697,7 @@ cmd_chat() {
   ceo_validate_vault || exit 1
   local registry_file="$CEO_DIR/registry.json"
 
-  if [ ! -f "$registry_file" ]; then
-    echo "No registry found. Run: ceo playbook scan"
-    exit 1
-  fi
+  _require_registry_current "$registry_file"
 
   local model="sonnet"
   local playbook_content=""

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -3,11 +3,12 @@
 # Source this file; do not execute it directly.
 #
 # Provides:
-#   ceo_detect_os()      — prints: wsl | linux | macos | unknown
-#   ceo_config_path()    — prints path to ~/.ceo/config
-#   ceo_load_config()    — resolves CEO_VAULT; returns 0 on success, 1 if empty
-#   ceo_require_vault()  — load config; exit 1 with operator guidance if unresolved
-#   ceo_validate_vault() — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_detect_os()         — prints: wsl | linux | macos | unknown
+#   ceo_config_path()       — prints path to ~/.ceo/config
+#   ceo_load_config()       — resolves CEO_VAULT; returns 0 on success, 1 if empty
+#   ceo_require_vault()     — load config; exit 1 with operator guidance if unresolved
+#   ceo_validate_vault()    — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_registry_validate() — verifies registry.json schema_version; returns 0/1/2
 #
 # Resolution order in ceo_load_config():
 #   1. CEO_VAULT already set in environment → use it as-is, return 0 (bypass mode)
@@ -108,6 +109,36 @@ ceo_augment_path() {
   : "${HOME:?HOME must be set before ceo_augment_path}"
   export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
   export _CEO_PATH_AUGMENTED=1
+}
+
+# ---------------------------------------------------------------------------
+# Registry schema. Bump CEO_REGISTRY_SCHEMA_VERSION whenever the on-disk
+# shape of registry.json changes — a peer host running an older binary will
+# then refuse to dispatch instead of silently downgrading the registry on
+# the next `ceo playbook scan`.
+#
+# Version history:
+#   2 — adds runner, script fields (PR #4)
+#   1 — implicit (pre-runner-script registry; missing field treated as <2)
+# ---------------------------------------------------------------------------
+CEO_REGISTRY_SCHEMA_VERSION=2
+
+# ceo_registry_validate <registry_file>
+#   0 — schema_version >= CEO_REGISTRY_SCHEMA_VERSION
+#   1 — registry file does not exist
+#   2 — schema_version missing or below current
+ceo_registry_validate() {
+  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  if [ ! -f "$registry_file" ]; then
+    return 1
+  fi
+  local v
+  v=$(jq -r '.schema_version // 0 | tonumber? // 0' "$registry_file" 2>/dev/null)
+  [ -z "$v" ] && v=0
+  if [ "$v" -lt "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
+    return 2
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -123,19 +123,32 @@ ceo_augment_path() {
 # ---------------------------------------------------------------------------
 CEO_REGISTRY_SCHEMA_VERSION=2
 
+# ceo_registry_version <registry_file>
+#   Prints the integer schema_version, or nothing if missing/malformed.
+ceo_registry_version() {
+  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  jq -r '
+    if has("schema_version")
+      and (.schema_version | type) == "number"
+      and (.schema_version | floor == .)
+    then .schema_version
+    else empty
+    end
+  ' "$registry_file" 2>/dev/null
+}
+
 # ceo_registry_validate <registry_file>
-#   0 — schema_version >= CEO_REGISTRY_SCHEMA_VERSION
+#   0 — schema_version is an integer >= CEO_REGISTRY_SCHEMA_VERSION
 #   1 — registry file does not exist
-#   2 — schema_version missing or below current
+#   2 — schema_version missing, malformed, or below current
 ceo_registry_validate() {
   local registry_file="${1:-${CEO_DIR:-}/registry.json}"
   if [ ! -f "$registry_file" ]; then
     return 1
   fi
   local v
-  v=$(jq -r '.schema_version // 0 | tonumber? // 0' "$registry_file" 2>/dev/null)
-  [ -z "$v" ] && v=0
-  if [ "$v" -lt "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
+  v=$(ceo_registry_version "$registry_file")
+  if ! [ "$v" -ge "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
     return 2
   fi
   return 0

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -101,6 +101,45 @@ test_ceo_help_works_on_fresh_host() {
   assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
 }
 
+test_registry_validate_accepts_integer_current_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":2,"playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "integer schema_version at current version must validate"
+}
+
+test_registry_validate_rejects_non_integer_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":1.5,"playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "float schema_version must reject instead of falling through"
+}
+
+test_registry_validate_rejects_string_schema() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":"2","playbooks":[]}\n' > "$registry"
+
+  local rc=0
+  env -i PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_registry_validate '$registry'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "string schema_version must reject instead of coercing"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -204,6 +204,7 @@ case "$REGISTRY_RC" in
     exit 1 ;;
   2)
     echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _record_failure "registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?)"
     _v "FATAL: registry.json schema_version too old. Run: ceo playbook scan"
     exit 1 ;;
 esac

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -194,11 +194,19 @@ preflight_has_auto_review_prs() {
 
 # --- Look up trigger in registry ---
 REGISTRY_FILE="$CEO_DIR/registry.json"
-if [ ! -f "$REGISTRY_FILE" ]; then
-  echo "$(date): FATAL — registry.json not found. Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
-  _v "FATAL: registry.json not found. Run: ceo playbook scan"
-  exit 1
-fi
+REGISTRY_RC=0
+ceo_registry_validate "$REGISTRY_FILE" || REGISTRY_RC=$?
+case "$REGISTRY_RC" in
+  0) ;;
+  1)
+    echo "$(date): FATAL — registry.json not found. Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _v "FATAL: registry.json not found. Run: ceo playbook scan"
+    exit 1 ;;
+  2)
+    echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _v "FATAL: registry.json schema_version too old. Run: ceo playbook scan"
+    exit 1 ;;
+esac
 
 ENTRY=$(jq -r --arg t "$TRIGGER" '.playbooks[] | select(.name == $t)' "$REGISTRY_FILE" 2>/dev/null)
 if [ -z "$ENTRY" ]; then

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -505,6 +505,85 @@ PB
   assert_file_exists "$HOME/claude-invoked.txt" "claude stub must fire (proves PATH augmentation reached dispatcher)"
 }
 
+test_playbook_scan_writes_schema_version_2() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: schema-version regression seed
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local v
+  v=$(jq -r '.schema_version // "missing"' "$CEO_DIR/registry.json")
+  assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
+}
+
+test_cron_skips_on_missing_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  jq 'del(.schema_version)' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CRON" example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit 1 when registry has no schema_version"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_cron_skips_on_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CRON" example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit 1 when registry schema_version is below current"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+}
+
 test_runner_script_missing_script_field_fails() {
   cat > "$CEO_DIR/playbooks/bad-intake.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -525,6 +525,33 @@ PB
   assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
 }
 
+test_playbook_scan_refuses_newer_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: schema-version downgrade guard
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  printf '{"schema_version":99,"future_field":"must-stay","playbooks":[]}\n' \
+    > "$CEO_DIR/registry.json"
+  local before
+  before=$(cat "$CEO_DIR/registry.json")
+
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook scan must refuse to overwrite newer registry schema"
+
+  local after
+  after=$(cat "$CEO_DIR/registry.json")
+  assert_eq "$after" "$before" "newer registry content must remain unchanged"
+}
+
 test_cron_skips_on_missing_schema_version() {
   cat > "$CEO_DIR/playbooks/example.md" << 'PB'
 ---
@@ -550,6 +577,10 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/claude-invoked.txt" ]; then
     printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
@@ -582,6 +613,59 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
+
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_list_rejects_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CEO_CLI" playbook list >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook list must reject old registry schema"
+}
+
+test_playbook_info_rejects_old_schema_version() {
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: noop
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
+  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+
+  local rc=0
+  bash "$CEO_CLI" playbook info example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "playbook info must reject old registry schema"
 }
 
 test_runner_script_missing_script_field_fails() {


### PR DESCRIPTION
Closes #7

## Description (Issue Fixed & New Behavior)

Adds a `schema_version` field to `registry.json` and gates every cron + CLI read site on it. Without this, an older binary on a Syncthing peer that runs `ceo playbook scan` silently rewrites the shared registry without the new `runner`/`script` fields (added by PR #4) — every host's dispatcher then defaults to `runner=claude` for what should be runner:script playbooks. The schema_version guard makes the older binary refuse to dispatch instead, surfacing the version skew loudly.

### Changes

`scripts/ceo-config.sh`:
- New `CEO_REGISTRY_SCHEMA_VERSION=2` constant (bump on each registry shape change)
- New `ceo_registry_validate <file>` helper returning 0 (ok) / 1 (missing) / 2 (schema too old or absent)

`scripts/ceo` (`cmd_playbook_scan`):
- Writes `schema_version: 2` into `registry.json`

`scripts/ceo-cron.sh`:
- Calls validator after the registry-file-exists check
- On rc=2 → `cron-skips.log` + `_v` warning + `exit 1` (matches existing FATAL pattern)

`scripts/ceo` (`cmd_playbook_list`, `cmd_playbook_info`):
- Same validator gate; CLI error + exit 1 on rc=2

### Out of scope

- `cmd_playbook_scan` does NOT gate — it's the migration path that writes the new field
- `cmd_chat` and `cmd_dryrun` also read the registry but are out of scope per the issue's `cmd_playbook_*` phrasing; can be added in a follow-up if useful

## Testing Procedure

1. Check out this branch and `cd` into a worktree.
2. Run `bash scripts/ceo-cron.test.sh` — expect **All tests passed. (19 tests)** including three new ones:
   - `test_playbook_scan_writes_schema_version_2` — confirms scan writes the field
   - `test_cron_skips_on_missing_schema_version` — strips the field, runs cron, asserts rc=1, claude stub never fires, skip log records the reason
   - `test_cron_skips_on_old_schema_version` — sets `schema_version: 1`, same assertions
3. Run `bash scripts/ceo-token-intake.test.sh` — expect **5/5** still green (unrelated tests, sanity check).
4. Run `bash scripts/ceo-config.test.sh` — expect **7/7** still green (PR #10's tests, sanity check).
5. Manual probe (optional): `bash scripts/ceo playbook list` against a registry where `schema_version` was deleted/downgraded should print the schema-mismatch error and exit 1.

Revert-fails verified locally: removing the helper or the cron gate flips the corresponding test red; restoring the fix flips it green.

## Additional Notes

- Stacked on PR #4 (`nh/feature/runner-script-and-token-intake`). Will go green when PR #4 merges to `main`.
- Bump `CEO_REGISTRY_SCHEMA_VERSION` in `ceo-config.sh` whenever the registry shape changes again. Version history is documented in the comment block above the constant.
