### PR TITLE
feat: value-tracker playbook for daily MCP tool-call value reports

### DIFF
--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -1,0 +1,45 @@
+---
+name: value-tracker
+description: Daily MCP tool-call value report — analyses Claude Code + Cursor sessions for used vs wasted tool calls
+trigger: cron
+schedule: "0 6 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: ceo-value-tracker.sh
+---
+
+# Value Tracker
+
+Shell-only playbook. The dispatcher invokes `scripts/ceo-value-tracker.sh` directly — no LLM call.
+
+## What it does
+
+Runs `lib/value-tracker` against the last 24h of Claude Code session JSONLs and Cursor SQLite tool bubbles, classifies each MCP tool call as plausibly-used, trivially-wasted, or unclear, and writes:
+
+- `<VAULT>/Projects/Development/nhangen/mcp-value-tracker/<TODAY>.md` — the report
+- A JSON snapshot under the tracker's default snapshot dir
+- One idempotent line in `CEO/inbox/<host>.md`:
+
+```
+- [ ] Review daily value-tracker report [[Projects/Development/nhangen/mcp-value-tracker/<TODAY>]]
+```
+
+The chat-triggered `inbox` playbook surfaces the line via `ceo chat inbox`.
+
+## Why daily, not weekly
+
+Daily cron means tool-use drift surfaces inside one work-cycle; a weekly digest becomes wallpaper. The inbox line keeps it visible without requiring you to open the vault.
+
+## Install
+
+Registered automatically by `ceo playbook scan`. Requires `bun` on PATH (resolved via `command -v` at runtime; the script aborts cleanly if missing).
+
+## Disable
+
+Set `status: inactive` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/value-tracker.md`) and re-scan.
+
+## Source
+
+The analyser lives at `lib/value-tracker/` — TypeScript + Bun, 50 unit tests. See `lib/value-tracker/README.md` for the engine layout. The directory keeps a clean boundary (no ceo imports) so it can be extracted to a standalone CLI later if the use case grows beyond personal analytics.

--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -18,12 +18,12 @@ Shell-only playbook. The dispatcher invokes `scripts/ceo-value-tracker.sh` direc
 
 Runs `lib/value-tracker` against the last 24h of Claude Code session JSONLs and Cursor SQLite tool bubbles, classifies each MCP tool call as plausibly-used, trivially-wasted, or unclear, and writes:
 
-- `<VAULT>/Projects/Development/nhangen/mcp-value-tracker/<TODAY>.md` — the report
+- `<VAULT>/Projects/Development/nhangen/claude-ceo/value-tracker/<TODAY>.md` — the report
 - A JSON snapshot under the tracker's default snapshot dir
 - One idempotent line in `CEO/inbox/<host>.md`:
 
 ```
-- [ ] Review daily value-tracker report [[Projects/Development/nhangen/mcp-value-tracker/<TODAY>]]
+- [ ] Review daily value-tracker report [[Projects/Development/nhangen/claude-ceo/value-tracker/<TODAY>]]
 ```
 
 The chat-triggered `inbox` playbook surfaces the line via `ceo chat inbox`.

--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -2,7 +2,7 @@
 name: value-tracker
 description: Daily MCP tool-call value report — analyses Claude Code + Cursor sessions for used vs wasted tool calls
 trigger: cron
-schedule: "0 6 * * *"
+schedule: "0 6 * * 1-5"
 preflight: none
 tier: read
 status: active

--- a/lib/value-tracker/.gitignore
+++ b/lib/value-tracker/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+dist/
+*.log

--- a/lib/value-tracker/README.md
+++ b/lib/value-tracker/README.md
@@ -52,3 +52,13 @@ cd ~/code/claude-ceo/lib/value-tracker && bun install && bun test
 ```
 
 50 tests covering ingest, classify, rollup, format, snapshot, CLI detection, Cursor SQLite extraction.
+
+## Fresh-clone install
+
+Cron invocation works without `bun install` — the engine has zero runtime deps, and `bun src/cli.ts` resolves the TS imports directly. `bun install` is only needed for `bun test` / `bun tsc --noEmit`, both of which require the dev-deps (`typescript`, `@types/bun`).
+
+After `git clone` or worktree creation, run once:
+
+```bash
+cd lib/value-tracker && bun install
+```

--- a/lib/value-tracker/README.md
+++ b/lib/value-tracker/README.md
@@ -1,0 +1,54 @@
+# value-tracker
+
+Internal CEO library — post-hoc analyser of MCP tool-call value from Claude Code and Cursor sessions.
+
+Reads:
+
+- Claude Code session JSONLs (`~/.claude/projects/*/...jsonl`)
+- Cursor SQLite tool bubbles (`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`)
+
+Classifies each MCP tool call as plausibly-used, trivially-wasted, or unclear by checking whether downstream turns echo symbols from the result. Writes a terminal report, a JSON snapshot, and an Obsidian note.
+
+## Not a public CLI
+
+This started as `nhangen/mcp-value-tracker` (standalone Bun CLI). It was folded into claude-ceo to ship as a cron-fired playbook instead of an npm package — the personal "did Claude use the tools it called?" question is better served by an unattended daily report than a CLI you'd forget to run.
+
+The directory keeps a clean boundary (no imports from ceo internals) so it can be extracted back into a standalone CLI later if the use case grows beyond personal analytics.
+
+## Invocation
+
+Not invoked directly. Wrapped by `scripts/ceo-value-tracker.sh`, which is dispatched by the `value-tracker` playbook on the ceo cron schedule.
+
+For ad-hoc runs:
+
+```bash
+bun ~/code/claude-ceo/lib/value-tracker/src/cli.ts --since "$(date -v-1d +%Y-%m-%d)" --dry-run
+```
+
+## Layout
+
+```
+src/
+├── cli.ts            entry point (#!/usr/bin/env bun)
+├── ingest/           per-source ingestors (claude-jsonl, cursor-sqlite)
+├── servers/          per-server tool registries (gitnexus, etc.)
+├── classify.ts       used / wasted / unclear bucketing
+├── rollup.ts         per-tool aggregation
+├── format.ts         terminal + Obsidian renderers
+├── snapshot.ts       JSON snapshot writer
+├── extract.ts        symbol extraction from tool results
+├── signals.ts        downstream-echo detection
+├── cli-detect.ts     classify Bash-routed CLI calls (gitnexus analyze, etc.)
+├── jsonl.ts          line-by-line JSONL reader
+└── types.ts
+
+tests/                bun test
+```
+
+## Tests
+
+```bash
+cd ~/code/claude-ceo/lib/value-tracker && bun install && bun test
+```
+
+50 tests covering ingest, classify, rollup, format, snapshot, CLI detection, Cursor SQLite extraction.

--- a/lib/value-tracker/bun.lock
+++ b/lib/value-tracker/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mcp-value-tracker",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/lib/value-tracker/bunfig.toml
+++ b/lib/value-tracker/bunfig.toml
@@ -1,1 +1,0 @@
-# mcp-value-tracker

--- a/lib/value-tracker/bunfig.toml
+++ b/lib/value-tracker/bunfig.toml
@@ -1,0 +1,1 @@
+# mcp-value-tracker

--- a/lib/value-tracker/package.json
+++ b/lib/value-tracker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ceo-value-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Internal CEO lib — post-hoc analyser of MCP tool-call value from Claude Code + Cursor sessions. Invoked by scripts/ceo-value-tracker.sh via the value-tracker playbook.",
+  "scripts": {
+    "typecheck": "bun tsc --noEmit",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  },
+  "engines": { "bun": ">=1.3.5" },
+  "license": "MIT"
+}

--- a/lib/value-tracker/src/classify.ts
+++ b/lib/value-tracker/src/classify.ts
@@ -1,0 +1,85 @@
+import { extractPathsAndSymbols } from "@/extract";
+import { resolveServer } from "@/servers";
+import type { Bucket, ClassifiedCall, ToolCall, ToolClass } from "@/types";
+
+const DEFAULT_WINDOW: Record<ToolClass, number> = {
+  exploratory: 10,
+  decisionSupport: 10,
+  sideEffecting: 0,
+  maintenance: 0,
+  meta: 0,
+};
+
+const EMPTY_THRESHOLD_TOKENS = 50;
+const TRIV_DOWNSTREAM_WINDOW = 3;
+
+function windowFor(call: ToolCall): number {
+  const spec = resolveServer(call.toolName);
+  const overrides = spec?.windowOverrides ?? {};
+  return overrides[call.toolClass] ?? DEFAULT_WINDOW[call.toolClass];
+}
+
+function inputContains(input: unknown, needles: Set<string>): boolean {
+  const s = JSON.stringify(input ?? "");
+  for (const n of needles) if (n && s.includes(n)) return true;
+  return false;
+}
+
+export function classifyCall(calls: ToolCall[], i: number): ClassifiedCall {
+  const c = calls[i]!;
+
+  if (c.toolClass === "sideEffecting") {
+    if (c.resultIsError) {
+      return { ...c, bucket: "trivially-wasted", bucketReason: "is_error", evidenceTurnIndex: null };
+    }
+    return { ...c, bucket: "plausibly-used", bucketReason: "side-effect-success", evidenceTurnIndex: null };
+  }
+
+  if (c.toolClass === "maintenance") {
+    if (c.resultIsError) {
+      return { ...c, bucket: "trivially-wasted", bucketReason: "is_error", evidenceTurnIndex: null };
+    }
+    return { ...c, bucket: "plausibly-used", bucketReason: "maintenance-success", evidenceTurnIndex: null };
+  }
+
+  if (c.resultIsError) {
+    return { ...c, bucket: "trivially-wasted", bucketReason: "is_error", evidenceTurnIndex: null };
+  }
+
+  const symbols = extractPathsAndSymbols(c.resultText);
+  const window = windowFor(c);
+
+  if (symbols.size > 0) {
+    for (let j = i + 1; j < calls.length; j++) {
+      const next = calls[j]!;
+      if (next.turnIndex - c.turnIndex > window) break;
+      if (inputContains(next.input, symbols)) {
+        return { ...c, bucket: "plausibly-used", bucketReason: "downstream-input-match", evidenceTurnIndex: next.turnIndex };
+      }
+    }
+  }
+
+  if (c.resultTokens < EMPTY_THRESHOLD_TOKENS && symbols.size === 0) {
+    const inputSyms = extractPathsAndSymbols(JSON.stringify(c.input ?? ""));
+    if (inputSyms.size === 0) {
+      return { ...c, bucket: "trivially-wasted", bucketReason: "empty-result-no-input-symbols", evidenceTurnIndex: null };
+    }
+    let echoed = false;
+    for (let j = i + 1; j < calls.length; j++) {
+      const next = calls[j]!;
+      if (next.turnIndex - c.turnIndex > TRIV_DOWNSTREAM_WINDOW) break;
+      if (inputContains(next.input, inputSyms)) { echoed = true; break; }
+    }
+    if (!echoed) {
+      return { ...c, bucket: "trivially-wasted", bucketReason: "empty-result-no-echo", evidenceTurnIndex: null };
+    }
+  }
+
+  return { ...c, bucket: "unclear", bucketReason: "no-evidence", evidenceTurnIndex: null };
+}
+
+export function classifySession(calls: ToolCall[]): ClassifiedCall[] {
+  return calls.map((_, i) => classifyCall(calls, i));
+}
+
+export const _internal = { DEFAULT_WINDOW, EMPTY_THRESHOLD_TOKENS, TRIV_DOWNSTREAM_WINDOW } as const;

