### PR TITLE
feat(dispatcher): add ollama and ollama-think runners

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -525,9 +525,9 @@ cmd_playbook_scan() {
     esac
 
     case "$runner" in
-      ""|claude|script) ;;
+      ""|claude|script|ollama|ollama-think) ;;
       *)
-        echo "  SKIP  $basename (unknown runner: '$runner', expected: claude|script)"
+        echo "  SKIP  $basename (unknown runner: '$runner', expected: claude|script|ollama|ollama-think)"
         skipped=$((skipped + 1))
         continue ;;
     esac

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -369,21 +369,18 @@ if [ "$RUNNER" = "script" ]; then
 fi
 
 # --- Ollama-runner branch: route playbook body to a local ollama model ---
-# One-shot prompt-in / text-out. No multi-turn chat, no AGENTS.md / IDENTITY.md
-# / TRAINING.md context injection — playbook body is the entire prompt. Use
-# this for cron-batch playbooks (classifiers, digests, summarizers) where the
-# token saving justifies giving up the CEO context preamble.
+# One-shot prompt-in / text-out; no AGENTS.md / IDENTITY.md / TRAINING.md preamble.
 if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
   if ! command -v ollama >/dev/null 2>&1; then
     _record_failure "ollama binary not found on PATH (playbook: $TRIGGER)"
     exit 1
   fi
-  # Daemon presence ≠ binary presence (per command-v-presence-vs-success).
-  # Skip the probe under tests (stubbed ollama on PATH won't have a daemon).
-  if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ] && ! command -v curl >/dev/null 2>&1; then
-    _v "WARNING: curl not available, skipping ollama daemon probe"
-  elif [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
-    if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+  if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
+    if ! command -v curl >/dev/null 2>&1; then
+      _record_failure "curl not available — cannot probe ollama daemon (playbook: $TRIGGER)"
+      exit 1
+    fi
+    if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>>"$LOG_DIR/cron-stderr.log"; then
       _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
       exit 1
     fi

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -402,6 +402,11 @@ if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
     _record_failure "ollama exited $OLLAMA_EXIT for $TRIGGER (model: $OLLAMA_MODEL)"
     exit "$OLLAMA_EXIT"
   fi
+  if [ -z "$(printf '%s' "$OLLAMA_OUT" | tr -d '[:space:]')" ]; then
+    _v "FAILED (empty output)"
+    _record_failure "ollama returned empty output for $TRIGGER (model: $OLLAMA_MODEL)"
+    exit 1
+  fi
   printf '\n## %s — %s (model: %s)\n\n%s\n' "$NOW" "$TRIGGER" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_FILE"
   _record_success
   exit 0

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -266,9 +266,9 @@ TIER=$(echo "$ENTRY" | jq -r '.tier // "read"')
 RUNNER=$(echo "$ENTRY" | jq -r '.runner // ""')
 [ -z "$RUNNER" ] && RUNNER="claude"
 case "$RUNNER" in
-  claude|script) ;;
+  claude|script|ollama|ollama-think) ;;
   *)
-    _record_failure "Unknown runner '$RUNNER' for $TRIGGER (expected: claude|script)"
+    _record_failure "Unknown runner '$RUNNER' for $TRIGGER (expected: claude|script|ollama|ollama-think)"
     exit 1 ;;
 esac
 SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
@@ -326,6 +326,17 @@ else
   _v "WARNING: Unknown preflight '$PREFLIGHT' — running anyway"
 fi
 
+# --- Shared file-read helper (used by ollama branch and claude tier blocks below) ---
+MAX_FILE_SIZE=10000  # 10KB max per context file
+
+safe_read() {
+  local file="$1"
+  local max="$2"
+  if [ -f "$file" ]; then
+    head -c "$max" "$file"
+  fi
+}
+
 # --- Script-runner branch: exec named script, skip claude --print ---
 if [ "$RUNNER" = "script" ]; then
   if [ -z "$SCRIPT_PATH" ]; then
@@ -357,17 +368,52 @@ if [ "$RUNNER" = "script" ]; then
   exit 0
 fi
 
