### PR TITLE
feat(ceo): per-host writes for token-intake + primary-host scan gate

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -275,7 +275,7 @@ cmd_preflight() {
   # Define preflights inline (can't source from ceo-cron.sh mid-script)
   preflight_none() { return 0; }
   preflight_has_unchecked_inbox() {
-    [ -f "$CEO_DIR/inbox.md" ] && grep -q "^- \[ \]" "$CEO_DIR/inbox.md"
+    ceo_inbox_has_unchecked
   }
   preflight_has_prs_to_review() {
     [ "${PR_REVIEW_COUNT:-0}" -gt 0 ]

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -368,6 +368,24 @@ cmd_playbook_scan() {
 
   ceo_validate_vault || exit 1
 
+  # Primary-host write gate: registry.json is Syncthing-shared, so only one
+  # host may rewrite it. Peers running an older binary would silently drop
+  # newer fields. Configure via settings.json: {"primary_host": "<host>"}.
+  # Unset → backward-compatible (any host may scan).
+  local settings_file="$CEO_DIR/settings.json"
+  if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
+    local primary_host
+    primary_host=$(jq -r '.primary_host // ""' "$settings_file" 2>/dev/null)
+    if [ -n "$primary_host" ]; then
+      local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
+      if [ "$this_host" != "$primary_host" ]; then
+        echo "ERROR: 'ceo playbook scan' must run on the primary host ($primary_host); this host is '$this_host'." >&2
+        echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
+        exit 1
+      fi
+    fi
+  fi
+
   local playbook_dir="$CEO_DIR/playbooks"
   local registry_file="$CEO_DIR/registry.json"
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -367,24 +367,7 @@ cmd_playbook_scan() {
   fi
 
   ceo_validate_vault || exit 1
-
-  # Primary-host write gate: registry.json is Syncthing-shared, so only one
-  # host may rewrite it. Peers running an older binary would silently drop
-  # newer fields. Configure via settings.json: {"primary_host": "<host>"}.
-  # Unset → backward-compatible (any host may scan).
-  local settings_file="$CEO_DIR/settings.json"
-  if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
-    local primary_host
-    primary_host=$(jq -r '.primary_host // ""' "$settings_file" 2>/dev/null)
-    if [ -n "$primary_host" ]; then
-      local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
-      if [ "$this_host" != "$primary_host" ]; then
-        echo "ERROR: 'ceo playbook scan' must run on the primary host ($primary_host); this host is '$this_host'." >&2
-        echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
-        exit 1
-      fi
-    fi
-  fi
+  ceo_assert_primary_host || exit 1
 
   local playbook_dir="$CEO_DIR/playbooks"
   local registry_file="$CEO_DIR/registry.json"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -161,3 +161,72 @@ ceo_inbox_has_unchecked() {
   fi
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# ceo_assert_primary_host — gate writes to Syncthing-shared state behind the
+# host configured as primary in CEO/settings.json.
+#
+# The invariant: only the primary host overwrites Syncthing-shared registry
+# state. The gate is opt-in — settings.json absent means no gate.
+#
+# Returns 0 (host is allowed to proceed) when:
+#   - CEO/settings.json is absent (backward-compatible, no gate configured)
+#   - settings.json is present, parseable, and primary_host is empty
+#   - settings.json is present, parseable, and primary_host == this host
+#
+# Returns 1 (host MUST NOT proceed) when:
+#   - settings.json is present but jq is not installed (cannot evaluate gate)
+#   - settings.json is present but malformed JSON
+#   - this host cannot be resolved (CEO_HOSTNAME unset and `hostname -s` empty)
+#   - primary_host is set and does not match this host
+#
+# Unknown top-level keys in settings.json emit a warning to stderr (typo
+# defense — see ~/.claude/rules/enum-config-typo-fallback.md). Failing-open
+# on a typo is the silent-regression shape this helper exists to prevent.
+# ---------------------------------------------------------------------------
+ceo_assert_primary_host() {
+  : "${CEO_DIR:?CEO_DIR must be set before ceo_assert_primary_host}"
+  local settings_file="$CEO_DIR/settings.json"
+  local jq_bin="${CEO_JQ_BIN:-jq}"
+
+  [ -f "$settings_file" ] || return 0
+
+  if ! command -v "$jq_bin" &>/dev/null; then
+    echo "ERROR: $settings_file exists but jq is not installed; cannot evaluate primary_host gate." >&2
+    echo "  Install jq (brew install jq | sudo apt install jq) or remove $settings_file." >&2
+    return 1
+  fi
+
+  if ! "$jq_bin" empty "$settings_file" 2>/dev/null; then
+    echo "ERROR: $settings_file is not valid JSON; refusing to evaluate primary_host gate." >&2
+    return 1
+  fi
+
+  local known_keys=" primary_host "
+  local k
+  while IFS= read -r k; do
+    [ -n "$k" ] || continue
+    case "$known_keys" in
+      *" $k "*) ;;
+      *) echo "WARNING: $settings_file contains unknown key '$k' — ignored. Known keys: primary_host" >&2 ;;
+    esac
+  done < <("$jq_bin" -r 'keys[]' "$settings_file" 2>/dev/null || true)
+
+  local primary_host
+  primary_host=$("$jq_bin" -r '.primary_host // ""' "$settings_file" 2>/dev/null || echo "")
+  [ -n "$primary_host" ] || return 0
+
+  local this_host="${CEO_HOSTNAME:-$(hostname -s)}"
+  if [ -z "$this_host" ]; then
+    echo "ERROR: cannot determine this host (CEO_HOSTNAME unset and 'hostname -s' returned empty)." >&2
+    return 1
+  fi
+
+  if [ "$this_host" != "$primary_host" ]; then
+    echo "ERROR: this operation must run on the primary host ($primary_host); this host is '$this_host'." >&2
+    echo "  Either run on $primary_host, or unset 'primary_host' in $settings_file." >&2
+    return 1
+  fi
+
+  return 0
+}

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -130,3 +130,34 @@ ceo_validate_vault() {
   fi
   return 0
 }
+
+# ---------------------------------------------------------------------------
+# ceo_inbox_has_unchecked — scan legacy CEO/inbox.md and per-host
+# CEO/inbox/<host>.md shadow files for any unchecked todo line.
+#
+# Per-host shadow files exist because Syncthing peers cannot safely share a
+# single inbox.md writer; see issue #5. The legacy inbox.md remains supported
+# for user-curated entries.
+#
+# Reads CEO_DIR from the environment (callers already have it set).
+#
+# Returns:
+#   0  at least one "- [ ]" line exists in any inbox source
+#   1  no unchecked items, or no inbox sources present
+# ---------------------------------------------------------------------------
+ceo_inbox_has_unchecked() {
+  local dir="${CEO_DIR:?CEO_DIR must be set before ceo_inbox_has_unchecked}"
+  if [ -f "$dir/inbox.md" ] && grep -q "^- \[ \]" "$dir/inbox.md" 2>/dev/null; then
+    return 0
+  fi
+  if [ -d "$dir/inbox" ]; then
+    local f
+    for f in "$dir/inbox/"*.md; do
+      [ -f "$f" ] || continue
+      if grep -q "^- \[ \]" "$f" 2>/dev/null; then
+        return 0
+      fi
+    done
+  fi
+  return 1
+}

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -101,6 +101,68 @@ test_ceo_help_works_on_fresh_host() {
   assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
 }
 
+# ceo_inbox_has_unchecked — preflight helper that scans both the legacy
+# CEO/inbox.md (user-curated) and per-host CEO/inbox/<host>.md shadow files.
+# Used by morning-brief and inbox cron preflights.
+
+_inbox_check() {
+  local ceo_dir="$1"
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    CEO_DIR='$ceo_dir' ceo_inbox_has_unchecked
+  " >/dev/null 2>&1
+}
+
+test_inbox_has_unchecked_returns_nonzero_when_no_files_exist() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "no inbox files anywhere → nothing to do"
+}
+
+test_inbox_has_unchecked_finds_legacy_inbox_md() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  printf -- '- [ ] something\n' > "$TEST_HOME/CEO/inbox.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "unchecked item in legacy inbox.md must trigger preflight"
+}
+
+test_inbox_has_unchecked_skips_legacy_when_all_checked() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO"
+  printf -- '- [x] done\n' > "$TEST_HOME/CEO/inbox.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "all-checked legacy inbox.md must not trigger preflight"
+}
+
+test_inbox_has_unchecked_finds_per_host_shadow_file() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [ ] from-mac\n' > "$TEST_HOME/CEO/inbox/mac-mini.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "unchecked item in per-host shadow must trigger preflight"
+}
+
+test_inbox_has_unchecked_skips_per_host_when_all_checked() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [x] done-on-mac\n' > "$TEST_HOME/CEO/inbox/mac-mini.md"
+  printf -- '- [x] done-on-wsl\n' > "$TEST_HOME/CEO/inbox/wsl-host.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "1" "all-checked per-host shadow files must not trigger preflight"
+}
+
+test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty() {
+  local rc=0
+  mkdir -p "$TEST_HOME/CEO/inbox"
+  printf -- '- [x] legacy-done\n' > "$TEST_HOME/CEO/inbox.md"
+  printf -- '- [ ] shadow-pending\n' > "$TEST_HOME/CEO/inbox/host-b.md"
+  _inbox_check "$TEST_HOME/CEO" || rc=$?
+  assert_eq "$rc" "0" "must find unchecked items even when legacy is clean"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -153,7 +153,7 @@ BRANCH_PREFIX=$(_cfg '.branch_prefix' 'ceo/')
 preflight_none() { return 0; }
 
 preflight_has_unchecked_inbox() {
-  [ -f "$CEO_DIR/inbox.md" ] && grep -q "^- \[ \]" "$CEO_DIR/inbox.md"
+  ceo_inbox_has_unchecked
 }
 
 preflight_has_prs_to_review() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -530,6 +530,73 @@ PB
   assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"
 }
 