--- a/lib/value-tracker/src/classify.ts
+++ b/lib/value-tracker/src/classify.ts
@@ -1,5 +1,6 @@
 import { extractPathsAndSymbols } from "@/extract";
 import { resolveServer } from "@/servers";
+import { EMPTY_THRESHOLD_TOKENS } from "@/signals";
 import type { Bucket, ClassifiedCall, ToolCall, ToolClass } from "@/types";
 
 const DEFAULT_WINDOW: Record<ToolClass, number> = {
@@ -10,7 +11,6 @@ const DEFAULT_WINDOW: Record<ToolClass, number> = {
   meta: 0,
 };
 
-const EMPTY_THRESHOLD_TOKENS = 50;
 const TRIV_DOWNSTREAM_WINDOW = 3;
 
 function windowFor(call: ToolCall): number {

--- a/lib/value-tracker/src/cli-detect.ts
+++ b/lib/value-tracker/src/cli-detect.ts
@@ -1,0 +1,46 @@
+import { registry } from "@/servers";
+import type { ServerSpec, ToolClass } from "@/types";
+
+export interface CliMatch {
+  serverPrefix: string;       // e.g. "mcp__gitnexus__"
+  shortName: string;          // e.g. "analyze"
+  toolClass: ToolClass;
+  syntheticToolName: string;  // e.g. "cli__gitnexus__analyze"
+}
+
+const COMMAND_HEAD_RE = /(?:^|[\n;()]|&&|\|\||\|)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*"?([\w./-]+)"?\s+(\w[\w-]*)/g;
+
+function lookupClass(spec: ServerSpec, shortName: string): ToolClass | null {
+  for (const [klass, members] of Object.entries(spec.partition) as [ToolClass, string[]][]) {
+    if (members.includes(shortName)) return klass;
+  }
+  return null;
+}
+
+export function detectCliInvocations(command: string): CliMatch[] {
+  const out: CliMatch[] = [];
+  if (!command) return out;
+  const stripped = command.replace(/^\s*#.*$/gm, "");
+
+  for (const spec of registry.values()) {
+    if (!spec.cliBinary) continue;
+    const binary = spec.cliBinary;
+    for (const m of stripped.matchAll(COMMAND_HEAD_RE)) {
+      const cmd = m[1] ?? "";
+      const sub = m[2] ?? "";
+      if (!cmd || !sub) continue;
+      const isBinary = cmd === binary || cmd.endsWith(`/${binary}`);
+      if (!isBinary) continue;
+      const klass = lookupClass(spec, sub);
+      if (!klass) continue;
+      const serverName = spec.serverPrefix.replace(/^mcp__/, "").replace(/__$/, "");
+      out.push({
+        serverPrefix: spec.serverPrefix,
+        shortName: sub,
+        toolClass: klass,
+        syntheticToolName: `cli__${serverName}__${sub}`,
+      });
+    }
+  }
+  return out;
+}

--- a/lib/value-tracker/src/cli.ts
+++ b/lib/value-tracker/src/cli.ts
@@ -75,9 +75,9 @@ function parseArgs(argv: string[]): Args {
 
 function usage(): string {
   return [
-    "mcp-value-tracker — analyse MCP tool-call value from Claude Code sessions",
+    "value-tracker — analyse MCP tool-call value from Claude Code sessions",
     "",
-    "Usage: mcp-value-tracker [options]",
+    "Usage: bun lib/value-tracker/src/cli.ts [options]",
     "  --since <YYYY-MM-DD>      window start (default: 7 days ago)",
     "  --project <fragment>      filter by cwd substring",
     "  --session <id>            analyse one session by id",
@@ -151,7 +151,7 @@ async function main() {
   }
 
   if (args.obsidianVault) {
-    const noteDir = join(args.obsidianVault, "Projects", "Development", "nhangen", "mcp-value-tracker");
+    const noteDir = join(args.obsidianVault, "Projects", "Development", "nhangen", "claude-ceo", "value-tracker");
     mkdirSync(noteDir, { recursive: true });
     const notePath = join(noteDir, `${snap.generatedAt.slice(0, 10)}.md`);
     writeFileSync(notePath, formatObsidian(snap));

--- a/lib/value-tracker/src/cli.ts
+++ b/lib/value-tracker/src/cli.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+import { existsSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { runIngestors } from "@/ingest";
+import { classifySession } from "@/classify";
+import { rollup } from "@/rollup";
+import { formatTerminal, formatObsidian } from "@/format";
+import { writeSnapshot, defaultSnapshotDir } from "@/snapshot";
+import { resolveServer } from "@/servers";
+import type { ClassifiedCall, RunSnapshot, ToolCall } from "@/types";
+
+interface Args {
+  since: number;
+  project: string | null;
+  session: string | null;
+  sessionFile: string | null;
+  obsidianVault: string | null;
+  noSnapshot: boolean;
+  dryRun: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = {
+    since: Date.now() - 7 * 24 * 60 * 60 * 1000,
+    project: null,
+    session: null,
+    sessionFile: null,
+    obsidianVault: existsSync(join(homedir(), "Documents", "Obsidian"))
+      ? join(homedir(), "Documents", "Obsidian")
+      : null,
+    noSnapshot: false,
+    dryRun: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i]!;
+    const v = argv[i + 1];
+    switch (k) {
+      case "-h":
+      case "--help":
+        a.help = true;
+        break;
+      case "--since":
+        a.since = Date.parse(v!);
+        i++;
+        break;
+      case "--project":
+        a.project = v!;
+        i++;
+        break;
+      case "--session":
+        a.session = v!;
+        i++;
+        break;
+      case "--session-file":
+        a.sessionFile = v!;
+        i++;
+        break;
+      case "--obsidian-vault":
+        a.obsidianVault = v!;
+        i++;
+        break;
+      case "--no-snapshot":
+        a.noSnapshot = true;
+        break;
+      case "--dry-run":
+        a.dryRun = true;
+        break;
+    }
+  }
+  return a;
+}
+
+function usage(): string {
+  return [
+    "mcp-value-tracker — analyse MCP tool-call value from Claude Code sessions",
+    "",
+    "Usage: mcp-value-tracker [options]",
+    "  --since <YYYY-MM-DD>      window start (default: 7 days ago)",
+    "  --project <fragment>      filter by cwd substring",
+    "  --session <id>            analyse one session by id",
+    "  --session-file <path>     analyse one JSONL file directly (testing)",
+    "  --obsidian-vault <path>   override Obsidian vault path",
+    "  --no-snapshot             skip JSON snapshot write",
+    "  --dry-run                 terminal output only, no files written",
+    "  -h, --help                show this help",
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const allCalls: ClassifiedCall[] = [];
+  const sessionIds = new Set<string>();
+  let unclassified = 0;
+
+  const ingestResults = runIngestors({
+    sessionFile: args.sessionFile,
+    projectFilter: args.project,
+    sinceMs: args.since,
+  });
+
+  // Group by sessionId so the classifier scans downstream within each session.
+  const bySession = new Map<string, ToolCall[]>();
+  for (const result of ingestResults) {
+    for (const c of result.calls) {
+      if (c.timestampMs < args.since) continue;
+      if (args.session && c.sessionId !== args.session) continue;
+      const arr = bySession.get(c.sessionId) ?? [];
+      arr.push(c);
+      bySession.set(c.sessionId, arr);
+    }
+  }
+
+  for (const [sid, calls] of bySession) {
+    if (calls.length === 0) continue;
+    for (const c of calls) {
+      if (c.toolName.startsWith("mcp__") && !resolveServer(c.toolName)) unclassified++;
+    }
+    const classified = classifySession(calls).filter((cc) => resolveServer(cc.toolName));
+    if (classified.length > 0) sessionIds.add(sid);
+    allCalls.push(...classified);
+  }
+
+  const rows = rollup(allCalls);
+  const snap: RunSnapshot = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    windowSinceMs: args.since,
+    serversAnalysed: ["gitnexus"],
+    sessionCount: sessionIds.size,
+    callCount: allCalls.length,
+    rows,
+    unclassifiedCalls: unclassified,
+  };
+
+  process.stdout.write(formatTerminal(snap) + "\n");
+
+  if (args.dryRun) return;
+
+  if (!args.noSnapshot) {
+    const path = writeSnapshot(snap, defaultSnapshotDir());
+    process.stdout.write(`\nSnapshot: ${path}\n`);
+  }
+
+  if (args.obsidianVault) {
+    const noteDir = join(args.obsidianVault, "Projects", "Development", "nhangen", "mcp-value-tracker");
+    mkdirSync(noteDir, { recursive: true });
+    const notePath = join(noteDir, `${snap.generatedAt.slice(0, 10)}.md`);
+    writeFileSync(notePath, formatObsidian(snap));
+    process.stdout.write(`Obsidian note: ${notePath}\n`);
+  }
+}
+
+main();

--- a/lib/value-tracker/src/extract.ts
+++ b/lib/value-tracker/src/extract.ts
@@ -1,0 +1,12 @@
+const PATH_RE = /(?:[\w./-]+\/)?[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|php|py|rb|go|rs|java|kt|sh|md|json|toml|yml|yaml|html|css|scss)\b/g;
+const NAMESPACED_SYMBOL_RE = /\b[A-Z][A-Za-z0-9_]*(?:\\[A-Z][A-Za-z0-9_]*)+\b/g;
+const DOUBLE_COLON_SYMBOL_RE = /\b[A-Z][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*\b/g;
+
+export function extractPathsAndSymbols(text: string): Set<string> {
+  const out = new Set<string>();
+  if (!text) return out;
+  for (const m of text.matchAll(PATH_RE)) out.add(m[0]);
+  for (const m of text.matchAll(NAMESPACED_SYMBOL_RE)) out.add(m[0]);
+  for (const m of text.matchAll(DOUBLE_COLON_SYMBOL_RE)) out.add(m[0]);
+  return out;
+}

--- a/lib/value-tracker/src/format.ts
+++ b/lib/value-tracker/src/format.ts
@@ -48,7 +48,7 @@ function emptyResultBanner(): string[] {
 
 export function formatTerminal(s: RunSnapshot): string {
   const lines: string[] = [];
-  lines.push(`mcp-value-tracker — ${s.serversAnalysed.join(", ")}`);
+  lines.push(`value-tracker — ${s.serversAnalysed.join(", ")}`);
   lines.push(`window from ${new Date(s.windowSinceMs).toISOString().slice(0, 10)} | sessions: ${s.sessionCount} | calls: ${s.callCount}`);
   lines.push("");
   if (s.callCount === 0) {
@@ -73,10 +73,10 @@ export function formatObsidian(s: RunSnapshot): string {
   const lines: string[] = [];
   lines.push("---");
   lines.push(`date: ${date}`);
-  lines.push(`tags: [mcp-value-tracker, ${s.serversAnalysed.join(", ")}]`);
+  lines.push(`tags: [value-tracker, ${s.serversAnalysed.join(", ")}]`);
   lines.push("---");
   lines.push("");
-  lines.push(`# mcp-value-tracker — ${date}`);
+  lines.push(`# value-tracker — ${date}`);
   lines.push("");
   lines.push(`Window: from ${new Date(s.windowSinceMs).toISOString().slice(0, 10)}`);
   lines.push(`Sessions analysed: ${s.sessionCount}`);

--- a/lib/value-tracker/src/format.ts
+++ b/lib/value-tracker/src/format.ts
@@ -1,0 +1,105 @@
+import type { RunSnapshot, SignalRow, ToolClass } from "@/types";
+
+const CLASS_LABEL: Record<ToolClass, string> = {
+  exploratory: "Exploratory tools",
+  decisionSupport: "Decision-support tools",
+  sideEffecting: "Side-effecting tools",
+  maintenance: "Maintenance tools",
+  meta: "Meta tools",
+};
+
+const CLASS_ORDER: ToolClass[] = ["exploratory", "decisionSupport", "sideEffecting", "maintenance", "meta"];
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(0)}%`;
+}
+
+function ms(n: number | null): string {
+  return n === null ? "—" : `${(n / 1000).toFixed(1)}s`;
+}
+
+function rowLine(r: SignalRow): string {
+  return [
+    r.shortName.padEnd(16),
+    String(r.calls).padStart(4),
+    String(r.buckets["plausibly-used"]).padStart(5),
+    String(r.buckets.unclear).padStart(5),
+    String(r.buckets["trivially-wasted"]).padStart(5),
+    pct(r.errorRate).padStart(5),
+    pct(r.emptyRate).padStart(5),
+    String(Math.round(r.meanResultTokens)).padStart(6),
+    ms(r.meanMsToNextTool).padStart(6),
+  ].join("  ");
+}
+
+const HEADER = ["tool".padEnd(16), "n".padStart(4), "used".padStart(5), "?".padStart(5), "waste".padStart(5),
+                "err".padStart(5), "empty".padStart(5), "tokens".padStart(6), "next".padStart(6)].join("  ");
+
+function emptyResultBanner(): string[] {
+  return [
+    "Note: this report covers Claude Code session JSONLs only.",
+    "Cursor SQLite (cursorDiskKV bubbles), claude-mem observations, and",
+    "non-Bash CLI usage are not yet ingested. A 0-call result here does",
+    "not mean the server is unused — see",
+    "docs/superpowers/findings/2026-05-10-v1-blind-spots.md.",
+    "",
+  ];
+}
+
+export function formatTerminal(s: RunSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`mcp-value-tracker — ${s.serversAnalysed.join(", ")}`);
+  lines.push(`window from ${new Date(s.windowSinceMs).toISOString().slice(0, 10)} | sessions: ${s.sessionCount} | calls: ${s.callCount}`);
+  lines.push("");
+  if (s.callCount === 0) {
+    lines.push(...emptyResultBanner());
+  }
+  for (const klass of CLASS_ORDER) {
+    const rows = s.rows.filter((r) => r.toolClass === klass);
+    if (rows.length === 0) continue;
+    lines.push(`[${CLASS_LABEL[klass]}] (${klass})`);
+    lines.push(HEADER);
+    for (const r of rows) lines.push(rowLine(r));
+    lines.push("");
+  }
+  if (s.unclassifiedCalls > 0) {
+    lines.push(`Unclassified MCP calls (other servers): ${s.unclassifiedCalls}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatObsidian(s: RunSnapshot): string {
+  const date = s.generatedAt.slice(0, 10);
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`date: ${date}`);
+  lines.push(`tags: [mcp-value-tracker, ${s.serversAnalysed.join(", ")}]`);
+  lines.push("---");
+  lines.push("");
+  lines.push(`# mcp-value-tracker — ${date}`);
+  lines.push("");
+  lines.push(`Window: from ${new Date(s.windowSinceMs).toISOString().slice(0, 10)}`);
+  lines.push(`Sessions analysed: ${s.sessionCount}`);
+  lines.push(`Total calls: ${s.callCount}`);
+  lines.push("");
+  if (s.callCount === 0) {
+    lines.push(...emptyResultBanner());
+  }
+  for (const klass of CLASS_ORDER) {
+    const rows = s.rows.filter((r) => r.toolClass === klass);
+    if (rows.length === 0) continue;
+    lines.push(`## ${CLASS_LABEL[klass]}`);
+    lines.push("");
+    lines.push("| tool | n | used | unclear | wasted | err | empty | tokens | next |");
+    lines.push("|---|---:|---:|---:|---:|---:|---:|---:|---:|");
+    for (const r of rows) {
+      lines.push(`| ${r.shortName} | ${r.calls} | ${r.buckets["plausibly-used"]} | ${r.buckets.unclear} | ${r.buckets["trivially-wasted"]} | ${pct(r.errorRate)} | ${pct(r.emptyRate)} | ${Math.round(r.meanResultTokens)} | ${ms(r.meanMsToNextTool)} |`);
+    }
+    lines.push("");
+  }
+  if (s.unclassifiedCalls > 0) {
+    lines.push(`Unclassified MCP calls (other servers): ${s.unclassifiedCalls}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/lib/value-tracker/src/ingest/claude-code-jsonl.ts
+++ b/lib/value-tracker/src/ingest/claude-code-jsonl.ts
@@ -1,0 +1,134 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { resolveServer } from "@/servers";
+import { detectCliInvocations } from "@/cli-detect";
+import type { ToolCall, ToolClass } from "@/types";
+
+export function findSessionFiles(projectsDir: string = join(homedir(), ".claude", "projects")): string[] {
+  const out: string[] = [];
+  if (!existsSync(projectsDir)) return out;
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name !== "subagents") walk(join(dir, entry.name));
+      } else if (entry.name.endsWith(".jsonl")) {
+        out.push(join(dir, entry.name));
+      }
+    }
+  }
+  walk(projectsDir);
+  return out;
+}
+
+interface ToolUseRef {
+  id: string;
+  name: string;
+  input: unknown;
+  turnIndex: number;
+  timestampMs: number;
+}
+
+function extractTextFromResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b): b is Record<string, unknown> => typeof b === "object" && b !== null)
+    .map((b) => (b["type"] === "text" && typeof b["text"] === "string" ? b["text"] : ""))
+    .join("\n");
+}
+
+function classifyToolName(name: string): { shortName: string; toolClass: ToolClass } {
+  const spec = resolveServer(name);
+  if (!spec) {
+    return { shortName: name, toolClass: "meta" };
+  }
+  const short = name.slice(spec.serverPrefix.length);
+  for (const [klass, members] of Object.entries(spec.partition) as [ToolClass, string[]][]) {
+    if (members.includes(short)) return { shortName: short, toolClass: klass };
+  }
+  return { shortName: short, toolClass: "meta" };
+}
+
+export function readSession(file: string): ToolCall[] {
+  const raw = readFileSync(file, "utf8");
+  const pendingByUseId = new Map<string, ToolUseRef>();
+  const calls: ToolCall[] = [];
+  let turnIndex = -1;
+  let sessionId = "";
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let obj: Record<string, unknown>;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const ts = new Date(String(obj["timestamp"] ?? "")).getTime();
+    sessionId = String(obj["sessionId"] ?? sessionId);
+
+    if (obj["type"] === "assistant") {
+      turnIndex++;
+      const msg = obj["message"] as Record<string, unknown> | undefined;
+      const blocks = (msg?.["content"] ?? []) as Record<string, unknown>[];
+      for (const b of Array.isArray(blocks) ? blocks : []) {
+        if (b["type"] === "tool_use" && typeof b["id"] === "string" && typeof b["name"] === "string") {
+          pendingByUseId.set(b["id"], {
+            id: b["id"],
+            name: b["name"],
+            input: b["input"],
+            turnIndex,
+            timestampMs: ts,
+          });
+        }
+      }
+    } else if (obj["type"] === "user") {
+      const msg = obj["message"] as Record<string, unknown> | undefined;
+      const blocks = (msg?.["content"] ?? []) as Record<string, unknown>[];
+      for (const b of Array.isArray(blocks) ? blocks : []) {
+        if (b["type"] !== "tool_result") continue;
+        const id = String(b["tool_use_id"] ?? "");
+        const ref = pendingByUseId.get(id);
+        if (!ref) continue;
+        pendingByUseId.delete(id);
+        const text = extractTextFromResultContent(b["content"]);
+        const { shortName, toolClass } = classifyToolName(ref.name);
+        calls.push({
+          sessionId,
+          timestampMs: ref.timestampMs,
+          turnIndex: ref.turnIndex,
+          toolName: ref.name,
+          shortName,
+          toolClass,
+          input: ref.input,
+          resultText: text,
+          resultIsError: b["is_error"] === true,
+          resultTokens: Math.ceil(text.length / 4),
+          msToNextTool: null,
+        });
+
+        if (ref.name === "Bash") {
+          const cmd = (ref.input as { command?: string } | null)?.command ?? "";
+          for (const match of detectCliInvocations(cmd)) {
+            calls.push({
+              sessionId,
+              timestampMs: ref.timestampMs,
+              turnIndex: ref.turnIndex,
+              toolName: match.syntheticToolName,
+              shortName: match.shortName,
+              toolClass: match.toolClass,
+              input: { command: cmd, viaBash: true },
+              resultText: text,
+              resultIsError: b["is_error"] === true,
+              resultTokens: Math.ceil(text.length / 4),
+              msToNextTool: null,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const sorted = calls.slice().sort((a, b) => a.timestampMs - b.timestampMs);
+  for (let i = 0; i < sorted.length - 1; i++) {
+    sorted[i]!.msToNextTool = sorted[i + 1]!.timestampMs - sorted[i]!.timestampMs;
+  }
+  return sorted;
+}

--- a/lib/value-tracker/src/ingest/cursor-sqlite.ts
+++ b/lib/value-tracker/src/ingest/cursor-sqlite.ts
@@ -1,0 +1,207 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { Database } from "bun:sqlite";
+import { resolveServer } from "@/servers";
+import type { ToolCall, ToolClass } from "@/types";
+
+// Cursor stores conversation bubbles in a SQLite KV at:
+//   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
+// table: cursorDiskKV, columns: key TEXT, value TEXT (JSON blob)
+//
+// Bubble keys: 'bubbleId:<composerId>:<bubbleSubId>'.
+// Composer keys: 'composerData:<composerId>' — has 'createdAt' (unix ms).
+//
+// Tool calls live at value.toolFormerData with shape:
+//   { name: "mcp-<server>-user-<server>-<tool>", params: ..., result: ...,
+//     status: ..., toolCallId, modelCallId, ... }
+//
+// Cursor's MCP naming differs from Claude Code's. We translate
+// 'mcp-gitnexus-user-gitnexus-impact' to 'mcp__gitnexus__impact' so the
+// resolveServer registry (which matches 'mcp__<server>__' prefixes) works.
+
+export function defaultCursorDbPath(): string {
+  return join(
+    homedir(),
+    "Library",
+    "Application Support",
+    "Cursor",
+    "User",
+    "globalStorage",
+    "state.vscdb",
+  );
+}
+
+const CURSOR_MCP_RE = /^mcp-([A-Za-z0-9_-]+)-user-\1-(.+)$/;
+
+function canonicalizeName(cursorName: string): string {
+  const m = CURSOR_MCP_RE.exec(cursorName);
+  if (m) return `mcp__${m[1]}__${m[2]}`;
+  // Fall-through on unexpected shape: log if it looks like an MCP call, so
+  // a silently-demoted-to-meta call is at least visible. Per
+  // billing-defensive-observability, silent fallbacks need a log line.
+  if (cursorName.startsWith("mcp-")) {
+    process.stderr.write(`cursor-sqlite: unrecognised MCP tool name shape, demoting to meta: ${cursorName}\n`);
+  }
+  return cursorName;
+}
+
+function classifyToolName(name: string): { shortName: string; toolClass: ToolClass } {
+  const spec = resolveServer(name);
+  if (!spec) return { shortName: name, toolClass: "meta" };
+  const short = name.slice(spec.serverPrefix.length);
+  for (const [klass, members] of Object.entries(spec.partition) as [ToolClass, string[]][]) {
+    if (members.includes(short)) return { shortName: short, toolClass: klass };
+  }
+  return { shortName: short, toolClass: "meta" };
+}
+
+function extractComposerIdFromKey(key: string): string | null {
+  // Real shape: 'bubbleId:<composerId>:<bubbleSubId>' — three segments.
+  // A two-segment key like 'bubbleId:<x>' isn't a real bubble row.
+  const parts = key.split(":");
+  if (parts.length < 3) return null;
+  const composerId = parts[1];
+  if (!composerId) return null;
+  return composerId;
+}
+
+interface RawTfd {
+  name?: string;
+  params?: unknown;
+  result?: unknown;
+  rawArgs?: unknown;
+  status?: string | number;
+  toolCallId?: string;
+}
+
+function resultIsError(status: unknown, result: unknown): boolean {
+  if (typeof status === "string" && /(error|fail|cancel)/i.test(status)) return true;
+  if (typeof status === "number" && status !== 0 && status !== 1 && status !== 2) return true;
+  if (result && typeof result === "object" && "error" in (result as object)) return true;
+  return false;
+}
+
+// Cursor stores params/result as JSON-encoded strings (sometimes doubly:
+// `result` is a string, which when parsed yields `{"result": "<another json
+// string>"}`, whose inner string is the actual MCP tool_result content).
+// Unwrap as far as we can so the classifier's path/symbol extractor sees
+// real text rather than escape soup.
+function unwrapStringJson(v: unknown, depth = 3): unknown {
+  let cur = v;
+  for (let i = 0; i < depth; i++) {
+    if (typeof cur !== "string") break;
+    const trimmed = cur.trim();
+    if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) break;
+    try { cur = JSON.parse(trimmed); } catch { break; }
+  }
+  return cur;
+}
+
+function resultToText(result: unknown): string {
+  const unwrapped = unwrapStringJson(result);
+  if (unwrapped === null || unwrapped === undefined) return "";
+  if (typeof unwrapped === "string") return unwrapped;
+  // Cursor wraps real MCP tool_result content under `{ result: { content: [{type:"text", text}] } }`.
+  // Pull the inner text array out if we recognise that shape.
+  if (typeof unwrapped === "object") {
+    const obj = unwrapped as Record<string, unknown>;
+    const inner = unwrapStringJson(obj["result"]);
+    if (inner && typeof inner === "object") {
+      const innerObj = inner as Record<string, unknown>;
+      const content = innerObj["content"];
+      if (Array.isArray(content)) {
+        return content
+          .filter((b): b is Record<string, unknown> => typeof b === "object" && b !== null)
+          .map((b) => (b["type"] === "text" && typeof b["text"] === "string" ? b["text"] : ""))
+          .join("\n");
+      }
+    }
+  }
+  return JSON.stringify(unwrapped);
+}
+
+export interface CursorIngestOptions {
+  dbPath?: string;
+  sinceMs?: number;
+}
+
+export function readCursorBubbles(opts: CursorIngestOptions = {}): ToolCall[] {
+  const dbPath = opts.dbPath ?? defaultCursorDbPath();
+  if (!existsSync(dbPath)) return [];
+  const sinceMs = opts.sinceMs ?? 0;
+
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const composerRows = db
+      .query("SELECT substr(key, length('composerData:') + 1) AS id, json_extract(value, '$.createdAt') AS createdAt FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND json_extract(value, '$.createdAt') IS NOT NULL")
+      .all() as { id: string; createdAt: number | null }[];
+    const createdAtById = new Map<string, number>();
+    for (const r of composerRows) {
+      if (typeof r.id === "string" && typeof r.createdAt === "number") {
+        createdAtById.set(r.id, r.createdAt);
+      }
+    }
+
+    const bubbleRows = db
+      .query(`
+        SELECT
+          key AS k,
+          json_extract(value, '$.toolFormerData') AS tfd,
+          json_extract(value, '$.type') AS bubbleType
+        FROM cursorDiskKV
+        WHERE key LIKE 'bubbleId:%'
+          AND json_extract(value, '$.toolFormerData') IS NOT NULL
+          AND json_extract(value, '$.toolFormerData.name') IS NOT NULL
+      `)
+      .all() as { k: string; tfd: string | null; bubbleType: number | null }[];
+
+    const calls: ToolCall[] = [];
+    const turnIndexByComposer = new Map<string, number>();
+
+    for (const row of bubbleRows) {
+      if (!row.tfd) continue;
+      let tfd: RawTfd;
+      try { tfd = JSON.parse(row.tfd) as RawTfd; } catch { continue; }
+      if (typeof tfd.name !== "string") continue;
+      const composerId = extractComposerIdFromKey(row.k);
+      if (!composerId) continue;
+
+      const ts = createdAtById.get(composerId) ?? 0;
+      if (ts < sinceMs) continue;
+
+      const turnIndex = turnIndexByComposer.get(composerId) ?? 0;
+      turnIndexByComposer.set(composerId, turnIndex + 1);
+
+      const canonical = canonicalizeName(tfd.name);
+      const { shortName, toolClass } = classifyToolName(canonical);
+      const text = resultToText(tfd.result);
+
+      calls.push({
+        sessionId: composerId,
+        timestampMs: ts,
+        turnIndex,
+        toolName: canonical,
+        shortName,
+        toolClass,
+        input: unwrapStringJson(tfd.params ?? tfd.rawArgs ?? null),
+        resultText: text,
+        resultIsError: resultIsError(tfd.status, tfd.result),
+        resultTokens: Math.ceil(text.length / 4),
+        msToNextTool: null,
+      });
+    }
+
+    const sorted = calls.slice().sort((a, b) => {
+      if (a.sessionId === b.sessionId) return a.turnIndex - b.turnIndex;
+      return a.timestampMs - b.timestampMs;
+    });
+    // msToNextTool is unreliable for Cursor: within one composer all bubbles
+    // share createdAt (Cursor schema doesn't store per-bubble timestamps in
+    // this surface), so the diff is always 0. Leave as null for all pairs so
+    // downstream rollups don't treat a meaningless 0 as a real signal.
+    return sorted;
+  } finally {
+    db.close();
+  }
+}

--- a/lib/value-tracker/src/ingest/cursor-sqlite.ts
+++ b/lib/value-tracker/src/ingest/cursor-sqlite.ts
@@ -77,7 +77,6 @@ interface RawTfd {
 
 function resultIsError(status: unknown, result: unknown): boolean {
   if (typeof status === "string" && /(error|fail|cancel)/i.test(status)) return true;
-  if (typeof status === "number" && status !== 0 && status !== 1 && status !== 2) return true;
   if (result && typeof result === "object" && "error" in (result as object)) return true;
   return false;
 }
@@ -165,7 +164,13 @@ export function readCursorBubbles(opts: CursorIngestOptions = {}): ToolCall[] {
       try { tfd = JSON.parse(row.tfd) as RawTfd; } catch { continue; }
       if (typeof tfd.name !== "string") continue;
       const composerId = extractComposerIdFromKey(row.k);
-      if (!composerId) continue;
+      if (!composerId) {
+        // Bubble carries a tool call but the key doesn't yield a composer id —
+        // surface schema drift instead of silently dropping. Mirrors the
+        // canonicalizeName log at line ~44.
+        process.stderr.write(`cursor-sqlite: bubble has toolFormerData but unparseable composer key, skipping: ${row.k}\n`);
+        continue;
+      }
 
       const ts = createdAtById.get(composerId) ?? 0;
       if (ts < sinceMs) continue;

--- a/lib/value-tracker/src/ingest/index.ts
+++ b/lib/value-tracker/src/ingest/index.ts
@@ -1,0 +1,56 @@
+import { findSessionFiles, readSession } from "@/ingest/claude-code-jsonl";
+import { readCursorBubbles } from "@/ingest/cursor-sqlite";
+import type { ToolCall } from "@/types";
+
+export interface IngestOptions {
+  sessionFile?: string | null;
+  projectFilter?: string | null;
+  sinceMs?: number;
+  /** Disable specific ingestors by name. */
+  disable?: Set<string>;
+}
+
+export interface IngestResult {
+  source: string;
+  calls: ToolCall[];
+}
+
+export type Ingestor = (opts: IngestOptions) => IngestResult[];
+
+const claudeCodeJsonlIngestor: Ingestor = (opts) => {
+  const files = opts.sessionFile
+    ? [opts.sessionFile]
+    : findSessionFiles().filter((f) => {
+        if (opts.projectFilter && !f.toLowerCase().includes(opts.projectFilter.toLowerCase())) return false;
+        return true;
+      });
+
+  const calls: ToolCall[] = [];
+  for (const file of files) {
+    calls.push(...readSession(file));
+  }
+  return [{ source: "claude-code-jsonl", calls }];
+};
+
+const cursorSqliteIngestor: Ingestor = (opts) => {
+  // sessionFile flag is only meaningful for the JSONL ingestor; if set, the
+  // user is targeting one specific JSONL file and Cursor data shouldn't be
+  // mixed in.
+  if (opts.sessionFile) return [{ source: "cursor-sqlite", calls: [] }];
+  const calls = readCursorBubbles({ sinceMs: opts.sinceMs });
+  return [{ source: "cursor-sqlite", calls }];
+};
+
+export const ingestors: Map<string, Ingestor> = new Map([
+  ["claude-code-jsonl", claudeCodeJsonlIngestor],
+  ["cursor-sqlite", cursorSqliteIngestor],
+]);
+
+export function runIngestors(opts: IngestOptions): IngestResult[] {
+  const out: IngestResult[] = [];
+  for (const [name, ingestor] of ingestors) {
+    if (opts.disable?.has(name)) continue;
+    out.push(...ingestor(opts));
+  }
+  return out;
+}

--- a/lib/value-tracker/src/jsonl.ts
+++ b/lib/value-tracker/src/jsonl.ts
@@ -1,0 +1,3 @@
+// Thin re-export for backwards compatibility.
+// Real implementation lives in src/ingest/claude-code-jsonl.ts.
+export { findSessionFiles, readSession } from "@/ingest/claude-code-jsonl";

--- a/lib/value-tracker/src/rollup.ts
+++ b/lib/value-tracker/src/rollup.ts
@@ -1,0 +1,41 @@
+import { computeSignals } from "@/signals";
+import type { Bucket, ClassifiedCall, SignalRow } from "@/types";
+
+export function rollup(calls: ClassifiedCall[]): SignalRow[] {
+  const byTool = new Map<string, ClassifiedCall[]>();
+  for (const c of calls) {
+    const arr = byTool.get(c.toolName) ?? [];
+    arr.push(c);
+    byTool.set(c.toolName, arr);
+  }
+
+  const rows: SignalRow[] = [];
+  for (const [toolName, group] of byTool) {
+    const first = group[0]!;
+    const buckets: Record<Bucket, number> = {
+      "trivially-wasted": 0,
+      "plausibly-used": 0,
+      unclear: 0,
+    };
+    for (const c of group) buckets[c.bucket]++;
+    const sig = computeSignals(group);
+    rows.push({
+      toolName,
+      shortName: first.shortName,
+      toolClass: first.toolClass,
+      calls: group.length,
+      ...sig,
+      buckets,
+    });
+  }
+
+  const order: Record<string, number> = {
+    exploratory: 0,
+    decisionSupport: 1,
+    sideEffecting: 2,
+    maintenance: 3,
+    meta: 4,
+  };
+  rows.sort((a, b) => order[a.toolClass]! - order[b.toolClass]! || b.calls - a.calls);
+  return rows;
+}

--- a/lib/value-tracker/src/servers/gitnexus.ts
+++ b/lib/value-tracker/src/servers/gitnexus.ts
@@ -1,0 +1,14 @@
+import type { ServerSpec } from "@/types";
+
+export const gitnexus: ServerSpec = {
+  serverPrefix: "mcp__gitnexus__",
+  partition: {
+    exploratory:     ["query", "cypher"],
+    decisionSupport: ["context", "impact", "route_map", "api_impact", "detect_changes", "shape_check", "tool_map"],
+    sideEffecting:   ["rename", "group_sync"],
+    maintenance:     ["analyze", "status", "clean", "index", "list", "wiki", "setup", "serve"],
+    meta:            ["list_repos", "group_list"],
+  },
+  windowOverrides: { sideEffecting: 0, maintenance: 0 },
+  cliBinary: "gitnexus",
+};

--- a/lib/value-tracker/src/servers/index.ts
+++ b/lib/value-tracker/src/servers/index.ts
@@ -1,0 +1,25 @@
+import type { ServerSpec, ToolClass } from "@/types";
+import { gitnexus } from "@/servers/gitnexus";
+
+export const registry: Map<string, ServerSpec> = new Map([
+  [gitnexus.serverPrefix, gitnexus],
+]);
+
+export function resolveServer(toolName: string): ServerSpec | null {
+  for (const spec of registry.values()) {
+    if (toolName.startsWith(spec.serverPrefix)) return spec;
+    const cliPrefix = "cli__" + spec.serverPrefix.replace(/^mcp__/, "");
+    if (toolName.startsWith(cliPrefix)) return spec;
+  }
+  return null;
+}
+
+export function classifyTool(toolName: string): { shortName: string; toolClass: ToolClass } | null {
+  const spec = resolveServer(toolName);
+  if (!spec) return null;
+  const shortName = toolName.slice(spec.serverPrefix.length);
+  for (const [klass, members] of Object.entries(spec.partition) as [ToolClass, string[]][]) {
+    if (members.includes(shortName)) return { shortName, toolClass: klass };
+  }
+  return { shortName, toolClass: "meta" };
+}

--- a/lib/value-tracker/src/signals.ts
+++ b/lib/value-tracker/src/signals.ts
@@ -1,0 +1,28 @@
+import type { ClassifiedCall } from "@/types";
+
+export const EMPTY_THRESHOLD_TOKENS = 50;
+
+export function computeSignals(calls: ClassifiedCall[]): {
+  errorRate: number;
+  emptyRate: number;
+  meanResultTokens: number;
+  meanMsToNextTool: number | null;
+} {
+  if (calls.length === 0) {
+    return { errorRate: 0, emptyRate: 0, meanResultTokens: 0, meanMsToNextTool: null };
+  }
+  const errors = calls.filter((c) => c.resultIsError).length;
+  const empties = calls.filter((c) => c.resultTokens < EMPTY_THRESHOLD_TOKENS).length;
+  const meanTokens = calls.reduce((s, c) => s + c.resultTokens, 0) / calls.length;
+  const withNext = calls.filter((c) => c.msToNextTool !== null);
+  const meanMs =
+    withNext.length > 0
+      ? withNext.reduce((s, c) => s + (c.msToNextTool ?? 0), 0) / withNext.length
+      : null;
+  return {
+    errorRate: errors / calls.length,
+    emptyRate: empties / calls.length,
+    meanResultTokens: meanTokens,
+    meanMsToNextTool: meanMs,
+  };
+}

--- a/lib/value-tracker/src/snapshot.ts
+++ b/lib/value-tracker/src/snapshot.ts
@@ -1,0 +1,16 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { RunSnapshot } from "@/types";
+
+export function defaultSnapshotDir(): string {
+  return join(homedir(), ".local", "share", "mcp-value-tracker", "runs");
+}
+
+export function writeSnapshot(snap: RunSnapshot, dir: string = defaultSnapshotDir()): string {
+  mkdirSync(dir, { recursive: true });
+  const stamp = snap.generatedAt.replace(/[-:]/g, "").replace(/\..*$/, "").replace("T", "-").slice(0, 13);
+  const path = join(dir, `${stamp}.json`);
+  writeFileSync(path, JSON.stringify(snap, null, 2));
+  return path;
+}

--- a/lib/value-tracker/src/snapshot.ts
+++ b/lib/value-tracker/src/snapshot.ts
@@ -4,7 +4,7 @@ import { homedir } from "os";
 import type { RunSnapshot } from "@/types";
 
 export function defaultSnapshotDir(): string {
-  return join(homedir(), ".local", "share", "mcp-value-tracker", "runs");
+  return join(homedir(), ".local", "share", "claude-ceo", "value-tracker", "runs");
 }
 
 export function writeSnapshot(snap: RunSnapshot, dir: string = defaultSnapshotDir()): string {

--- a/lib/value-tracker/src/types.ts
+++ b/lib/value-tracker/src/types.ts
@@ -1,0 +1,55 @@
+// src/types.ts
+
+export type Bucket = "trivially-wasted" | "plausibly-used" | "unclear";
+
+export type ToolClass = "exploratory" | "decisionSupport" | "sideEffecting" | "maintenance" | "meta";
+
+export interface ServerSpec {
+  serverPrefix: string;                              // e.g. "mcp__gitnexus__"
+  partition: Record<ToolClass, string[]>;            // tool short names per class
+  windowOverrides?: Partial<Record<ToolClass, number>>;
+  cliBinary?: string;                                // e.g. "gitnexus" — short name detected in Bash commands
+}
+
+export interface ToolCall {
+  sessionId: string;
+  timestampMs: number;
+  turnIndex: number;          // 0-based position in session
+  toolName: string;           // full name e.g. mcp__gitnexus__context
+  shortName: string;          // e.g. context
+  toolClass: ToolClass;
+  input: unknown;             // raw tool_use input
+  resultText: string;         // concatenated tool_result text content (or "")
+  resultIsError: boolean;
+  resultTokens: number;       // crude: result text length / 4 (no upstream tokens here)
+  msToNextTool: number | null;
+}
+
+export interface ClassifiedCall extends ToolCall {
+  bucket: Bucket;
+  bucketReason: string;       // short tag e.g. "is_error", "edit-followthrough", "no-evidence"
+  evidenceTurnIndex: number | null;
+}
+
+export interface SignalRow {
+  toolName: string;
+  shortName: string;
+  toolClass: ToolClass;
+  calls: number;
+  errorRate: number;
+  emptyRate: number;
+  meanResultTokens: number;
+  meanMsToNextTool: number | null;
+  buckets: Record<Bucket, number>;
+}
+
+export interface RunSnapshot {
+  schemaVersion: 1;
+  generatedAt: string;        // ISO
+  windowSinceMs: number;
+  serversAnalysed: string[];  // ["gitnexus"]
+  sessionCount: number;
+  callCount: number;
+  rows: SignalRow[];
+  unclassifiedCalls: number;  // tool calls whose server prefix isn't registered
+}

--- a/lib/value-tracker/tests/classify.test.ts
+++ b/lib/value-tracker/tests/classify.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCall } from "@/classify";
+import type { ToolCall } from "@/types";
+
+function call(p: Partial<ToolCall> & { turnIndex: number; toolName: string }): ToolCall {
+  return {
+    sessionId: "S",
+    timestampMs: p.turnIndex * 1000,
+    shortName: p.toolName.replace(/^mcp__gitnexus__/, ""),
+    toolClass: "decisionSupport",
+    input: p.input ?? {},
+    resultText: p.resultText ?? "",
+    resultIsError: p.resultIsError ?? false,
+    resultTokens: p.resultTokens ?? Math.ceil((p.resultText ?? "").length / 4),
+    msToNextTool: null,
+    ...p,
+  };
+}
+
+describe("classifyCall", () => {
+  test("error result → trivially-wasted", () => {
+    const calls = [call({ turnIndex: 0, toolName: "mcp__gitnexus__context", resultIsError: true })];
+    const c = classifyCall(calls, 0);
+    expect(c.bucket).toBe("trivially-wasted");
+    expect(c.bucketReason).toBe("is_error");
+  });
+
+  test("empty result, no downstream evidence → trivially-wasted", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__query", resultText: "" }),
+      call({ turnIndex: 1, toolName: "Read", input: { file: "unrelated.ts" } }),
+    ];
+    expect(classifyCall(calls, 0).bucket).toBe("trivially-wasted");
+  });
+
+  test("plausibly-used: result path appears in later tool input", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__context", resultText: "see src/foo.ts:12" }),
+      call({ turnIndex: 1, toolName: "Edit", input: { file_path: "src/foo.ts" } }),
+    ];
+    const c = classifyCall(calls, 0);
+    expect(c.bucket).toBe("plausibly-used");
+    expect(c.evidenceTurnIndex).toBe(1);
+  });
+
+  test("evidence outside window → unclear", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__context", resultText: "see src/foo.ts" }),
+      ...Array.from({ length: 11 }, (_, i) =>
+        call({ turnIndex: i + 1, toolName: "Read", input: { file: "other.ts" } })),
+      call({ turnIndex: 12, toolName: "Edit", input: { file_path: "src/foo.ts" } }),
+    ];
+    expect(classifyCall(calls, 0).bucket).toBe("unclear");
+  });
+
+  test("side-effecting tool: success → plausibly-used regardless of downstream", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__rename", toolClass: "sideEffecting", resultText: "renamed", resultIsError: false }),
+    ];
+    const c = classifyCall(calls, 0);
+    expect(c.bucket).toBe("plausibly-used");
+    expect(c.bucketReason).toBe("side-effect-success");
+  });
+
+  test("side-effecting tool: error → trivially-wasted", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__rename", toolClass: "sideEffecting", resultIsError: true }),
+    ];
+    expect(classifyCall(calls, 0).bucket).toBe("trivially-wasted");
+  });
+
+  test("maintenance tool: success → plausibly-used", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__analyze", toolClass: "maintenance", resultText: "indexed 1234 symbols" }),
+    ];
+    const c = classifyCall(calls, 0);
+    expect(c.bucket).toBe("plausibly-used");
+    expect(c.bucketReason).toBe("maintenance-success");
+  });
+
+  test("maintenance tool: error → trivially-wasted", () => {
+    const calls = [
+      call({ turnIndex: 0, toolName: "mcp__gitnexus__analyze", toolClass: "maintenance", resultIsError: true }),
+    ];
+    expect(classifyCall(calls, 0).bucket).toBe("trivially-wasted");
+  });
+});

--- a/lib/value-tracker/tests/cli-detect.test.ts
+++ b/lib/value-tracker/tests/cli-detect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { detectCliInvocations } from "@/cli-detect";
+
+describe("detectCliInvocations", () => {
+  test("matches plain gitnexus subcommand", () => {
+    const r = detectCliInvocations("gitnexus analyze");
+    expect(r.length).toBe(1);
+    expect(r[0]!.shortName).toBe("analyze");
+    expect(r[0]!.toolClass).toBe("maintenance");
+    expect(r[0]!.syntheticToolName).toBe("cli__gitnexus__analyze");
+  });
+
+  test("matches absolute path to gitnexus binary", () => {
+    const r = detectCliInvocations('"/opt/homebrew/bin/gitnexus" analyze --force');
+    expect(r.length).toBe(1);
+    expect(r[0]!.shortName).toBe("analyze");
+  });
+
+  test("matches gitnexus inside a chained command", () => {
+    const r = detectCliInvocations("cd /tmp && gitnexus status");
+    expect(r.length).toBe(1);
+    expect(r[0]!.shortName).toBe("status");
+  });
+
+  test("matches multiple invocations", () => {
+    const r = detectCliInvocations("gitnexus analyze; gitnexus status");
+    expect(r.length).toBe(2);
+    expect(r.map((m) => m.shortName)).toEqual(["analyze", "status"]);
+  });
+
+  test("ignores comments referencing gitnexus", () => {
+    const r = detectCliInvocations("# gitnexus analyze was run manually\nls");
+    expect(r.length).toBe(0);
+  });
+
+  test("ignores echo / string payloads", () => {
+    const r = detectCliInvocations('echo "reset gitnexus"');
+    expect(r.length).toBe(0);
+  });
+
+  test("ignores unknown subcommand (not in any partition)", () => {
+    const r = detectCliInvocations("gitnexus zzz-nonexistent");
+    expect(r.length).toBe(0);
+  });
+
+  test("returns empty for empty input", () => {
+    expect(detectCliInvocations("")).toEqual([]);
+  });
+});

--- a/lib/value-tracker/tests/cli.test.ts
+++ b/lib/value-tracker/tests/cli.test.ts
@@ -8,7 +8,7 @@ describe("cli", () => {
   test("--help prints usage and exits 0", () => {
     const r = spawnSync("bun", [CLI, "--help"], { encoding: "utf8" });
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain("mcp-value-tracker");
+    expect(r.stdout).toContain("value-tracker");
     expect(r.stdout).toContain("--since");
   });
 
@@ -16,7 +16,7 @@ describe("cli", () => {
     const fixture = join(import.meta.dir, "fixtures", "tiny-session.jsonl");
     const r = spawnSync("bun", [CLI, "--session-file", fixture, "--dry-run"], { encoding: "utf8" });
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain("mcp-value-tracker");
+    expect(r.stdout).toContain("value-tracker");
     expect(r.stdout).toContain("decisionSupport");
   });
 });

--- a/lib/value-tracker/tests/cli.test.ts
+++ b/lib/value-tracker/tests/cli.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+
+describe("cli", () => {
+  test("--help prints usage and exits 0", () => {
+    const r = spawnSync("bun", [CLI, "--help"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("mcp-value-tracker");
+    expect(r.stdout).toContain("--since");
+  });
+
+  test("--dry-run on fixture file produces terminal output", () => {
+    const fixture = join(import.meta.dir, "fixtures", "tiny-session.jsonl");
+    const r = spawnSync("bun", [CLI, "--session-file", fixture, "--dry-run"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("mcp-value-tracker");
+    expect(r.stdout).toContain("decisionSupport");
+  });
+});

--- a/lib/value-tracker/tests/cursor-sqlite.test.ts
+++ b/lib/value-tracker/tests/cursor-sqlite.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { readCursorBubbles } from "@/ingest/cursor-sqlite";
+
+function makeFixtureDb(): { dbPath: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "mvt-cursor-"));
+  const dbPath = join(dir, "state.vscdb");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)");
+
+  const composerId = "11111111-1111-1111-1111-111111111111";
+  const createdAt = Date.parse("2026-05-09T12:00:00Z");
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `composerData:${composerId}`,
+    JSON.stringify({ createdAt, _v: 3 }),
+  );
+
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `bubbleId:${composerId}:bbb1`,
+    JSON.stringify({
+      _v: 3, type: 2, bubbleId: "bbb1",
+      toolFormerData: {
+        name: "mcp-gitnexus-user-gitnexus-impact",
+        params: { target: "Foo", direction: "upstream" },
+        result: { risk: "MEDIUM", impactedCount: 7 },
+        status: "success",
+      },
+    }),
+  );
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `bubbleId:${composerId}:bbb2`,
+    JSON.stringify({
+      _v: 3, type: 2, bubbleId: "bbb2",
+      toolFormerData: {
+        name: "mcp-gitnexus-user-gitnexus-query",
+        params: { query: "auth flow" },
+        result: "long text result",
+        status: "success",
+      },
+    }),
+  );
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `bubbleId:${composerId}:bbb3`,
+    JSON.stringify({
+      _v: 3, type: 2, bubbleId: "bbb3",
+      toolFormerData: {
+        name: "mcp-gitnexus-user-gitnexus-impact",
+        params: { target: "Bar" },
+        result: { error: "Target not found" },
+        status: "error",
+      },
+    }),
+  );
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `bubbleId:${composerId}:bbb4`,
+    JSON.stringify({
+      _v: 3, type: 2, bubbleId: "bbb4",
+      toolFormerData: {
+        name: "read_file_v2",
+        params: { path: "src/foo.ts" },
+        result: "(file contents)",
+        status: "success",
+      },
+    }),
+  );
+  db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    `bubbleId:${composerId}:bbb5`,
+    JSON.stringify({ _v: 3, type: 1, bubbleId: "bbb5", text: "hi" }),
+  );
+
+  db.close();
+  return { dbPath, cleanup: () => rmSync(dir, { recursive: true }) };
+}
+
+describe("readCursorBubbles", () => {
+  test("returns empty list when DB does not exist", () => {
+    expect(readCursorBubbles({ dbPath: "/nope/state.vscdb" })).toEqual([]);
+  });
+
+  test("translates Cursor MCP names to canonical mcp__server__tool form", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      const impactCall = calls.find((c) => c.toolName === "mcp__gitnexus__impact");
+      expect(impactCall).toBeDefined();
+      expect(impactCall!.shortName).toBe("impact");
+      expect(impactCall!.toolClass).toBe("decisionSupport");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("classifies query as exploratory", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      const queryCall = calls.find((c) => c.toolName === "mcp__gitnexus__query");
+      expect(queryCall).toBeDefined();
+      expect(queryCall!.toolClass).toBe("exploratory");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("flags resultIsError when status is error", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      const errorCall = calls.find((c) => c.input && JSON.stringify(c.input).includes("Bar"));
+      expect(errorCall).toBeDefined();
+      expect(errorCall!.resultIsError).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("uses composer createdAt as bubble timestamp", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      expect(calls.length).toBeGreaterThan(0);
+      for (const c of calls) {
+        expect(c.timestampMs).toBe(Date.parse("2026-05-09T12:00:00Z"));
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("respects sinceMs filter", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const future = Date.parse("2026-06-01T00:00:00Z");
+      const calls = readCursorBubbles({ dbPath, sinceMs: future });
+      expect(calls).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips bubbles without toolFormerData", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      expect(calls.some((c) => JSON.stringify(c.input ?? "").includes("hi"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-MCP tools are ingested but classified meta", () => {
+    const { dbPath, cleanup } = makeFixtureDb();
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      const readFileCall = calls.find((c) => c.toolName === "read_file_v2");
+      expect(readFileCall).toBeDefined();
+      expect(readFileCall!.toolClass).toBe("meta");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unwraps doubly-encoded JSON params and result (real Cursor shape)", () => {
+    // Real Cursor stores params/result as JSON-encoded strings, sometimes
+    // doubly: `result` is a string whose parse yields { result: "<json string>" }
+    // whose inner parse yields { content: [{type: "text", text: "..."}] }.
+    const dir = mkdtempSync(join(tmpdir(), "mvt-cursor-real-"));
+    const dbPath = join(dir, "state.vscdb");
+    const db = new Database(dbPath);
+    db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)");
+
+    const composerId = "22222222-2222-2222-2222-222222222222";
+    db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+      `composerData:${composerId}`,
+      JSON.stringify({ createdAt: Date.now(), _v: 3 }),
+    );
+
+    const innerResult = JSON.stringify({
+      content: [{ type: "text", text: "Foo lives in src/foo.ts:12 — see Class:src/foo.ts:Foo" }],
+    });
+    const outerResult = JSON.stringify({ result: innerResult });
+
+    db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+      `bubbleId:${composerId}:bbb`,
+      JSON.stringify({
+        _v: 3, type: 2,
+        toolFormerData: {
+          name: "mcp-gitnexus-user-gitnexus-context",
+          params: JSON.stringify({ tools: [{ name: "context", parameters: '{"name":"Foo"}', serverName: "gitnexus" }] }),
+          result: outerResult,
+          status: "completed",
+        },
+      }),
+    );
+    db.close();
+
+    try {
+      const calls = readCursorBubbles({ dbPath });
+      expect(calls.length).toBe(1);
+      const c = calls[0]!;
+      // Result text should be the human-readable inner content, not escape soup.
+      expect(c.resultText).toContain("Foo lives in src/foo.ts:12");
+      expect(c.resultText).not.toContain("\\\\\""); // no leftover escape sequences
+      // Input should be the parsed object, not a string.
+      expect(typeof c.input).toBe("object");
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});

--- a/lib/value-tracker/tests/extract.test.ts
+++ b/lib/value-tracker/tests/extract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { extractPathsAndSymbols } from "@/extract";
+
+describe("extractPathsAndSymbols", () => {
+  test("finds file paths with extensions", () => {
+    const r = extractPathsAndSymbols("see src/foo/bar.ts and /abs/path/baz.php for details");
+    expect(r.has("src/foo/bar.ts")).toBe(true);
+    expect(r.has("/abs/path/baz.php")).toBe(true);
+  });
+
+  test("finds dotted symbol names", () => {
+    const r = extractPathsAndSymbols("class AwesomeMotive\\OptinMonsterApp\\Util\\Stripe::refund() at line 42");
+    expect(r.has("AwesomeMotive\\OptinMonsterApp\\Util\\Stripe")).toBe(true);
+  });
+
+  test("finds JSON-shaped path fields", () => {
+    const json = JSON.stringify({ path: "src/cli.ts", calls: [{ symbol: "Foo::bar" }] });
+    const r = extractPathsAndSymbols(json);
+    expect(r.has("src/cli.ts")).toBe(true);
+    expect(r.has("Foo::bar")).toBe(true);
+  });
+
+  test("ignores noise tokens", () => {
+    const r = extractPathsAndSymbols("the result was OK. nothing here.");
+    expect(r.size).toBe(0);
+  });
+
+  test("dedupes occurrences", () => {
+    const r = extractPathsAndSymbols("src/cli.ts and src/cli.ts again");
+    expect(r.size).toBe(1);
+  });
+});

--- a/lib/value-tracker/tests/fixtures/tiny-session.jsonl
+++ b/lib/value-tracker/tests/fixtures/tiny-session.jsonl
@@ -1,0 +1,4 @@
+{"type":"assistant","sessionId":"S1","cwd":"/proj","timestamp":"2026-05-08T10:00:00Z","uuid":"u1","message":{"model":"claude-opus","content":[{"type":"tool_use","id":"t1","name":"mcp__gitnexus__context","input":{"name":"Foo"}}]}}
+{"type":"user","sessionId":"S1","timestamp":"2026-05-08T10:00:05Z","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":false,"content":[{"type":"text","text":"Foo lives in src/foo.ts:12"}]}]}}
+{"type":"assistant","sessionId":"S1","cwd":"/proj","timestamp":"2026-05-08T10:00:10Z","uuid":"u2","message":{"model":"claude-opus","content":[{"type":"tool_use","id":"t2","name":"Edit","input":{"file_path":"src/foo.ts"}}]}}
+{"type":"user","sessionId":"S1","timestamp":"2026-05-08T10:00:11Z","message":{"content":[{"type":"tool_result","tool_use_id":"t2","is_error":false,"content":[{"type":"text","text":"ok"}]}]}}

--- a/lib/value-tracker/tests/format.test.ts
+++ b/lib/value-tracker/tests/format.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { formatTerminal, formatObsidian } from "@/format";
+import type { RunSnapshot } from "@/types";
+
+function snap(): RunSnapshot {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-05-09T12:00:00Z",
+    windowSinceMs: Date.parse("2026-05-02T00:00:00Z"),
+    serversAnalysed: ["gitnexus"],
+    sessionCount: 3,
+    callCount: 7,
+    unclassifiedCalls: 0,
+    rows: [
+      {
+        toolName: "mcp__gitnexus__context", shortName: "context", toolClass: "decisionSupport",
+        calls: 5, errorRate: 0.2, emptyRate: 0.4, meanResultTokens: 120, meanMsToNextTool: 4500,
+        buckets: { "trivially-wasted": 1, "plausibly-used": 3, "unclear": 1 },
+      },
+      {
+        toolName: "mcp__gitnexus__cypher", shortName: "cypher", toolClass: "exploratory",
+        calls: 2, errorRate: 0, emptyRate: 0, meanResultTokens: 800, meanMsToNextTool: 3000,
+        buckets: { "trivially-wasted": 0, "plausibly-used": 1, "unclear": 1 },
+      },
+    ],
+  };
+}
+
+describe("formatTerminal", () => {
+  test("renders rows grouped by class", () => {
+    const out = formatTerminal(snap());
+    expect(out).toContain("exploratory");
+    expect(out).toContain("decisionSupport");
+    expect(out).toContain("context");
+    expect(out).toContain("cypher");
+    expect(out).toContain("3");  // plausibly-used count for context
+  });
+});
+
+describe("formatObsidian", () => {
+  test("emits markdown with frontmatter and headers", () => {
+    const out = formatObsidian(snap());
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain("date: 2026-05-09");
+    expect(out).toContain("## Decision-support tools");
+    expect(out).toContain("| context |");
+    expect(out).toContain("Sessions analysed: 3");
+  });
+});
+
+describe("empty-result banner", () => {
+  function emptySnap(): RunSnapshot {
+    return {
+      schemaVersion: 1,
+      generatedAt: "2026-05-10T12:00:00Z",
+      windowSinceMs: Date.parse("2026-05-09T00:00:00Z"),
+      serversAnalysed: ["gitnexus"],
+      sessionCount: 0,
+      callCount: 0,
+      unclassifiedCalls: 0,
+      rows: [],
+    };
+  }
+
+  test("formatTerminal includes the disclaimer when callCount is 0", () => {
+    const out = formatTerminal(emptySnap());
+    expect(out).toContain("Claude Code session JSONLs only");
+    expect(out).toContain("Cursor SQLite");
+    expect(out).toContain("v1-blind-spots");
+  });
+
+  test("formatObsidian includes the disclaimer when callCount is 0", () => {
+    const out = formatObsidian(emptySnap());
+    expect(out).toContain("Claude Code session JSONLs only");
+    expect(out).toContain("v1-blind-spots");
+  });
+
+  test("non-empty snapshots do NOT include the disclaimer", () => {
+    const out = formatTerminal(snap());
+    expect(out).not.toContain("Claude Code session JSONLs only");
+  });
+});

--- a/lib/value-tracker/tests/jsonl.test.ts
+++ b/lib/value-tracker/tests/jsonl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readSession } from "@/jsonl";
+
+describe("readSession", () => {
+  test("parses tool_use+tool_result pairs in order", () => {
+    const calls = readSession("tests/fixtures/tiny-session.jsonl");
+    expect(calls.length).toBe(2);
+    expect(calls[0]!.toolName).toBe("mcp__gitnexus__context");
+    expect(calls[0]!.resultText).toBe("Foo lives in src/foo.ts:12");
+    expect(calls[0]!.resultIsError).toBe(false);
+    expect(calls[1]!.toolName).toBe("Edit");
+    expect(calls[1]!.turnIndex).toBe(1);
+  });
+
+  test("computes msToNextTool", () => {
+    const calls = readSession("tests/fixtures/tiny-session.jsonl");
+    expect(calls[0]!.msToNextTool).toBe(10_000);
+    expect(calls[1]!.msToNextTool).toBe(null);
+  });
+});

