### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ceo",
       "description": "Autonomous CEO agent. Reads Obsidian vault, dispatches 6 specialized subagents, proposes actions by authority tier, learns from corrections.",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ceo",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Autonomous CEO agent for Claude Code. Reads your Obsidian vault, prioritizes work, dispatches 6 specialized subagents, and learns from corrections via playbooks and training files.",
   "author": {
     "name": "nhangen"


### PR DESCRIPTION
Patch bump to release the plugin-cli resolver from #38.

Previous bump #36 (0.12.0) landed immediately before #38 merged, so reinstalls at 0.12.0 don't pick up the fix. This bump makes the resolver part of a tagged release.

## Testing Procedure

1. `cat .claude-plugin/plugin.json` — version is `0.12.1`.
2. After merge, reinstalling the plugin should pull a cache dir at `~/.claude/plugins/cache/nhangen-tools/ceo/0.12.1/` containing `scripts/ceo-config.sh` with `ceo_resolve_plugin_cli`.