### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ceo",
       "description": "Autonomous CEO agent. Reads Obsidian vault, dispatches 6 specialized subagents, proposes actions by authority tier, learns from corrections.",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ceo",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Autonomous CEO agent for Claude Code. Reads your Obsidian vault, prioritizes work, dispatches 6 specialized subagents, and learns from corrections via playbooks and training files.",
   "author": {
     "name": "nhangen"

--- a/skills/ceo/brief/SKILL.md
+++ b/skills/ceo/brief/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ceo-brief
 description: Generate a morning briefing summarizing priorities, open PRs, pending approvals, and relevant questions. Triggers on "/ceo:brief", "morning brief", "daily brief", "what's on my plate".
-version: 0.1.0
+version: 0.2.0
 ---
 
 # CEO Brief


### PR DESCRIPTION
Closes #none

## Description

Bumps the ceo plugin manifest + marketplace listing from `0.11.0` to `0.12.0` to reflect features merged since the last bump. Also bumps the `ceo-brief` skill manifest from `0.1.0` to `0.2.0` (new Step 10, new yq dependency, new external producer integration).

### What's in 0.12.0

- #24 feat(playbook-scan): auto-register repo playbooks from `docs/playbooks/`
- #25 fix(token-intake): per-OS PATH + propagate capture failures
- #27 brief: surface weekly merged-PR count from `am-weekly-merges` INDEX
- #29 feat(dispatcher): add `ollama` and `ollama-think` runners
- #28 brief: clarify merged-PR line reflects user-authored PRs only

## Testing Procedure

1. Check out this branch.
2. `git grep -n "\"version\": \"0.11.0\""` — should return no matches.
3. `git grep -n "\"version\": \"0.12.0\""` — should match both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
4. `head -5 skills/ceo/brief/SKILL.md` — frontmatter `version: 0.2.0`.

## Additional Notes

Tag + GitHub release will follow after merge.