--- a/lib/value-tracker/tests/rollup.test.ts
+++ b/lib/value-tracker/tests/rollup.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { rollup } from "@/rollup";
+import type { ClassifiedCall } from "@/types";
+
+function cc(p: Partial<ClassifiedCall> & { toolName: string; bucket: ClassifiedCall["bucket"] }): ClassifiedCall {
+  return {
+    sessionId: "S",
+    timestampMs: 0,
+    turnIndex: 0,
+    shortName: p.toolName.replace(/^mcp__gitnexus__/, ""),
+    toolClass: p.toolClass ?? "decisionSupport",
+    input: {},
+    resultText: "",
+    resultIsError: p.resultIsError ?? false,
+    resultTokens: p.resultTokens ?? 0,
+    msToNextTool: p.msToNextTool ?? 1000,
+    bucketReason: "x",
+    evidenceTurnIndex: null,
+    ...p,
+  };
+}
+
+describe("rollup", () => {
+  test("counts buckets per tool, computes free signals", () => {
+    const calls: ClassifiedCall[] = [
+      cc({ toolName: "mcp__gitnexus__context", bucket: "plausibly-used", resultTokens: 200, msToNextTool: 5000 }),
+      cc({ toolName: "mcp__gitnexus__context", bucket: "trivially-wasted", resultIsError: true, resultTokens: 0 }),
+      cc({ toolName: "mcp__gitnexus__context", bucket: "unclear", resultTokens: 100 }),
+      cc({ toolName: "mcp__gitnexus__cypher", bucket: "trivially-wasted", resultTokens: 10, toolClass: "exploratory" }),
+    ];
+    const rows = rollup(calls);
+    const ctx = rows.find((r) => r.toolName === "mcp__gitnexus__context")!;
+    expect(ctx.calls).toBe(3);
+    expect(ctx.errorRate).toBeCloseTo(1 / 3);
+    expect(ctx.buckets["plausibly-used"]).toBe(1);
+    expect(ctx.buckets["trivially-wasted"]).toBe(1);
+    expect(ctx.buckets.unclear).toBe(1);
+    expect(ctx.meanResultTokens).toBeCloseTo(100);
+    const cyph = rows.find((r) => r.toolName === "mcp__gitnexus__cypher")!;
+    expect(cyph.toolClass).toBe("exploratory");
+  });
+
+  test("emptyRate counts results below 50 tokens", () => {
+    const calls: ClassifiedCall[] = [
+      cc({ toolName: "mcp__gitnexus__context", bucket: "unclear", resultTokens: 10 }),
+      cc({ toolName: "mcp__gitnexus__context", bucket: "plausibly-used", resultTokens: 200 }),
+    ];
+    const r = rollup(calls)[0]!;
+    expect(r.emptyRate).toBe(0.5);
+  });
+});

