### PR TITLE
fix(token-intake): per-OS PATH + propagate capture failures

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -112,7 +112,17 @@ ceo_require_vault() {
 ceo_augment_path() {
   [ -n "${_CEO_PATH_AUGMENTED:-}" ] && return 0
   : "${HOME:?HOME must be set before ceo_augment_path}"
-  export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+  case "$(ceo_detect_os)" in
+    macos)
+      export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+      ;;
+    wsl|linux)
+      export PATH="$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:/usr/local/bin:$PATH"
+      ;;
+    *)
+      export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+      ;;
+  esac
   export _CEO_PATH_AUGMENTED=1
 }
 

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -120,6 +120,7 @@ ceo_augment_path() {
       export PATH="$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:/usr/local/bin:$PATH"
       ;;
     *)
+      # Minimal trusted set when OS detection fails — do not normalize-merge with the branches above.
       export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
       ;;
   esac

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -39,16 +39,29 @@ INBOX_LINE="- [ ] Review daily token report $WIKILINK"
 mkdir -p "$TOKEN_DIR" "$INBOX_DIR"
 
 # capture <label> <cmd> [args...] — run a command and wrap its output in a fenced block.
-# Falls back to "<cmd> unavailable" so the inbox link always resolves to readable content.
+# Writes a sentinel into the report on failure so the link resolves to readable
+# content, AND returns non-zero so the script exits non-zero and ceo-cron records
+# a failure (otherwise a missing/broken binary leaves cron telemetry green).
+CAPTURE_FAILED=0
 capture() {
   local label="$1"; shift
+  local cmd="$1"
   printf '\n## %s\n\n```\n' "$label"
-  if command -v "$1" >/dev/null 2>&1; then
-    "$@" 2>&1 || printf '\n[command exited non-zero]\n'
-  else
-    printf '%s unavailable on PATH=%s\n' "$1" "$PATH"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    printf '%s unavailable on PATH=%s\n' "$cmd" "$PATH"
+    printf '```\n'
+    echo "ERROR: capture: '$cmd' not on PATH" >&2
+    CAPTURE_FAILED=1
+    return 0
   fi
+  local rc=0
+  "$@" 2>&1 || rc=$?
   printf '```\n'
+  if [ "$rc" -ne 0 ]; then
+    echo "ERROR: capture: '$cmd' exited $rc" >&2
+    CAPTURE_FAILED=1
+  fi
+  return 0
 }
 
 if ! {
@@ -63,6 +76,10 @@ if ! {
   exit 1
 fi
 [ -s "$REPORT_FILE" ] || { echo "ERROR: empty report $REPORT_FILE" >&2; exit 1; }
+if [ "$CAPTURE_FAILED" -ne 0 ]; then
+  echo "ERROR: one or more capture commands failed; see report $REPORT_FILE" >&2
+  exit 1
+fi
 
 # Idempotently append the inbox line. Dedupe on the wikilink target
 # rather than the full line so a `[x]` checkoff doesn't re-trigger the

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -196,6 +196,73 @@ EOF
     "rtk must see HOME=$pinned (resolver target), not the sandbox HOME the caller passed"
 }
 
+test_exits_nonzero_when_capture_command_missing() {
+  rm -f "$TEST_HOME/.bun/bin/token-scope"
+  local rc=0
+  bash "$INTAKE" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] script must exit non-zero when a capture binary is missing\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ -f "$CEO_DIR/inbox/$CEO_HOSTNAME.md" ] && grep -qF "[[CEO/reports/token/" "$CEO_DIR/inbox/$CEO_HOSTNAME.md"; then
+    printf '  FAIL [%s] inbox must NOT have a line when capture failed\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  local today report
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
+  if [ -f "$report" ] && ! grep -qF "unavailable on PATH=" "$report"; then
+    printf '  FAIL [%s] report must record the missing-binary sentinel for forensics\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_exits_nonzero_when_capture_command_fails() {
+  cat > "$TEST_HOME/.bun/bin/rtk" << 'STUB'
+#!/bin/bash
+echo "boom: simulated failure" >&2
+exit 7
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/rtk"
+  local rc=0
+  bash "$INTAKE" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] script must exit non-zero when a capture command exits non-zero\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ -f "$CEO_DIR/inbox/$CEO_HOSTNAME.md" ] && grep -qF "[[CEO/reports/token/" "$CEO_DIR/inbox/$CEO_HOSTNAME.md"; then
+    printf '  FAIL [%s] inbox must NOT have a line when capture failed\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_augment_path_branches_per_os() {
+  # shellcheck source=ceo-config.sh
+  source "$SCRIPT_DIR/ceo-config.sh"
+  local got
+  unset _CEO_PATH_AUGMENTED
+  PATH="/usr/bin:/bin"
+  ceo_detect_os() { echo "wsl"; }
+  ceo_augment_path
+  got="$PATH"
+  if [[ "$got" == *"/opt/homebrew/bin"* ]]; then
+    printf '  FAIL [%s] wsl branch must NOT prepend /opt/homebrew/bin\n    got: %q\n' "$CURRENT_TEST" "$got"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$got" "$HOME/.bun/bin" "wsl branch must include \$HOME/.bun/bin"
+  assert_contains "$got" "$HOME/.local/bin" "wsl branch must include \$HOME/.local/bin"
+
+  unset _CEO_PATH_AUGMENTED
+  PATH="/usr/bin:/bin"
+  ceo_detect_os() { echo "macos"; }
+  ceo_augment_path
+  got="$PATH"
+  assert_contains "$got" "/opt/homebrew/bin" "macos branch must include /opt/homebrew/bin"
+  assert_contains "$got" "$HOME/.bun/bin" "macos branch must include \$HOME/.bun/bin"
+  unset _CEO_PATH_AUGMENTED
+  unset -f ceo_detect_os
+}
+
 test_aborts_on_unwritable_report_dir() {
   if [ "$(id -u)" = "0" ]; then
     return 0


### PR DESCRIPTION
Closes #14
Closes #12

## Description (Issue Fixed & New Behavior)

Two related fixes in `ceo-token-intake.sh` and `ceo-config.sh`:

1. **`ceo_augment_path` is now per-OS** (closes #14). The macOS-tuned prefix list (`/opt/homebrew/bin`, `$HOME/.bun/bin`, `/usr/local/bin`, `$HOME/.local/bin`) was a no-op on WSL/Linux, so a binary installed under `$HOME/.bun/bin` or `$HOME/.cargo/bin` on WSL never resolved and `capture()` printed `<cmd> unavailable on PATH=...` into the report. Now branches on `ceo_detect_os`:
   - `macos` → `$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.cargo/bin`
   - `wsl|linux` → `$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:/usr/local/bin`
   - `unknown` → `$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin`

2. **`capture()` no longer swallows failures** (closes #12). Missing binary and non-zero exit both still write a sentinel into the report (so the inbox link resolves to forensic content) but now flag `CAPTURE_FAILED=1`. The script exits 1 at the end if any capture failed, which means `ceo-cron.sh:353` records `_record_failure`, increments `.fail-count`, and the `≥3 fails → approvals/pending.md` alert path can fire. Previously the inbox line was appended unconditionally and cron telemetry stayed green even with a fully degenerate report.

## Testing Procedure

1. Check out the branch in a worktree of `claude-ceo`.
2. Run `bash scripts/ceo-token-intake.test.sh` — all 11 tests pass (8 pre-existing + 3 new).
3. Run `bash scripts/ceo-config.test.sh` — all 19 tests pass.
4. Verify regression coverage by reverting either fix:
   - Revert the `capture()` change → `test_exits_nonzero_when_capture_command_missing` and `test_exits_nonzero_when_capture_command_fails` fail.
   - Revert the per-OS branch → `test_augment_path_branches_per_os` fails (wsl branch leaks `/opt/homebrew/bin`).
5. On WSL, run the morning report manually (`bash scripts/ceo-token-intake.sh`) and confirm the report contains real `token-scope` output instead of `token-scope unavailable on PATH=...`.

## Additional Notes / HelpScout Tickets

Symptom surfaced via the daily CEO morning report on WSL emitting `token-scope unavailable on PATH=/home/nhang/.bun/bin:/opt/homebrew/bin:...` — the WSL host had token-scope installed but the macOS-tuned `ceo_augment_path` prefix list never reached the right directory, and the silent-success path made it invisible to cron telemetry.