+test_playbook_scan_blocks_non_primary_host() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "non-primary host must be refused"
+  assert_contains "$out" "primary host" "error must mention primary host gating"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] non-primary host wrote registry.json (must not)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_scan_succeeds_on_primary_host() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0
+  CEO_HOSTNAME=alpha bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "primary host must be allowed to scan"
+  assert_file_exists "$CEO_DIR/registry.json" "registry must be written by primary host"
+}
+
+test_playbook_scan_unrestricted_when_primary_host_unset() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0
+  CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "no primary_host setting → backward-compatible (any host can scan)"
+  assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -597,6 +597,79 @@ PB
   assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
 }
 
+test_playbook_scan_typoed_primary_host_field_emits_warning() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"promary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "0" "typo'd key falls through to no-gate (backward-compat) but must warn"
+  assert_contains "$out" "unknown key 'promary_host'" "typo'd key must surface a warning so operator notices"
+  assert_file_exists "$CEO_DIR/registry.json" "scan continues despite typo (gate is not configured from parser's view)"
+}
+
+test_playbook_scan_malformed_settings_json_fails_loud() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf 'not valid json\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "malformed settings.json must fail loud, not silently fall through"
+  assert_contains "$out" "not valid JSON" "error must name the JSON parse failure"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] registry written despite malformed settings.json\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_scan_missing_jq_with_settings_fails_loud() {
+  cat > "$CEO_DIR/playbooks/probe.md" << 'PB'
+---
+name: probe
+description: probe
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
+  rm -f "$CEO_DIR/registry.json"
+
+  local rc=0 out
+  out=$(CEO_JQ_BIN=jq-deliberately-missing-for-test CEO_HOSTNAME=anyhost \
+        bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "1" "missing jq with settings.json must fail loud"
+  assert_contains "$out" "jq is not installed" "error must name the missing dependency"
+  if [ -f "$CEO_DIR/registry.json" ]; then
+    printf '  FAIL [%s] registry written despite missing-jq error\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # ceo-token-intake.sh — Daily RTK + token-scope spend intake.
-# Captures four command outputs to CEO/reports/token/<TODAY>.md and idempotently
-# appends one inbox line linking to it. The chat-triggered inbox playbook
-# surfaces the line for morning discussion via `ceo chat inbox`.
+# Captures four command outputs to CEO/reports/token/<TODAY>-<host>.md and
+# idempotently appends one inbox line to CEO/inbox/<host>.md linking to it.
+# Per-host filenames keep two Syncthing peers from racing on the same path.
+# The chat-triggered inbox playbook surfaces the line via `ceo chat inbox`.
 #
 # Invoked by ceo-cron.sh when the token-intake playbook (runner:script) fires.
 
@@ -17,13 +18,17 @@ ceo_augment_path
 
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
-INBOX_FILE="$CEO_DIR/inbox.md"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+INBOX_DIR="$CEO_DIR/inbox"
+INBOX_FILE="$INBOX_DIR/$HOST.md"
 TOKEN_DIR="$CEO_DIR/reports/token"
 TODAY=$(date +%Y-%m-%d)
-REPORT_FILE="$TOKEN_DIR/$TODAY.md"
-INBOX_LINE="- [ ] Review daily token report [[CEO/reports/token/$TODAY]]"
+REPORT_FILE="$TOKEN_DIR/$TODAY-$HOST.md"
+WIKILINK="[[CEO/reports/token/$TODAY-$HOST]]"
+INBOX_LINE="- [ ] Review daily token report $WIKILINK"
 
-mkdir -p "$TOKEN_DIR"
+mkdir -p "$TOKEN_DIR" "$INBOX_DIR"
 
 # capture <label> <cmd> [args...] — run a command and wrap its output in a fenced block.
 # Falls back to "<cmd> unavailable" so the inbox link always resolves to readable content.
@@ -55,7 +60,6 @@ fi
 # rather than the full line so a `[x]` checkoff doesn't re-trigger the
 # append.
 touch "$INBOX_FILE"
-WIKILINK="[[CEO/reports/token/$TODAY]]"
 if ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then
   printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
 fi

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -41,8 +41,8 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="testhost"
   mkdir -p "$CEO_DIR/reports/token"
-  : > "$CEO_DIR/inbox.md"
 
   mkdir -p "$TEST_HOME/.bun/bin"
   cat > "$TEST_HOME/.bun/bin/rtk" << 'STUB'
@@ -61,47 +61,75 @@ teardown() {
   rm -rf "$TEST_HOME"
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+  unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP
 }
 
-test_creates_report_and_appends_inbox_line() {
+test_creates_host_suffixed_report_and_appends_per_host_inbox_line() {
   bash "$INTAKE" >/dev/null 2>&1
-  local today report
+  local today report inbox
   today=$(date +%Y-%m-%d)
-  report="$CEO_DIR/reports/token/$today.md"
-  assert_file_exists "$report" "report file must exist after intake"
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_file_exists "$report" "report path must include hostname suffix"
+  assert_file_exists "$inbox" "per-host inbox shadow file must be created"
   local count
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
-  assert_eq "$count" "1" "inbox must contain exactly one wikilink to today's report"
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
+  assert_eq "$count" "1" "per-host inbox must contain wikilink to host-suffixed report"
+}
+
+test_does_not_write_to_shared_inbox_md() {
+  bash "$INTAKE" >/dev/null 2>&1
+  if [ -f "$CEO_DIR/inbox.md" ] && [ -s "$CEO_DIR/inbox.md" ]; then
+    printf '  FAIL [%s] writer must not touch shared CEO/inbox.md\n    contents: %q\n' \
+      "$CURRENT_TEST" "$(cat "$CEO_DIR/inbox.md")"
+    FAILS=$((FAILS + 1))
+  fi
 }
 
 test_idempotent_same_day() {
   bash "$INTAKE" >/dev/null 2>&1
   bash "$INTAKE" >/dev/null 2>&1
-  local today count
+  local today inbox count
   today=$(date +%Y-%m-%d)
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "two runs must leave exactly one inbox line"
 }
 
 test_does_not_re_append_after_inbox_checkoff() {
   bash "$INTAKE" >/dev/null 2>&1
-  local today
+  local today inbox
   today=$(date +%Y-%m-%d)
-  sed -i.bak "s|- \[ \] Review daily token report \[\[CEO/reports/token/$today\]\]|- [x] Review daily token report [[CEO/reports/token/$today]]|" "$CEO_DIR/inbox.md"
-  rm -f "$CEO_DIR/inbox.md.bak"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  sed -i.bak "s|^- \[ \]|- [x]|" "$inbox"
+  rm -f "$inbox.bak"
 
   bash "$INTAKE" >/dev/null 2>&1
   local count
-  count=$(grep -c -F "[[CEO/reports/token/$today]]" "$CEO_DIR/inbox.md")
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "checked-off line must not trigger re-append"
+}
+
+test_two_hosts_write_disjoint_files() {
+  CEO_HOSTNAME="alpha" bash "$INTAKE" >/dev/null 2>&1
+  CEO_HOSTNAME="beta"  bash "$INTAKE" >/dev/null 2>&1
+  local today
+  today=$(date +%Y-%m-%d)
+  assert_file_exists "$CEO_DIR/reports/token/$today-alpha.md" "alpha report"
+  assert_file_exists "$CEO_DIR/reports/token/$today-beta.md"  "beta report"
+  assert_file_exists "$CEO_DIR/inbox/alpha.md" "alpha inbox shadow"
+  assert_file_exists "$CEO_DIR/inbox/beta.md"  "beta inbox shadow"
+  if [ -f "$CEO_DIR/inbox/beta.md" ] && grep -qF "alpha" "$CEO_DIR/inbox/beta.md"; then
+    printf '  FAIL [%s] beta inbox shadow must not reference alpha\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
 }
 
 test_invokes_ceo_augment_path() {
   PATH=/usr/bin:/bin bash "$INTAKE" >/dev/null 2>&1
   local today report body
   today=$(date +%Y-%m-%d)
-  report="$CEO_DIR/reports/token/$today.md"
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
   assert_file_exists "$report" "report file must exist"
   body=$(cat "$report")
   assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
@@ -109,7 +137,7 @@ test_invokes_ceo_augment_path() {
 
 test_aborts_on_unwritable_report_dir() {
   if [ "$(id -u)" = "0" ]; then
-    return 0  # chmod doesn't apply to root
+    return 0
   fi
   chmod 0500 "$CEO_DIR/reports/token"
   local rc=0
@@ -119,11 +147,8 @@ test_aborts_on_unwritable_report_dir() {
     printf '  FAIL [%s] script must exit non-zero on unwritable report dir (got rc=0)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
-  local inbox
-  inbox=$(cat "$CEO_DIR/inbox.md")
-  if [[ "$inbox" == *"[[CEO/reports/token/"* ]]; then
-    printf '  FAIL [%s] inbox must NOT have an inbox line when the report write failed\n    inbox: %q\n' \
-      "$CURRENT_TEST" "$inbox"
+  if [ -f "$CEO_DIR/inbox/$CEO_HOSTNAME.md" ] && grep -qF "[[CEO/reports/token/" "$CEO_DIR/inbox/$CEO_HOSTNAME.md"; then
+    printf '  FAIL [%s] per-host inbox must NOT have an inbox line when the report write failed\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
 }


### PR DESCRIPTION
Closes #5

## Description (Issue Fixed & New Behavior)

Three Syncthing-shared files were written by every host with no
cross-host coordination. The cron-level `flock /tmp/ceo-cron.lock` is
per-host; `/tmp` is not synced. This PR addresses two of the three
implicated paths; the third (`registry.json` schema-version handshake)
is tracked in #7.

**A. `reports/token/<TODAY>.md` (truncate-write race)**

Two peers running the same `45 8 * * 1-5` cron entry wrote the same
path. New filename: `reports/token/<TODAY>-<host>.md`. Disjoint paths
per host, no Syncthing collision possible. Wikilink in the inbox line
matches the new filename so links resolve.

**B. `inbox.md` (read-grep-append race)**

`ceo-token-intake.sh` greps the local copy then appends. If host A
appends but Syncthing hasn't propagated yet, host B also appends —
both writes converge into a sync-conflict file.

The writer now writes to `CEO/inbox/<host>.md` shadow files. The local
grep is local-correct again because the file is host-local. Two new
helpers/changes on the read side:

- `ceo_inbox_has_unchecked()` in `ceo-config.sh`: scans both legacy
  `inbox.md` (still supported for user-curated entries) and per-host
  `inbox/*.md`.
- The two `preflight_has_unchecked_inbox` call sites in `ceo-cron.sh`
  and `scripts/ceo` (`cmd_preflight`) delegate to the helper.

**C′. `cmd_playbook_scan` primary-host gate**

`registry.json` is rewritten in full by `cmd_playbook_scan`; whichever
host last ran it wins. Opt-in gate via `CEO/settings.json`:

```json
{ "primary_host": "<hostname>" }
```

When set, only that host may run `ceo playbook scan`; others exit 1
with a clear error pointing at the primary. Unset → any host may scan
(backward-compatible).

The schema-version handshake that prevents *silent downgrades* even
when the gate isn't configured is the other half of the registry
concern, scoped to #7.

`${CEO_HOSTNAME:-$(hostname -s)}` is used in both `ceo-token-intake.sh`
and `cmd_playbook_scan`, with `CEO_HOSTNAME` overrideable for
deterministic tests.

## Testing Procedure

All tests are self-contained shell harnesses (no network, no real
vault, no real cron). From the PR worktree:

1. **Run the full test suite.** Each suite must report `All tests
   passed.`:
   ```bash
   bash scripts/ceo-config.test.sh         # 13 tests
   bash scripts/ceo-cron.test.sh           # 19 tests
   bash scripts/ceo-token-intake.test.sh   # 7 tests
   bash scripts/count-blessings.test.sh    # pre-existing, must still pass
   ```

2. **Verify the new token-intake tests cover the multi-host case.**
   `test_two_hosts_write_disjoint_files` runs the intake twice with
   `CEO_HOSTNAME=alpha` and `CEO_HOSTNAME=beta` and asserts:
   - `reports/token/<TODAY>-alpha.md` and `reports/token/<TODAY>-beta.md`
     both exist
   - `inbox/alpha.md` and `inbox/beta.md` both exist
   - `inbox/beta.md` contains no reference to `alpha`

3. **Verify the inbox-helper covers both legacy and shadow sources.**
   In `ceo-config.test.sh`:
   - `test_inbox_has_unchecked_finds_legacy_inbox_md` — legacy path
   - `test_inbox_has_unchecked_finds_per_host_shadow_file` — new path
   - `test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty` —
     both present, mixed states

4. **Verify the primary-host gate.** In `ceo-cron.test.sh`:
   - `test_playbook_scan_blocks_non_primary_host` — `primary_host=alpha`
     in settings, `CEO_HOSTNAME=beta` runs scan → exit 1, registry not
     written, error mentions "primary host"
   - `test_playbook_scan_succeeds_on_primary_host` — same settings,
     `CEO_HOSTNAME=alpha` → exit 0, registry written
   - `test_playbook_scan_unrestricted_when_primary_host_unset` — empty
     settings → any host can scan (backward compat)

5. **Manually confirm backward compatibility.** Existing scan-using
   tests in `ceo-cron.test.sh` (10+ call sites) all run without setting
   `primary_host` and continue to pass — proof that the new gate does
   not break the no-op default.

## Additional Notes

- **Stacked on #4.** Base is `nh/feature/runner-script-and-token-intake`.
  Merge order is #21 → #4 → main (this PR merges into #4's branch
  first; #4 then carries everything to main).
- **Related: #7** — registry `schema_version` (silent-downgrade
  prevention). Independent code path; the two PRs land cleanly together.
- **Vault-side follow-up** (not in this repo): the chat-triggered
  `inbox` playbook in the user's vault should be updated to read both
  `CEO/inbox.md` and `CEO/inbox/*.md` for full visibility. Until then,
  per-host shadow items only surface when the host running `ceo chat
  inbox` is the same host that wrote them — same coverage as today's
  shared `inbox.md` view.
- `syncthing/shared.stignore` and `syncthing/README.md` are unchanged
  on purpose. With per-host filenames, no path needs ignoring; the
  primary-host gate is documented in this PR.