--- a/lib/value-tracker/tests/servers.test.ts
+++ b/lib/value-tracker/tests/servers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { resolveServer, registry, classifyTool } from "@/servers";
+
+describe("server registry", () => {
+  test("resolves gitnexus by prefix", () => {
+    const spec = resolveServer("mcp__gitnexus__context");
+    expect(spec?.serverPrefix).toBe("mcp__gitnexus__");
+  });
+
+  test("returns null for unregistered server", () => {
+    expect(resolveServer("mcp__zenhub__listSprints")).toBeNull();
+  });
+
+  test("classifies decision-support tools", () => {
+    expect(classifyTool("mcp__gitnexus__context")).toEqual({
+      shortName: "context", toolClass: "decisionSupport",
+    });
+    expect(classifyTool("mcp__gitnexus__impact")).toEqual({
+      shortName: "impact", toolClass: "decisionSupport",
+    });
+  });
+
+  test("classifies exploratory tools", () => {
+    expect(classifyTool("mcp__gitnexus__cypher")?.toolClass).toBe("exploratory");
+    expect(classifyTool("mcp__gitnexus__query")?.toolClass).toBe("exploratory");
+  });
+
+  test("classifies side-effecting tools", () => {
+    expect(classifyTool("mcp__gitnexus__rename")?.toolClass).toBe("sideEffecting");
+  });
+
+  test("classifies maintenance tools", () => {
+    expect(classifyTool("mcp__gitnexus__analyze")?.toolClass).toBe("maintenance");
+    expect(classifyTool("mcp__gitnexus__status")?.toolClass).toBe("maintenance");
+    expect(classifyTool("mcp__gitnexus__clean")?.toolClass).toBe("maintenance");
+  });
+
+  test("classifies meta tools", () => {
+    expect(classifyTool("mcp__gitnexus__list_repos")?.toolClass).toBe("meta");
+  });
+
+  test("registry exposes gitnexus only in v1", () => {
+    expect([...registry.keys()]).toEqual(["mcp__gitnexus__"]);
+  });
+});