-# --- Read context files (with size limits for injection safety) ---
-MAX_FILE_SIZE=10000  # 10KB max per context file
-
-safe_read() {
-  local file="$1"
-  local max="$2"
-  if [ -f "$file" ]; then
-    head -c "$max" "$file"
+# --- Ollama-runner branch: route playbook body to a local ollama model ---
+# One-shot prompt-in / text-out. No multi-turn chat, no AGENTS.md / IDENTITY.md
+# / TRAINING.md context injection — playbook body is the entire prompt. Use
+# this for cron-batch playbooks (classifiers, digests, summarizers) where the
+# token saving justifies giving up the CEO context preamble.
+if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
+  if ! command -v ollama >/dev/null 2>&1; then
+    _record_failure "ollama binary not found on PATH (playbook: $TRIGGER)"
+    exit 1
   fi
-}
+  # Daemon presence ≠ binary presence (per command-v-presence-vs-success).
+  # Skip the probe under tests (stubbed ollama on PATH won't have a daemon).
+  if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ] && ! command -v curl >/dev/null 2>&1; then
+    _v "WARNING: curl not available, skipping ollama daemon probe"
+  elif [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
+    if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+      _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
+      exit 1
+    fi
+  fi
+  # Resolve model: explicit playbook tag wins. Scanner writes "" for missing
+  # model (ceo:493) and jq `// "sonnet"` only fires on null — so both "" and
+  # "sonnet" mean "no override, use runner default".
+  if [ -z "$MODEL" ] || [ "$MODEL" = "sonnet" ]; then
+    case "$RUNNER" in
+      ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
+      ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
+    esac
+  else
+    OLLAMA_MODEL="$MODEL"
+  fi
+  _v "Runner: $RUNNER — model: $OLLAMA_MODEL"
+  OLLAMA_PROMPT=$(safe_read "$PLAYBOOK_FILE" "$MAX_FILE_SIZE")
+  OLLAMA_EXIT=0
+  OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | ollama run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
+  if [ "$OLLAMA_EXIT" -ne 0 ]; then
+    _v "FAILED (exit: $OLLAMA_EXIT)"
+    _record_failure "ollama exited $OLLAMA_EXIT for $TRIGGER (model: $OLLAMA_MODEL)"
+    exit "$OLLAMA_EXIT"
+  fi
+  printf '\n## %s — %s (model: %s)\n\n%s\n' "$NOW" "$TRIGGER" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_FILE"
+  _record_success
+  exit 0
+fi
 
+# --- Read context files (with size limits for injection safety) ---
 AGENTS_CONTENT=$(safe_read "$CEO_DIR/AGENTS.md" "$MAX_FILE_SIZE")
 IDENTITY_CONTENT=$(safe_read "$CEO_DIR/IDENTITY.md" "$MAX_FILE_SIZE")
 TRAINING_CONTENT=$(safe_read "$CEO_DIR/TRAINING.md" "$MAX_FILE_SIZE")

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -258,7 +258,7 @@ if [ -z "$ENTRY" ]; then
 fi
 
 PLAYBOOK_REL=$(echo "$ENTRY" | jq -r '.file')
-MODEL=$(echo "$ENTRY" | jq -r '.model // "sonnet"')
+MODEL=$(echo "$ENTRY" | jq -r '.model // ""')
 PREFLIGHT=$(echo "$ENTRY" | jq -r '.preflight // "none"')
 STATUS=$(echo "$ENTRY" | jq -r '.status // "active"')
 TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
@@ -388,10 +388,7 @@ if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
       exit 1
     fi
   fi
-  # Resolve model: explicit playbook tag wins. Scanner writes "" for missing
-  # model (ceo:493) and jq `// "sonnet"` only fires on null — so both "" and
-  # "sonnet" mean "no override, use runner default".
-  if [ -z "$MODEL" ] || [ "$MODEL" = "sonnet" ]; then
+  if [ -z "$MODEL" ]; then
     case "$RUNNER" in
       ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
       ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
@@ -412,6 +409,8 @@ if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
   _record_success
   exit 0
 fi
+
+MODEL="${MODEL:-sonnet}"
 
 # --- Read context files (with size limits for injection safety) ---
 AGENTS_CONTENT=$(safe_read "$CEO_DIR/AGENTS.md" "$MAX_FILE_SIZE")

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -698,6 +698,43 @@ STUB
   fi
 }
 
