### PR TITLE
fix(playbook-scan): scope bin prune to manifest, pin LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Force LF on every shell script and bare-named CLI on checkout, regardless of
+# the cloning machine's core.autocrlf setting. Windows defaults to autocrlf=true,
+# which converts LF -> CRLF on checkout and breaks /bin/bash with
+# "bad interpreter: /bin/bash^M: no such file or directory". WSL clones from
+# the Windows-side filesystem hit the same break.
+*               text=auto eol=lf
+*.sh            text eol=lf
+ceo             text eol=lf
+*.md            text eol=lf
+*.json          text eol=lf
+*.yaml          text eol=lf
+*.yml           text eol=lf

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -577,9 +577,16 @@ _playbook_sync_bins() {
     done < "$manifest"
   fi
 
-  local manifest_tmp="$manifest.tmp"
-  printf '%s' "$declared_names" > "$manifest_tmp"
-  mv -f "$manifest_tmp" "$manifest"
+  local manifest_tmp
+  manifest_tmp=$(mktemp "$manifest.XXXXXX") || {
+    echo "WARN: mktemp failed for manifest" >&2
+    return 1
+  }
+  if ! printf '%s' "$declared_names" > "$manifest_tmp" || ! mv -f "$manifest_tmp" "$manifest"; then
+    rm -f "$manifest_tmp"
+    echo "WARN: manifest update failed" >&2
+    return 1
+  fi
 
   echo "Bins: $created created/updated, $removed removed"
 }

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -530,12 +530,14 @@ cmd_playbook_scan() {
 _playbook_sync_bins() {
   local registry="$1"
   local bin_dir="$HOME/.local/bin"
-  mkdir -p "$bin_dir"
+  local manifest_dir="$HOME/.ceo"
+  local manifest="$manifest_dir/managed-bins"
+  mkdir -p "$bin_dir" "$manifest_dir"
 
   local created=0
   local removed=0
+  local declared_names=""
 
-  # Create/update symlinks for active playbooks that declare a bin
   while IFS= read -r row; do
     local p_name p_bin p_status
     p_name=$(echo "$row" | jq -r '.name')
@@ -551,26 +553,32 @@ _playbook_sync_bins() {
 
     ln -sf "$target" "$link_path"
     echo "  BIN   $link_name -> $target"
+    declared_names+="$link_name"$'\n'
     created=$((created + 1))
   done < <(echo "$registry" | jq -c '.playbooks[]')
 
-  # Remove stale symlinks into SCRIPT_DIR that no active playbook declares
-  local declared_bins
-  declared_bins=$(echo "$registry" | jq -r '[.playbooks[] | select(.status=="active") | select(.bin != null and .bin != "") | .bin | ltrimstr("") | if endswith(".sh") then .[:-3] else . end] | join("\n")' 2>/dev/null || true)
-
-  for link in "$bin_dir"/*; do
-    [ -L "$link" ] || continue
-    local tgt
-    tgt=$(readlink "$link")
-    [[ "$tgt" == "$SCRIPT_DIR/"* ]] || continue
-    local link_name
-    link_name=$(basename "$link")
-    if ! printf '%s\n' "$declared_bins" | grep -qx "$link_name"; then
+  # Prune only entries this function created previously. The manifest lists
+  # link names from the most recent successful sync; user-installed CLIs
+  # (e.g. ~/.local/bin/ceo, ~/.local/bin/count-blessings) are never recorded
+  # there and so survive every scan.
+  if [ -f "$manifest" ]; then
+    while IFS= read -r prev_name; do
+      [ -z "$prev_name" ] && continue
+      printf '%s' "$declared_names" | grep -qx "$prev_name" && continue
+      local link="$bin_dir/$prev_name"
+      [ -L "$link" ] || continue
+      local tgt
+      tgt=$(readlink "$link")
+      [[ "$tgt" == "$SCRIPT_DIR/"* ]] || continue
       rm -f "$link"
-      echo "  UNBIN $link_name (removed)"
+      echo "  UNBIN $prev_name (removed)"
       removed=$((removed + 1))
-    fi
-  done
+    done < "$manifest"
+  fi
+
+  local manifest_tmp="$manifest.tmp"
+  printf '%s' "$declared_names" > "$manifest_tmp"
+  mv -f "$manifest_tmp" "$manifest"
 
   echo "Bins: $created created/updated, $removed removed"
 }

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -528,6 +528,7 @@ cmd_playbook_scan() {
 }
 
 _playbook_sync_bins() {
+  : "${HOME:?HOME must be set before _playbook_sync_bins}"
   local registry="$1"
   local bin_dir="$HOME/.local/bin"
   local manifest_dir="$HOME/.ceo"

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -564,7 +564,7 @@ _playbook_sync_bins() {
   if [ -f "$manifest" ]; then
     while IFS= read -r prev_name; do
       [ -z "$prev_name" ] && continue
-      printf '%s' "$declared_names" | grep -qx "$prev_name" && continue
+      printf '%s' "$declared_names" | grep -Fqx "$prev_name" && continue
       local link="$bin_dir/$prev_name"
       [ -L "$link" ] || continue
       local tgt

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -902,6 +902,53 @@ PB
   fi
 }
 
+test_playbook_scan_prunes_dropped_bin_but_keeps_user_bins() {
+  cat > "$CEO_DIR/playbooks/blessings-cli.md" << 'PB'
+---
+name: blessings-cli
+description: declares a bin
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+bin: count-blessings.sh
+---
+PB
+  mkdir -p "$HOME/.local/bin"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  if [ ! -L "$HOME/.local/bin/count-blessings" ]; then
+    printf '  FAIL [%s] declared bin should be symlinked on first scan\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+    return
+  fi
+
+  ln -s "$SCRIPT_DIR/ceo" "$HOME/.local/bin/ceo"
+
+  cat > "$CEO_DIR/playbooks/blessings-cli.md" << 'PB'
+---
+name: blessings-cli
+description: dropped the bin
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  if [ -L "$HOME/.local/bin/count-blessings" ]; then
+    printf '  FAIL [%s] manifest-driven prune should remove dropped bin\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ ! -L "$HOME/.local/bin/ceo" ]; then
+    printf '  FAIL [%s] user-installed ceo symlink should survive prune\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -833,6 +833,75 @@ PB
   fi
 }
 
+test_playbook_scan_preserves_user_installed_bins() {
+  mkdir -p "$HOME/.local/bin"
+  ln -s "$SCRIPT_DIR/count-blessings.sh" "$HOME/.local/bin/count-blessings"
+  ln -s "$SCRIPT_DIR/ceo" "$HOME/.local/bin/ceo"
+
+  cat > "$CEO_DIR/playbooks/example.md" << 'PB'
+---
+name: example
+description: regression seed — no bin declared
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  if [ ! -L "$HOME/.local/bin/count-blessings" ]; then
+    printf '  FAIL [%s] playbook scan removed user-installed count-blessings symlink\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ ! -L "$HOME/.local/bin/ceo" ]; then
+    printf '  FAIL [%s] playbook scan removed user-installed ceo symlink\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_playbook_scan_creates_and_prunes_declared_bin() {
+  cat > "$CEO_DIR/playbooks/blessings-cli.md" << 'PB'
+---
+name: blessings-cli
+description: declares a bin
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+bin: count-blessings.sh
+---
+PB
+  mkdir -p "$HOME/.local/bin"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  if [ ! -L "$HOME/.local/bin/count-blessings" ]; then
+    printf '  FAIL [%s] declared bin should be symlinked\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+    return
+  fi
+
+  cat > "$CEO_DIR/playbooks/blessings-cli.md" << 'PB'
+---
+name: blessings-cli
+description: dropped the bin
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  if [ -L "$HOME/.local/bin/count-blessings" ]; then
+    printf '  FAIL [%s] previously-managed bin should be pruned when playbook drops it\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do


### PR DESCRIPTION
## Summary

Two independent fixes triggered by `ceo playbook scan` wiping `~/.local/bin/ceo` and `~/.local/bin/count-blessings`.

### `_playbook_sync_bins`: prune by manifest, not by directory walk (commit 0bcf95a)

The previous prune pass walked every symlink in `~/.local/bin` whose target started with `$SCRIPT_DIR/` and removed any whose basename was not declared as a `bin:` field on an active playbook. With zero playbooks declaring `bin:` fields today, that meant the README-installed CLIs (`~/.local/bin/ceo`, `~/.local/bin/count-blessings`) were treated as "stale" and removed on every scan.

The function now records the link names it created in `~/.ceo/managed-bins` after each successful sync, and the prune pass walks that manifest instead of the bin directory. Anything the user installed by hand is never recorded there, so it cannot be removed. First scan after upgrade prunes nothing (no manifest yet) and seeds the manifest from the active set — anyone whose CLIs were already wiped can simply re-link and run `playbook scan` once with no further loss.

### `.gitattributes`: pin LF for Windows/WSL clones (commit c3656bb)

The repo had no `.gitattributes`. A Windows clone with the default `core.autocrlf=true` converts LF → CRLF on checkout and breaks every shell script with `bad interpreter: /bin/bash^M`. WSL clones from the Windows-side filesystem hit the same break. README lists WSL as a supported platform.

Pins LF on `*.sh`, the bare-named `ceo` CLI, and the markdown/JSON/YAML files the dispatcher reads, plus a default `* text=auto eol=lf`.

## Test plan

- [ ] `bash scripts/ceo-cron.test.sh` — all 30 tests pass (2 new bin-prune tests included)
- [ ] Revert the `_playbook_sync_bins` change, re-run the suite — `test_playbook_scan_preserves_user_installed_bins` fails with the original symptom (count-blessings + ceo symlinks removed). Re-apply, suite passes.
- [ ] After merge, on a host that already ran the buggy scan: re-create symlinks (`ln -sfn $REPO/scripts/ceo ~/.local/bin/ceo`, `ln -sfn $REPO/scripts/count-blessings.sh ~/.local/bin/count-blessings`), then `ceo playbook scan` — symlinks survive.
- [ ] On a Windows or WSL machine: fresh `git clone` then `file scripts/ceo` — reports LF-only, scripts execute without `^M` errors.