--- a/lib/value-tracker/tests/snapshot.test.ts
+++ b/lib/value-tracker/tests/snapshot.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { writeSnapshot } from "@/snapshot";
+import type { RunSnapshot } from "@/types";
+
+describe("writeSnapshot", () => {
+  test("writes JSON and returns path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvt-"));
+    const snap: RunSnapshot = {
+      schemaVersion: 1, generatedAt: "2026-05-09T12:00:00Z",
+      windowSinceMs: 0, serversAnalysed: ["gitnexus"],
+      sessionCount: 0, callCount: 0, rows: [], unclassifiedCalls: 0,
+    };
+    const path = writeSnapshot(snap, dir);
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    expect(parsed.schemaVersion).toBe(1);
+    rmSync(dir, { recursive: true });
+  });
+});

--- a/lib/value-tracker/tsconfig.json
+++ b/lib/value-tracker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "types": ["bun-types"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -58,6 +58,6 @@ bun "$ENTRY" \
   --obsidian-vault "$VAULT"
 
 # Idempotent inbox append — skip if the line is already there.
-if [ ! -f "$INBOX_FILE" ] || ! grep -qF "$WIKILINK" "$INBOX_FILE"; then
+if [ ! -f "$INBOX_FILE" ] || ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then
   printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
 fi

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -18,11 +18,15 @@ source "$SCRIPT_DIR/ceo-config.sh"
 
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
 
+# Validate before any helper that reads $HOME. `set -u` does not catch
+# HOME="" (set-but-empty); that's the cron / stripped-env shape from PR #11
+# where ceo_augment_path emits dangling `/.bun/bin` paths silently.
+: "${HOME:?HOME must be set}"
+
 # Pin $HOME before PATH augmentation so cron-stripped env still resolves bun.
 ceo_pin_home_or_warn || true
 ceo_augment_path
 
-: "${HOME:?HOME must be set}"
 : "${CEO_VAULT:?CEO_VAULT must be set}"
 
 if ! command -v bun >/dev/null 2>&1; then
@@ -42,7 +46,8 @@ HOST="${CEO_HOSTNAME:-$(hostname -s)}"
 INBOX_DIR="$CEO_DIR/inbox"
 INBOX_FILE="$INBOX_DIR/$HOST.md"
 TODAY=$(date +%Y-%m-%d)
-SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || true)
+: "${SINCE:?SINCE computation failed; neither BSD nor GNU date resolved (check cron PATH)}"
 
 NOTE_DIR="$VAULT/Projects/Development/nhangen/claude-ceo/value-tracker"
 NOTE_PATH="$NOTE_DIR/$TODAY.md"

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -44,9 +44,9 @@ INBOX_FILE="$INBOX_DIR/$HOST.md"
 TODAY=$(date +%Y-%m-%d)
 SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
 
