### PR TITLE
brief: clarify merged-PR line reflects user-authored PRs only

### DIFF
--- a/skills/ceo/brief/SKILL.md
+++ b/skills/ceo/brief/SKILL.md
@@ -53,7 +53,7 @@ weekly_merges_dir: Awesome Motive/weekly-merges/
 
 9. **Read today's daily note** — if `$VAULT/Daily/YYYY-MM-DD.md` exists, read Top 3 and Tasks sections.
 
-10. **Read merged-PR trend** — surface a single line summarizing weekly merged-PR activity from the `am-weekly-merges` (external producer skill) INDEX files.
+10. **Read merged-PR trend** — surface a single line summarizing the user's own weekly merged-PR activity from the `am-weekly-merges` (external producer skill) INDEX files. The producer counts **PRs authored by its configured `gh` user that landed during the window** — not PRs merged on others' behalf, not tickets, not reviews. Render the line as first-person ("My merged PRs ...") to reflect that scope.
 
     **10a. Compute `<current-quarter>`** from today's UTC date as `YYYY-QN` (Q1=Jan–Mar, Q2=Apr–Jun, Q3=Jul–Sep, Q4=Oct–Dec). UTC is required so the value matches the `generated` timestamp in INDEX frontmatter. If current is Q1, the previous quarter is `(YYYY-1)-Q4`.
 
@@ -77,10 +77,10 @@ weekly_merges_dir: Awesome Motive/weekly-merges/
     **10e. Skip / diagnostic guards** (mirror the `if file exists` shape used in steps 8–9):
     - If neither `CURRENT` nor `PREVIOUS` exists: skip the line entirely.
     - If `CURRENT` exists with `latest_week == "none"` AND `PREVIOUS` is absent or also `latest_week == "none"`: skip the line.
-    - If `yq` fails to parse either file's frontmatter: emit a muted diagnostic line instead of silent-skip — `Merged PRs: (index frontmatter unreadable for <file>)`. A stalled producer cron must be distinguishable from a genuine no-merges week.
+    - If `yq` fails to parse either file's frontmatter: emit a muted diagnostic line instead of silent-skip — `My merged PRs: (index frontmatter unreadable for <file>)`. A stalled producer cron must be distinguishable from a genuine no-merges week.
 
     **10f. Render** the merged line (single template, no `==4` special case):
-    `Merged PRs (last week, {latest_week}): {latest_count} — {rolling_avg_n}wk avg {rolling_avg_4w}`
+    `My merged PRs (last week, {latest_week}): {latest_count} — {rolling_avg_n}wk avg {rolling_avg_4w}`
 
 11. **Write brief** — create or append to `$VAULT/CEO/log/YYYY-MM-DD.md`:
 


### PR DESCRIPTION
Closes #none

## Description

The `am-weekly-merges` producer queries `gh search prs --author=<user> --merged`, so the count in the INDEX frontmatter represents PRs the user **authored** that landed during the window — not PRs they merged on someone else's behalf, not tickets, not code-review activity.

Step 10's rendered line previously read `Merged PRs (last week, ...)`, which is ambiguous (could be read as "PRs you merged" by a generous reader). Update to `My merged PRs (last week, ...)` so the scope matches the data.

Also updates the Step 10 description and the `yq`-parse-failure diagnostic to read `My merged PRs:` for consistency.

## Testing Procedure

1. Check out this branch.
2. Confirm `~/Documents/Obsidian/Awesome Motive/weekly-merges/INDEX-2026-Q2.md` exists with frontmatter populated.
3. In a fresh Claude Code session, invoke the brief.
4. Verify the brief output contains a line of the shape `My merged PRs (last week, ...): N — Nwk avg N.N` (not `Merged PRs ...`).
5. Temporarily corrupt the INDEX frontmatter and rerun: verify the diagnostic line reads `My merged PRs: (index frontmatter unreadable for <file>)`.

## Additional Notes

Producer-side wording also updated in the personal `am-weekly-merges` skill (untracked, lives in OM `wp-content/.claude/skills/`). Per-week note titles now read `My AwesomeMotive merged PRs — week of <date>` and the INDEX H1 reads `My AM merged PRs — <quarter>`. Backfilled W14–W20 of 2026-Q2 with corrected counts and new wording.