+test_runner_ollama_empty_output_records_failure() {
+  cat > "$CEO_DIR/playbooks/ollama-empty.md" << 'PB'
+---
+name: ollama-empty
+description: ollama exits 0 but emits nothing
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+#!/bin/bash
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/ollama"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-empty >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "empty ollama output must increment FAIL_COUNT_FILE (alert threshold relies on this)"
+
+  local runs_log
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  if [[ "$runs_log" == *"ollama-empty completed"* ]]; then
+    printf '  FAIL [%s] empty ollama output must NOT log completed\n    runs_log: %q\n' \
+      "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 test_runner_ollama_works_under_stripped_path() {
   cat > "$CEO_DIR/playbooks/ollama-strip.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -42,6 +42,9 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
+  # Bypass the ollama daemon HTTP probe in tests (the stubbed ollama binary
+  # has no daemon backing it). Production runs leave this unset.
+  export CEO_OLLAMA_SKIP_PROBE=1
 
   mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports"
   : > "$CEO_DIR/AGENTS.md"
@@ -72,6 +75,20 @@ echo "ACTION: 1 | read | noop | n/a"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/claude"
 
+  # Stub ollama on PATH for runner:ollama / runner:ollama-think tests. Captures
+  # the model argument so tests can assert which model was dispatched.
+  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+#!/bin/bash
+if [ "${1:-}" = "run" ]; then
+  echo "$2" > "$HOME/ollama-invoked-model.txt"
+  cat > "$HOME/ollama-invoked-prompt.txt"
+  echo "ollama-stub-response"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/ollama"
+
   # macOS lacks `timeout` from GNU coreutils; the dispatcher uses
   # `timeout N claude ...`. Stub it as a transparent passthrough.
   if ! command -v timeout >/dev/null 2>&1; then
@@ -90,7 +107,7 @@ teardown() {
   rm -rf "$TEST_HOME"
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR
+  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR CEO_OLLAMA_SKIP_PROBE
 }
 
 test_runner_script_execs_named_script_and_skips_claude() {
@@ -438,6 +455,185 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Unknown runner 'scrpt'" "skips log must record unknown-runner rejection"
+}
+
+test_runner_ollama_accepted_at_scan() {
+  cat > "$CEO_DIR/playbooks/ollama-ok.md" << 'PB'
+---
+name: ollama-ok
+description: Playbook with runner:ollama
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+PB
+
+  local scan_out
+  scan_out=$(bash "$CEO_CLI" playbook scan 2>&1 || true)
+  if [[ "$scan_out" == *"unknown runner: 'ollama'"* ]]; then
+    printf '  FAIL [%s] runner:ollama must be accepted at scan\n    scan_out: %q\n' \
+      "$CURRENT_TEST" "$scan_out"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local entry
+  entry=$(jq -r '.playbooks[] | select(.name=="ollama-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  assert_eq "$entry" "ollama" "ollama playbook must be registered with runner:ollama"
+}
+
+test_runner_ollama_invokes_ollama_and_skips_claude() {
+  cat > "$CEO_DIR/playbooks/ollama-dispatch.md" << 'PB'
+---
+name: ollama-dispatch
+description: Routes to ollama
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" ollama-dispatch >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "dispatcher must exit 0 on ollama success"
+
+  assert_file_exists "$HOME/ollama-invoked-model.txt" "ollama must have been invoked"
+  if [ -f "$HOME/claude-invoked.txt" ]; then
+    printf '  FAIL [%s] claude was invoked but the ollama-runner branch must skip it\n' \
+      "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local model
+  model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$model" "mistral-small3.2:24b" "runner:ollama default must be mistral-small3.2:24b"
+}
+
+test_runner_ollama_think_uses_gpt_oss_default() {
+  cat > "$CEO_DIR/playbooks/ollama-think-dispatch.md" << 'PB'
+---
+name: ollama-think-dispatch
+description: Routes to ollama-think
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama-think
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" ollama-think-dispatch >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "dispatcher must exit 0 on ollama-think success"
+
+  local model
+  model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$model" "gpt-oss:20b" "runner:ollama-think default must be gpt-oss:20b"
+}
+
+test_runner_ollama_explicit_model_overrides_default() {
+  cat > "$CEO_DIR/playbooks/ollama-explicit.md" << 'PB'
+---
+name: ollama-explicit
+description: Explicit model override
+trigger: cron
+schedule: "0 9 * * *"
+model: qwen3:14b
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" ollama-explicit >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "dispatcher must exit 0 with explicit ollama model"
+
+  local model
+  model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$model" "qwen3:14b" "explicit model: tag must override runner default"
+}
+
+test_runner_ollama_failure_increments_fail_count() {
+  cat > "$CEO_DIR/playbooks/ollama-fail.md" << 'PB'
+---
+name: ollama-fail
+description: ollama exits non-zero
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  # Override the default ollama stub for this test to simulate failure.
+  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+#!/bin/bash
+echo "ollama-error-sentinel" >&2
+exit 9
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/ollama"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-fail >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after ollama failure"
+
+  # Pin: failure must come from the ollama branch specifically. cron-runs.log must
+  # NOT contain a completion line for this playbook — that's what proves the
+  # ollama branch (not an earlier preflight/schema/missing-file path) failed.
+  local runs_log
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  if [[ "$runs_log" == *"ollama-fail completed"* ]]; then
+    printf '  FAIL [%s] ollama failure must NOT log completed\n    runs_log: %q\n' \
+      "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "ollama-error-sentinel" "ollama stderr must be appended to cron-stderr.log"
+}
+
+test_runner_ollama_works_under_stripped_path() {
+  cat > "$CEO_DIR/playbooks/ollama-strip.md" << 'PB'
+---
+name: ollama-strip
+description: ollama dispatch under stripped PATH (proves ceo_augment_path reaches branch)
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local rc=0
+  PATH=/usr/bin:/bin bash "$CRON" ollama-strip >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ollama branch must resolve ollama via ceo_augment_path under stripped PATH"
+  assert_file_exists "$HOME/ollama-invoked-model.txt" "ollama stub must fire under stripped PATH"
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -664,6 +664,40 @@ PB
   assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to mistral default)"
 }
 
+test_runner_ollama_daemon_unreachable_records_failure() {
+  cat > "$CEO_DIR/playbooks/ollama-noprobe.md" << 'PB'
+---
+name: ollama-noprobe
+description: Daemon probe enabled, curl fails
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+exit 7
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  env -u CEO_OLLAMA_SKIP_PROBE CEO_VERBOSE=1 bash "$CRON" ollama-noprobe >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "unreachable ollama daemon must increment FAIL_COUNT_FILE"
+
+  if [ -f "$HOME/ollama-invoked-model.txt" ]; then
+    printf '  FAIL [%s] ollama must NOT be invoked when daemon probe fails\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 test_runner_ollama_works_under_stripped_path() {
   cat > "$CEO_DIR/playbooks/ollama-strip.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -613,6 +613,57 @@ STUB
   assert_contains "$stderr_log" "ollama-error-sentinel" "ollama stderr must be appended to cron-stderr.log"
 }
 
+test_runner_ollama_think_accepted_at_scan() {
+  cat > "$CEO_DIR/playbooks/ollama-think-ok.md" << 'PB'
+---
+name: ollama-think-ok
+description: Playbook with runner:ollama-think
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama-think
+---
+PB
+
+  local scan_out
+  scan_out=$(bash "$CEO_CLI" playbook scan 2>&1 || true)
+  if [[ "$scan_out" == *"unknown runner: 'ollama-think'"* ]]; then
+    printf '  FAIL [%s] runner:ollama-think must be accepted at scan\n    scan_out: %q\n' \
+      "$CURRENT_TEST" "$scan_out"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local entry
+  entry=$(jq -r '.playbooks[] | select(.name=="ollama-think-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  assert_eq "$entry" "ollama-think" "ollama-think playbook must be registered with runner:ollama-think"
+}
+
+test_runner_ollama_model_sonnet_passes_literal() {
+  cat > "$CEO_DIR/playbooks/ollama-sonnet.md" << 'PB'
+---
+name: ollama-sonnet
+description: Misconfigured — model:sonnet on ollama runner
+trigger: cron
+schedule: "0 9 * * *"
+model: sonnet
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-sonnet >/dev/null 2>&1 || true
+
+  local model
+  model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to mistral default)"
+}
+
 test_runner_ollama_works_under_stripped_path() {
   cat > "$CEO_DIR/playbooks/ollama-strip.md" << 'PB'
 ---


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

Adds two new playbook runner values so cron-batch playbooks can route to local Ollama models on the WSL host instead of Claude, saving tokens on chat/admin work that doesn't need tool use or multi-step reasoning.

**New enum values (`scripts/ceo`, `scripts/ceo-cron.sh`):**

- `runner: ollama` → default model `mistral-small3.2:24b` (fast, clean output, no chain-of-thought noise)
- `runner: ollama-think` → default model `gpt-oss:20b` (emits CoT, better at diagnostic reasoning)

Per-playbook `model:` frontmatter overrides the default. Detection is runner-gated rather than tag-shape heuristics, so a future `claude-sonnet-4:latest`-style alias won't accidentally route to Ollama.

**Scope (deliberately narrow):**

One-shot prompt-in / text-out, cron-batch only. Multi-turn chat is **out of scope** and would need session/history infrastructure. Playbook body is the entire prompt — `AGENTS.md`/`IDENTITY.md`/`TRAINING.md` context is deliberately skipped because skipping the 30KB preamble is half the token-saving point.

**Safety:**

- Scan-time and dispatch-time enum allowlists updated together (unknown values still reject — preserves `enum-config-typo-fallback` discipline).
- `command -v ollama` for binary presence **and** `curl http://127.0.0.1:11434/api/tags` for daemon reachability — presence ≠ capability.
- `stderr` captured to `cron-stderr.log` on failure.
- `MAX_FILE_SIZE` and `safe_read` helpers moved above both runner branches (previously defined after the script-runner exit, would have been undefined in the new branch).

## Testing Procedure

1. Check out the branch and `cd scripts/`.
2. Run the full test suite: `bash ceo-cron.test.sh`. Expect: `All tests passed. (45 tests)`.
3. Inspect the 6 new runner tests (`grep -n 'test_runner_ollama' ceo-cron.test.sh`) — they cover scan acceptance, dispatch + claude-skip, default model resolution per runner, explicit `model:` override, failure path increments fail count, and stripped-PATH operation.
4. Optional smoke test on ml-1 WSL (where Ollama is installed):
   - Create a tiny playbook with `runner: ollama` and a self-contained body.
   - `ceo playbook scan` → confirm it lands in `registry.json` with the right runner.
   - `ceo-cron.sh <playbook-name>` → confirm `cron-runs.log` records completion and the response lands in today's CEO log.
5. Revert verification: temporarily roll back the case-statement extension on `scripts/ceo-cron.sh:268-273` and re-run the tests — the 6 ollama tests should fail. Confirms the tests pin the dispatcher patch, not a stub or unrelated path.

## Additional Notes / HelpScout Tickets

Plan was audited before patching via `pr-review-toolkit:code-reviewer`. The audit caught seven real issues:

1. Test 5 originally only checked `fail-count == 1`, which any earlier failure path also produces. Added a `cron-runs.log` "did NOT complete" assertion to pin the ollama branch specifically.
2. Tests 2–4 missing `assert_eq "$rc" "0"`. Added.
3. Stripped-PATH test missing (the existing PATH inheritance made tests pass for the wrong reason). Added `test_runner_ollama_works_under_stripped_path` mirroring the claude variant.
4. Original colon heuristic for model resolution would have collided with future colon-bearing Claude aliases. Replaced with runner-gated resolution.
5. `MAX_FILE_SIZE` ordering bug (would have been undefined in the new branch at runtime — tests with tiny playbook bodies wouldn't have caught it).
6. Ollama daemon connectivity unaddressed — added `curl` probe with `CEO_OLLAMA_SKIP_PROBE` env-var bypass for tests.
7. Unquoted stderr redirect — quoted to match script-runner branch precedent.

Local models available on the ml-1 WSL host post-pull: `gpt-oss:20b`, `mistral-small3.2:24b`, `deepseek-r1:14b`, plus the pre-existing lineup (`qwen3:14b`, `phi4:14b`, `gemma3:12b`, `qwen2.5-coder:14b`, etc.). Selection rationale based on a 5-prompt head-to-head interview before patching — mistral-small3.2 was the only model emitting clean output without chain-of-thought noise; gpt-oss was the only one to produce a specific diagnostic answer ("stale lock file") on the reasoning prompt rather than a generic "resource constraint."