-NOTE_DIR="$VAULT/Projects/Development/nhangen/mcp-value-tracker"
+NOTE_DIR="$VAULT/Projects/Development/nhangen/claude-ceo/value-tracker"
 NOTE_PATH="$NOTE_DIR/$TODAY.md"
-WIKILINK="[[Projects/Development/nhangen/mcp-value-tracker/$TODAY]]"
+WIKILINK="[[Projects/Development/nhangen/claude-ceo/value-tracker/$TODAY]]"
 INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
 mkdir -p "$INBOX_DIR" "$NOTE_DIR"

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# ceo-value-tracker.sh — Daily MCP tool-call value report.
+# Invokes lib/value-tracker over the last 24h, writing an Obsidian note and a
+# JSON snapshot. Idempotently appends one inbox line linking to the note so the
+# chat-triggered inbox playbook surfaces it.
+#
+# Invoked by ceo-cron.sh when the value-tracker playbook (runner:script) fires.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_DIR="$REPO_ROOT/lib/value-tracker"
+ENTRY="$LIB_DIR/src/cli.ts"
+
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+
+# Pin $HOME before PATH augmentation so cron-stripped env still resolves bun.
+ceo_pin_home_or_warn || true
+ceo_augment_path
+
+: "${HOME:?HOME must be set}"
+: "${CEO_VAULT:?CEO_VAULT must be set}"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "ERROR: bun not on PATH; cannot run value-tracker" >&2
+  exit 1
+fi
+
+if [ ! -f "$ENTRY" ]; then
+  echo "ERROR: value-tracker entry not found at $ENTRY" >&2
+  exit 1
+fi
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+INBOX_DIR="$CEO_DIR/inbox"
+INBOX_FILE="$INBOX_DIR/$HOST.md"
+TODAY=$(date +%Y-%m-%d)
+SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+
+NOTE_DIR="$VAULT/Projects/Development/nhangen/mcp-value-tracker"
+NOTE_PATH="$NOTE_DIR/$TODAY.md"
+WIKILINK="[[Projects/Development/nhangen/mcp-value-tracker/$TODAY]]"
+INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
+
+mkdir -p "$INBOX_DIR" "$NOTE_DIR"
+
+# Run the analyser. --obsidian-vault is auto-detected from $HOME/Documents/Obsidian
+# but pass it explicitly so non-default vault paths work via $CEO_VAULT.
+bun "$ENTRY" \
+  --since "$SINCE" \
+  --obsidian-vault "$VAULT"
+
+# Idempotent inbox append — skip if the line is already there.
+if [ ! -f "$INBOX_FILE" ] || ! grep -qF "$WIKILINK" "$INBOX_FILE"; then
+  printf '%s\n' "$INBOX_LINE" >> "$INBOX_FILE"
+fi


