### PR TITLE
feat(playbook-scan): auto-register repo playbooks from docs/playbooks/

### DIFF
--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -35,6 +35,8 @@ The chat-triggered `inbox` playbook picks the line up next time `ceo chat inbox`
 
 Registered automatically by `ceo playbook scan`. Repo playbooks under `docs/playbooks/` are picked up alongside vault playbooks; a vault playbook with the same `name` shadows the repo copy.
 
+Note: cron entries for repo playbooks bake in `$INSTALL_DIR` at scan time. If the repo moves (re-clone, worktree shuffle), re-run `ceo playbook scan` to refresh the crontab.
+
 ## Disable
 
 Set `status: inactive` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/token-intake.md`) and re-scan.

--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -33,13 +33,8 @@ The chat-triggered `inbox` playbook picks the line up next time `ceo chat inbox`
 
 ## Install
 
-Copy this file into the vault, then re-scan:
-
-```
-cp docs/playbooks/token-intake.md "$CEO_VAULT/CEO/playbooks/"
-ceo playbook scan
-```
+Registered automatically by `ceo playbook scan`. Repo playbooks under `docs/playbooks/` are picked up alongside vault playbooks; a vault playbook with the same `name` shadows the repo copy.
 
 ## Disable
 
-Set `status: inactive` and re-scan.
+Set `status: inactive` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/token-intake.md`) and re-scan.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -396,7 +396,7 @@ cmd_playbook_scan() {
   ceo_assert_primary_host || exit 1
 
   local playbook_dir="$CEO_DIR/playbooks"
-  local repo_playbook_dir="$INSTALL_DIR/docs/playbooks"
+  local repo_playbook_dir="${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}"
   local registry_file="$CEO_DIR/registry.json"
 
   if [ ! -d "$playbook_dir" ]; then
@@ -435,7 +435,8 @@ cmd_playbook_scan() {
   local found=0
   local skipped=0
 
-  local seen_names=""
+  local seen_names_vault=""
+  local seen_names_repo=""
   local shadowed=0
 
   local scan_dirs=( "$playbook_dir" )
@@ -457,7 +458,15 @@ cmd_playbook_scan() {
       continue
     fi
 
-    if grep -qxF "$name" <<< "$seen_names"; then
+    case "$name" in
+      *$'\n'*)
+        echo "  SKIP  $basename (name contains newline; YAML block scalars not supported)"
+        skipped=$((skipped + 1))
+        continue
+        ;;
+    esac
+
+    if grep -qxF "$name" <<< "$seen_names_vault"; then
       if [ "$from_repo" = "1" ]; then
         echo "  SHADOW $basename (vault override of repo playbook '$name')"
         shadowed=$((shadowed + 1))
@@ -467,7 +476,16 @@ cmd_playbook_scan() {
       fi
       continue
     fi
-    seen_names="${seen_names}${name}"$'\n'
+    if grep -qxF "$name" <<< "$seen_names_repo"; then
+      echo "  DUP    $basename (duplicate name '$name')"
+      skipped=$((skipped + 1))
+      continue
+    fi
+    if [ "$from_repo" = "1" ]; then
+      seen_names_repo="${seen_names_repo}${name}"$'\n'
+    else
+      seen_names_vault="${seen_names_vault}${name}"$'\n'
+    fi
 
     description=$(yq --front-matter=extract '.description // ""' "$f" 2>/dev/null || echo "")
     trigger=$(yq --front-matter=extract '.trigger // ""' "$f" 2>/dev/null || echo "")

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -396,6 +396,7 @@ cmd_playbook_scan() {
   ceo_assert_primary_host || exit 1
 
   local playbook_dir="$CEO_DIR/playbooks"
+  local repo_playbook_dir="$INSTALL_DIR/docs/playbooks"
   local registry_file="$CEO_DIR/registry.json"
 
   if [ ! -d "$playbook_dir" ]; then
@@ -434,10 +435,15 @@ cmd_playbook_scan() {
   local found=0
   local skipped=0
 
-  for f in "$playbook_dir"/*.md; do
+  local seen_names=""
+  local shadowed=0
+
+  for f in "$playbook_dir"/*.md "$repo_playbook_dir"/*.md; do
     [ -f "$f" ] || continue
     local basename
     basename=$(basename "$f")
+    local from_repo=0
+    [[ "$f" == "$repo_playbook_dir"/* ]] && from_repo=1
 
     local name description trigger schedule model preflight tier status bin runner script inputs
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
@@ -446,6 +452,18 @@ cmd_playbook_scan() {
       skipped=$((skipped + 1))
       continue
     fi
+
+    if echo "$seen_names" | tr ' ' '\n' | grep -qx "$name"; then
+      if [ "$from_repo" = "1" ]; then
+        echo "  SHADOW $basename (vault override of repo playbook '$name')"
+        shadowed=$((shadowed + 1))
+      else
+        echo "  DUP    $basename (duplicate name '$name')"
+        skipped=$((skipped + 1))
+      fi
+      continue
+    fi
+    seen_names="$seen_names $name"
 
     description=$(yq --front-matter=extract '.description // ""' "$f" 2>/dev/null || echo "")
     trigger=$(yq --front-matter=extract '.trigger // ""' "$f" 2>/dev/null || echo "")
@@ -492,6 +510,13 @@ cmd_playbook_scan() {
         continue ;;
     esac
 
+    local entry_file
+    if [ "$from_repo" = "1" ]; then
+      entry_file="$f"
+    else
+      entry_file="playbooks/$basename"
+    fi
+
     local entry
     entry=$(jq -n \
       --arg name "$name" \
@@ -506,7 +531,7 @@ cmd_playbook_scan() {
       --arg runner "$runner" \
       --arg script "$script" \
       --argjson inputs "$inputs" \
-      --arg file "playbooks/$basename" \
+      --arg file "$entry_file" \
       '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, inputs:$inputs, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
@@ -562,7 +587,7 @@ cmd_playbook_scan() {
   mv "$registry_tmp" "$registry_file"
 
   echo ""
-  echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped)"
+  echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed)"
   echo "Wrote: $registry_file"
 
   _playbook_sync_bins "$new_registry"
@@ -975,7 +1000,12 @@ cmd_playbook_info() {
 
   local playbook_file
   playbook_file=$(echo "$entry" | jq -r '.file')
-  local full_path="$CEO_DIR/$playbook_file"
+  local full_path
+  if [[ "$playbook_file" = /* ]]; then
+    full_path="$playbook_file"
+  else
+    full_path="$CEO_DIR/$playbook_file"
+  fi
   if [ -f "$full_path" ]; then
     echo ""
     echo "--- Body ---"
@@ -1024,7 +1054,12 @@ cmd_chat() {
     local playbook_rel
     playbook_rel=$(echo "$entry" | jq -r '.file')
     model=$(echo "$entry" | jq -r '.model // "sonnet"')
-    local playbook_file="$CEO_DIR/$playbook_rel"
+    local playbook_file
+    if [[ "$playbook_rel" = /* ]]; then
+      playbook_file="$playbook_rel"
+    else
+      playbook_file="$CEO_DIR/$playbook_rel"
+    fi
 
     if [ ! -f "$playbook_file" ]; then
       echo "Playbook file not found: $playbook_file"

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -438,12 +438,16 @@ cmd_playbook_scan() {
   local seen_names=""
   local shadowed=0
 
-  for f in "$playbook_dir"/*.md "$repo_playbook_dir"/*.md; do
-    [ -f "$f" ] || continue
+  local scan_dirs=( "$playbook_dir" )
+  [ -d "$repo_playbook_dir" ] && scan_dirs+=( "$repo_playbook_dir" )
+
+  for d in "${scan_dirs[@]}"; do
+    for f in "$d"/*.md; do
+      [ -f "$f" ] || continue
     local basename
     basename=$(basename "$f")
     local from_repo=0
-    [[ "$f" == "$repo_playbook_dir"/* ]] && from_repo=1
+    [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
     local name description trigger schedule model preflight tier status bin runner script inputs
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
@@ -453,7 +457,7 @@ cmd_playbook_scan() {
       continue
     fi
 
-    if echo "$seen_names" | tr ' ' '\n' | grep -qx "$name"; then
+    if grep -qxF "$name" <<< "$seen_names"; then
       if [ "$from_repo" = "1" ]; then
         echo "  SHADOW $basename (vault override of repo playbook '$name')"
         shadowed=$((shadowed + 1))
@@ -463,7 +467,7 @@ cmd_playbook_scan() {
       fi
       continue
     fi
-    seen_names="$seen_names $name"
+    seen_names="${seen_names}${name}"$'\n'
 
     description=$(yq --front-matter=extract '.description // ""' "$f" 2>/dev/null || echo "")
     trigger=$(yq --front-matter=extract '.trigger // ""' "$f" 2>/dev/null || echo "")
@@ -536,6 +540,7 @@ cmd_playbook_scan() {
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))
+    done
   done
 
   # Compare old vs new

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -294,7 +294,11 @@ if [ "$TRIGGER_TYPE" = "chat" ]; then
   exit 0
 fi
 
-PLAYBOOK_FILE="$CEO_DIR/$PLAYBOOK_REL"
+if [[ "$PLAYBOOK_REL" = /* ]]; then
+  PLAYBOOK_FILE="$PLAYBOOK_REL"
+else
+  PLAYBOOK_FILE="$CEO_DIR/$PLAYBOOK_REL"
+fi
 _v "Playbook: $PLAYBOOK_REL (model: $MODEL, preflight: $PREFLIGHT, status: $STATUS)"
 
 if [ ! -f "$PLAYBOOK_FILE" ]; then

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1116,6 +1116,72 @@ PB
   assert_contains "$prompt" "PRs requesting review:" "non-array inputs must default to all (pr_data present)"
 }
 
+test_repo_playbook_auto_registers_with_absolute_file_path() {
+  local repo_dir="$SCRIPT_DIR/../docs/playbooks"
+  local repo_pb="$repo_dir/_test-repo-pb.md"
+  mkdir -p "$repo_dir"
+  cat > "$repo_pb" << 'PB'
+---
+name: _test-repo-pb
+description: Repo-side playbook for scan test
+trigger: chat
+preflight: none
+tier: read
+status: active
+---
+PB
+
+  local out
+  out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  rm -f "$repo_pb"
+
+  assert_contains "$out" "ADD   _test-repo-pb" "repo playbook must be picked up by scan"
+
+  local file_field
+  file_field=$(jq -r '.playbooks[] | select(.name=="_test-repo-pb") | .file' "$CEO_DIR/registry.json")
+  assert_eq "${file_field:0:1}" "/" "repo playbook .file must be absolute"
+  assert_contains "$file_field" "docs/playbooks/_test-repo-pb.md" "repo playbook .file must point at repo path"
+}
+
+test_vault_playbook_shadows_repo_playbook_with_same_name() {
+  local repo_dir="$SCRIPT_DIR/../docs/playbooks"
+  local repo_pb="$repo_dir/_test-shadow.md"
+  mkdir -p "$repo_dir"
+  cat > "$repo_pb" << 'PB'
+---
+name: _test-shadow
+description: Repo version
+trigger: chat
+preflight: none
+tier: read
+status: active
+---
+PB
+
+  cat > "$CEO_DIR/playbooks/_test-shadow.md" << 'PB'
+---
+name: _test-shadow
+description: Vault override
+trigger: chat
+preflight: none
+tier: read
+status: inactive
+---
+PB
+
+  local out
+  out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  rm -f "$repo_pb"
+
+  assert_contains "$out" "SHADOW" "scan must report shadowing"
+
+  local desc status
+  desc=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .description' "$CEO_DIR/registry.json")
+  status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$CEO_DIR/registry.json")
+  assert_eq "$desc" "Vault override" "vault entry must win on collision"
+  assert_eq "$status" "inactive" "vault status must override repo status"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -88,6 +88,7 @@ STUB
 
 teardown() {
   rm -rf "$TEST_HOME"
+  rm -f "$SCRIPT_DIR/../docs/playbooks/"_test-*.md
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
   unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -88,10 +88,9 @@ STUB
 
 teardown() {
   rm -rf "$TEST_HOME"
-  rm -f "$SCRIPT_DIR/../docs/playbooks/"_test-*.md
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR
 }
 
 test_runner_script_execs_named_script_and_skips_claude() {
@@ -1118,9 +1117,10 @@ PB
 }
 
 test_repo_playbook_auto_registers_with_absolute_file_path() {
-  local repo_dir="$SCRIPT_DIR/../docs/playbooks"
+  local repo_dir="$TEST_HOME/repo-pb"
   local repo_pb="$repo_dir/_test-repo-pb.md"
   mkdir -p "$repo_dir"
+  export CEO_REPO_PLAYBOOK_DIR="$repo_dir"
   cat > "$repo_pb" << 'PB'
 ---
 name: _test-repo-pb
@@ -1134,20 +1134,21 @@ PB
 
   local out
   out=$(bash "$CEO_CLI" playbook scan 2>&1)
-  rm -f "$repo_pb"
+  unset CEO_REPO_PLAYBOOK_DIR
 
   assert_contains "$out" "ADD   _test-repo-pb" "repo playbook must be picked up by scan"
 
   local file_field
   file_field=$(jq -r '.playbooks[] | select(.name=="_test-repo-pb") | .file' "$CEO_DIR/registry.json")
   assert_eq "${file_field:0:1}" "/" "repo playbook .file must be absolute"
-  assert_contains "$file_field" "docs/playbooks/_test-repo-pb.md" "repo playbook .file must point at repo path"
+  assert_contains "$file_field" "_test-repo-pb.md" "repo playbook .file must point at repo path"
 }
 
 test_vault_playbook_shadows_repo_playbook_with_same_name() {
-  local repo_dir="$SCRIPT_DIR/../docs/playbooks"
+  local repo_dir="$TEST_HOME/repo-pb"
   local repo_pb="$repo_dir/_test-shadow.md"
   mkdir -p "$repo_dir"
+  export CEO_REPO_PLAYBOOK_DIR="$repo_dir"
   cat > "$repo_pb" << 'PB'
 ---
 name: _test-shadow
@@ -1172,7 +1173,7 @@ PB
 
   local out
   out=$(bash "$CEO_CLI" playbook scan 2>&1)
-  rm -f "$repo_pb"
+  unset CEO_REPO_PLAYBOOK_DIR
 
   assert_contains "$out" "SHADOW" "scan must report shadowing"
 
@@ -1181,6 +1182,43 @@ PB
   status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$CEO_DIR/registry.json")
   assert_eq "$desc" "Vault override" "vault entry must win on collision"
   assert_eq "$status" "inactive" "vault status must override repo status"
+}
+
+test_repo_internal_duplicate_logs_dup_not_shadow() {
+  local repo_dir="$TEST_HOME/repo-pb"
+  mkdir -p "$repo_dir"
+  export CEO_REPO_PLAYBOOK_DIR="$repo_dir"
+
+  cat > "$repo_dir/_test-twin-a.md" << 'PB'
+---
+name: _test-twin
+description: First repo file
+trigger: chat
+preflight: none
+tier: read
+status: active
+---
+PB
+  cat > "$repo_dir/_test-twin-b.md" << 'PB'
+---
+name: _test-twin
+description: Second repo file
+trigger: chat
+preflight: none
+tier: read
+status: active
+---
+PB
+
+  local out
+  out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  unset CEO_REPO_PLAYBOOK_DIR
+
+  assert_contains "$out" "DUP" "two repo files with same name must log DUP"
+  if [[ "$out" == *"SHADOW"* ]]; then
+    printf '  FAIL [%s] repo-internal dup must NOT log SHADOW (no vault override exists)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
 }
 
 run_tests() {


### PR DESCRIPTION
## Summary

Removes the manual `cp` + re-scan friction for distributing playbooks that ship with the repo. `ceo playbook scan` now reads `$CEO_DIR/playbooks/` AND `$INSTALL_DIR/docs/playbooks/`. Vault entries shadow same-named repo entries (local-override pattern). The surfacing case was `token-intake` — its install instructions used to literally say `cp docs/playbooks/token-intake.md "$CEO_VAULT/CEO/playbooks/" && ceo playbook scan` and got out-of-date on every change.

## Behavior

- **Scan order:** vault first, then repo. Vault wins on `name` collision (logs `SHADOW`), repo same-name dups log `DUP` and skip.
- **Registry `.file`:** vault entries stay relative (`playbooks/<basename>`). Repo entries store an absolute path. Consumers (`ceo` x2, `ceo-cron.sh` x1) accept both.
- **Cron staleness:** repo-playbook crontab entries bake in `$INSTALL_DIR`. Re-scan after a re-clone or worktree move to refresh. Documented in `docs/playbooks/token-intake.md`.

## Tests

- 2 new tests in `scripts/ceo-cron.test.sh`:
  - `test_repo_playbook_auto_registers_with_absolute_file_path`
  - `test_vault_playbook_shadows_repo_playbook_with_same_name`
- Verified the new tests fail (4 failures) when `scripts/ceo` is reverted to `main`.
- Full suite passes: 88 tests across 6 files.
- Sandbox test with regex-meta name `foo.*bar` confirms fixed-string dedup.

## Audit pass

Pre-commit audit caught and fixed:
- Test file leak on mid-test abort → unconditional cleanup + teardown safety net
- `seen_names` dedup using regex grep → `grep -qxF` (fixed-string), newline-separated
- Unguarded `$repo_playbook_dir` glob → conditional `scan_dirs` array

## Test plan

- [ ] On a host where the repo is at a known path, run `ceo playbook scan`. Confirm `token-intake` registers and points at `<repo>/docs/playbooks/token-intake.md`.
- [ ] Drop a vault file at `$CEO_VAULT/CEO/playbooks/token-intake.md` with `status: inactive`. Re-scan. Confirm `SHADOW` log and that the registry reflects the vault version.
- [ ] Move the repo (or worktree) to a new path. Re-run `ceo playbook scan`. Confirm crontab entries point at the new path.