### PR TITLE
fix(token-intake): pin $HOME to real user's home before rtk/ccusage capture

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -8,7 +8,11 @@
 #   ceo_load_config()       — resolves CEO_VAULT; returns 0 on success, 1 if empty
 #   ceo_require_vault()     — load config; exit 1 with operator guidance if unresolved
 #   ceo_validate_vault()    — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_augment_path()      — prepend bun/Homebrew/.local prefixes to PATH (idempotent)
+#   ceo_resolve_real_home() — print passwd-canonical $HOME for running user; rc=0/1
 #   ceo_pin_home_or_warn()  — resolve+export $HOME from passwd; warn-and-rc=1 on fail
+#   ceo_inbox_has_unchecked() — scan inbox sources for an unchecked todo; rc=0/1
+#   ceo_assert_primary_host() — gate Syncthing-shared writes; rc=0 allowed/1 deny
 #   ceo_registry_validate() — verifies registry.json schema_version; returns 0/1/2
 #
 # Resolution order in ceo_load_config():
@@ -117,15 +121,23 @@ ceo_augment_path() {
 # ignoring $HOME. Use when a script needs access to real-user state (rtk DB,
 # ccusage data, keyring tokens) and may be invoked from contexts that scrubbed
 # or sandboxed $HOME (env -i, sudo without -E, test harness with HOME=mktemp).
-# Prints the resolved path on stdout. Returns 0 on success, 1 if unable.
+# Prints the resolved path on stdout.
+#
+# Returns:
+#   0  resolved path printed
+#   1  one of: id -un failed (no usable user identity); both getent and dscl
+#      unavailable; resolver returned an empty string (e.g. Homebrew gnu-getent
+#      which is host-only); resolved path failed [ -d ] check (stale passwd
+#      entry, mobile-account home migration, etc.).
 # ---------------------------------------------------------------------------
 ceo_resolve_real_home() {
   local user resolved=""
   user=$(id -un 2>/dev/null) || return 1
   if command -v getent >/dev/null 2>&1; then
     resolved=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
-  elif [ "$(uname)" = "Darwin" ] && command -v dscl >/dev/null 2>&1; then
-    resolved=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '/^NFSHomeDirectory:/ {print $2}')
+  fi
+  if [ -z "$resolved" ] && [ "$(uname)" = "Darwin" ] && command -v dscl >/dev/null 2>&1; then
+    resolved=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | sed -n 's/^NFSHomeDirectory: //p')
   fi
   if [ -n "$resolved" ] && [ -d "$resolved" ]; then
     printf '%s\n' "$resolved"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -112,6 +112,28 @@ ceo_augment_path() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_resolve_real_home — print the running user's canonical home from passwd,
+# ignoring $HOME. Use when a script needs access to real-user state (rtk DB,
+# ccusage data, keyring tokens) and may be invoked from contexts that scrubbed
+# or sandboxed $HOME (env -i, sudo without -E, test harness with HOME=mktemp).
+# Prints the resolved path on stdout. Returns 0 on success, 1 if unable.
+# ---------------------------------------------------------------------------
+ceo_resolve_real_home() {
+  local user resolved=""
+  user=$(id -un 2>/dev/null) || return 1
+  if command -v getent >/dev/null 2>&1; then
+    resolved=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
+  elif [ "$(uname)" = "Darwin" ] && command -v dscl >/dev/null 2>&1; then
+    resolved=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '/^NFSHomeDirectory:/ {print $2}')
+  fi
+  if [ -n "$resolved" ] && [ -d "$resolved" ]; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # Registry schema. Bump CEO_REGISTRY_SCHEMA_VERSION whenever the on-disk
 # shape of registry.json changes — a peer host running an older binary will
 # then refuse to dispatch instead of silently downgrading the registry on

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -8,6 +8,7 @@
 #   ceo_load_config()       — resolves CEO_VAULT; returns 0 on success, 1 if empty
 #   ceo_require_vault()     — load config; exit 1 with operator guidance if unresolved
 #   ceo_validate_vault()    — verifies CEO/inbox.md exists; returns 0 on pass, 1 on fail
+#   ceo_pin_home_or_warn()  — resolve+export $HOME from passwd; warn-and-rc=1 on fail
 #   ceo_registry_validate() — verifies registry.json schema_version; returns 0/1/2
 #
 # Resolution order in ceo_load_config():