### PR DESCRIPTION
Closes #none

## Description

Folds the standalone `nhangen/mcp-value-tracker` Bun CLI into claude-ceo as a cron-fired playbook. The standalone repo has been archived on GitHub.

Why: the personal "did Claude actually use the tools it called?" question is better served by an unattended daily report than by an npm CLI you'd forget to run. Removing the npm-publish + `bunx`-on-cron path also drops the registry-fetch fragility flagged by an auditor pass (stripped cron env + transient DNS = silent failures).

### What's in this PR

- `lib/value-tracker/` — TS+Bun engine (src + tests + tsconfig + package.json). Private internal lib, zero runtime deps. 50/50 tests passing.
- `scripts/ceo-value-tracker.sh` — shell wrapper following the existing `ceo-token-intake.sh` pattern. Pins `$HOME`, augments PATH, validates `bun` availability with `command -v`, idempotently appends one inbox line linking to the daily report.
- `docs/playbooks/value-tracker.md` — `runner: script`, `schedule: \"0 6 * * *\"` (daily 6am), `tier: read`, `status: active`.
- Vault path nested under `claude-ceo/value-tracker/` and tool self-name dropped redundant `mcp-` prefix.

The engine keeps a clean boundary — no imports from ceo internals — so it can be extracted back to a standalone CLI later if the use case grows beyond personal analytics.

## Testing Procedure

1. Check out this branch and `cd lib/value-tracker && bun install && bun test` — confirm 50/50 pass.
2. Run the wrapper directly to confirm it produces an Obsidian note + inbox line:
   ```bash
   bash scripts/ceo-value-tracker.sh
   ```
   Verify a file appears at `\$CEO_VAULT/Projects/Development/nhangen/claude-ceo/value-tracker/<TODAY>.md` and one line is appended to `\$CEO_VAULT/CEO/inbox/<host>.md`.
3. Run the wrapper a second time the same day — confirm the inbox line is NOT duplicated (idempotency check).
4. After merge, run `ceo playbook scan` to register the cron entry.

## Additional Notes

- Auditor pass during development flagged: empty leftover `bunfig.toml`, missing `grep -- \"\$LINK\"` separator in dedupe, and a doc gap on the fresh-clone `bun install` story. All addressed in commit `295436b`.
- The standalone `nhangen/mcp-value-tracker` repo is archived; the local `~/ML-AI/claude/mcp-value-tracker/` can be deleted whenever.