### PR TITLE
Resolve plugin-provided CLIs via cache, not PATH (#37)

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -128,6 +128,45 @@ ceo_augment_path() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_resolve_plugin_cli — resolve a Claude Code plugin-provided CLI entrypoint
+# from the local plugin cache, returning the runtime command and absolute entry
+# path on stdout (one per line, suitable for `mapfile`).
+#
+# Plugins land at ~/.claude/plugins/cache/<owner>/<plugin>/<version>/ and do
+# not install anything on PATH. Consumers that need to invoke a plugin-provided
+# CLI from cron/scripts should resolve via the cache rather than rely on stale
+# PATH symlinks from prior standalone installs. See nhangen/claude-ceo#37.
+#
+# Usage:
+#   mapfile -t TS_CMD < <(ceo_resolve_plugin_cli "nhangen-tools/token-scope" "src/cli.ts")
+#   "${TS_CMD[@]}" --since 1d
+#
+# Args:
+#   $1  owner/plugin slug (e.g. nhangen-tools/token-scope)
+#   $2  entry path relative to the version directory (e.g. src/cli.ts)
+#   $3  runtime to prepend (optional, default: bun)
+#
+# Returns:
+#   0  prints "<runtime>\n<abs-entry-path>" on stdout
+#   1  plugin not installed; entry missing; HOME unset
+# ---------------------------------------------------------------------------
+ceo_resolve_plugin_cli() {
+  : "${HOME:?HOME must be set before ceo_resolve_plugin_cli}"
+  local slug="${1:?slug required (owner/plugin)}"
+  local entry="${2:?entry path required (relative to version dir)}"
+  local runtime="${3:-bun}"
+  local cache_root="$HOME/.claude/plugins/cache/$slug"
+  local latest
+  latest=$(ls -1d "$cache_root"/*/ 2>/dev/null | sort -V | tail -1) || true
+  if [ -z "$latest" ] || [ ! -d "$latest" ]; then
+    return 1
+  fi
+  local abs="${latest%/}/$entry"
+  [ -f "$abs" ] || return 1
+  printf '%s\n%s\n' "$runtime" "$abs"
+}
+
+# ---------------------------------------------------------------------------
 # ceo_resolve_real_home — print the running user's canonical home from passwd,
 # ignoring $HOME. Use when a script needs access to real-user state (rtk DB,
 # ccusage data, keyring tokens) and may be invoked from contexts that scrubbed

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -130,16 +130,19 @@ ceo_augment_path() {
 # ---------------------------------------------------------------------------
 # ceo_resolve_plugin_cli — resolve a Claude Code plugin-provided CLI entrypoint
 # from the local plugin cache, returning the runtime command and absolute entry
-# path on stdout (one per line, suitable for `mapfile`).
+# path on stdout (one per line).
 #
 # Plugins land at ~/.claude/plugins/cache/<owner>/<plugin>/<version>/ and do
 # not install anything on PATH. Consumers that need to invoke a plugin-provided
 # CLI from cron/scripts should resolve via the cache rather than rely on stale
 # PATH symlinks from prior standalone installs. See nhangen/claude-ceo#37.
 #
-# Usage:
-#   mapfile -t TS_CMD < <(ceo_resolve_plugin_cli "nhangen-tools/token-scope" "src/cli.ts")
-#   "${TS_CMD[@]}" --since 1d
+# Usage (bash 3.2 compatible — macOS default lacks mapfile/readarray):
+#   if out=$(ceo_resolve_plugin_cli "nhangen-tools/token-scope" "src/cli.ts"); then
+#     runtime=$(printf '%s\n' "$out" | sed -n '1p')
+#     entry=$(printf '%s\n' "$out" | sed -n '2p')
+#     "$runtime" "$entry" --since 1d
+#   fi
 #
 # Args:
 #   $1  owner/plugin slug (e.g. nhangen-tools/token-scope)

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -283,6 +283,85 @@ test_pin_home_or_warn_emits_warn_on_resolver_failure() {
   esac
 }
 
+test_resolve_plugin_cli_returns_runtime_and_abs_path() {
+  local cache="$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1/src"
+  mkdir -p "$cache"
+  : > "$cache/cli.ts"
+
+  local out rc=0
+  out=$(env HOME="$TEST_HOME" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
+  " 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "resolver should succeed when cache + entry exist"
+  local line1 line2
+  line1=$(printf '%s\n' "$out" | sed -n '1p')
+  line2=$(printf '%s\n' "$out" | sed -n '2p')
+  assert_eq "$line1" "bun" "default runtime should be bun"
+  assert_eq "$line2" "$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1/src/cli.ts" \
+    "second line should be absolute entry path"
+}
+
+test_resolve_plugin_cli_picks_latest_version() {
+  local base="$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope"
+  for v in 1.2.0 1.3.0 1.3.1; do
+    mkdir -p "$base/$v/src"
+    : > "$base/$v/src/cli.ts"
+  done
+
+  local out rc=0
+  out=$(env HOME="$TEST_HOME" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
+  " 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "resolver should succeed with multiple versions present"
+  local picked
+  picked=$(printf '%s\n' "$out" | sed -n '2p')
+  assert_eq "$picked" "$base/1.3.1/src/cli.ts" "resolver must pick the highest version via sort -V"
+}
+
+test_resolve_plugin_cli_fails_when_plugin_absent() {
+  local rc=0
+  env HOME="$TEST_HOME" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "resolver must return 1 when no cache directory exists"
+}
+
+test_resolve_plugin_cli_fails_when_entry_missing() {
+  local cache="$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1"
+  mkdir -p "$cache"
+
+  local rc=0
+  env HOME="$TEST_HOME" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "resolver must return 1 when entry file is missing"
+}
+
+test_resolve_plugin_cli_honors_runtime_override() {
+  local cache="$TEST_HOME/.claude/plugins/cache/owner/tool/0.1.0/bin"
+  mkdir -p "$cache"
+  : > "$cache/run.js"
+
+  local out rc=0
+  out=$(env HOME="$TEST_HOME" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_resolve_plugin_cli 'owner/tool' 'bin/run.js' 'node'
+  " 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "resolver should succeed with custom runtime"
+  local runtime
+  runtime=$(printf '%s\n' "$out" | sed -n '1p')
+  assert_eq "$runtime" "node" "runtime arg must override the bun default"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -64,13 +64,27 @@ capture() {
   return 0
 }
 
+# Resolve token-scope from the Claude Code plugin cache rather than PATH —
+# the plugin doesn't install a wrapper, and stale ~/.bun/bin symlinks from
+# prior standalone installs satisfy `command -v` but dangle. See #37.
+# Avoid mapfile here: macOS ships bash 3.2 by default, which lacks it.
+TS_CMD=(token-scope)
+if _ts_resolved=$(ceo_resolve_plugin_cli "nhangen-tools/token-scope" "src/cli.ts" 2>/dev/null); then
+  _ts_runtime=$(printf '%s\n' "$_ts_resolved" | sed -n '1p')
+  _ts_path=$(printf '%s\n' "$_ts_resolved" | sed -n '2p')
+  if [ -n "$_ts_runtime" ] && [ -n "$_ts_path" ]; then
+    TS_CMD=("$_ts_runtime" "$_ts_path")
+  fi
+fi
+unset _ts_resolved _ts_runtime _ts_path
+
 if ! {
   printf -- '---\ndate: %s\ntype: ceo-token-intake\n---\n\n' "$TODAY"
   printf '# Token Report — %s\n' "$TODAY"
   capture "RTK — global savings" rtk gain
   capture "RTK — current project" rtk gain -p
   capture "RTK — Claude Code economics" rtk cc-economics
-  capture "token-scope — last 24h" token-scope --since 1d
+  capture "token-scope — last 24h" "${TS_CMD[@]}" --since 1d
 } > "$REPORT_FILE"; then
   echo "ERROR: failed to write $REPORT_FILE" >&2
   exit 1

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -69,12 +69,16 @@ capture() {
 # prior standalone installs satisfy `command -v` but dangle. See #37.
 # Avoid mapfile here: macOS ships bash 3.2 by default, which lacks it.
 TS_CMD=(token-scope)
+_ts_resolved=""
 if _ts_resolved=$(ceo_resolve_plugin_cli "nhangen-tools/token-scope" "src/cli.ts" 2>/dev/null); then
   _ts_runtime=$(printf '%s\n' "$_ts_resolved" | sed -n '1p')
   _ts_path=$(printf '%s\n' "$_ts_resolved" | sed -n '2p')
   if [ -n "$_ts_runtime" ] && [ -n "$_ts_path" ]; then
     TS_CMD=("$_ts_runtime" "$_ts_path")
   fi
+fi
+if [ "${TS_CMD[0]}" = "token-scope" ]; then
+  echo "WARN: token-scope plugin cache not resolved; falling back to PATH (stale symlinks may dangle)" >&2
 fi
 unset _ts_resolved _ts_runtime _ts_path
 

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -287,15 +287,24 @@ test_prefers_plugin_cache_over_path_for_token_scope() {
   # token-scope from setup() should be ignored when the cache resolves.
   local cache="$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1/src"
   mkdir -p "$cache"
-  cat > "$cache/cli.ts" << 'STUB'
+  cat > "$cache/cli.ts" << STUB
 #!/bin/bash
-echo "token-scope-from-cache: $*"
+echo "token-scope-from-cache: \$*"
 STUB
   chmod +x "$cache/cli.ts"
 
-  cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
+  # Stub bun must receive the absolute cache path as \$1 — that's how the
+  # caller proves it actually used the resolver's runtime+path pair, not
+  # an accidental "bash cli.ts" fallback. A regression that drops
+  # \$_ts_runtime from TS_CMD would invoke the .ts directly and miss this.
+  local expected_entry="$cache/cli.ts"
+  cat > "$TEST_HOME/.bun/bin/bun" << STUB
 #!/bin/bash
-exec bash "$@"
+if [ "\$1" != "$expected_entry" ]; then
+  echo "bun-stub-WRONG-ARG: expected '$expected_entry', got '\$1'" >&2
+  exit 2
+fi
+exec bash "\$@"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 
@@ -317,6 +326,10 @@ STUB
     "intake must invoke the cache-resolved token-scope, not the PATH stub"
   if [[ "$body" == *"token-scope-from-PATH-WRONG"* ]]; then
     printf '  FAIL [%s] cache resolver was bypassed; PATH stub ran instead\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [[ "$body" == *"bun-stub-WRONG-ARG"* ]]; then
+    printf '  FAIL [%s] bun stub received wrong entry path (runtime+path pair mismatched)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
 }

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -281,6 +281,46 @@ test_aborts_on_unwritable_report_dir() {
   fi
 }
 
+test_prefers_plugin_cache_over_path_for_token_scope() {
+  # Stage a plugin-cache token-scope that announces itself, plus a stub `bun`
+  # runtime that just exec's the script it's handed. The PATH-level
+  # token-scope from setup() should be ignored when the cache resolves.
+  local cache="$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1/src"
+  mkdir -p "$cache"
+  cat > "$cache/cli.ts" << 'STUB'
+#!/bin/bash
+echo "token-scope-from-cache: $*"
+STUB
+  chmod +x "$cache/cli.ts"
+
+  cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
+#!/bin/bash
+exec bash "$@"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/bun"
+
+  # Make the PATH stub trip a sentinel so a regression that falls through to
+  # PATH lights up as a failed assertion below.
+  cat > "$TEST_HOME/.bun/bin/token-scope" << 'STUB'
+#!/bin/bash
+echo "token-scope-from-PATH-WRONG: $*"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/token-scope"
+
+  bash "$INTAKE" >/dev/null 2>&1
+  local today report body
+  today=$(date +%Y-%m-%d)
+  report="$CEO_DIR/reports/token/$today-$CEO_HOSTNAME.md"
+  assert_file_exists "$report" "report must be written"
+  body=$(cat "$report")
+  assert_contains "$body" "token-scope-from-cache:" \
+    "intake must invoke the cache-resolved token-scope, not the PATH stub"
+  if [[ "$body" == *"token-scope-from-PATH-WRONG"* ]]; then
+    printf '  FAIL [%s] cache resolver was bypassed; PATH stub ran instead\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do


### PR DESCRIPTION
Closes #37

## Description

The `token-intake` cron playbook on ml-1 failed because its capture step invoked `token-scope` via PATH, which fell through to a stale `~/.bun/bin/token-scope` symlink (from a prior standalone install) whose target had been pruned. `command -v` reported the symlink present, so the in-script availability check passed, but invoking it failed.

Claude Code plugins drop their source at `~/.claude/plugins/cache/<owner>/<plugin>/<version>/` and don't install a PATH wrapper — by design. The fix belongs in the consumer (the playbook runner), not in token-scope. Originally filed as nhangen/token-scope#5 and closed as wrong layer.

This PR adds `ceo_resolve_plugin_cli` to `ceo-config.sh`: it looks up the latest cached version of a plugin via `ls -1d ~/.claude/plugins/cache/<owner>/<plugin>/*/ | sort -V | tail -1` and returns the runtime + absolute entry path on stdout. `ceo-token-intake.sh` uses it for `token-scope` and falls back to PATH only when the cache lookup misses (so existing standalone installs keep working).

Avoids `mapfile` — macOS ships bash 3.2 by default which lacks it; result is split with `sed -n`.

## Testing Procedure

1. Check out this branch in `~/code/claude-ceo`.
2. Run \`bash scripts/ceo-config.test.sh\` — confirm 24 tests pass (includes 5 new resolver tests: success path, version sort, missing plugin, missing entry, custom runtime).
3. Run \`bash scripts/ceo-token-intake.test.sh\` — confirm 12 tests pass (includes \`test_prefers_plugin_cache_over_path_for_token_scope\` which stages both a cache cli.ts and a PATH stub and asserts the cache one ran).
4. Run \`for t in scripts/*.test.sh; do bash \"\$t\" 2>&1 | tail -3; done\` — confirm all 6 suites green (107 tests total).
5. Smoke against the real cache: \`bash -c 'source scripts/ceo-config.sh && ceo_resolve_plugin_cli nhangen-tools/token-scope src/cli.ts'\` — should print \`bun\` and an absolute path under \`~/.claude/plugins/cache/nhangen-tools/token-scope/<latest>/src/cli.ts\`.

## Additional Notes

- ml-1 (WSL) is where the original failure happened; after merge, re-run \`ceo playbook scan\` there if cron entries need refreshing, but the script change is picked up automatically on next cron fire — no re-scan needed.
- The stale \`~/.bun/bin/token-scope\` symlink on ml-1 can stay; the fallback path is still there for hosts that legitimately use a standalone install.
- Filed from nhangen/token-scope#5 (closed as wrong layer).