@@ -130,6 +131,28 @@ ceo_resolve_real_home() {
     printf '%s\n' "$resolved"
     return 0
   fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# ceo_pin_home_or_warn — resolve passwd-canonical $HOME and export it; warn on
+# failure. Use when a script needs access to real-user state (rtk DB, ccusage)
+# and may be invoked from contexts that scrubbed or sandboxed $HOME (env -i,
+# sudo without -E, test harness with HOME=mktemp).
+#
+# Returns 0 on success (HOME re-exported); 1 if ceo_resolve_real_home failed.
+# On failure $HOME is left as the caller passed it and a WARN line goes to
+# stderr with diagnostic context. Folds resolve+export+warn into one call so
+# future callers can't copy a silent if-block.
+# ---------------------------------------------------------------------------
+ceo_pin_home_or_warn() {
+  local real_home
+  if real_home=$(ceo_resolve_real_home); then
+    export HOME="$real_home"
+    return 0
+  fi
+  printf 'WARN: ceo_pin_home_or_warn: passwd resolution failed; HOME=%q (id=%s, uname=%s)\n' \
+    "${HOME:-<unset>}" "$(id -un 2>/dev/null || echo \?)" "$(uname)" >&2
   return 1
 }
 

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -202,6 +202,25 @@ test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty() {
   assert_eq "$rc" "0" "must find unchecked items even when legacy is clean"
 }
 
+test_resolve_real_home_ignores_env_HOME() {
+  # Regression guard: rtk and ccusage discover state via $HOME-rooted paths.
+  # When the script is invoked from env -i / sandbox / sudo without -E, $HOME
+  # may point somewhere that doesn't have the real user's DBs. The helper
+  # must resolve from passwd, not from $HOME.
+  local got expected
+  expected=$(eval echo "~$(id -un)")
+  if [ ! -d "$expected" ]; then
+    printf "  SKIP [%s] expected home %q is not a directory\n" "$CURRENT_TEST" "$expected"
+    return 0
+  fi
+  got=$(env -i HOME=/tmp/this-is-not-the-real-home PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_real_home
+  ")
+  assert_eq "$got" "$expected" "ceo_resolve_real_home must use passwd, not \$HOME"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -221,6 +221,27 @@ test_resolve_real_home_ignores_env_HOME() {
   assert_eq "$got" "$expected" "ceo_resolve_real_home must use passwd, not \$HOME"
 }
 
+test_pin_home_or_warn_emits_warn_on_resolver_failure() {
+  # Force ceo_resolve_real_home to fail by stripping all binaries from PATH:
+  # id, getent, and dscl are all unqualified inside the helper. Use absolute
+  # /bin/bash because env(1) needs to locate bash itself before applying the
+  # stripped PATH to the child process.
+  local empty_dir="$TEST_HOME/empty"
+  mkdir -p "$empty_dir"
+  local stderr rc=0
+  stderr=$(env -i HOME=/tmp/fake PATH="$empty_dir" /bin/bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_pin_home_or_warn
+  " 2>&1 >/dev/null) || rc=$?
+  assert_eq "$rc" "1" "ceo_pin_home_or_warn must return 1 when resolver fails"
+  case "$stderr" in
+    *"WARN: ceo_pin_home_or_warn"*"passwd resolution failed"*) ;;
+    *) printf '  FAIL [%s] expected WARN line on stderr, got: %q\n' "$CURRENT_TEST" "$stderr"
+       FAILS=$((FAILS + 1)) ;;
+  esac
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -210,6 +210,11 @@ test_resolve_real_home_ignores_env_HOME() {
   local got expected
   expected=$(eval echo "~$(id -un)")
   if [ ! -d "$expected" ]; then
+    if [ -n "${CI:-}" ]; then
+      printf '  FAIL [%s] CI environment must have a real home for the test user\n' "$CURRENT_TEST"
+      FAILS=$((FAILS + 1))
+      return 0
+    fi
     printf "  SKIP [%s] expected home %q is not a directory\n" "$CURRENT_TEST" "$expected"
     return 0
   fi
@@ -219,6 +224,42 @@ test_resolve_real_home_ignores_env_HOME() {
     ceo_resolve_real_home
   ")
   assert_eq "$got" "$expected" "ceo_resolve_real_home must use passwd, not \$HOME"
+}
+
+test_resolve_real_home_falls_back_to_dscl_when_getent_returns_empty() {
+  # Verifies the elif → if fix: when getent is on PATH but produces empty
+  # output (Homebrew gnu-getent is host-resolution only, not passwd), the
+  # resolver must fall through to dscl on Darwin. With the old elif shape
+  # the dscl branch was unreachable once command -v getent succeeded.
+  if [ "$(uname)" != "Darwin" ]; then
+    printf "  SKIP [%s] non-Darwin\n" "$CURRENT_TEST"
+    return 0
+  fi
+  local stub_dir="$TEST_HOME/stubs"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/getent" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+  chmod +x "$stub_dir/getent"
+
+  local got expected
+  expected=$(eval echo "~$(id -un)")
+  if [ ! -d "$expected" ]; then
+    if [ -n "${CI:-}" ]; then
+      printf '  FAIL [%s] CI environment must have a real home for the test user\n' "$CURRENT_TEST"
+      FAILS=$((FAILS + 1))
+      return 0
+    fi
+    printf "  SKIP [%s] expected home %q is not a directory\n" "$CURRENT_TEST" "$expected"
+    return 0
+  fi
+  got=$(env -i HOME=/tmp/fake PATH="$stub_dir:/usr/bin:/bin" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_real_home
+  ")
+  assert_eq "$got" "$expected" "must fall through to dscl when getent on PATH returns empty"
 }
 
 test_pin_home_or_warn_emits_warn_on_resolver_failure() {

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -14,16 +14,15 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
-ceo_augment_path
 
 # rtk and ccusage discover their state via $HOME-rooted paths
 # (Library/Application Support/rtk/history.db on Mac, .local/share on Linux).
-# Pin $HOME to the running user's canonical home so we read the real DBs even
-# if invoked from a context that scrubbed or sandboxed $HOME. Without this,
-# rtk silently returns "No tracking data yet" and the report ships empty.
-if real_home=$(ceo_resolve_real_home); then
-  export HOME="$real_home"
-fi
+# Pin $HOME BEFORE ceo_augment_path so PATH augmentation reads the real
+# user's home (~/.bun/bin etc.) instead of a scrubbed/sandboxed value. The
+# helper warns to stderr on resolver failure; we proceed regardless so
+# cron-invoked runs aren't blocked by an unresolvable user identity.
+ceo_pin_home_or_warn || true
+ceo_augment_path
 
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -16,6 +16,15 @@ source "$SCRIPT_DIR/ceo-config.sh"
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
 ceo_augment_path
 
+# rtk and ccusage discover their state via $HOME-rooted paths
+# (Library/Application Support/rtk/history.db on Mac, .local/share on Linux).
+# Pin $HOME to the running user's canonical home so we read the real DBs even
+# if invoked from a context that scrubbed or sandboxed $HOME. Without this,
+# rtk silently returns "No tracking data yet" and the report ships empty.
+if real_home=$(ceo_resolve_real_home); then
+  export HOME="$real_home"
+fi
+
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 HOST="${CEO_HOSTNAME:-$(hostname -s)}"

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -54,7 +54,24 @@ STUB
 echo "token-scope-stub: $*"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/rtk" "$TEST_HOME/.bun/bin/token-scope"
-  export PATH="$TEST_HOME/.bun/bin:$PATH"
+
+  # Stage a getent stub so ceo_pin_home_or_warn (via ceo_resolve_real_home)
+  # resolves to $TEST_HOME instead of the developer's real ~/. Without this,
+  # the script's HOME re-export would point PATH augmentation at the user's
+  # actual ~/.bun/bin and bypass the test stubs above.
+  local user
+  user=$(id -un)
+  mkdir -p "$TEST_HOME/stubs"
+  cat > "$TEST_HOME/stubs/getent" << EOF
+#!/bin/bash
+if [ "\$1" = "passwd" ] && [ "\$2" = "$user" ]; then
+  printf '%s:x:0:0::%s:/bin/bash\n' "$user" "$TEST_HOME"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$TEST_HOME/stubs/getent"
+  export PATH="$TEST_HOME/stubs:$TEST_HOME/.bun/bin:$PATH"
 }
 
 teardown() {
@@ -126,13 +143,57 @@ test_two_hosts_write_disjoint_files() {
 }
 
 test_invokes_ceo_augment_path() {
-  PATH=/usr/bin:/bin bash "$INTAKE" >/dev/null 2>&1
+  # Keep the getent stub on PATH so ceo_pin_home_or_warn resolves to
+  # $TEST_HOME instead of the developer's real ~/. Without it, dscl on Mac
+  # would return the real user's home and PATH augmentation would prefer the
+  # real ~/.bun/bin/rtk over the test stub.
+  PATH="$TEST_HOME/stubs:/usr/bin:/bin" bash "$INTAKE" >/dev/null 2>&1
   local today report body
   today=$(date +%Y-%m-%d)
   report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
   assert_file_exists "$report" "report file must exist"
   body=$(cat "$report")
   assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
+}
+
+test_pins_home_to_resolved_user_home_before_capture() {
+  local pinned="$TEST_HOME/pinned-home"
+  mkdir -p "$pinned/.bun/bin"
+  cat > "$pinned/.bun/bin/rtk" << 'STUB'
+#!/bin/bash
+echo "rtk-saw-HOME=$HOME"
+STUB
+  chmod +x "$pinned/.bun/bin/rtk"
+  cp "$TEST_HOME/.bun/bin/token-scope" "$pinned/.bun/bin/token-scope"
+
+  local stub_dir="$TEST_HOME/stubs" user
+  mkdir -p "$stub_dir"
+  user=$(id -un)
+  cat > "$stub_dir/getent" << EOF
+#!/bin/bash
+if [ "\$1" = "passwd" ] && [ "\$2" = "$user" ]; then
+  printf '%s:x:0:0::%s:/bin/bash\n' "$user" "$pinned"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$stub_dir/getent"
+
+  local sandbox="$TEST_HOME/scrubbed"
+  mkdir -p "$sandbox"
+  HOME="$sandbox" PATH="$stub_dir:$TEST_HOME/.bun/bin:/usr/bin:/bin" \
+    bash "$INTAKE" >/dev/null 2>&1
+
+  local today report body
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
+  if [ ! -f "$report" ]; then
+    printf '  FAIL [%s] report missing at %q\n' "$CURRENT_TEST" "$report"
+    FAILS=$((FAILS + 1)); return
+  fi
+  body=$(cat "$report")
+  assert_contains "$body" "rtk-saw-HOME=$pinned" \
+    "rtk must see HOME=$pinned (resolver target), not the sandbox HOME the caller passed"
 }
 
 test_aborts_on_unwritable_report_dir() {


### PR DESCRIPTION
## Description (Issue Fixed & New Behavior)

`rtk` and `ccusage` discover their state via `$HOME`-rooted paths:
- Mac: `$HOME/Library/Application Support/rtk/history.db`
- Linux/WSL: `$HOME/.local/share/rtk/history.db`

When `ceo-token-intake.sh` is invoked from a context that scrubbed or sandboxed `$HOME` — `env -i`, `sudo` without `-E`, a test harness with `HOME=mktemp` — those tools silently return `"No tracking data yet"` and the daily token report ships empty. Reproduced from the 2026-04-29 report on this Mac:

```
## RTK — global savings
No tracking data yet.
Run some rtk commands to start tracking savings.
```

…despite the same run's ccusage section showing real `$37.80` of Claude Code spend.

## Fix

Adds `ceo_resolve_real_home()` to `ceo-config.sh`. Prints the running user's canonical home from passwd, ignoring `$HOME`:
- `getent passwd "$user" | cut -d: -f6` on Linux/WSL
- `dscl . -read "/Users/$user" NFSHomeDirectory` on Mac
- Returns 1 if neither resolver is reachable

`ceo-token-intake.sh` calls the helper after `ceo_augment_path` and re-exports `$HOME` to the resolved path before the rtk/ccusage capture. This is opt-in for token-intake (and any future runner-script that needs real-user state) — `ceo_augment_path` itself stays focused on PATH and is unaffected, so existing test sandboxing in `ceo-cron.test.sh` keeps working.

## Why not modify `ceo_augment_path`

`ceo_augment_path` is called from the dispatcher and has tests that depend on test-harness `$HOME` being honored (stubs at `$TEST_HOME/.bun/bin`). Overriding `$HOME` there would silently break test isolation. Keeping the HOME re-export opt-in at the script level preserves that invariant.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-config.test.sh` — 17 tests pass, including the new `test_resolve_real_home_ignores_env_HOME`.
3. Reproduce the original failure: `HOME=/tmp/fake rtk gain` → `"No tracking data yet."`
4. Verify the helper resolves correctly: `bash -c 'source scripts/ceo-config.sh && ceo_resolve_real_home'` → prints `/Users/<you>` (or your real home).
5. End-to-end smoke test:
   ```bash
   REAL_VAULT="$HOME/Documents/Obsidian"
   rm -f "$REAL_VAULT/CEO/reports/token/$(date +%F)-$(hostname -s).md"
   HOME=/tmp/sandbox-fake CEO_VAULT="$REAL_VAULT" bash scripts/ceo-token-intake.sh
   grep "Total commands" "$REAL_VAULT/CEO/reports/token/$(date +%F)-$(hostname -s).md"
   ```
   Expected: real RTK command counts in both global and project sections (not "No tracking data yet").
6. Run the existing `bash scripts/ceo-cron.test.sh` and `bash scripts/ceo-token-intake.test.sh` — both still pass (28 + 7).

## Additional Notes / HelpScout Tickets

Diagnosed from the 2026-04-29 token report on Mac. Originally surfaced as "why is this scoped to a project and not globally" — both global and project sections had run, both came back empty due to the same HOME-rooted DB miss.

`ceo_augment_path` is unchanged. Only `ceo_resolve_real_home` is new.

N/A