### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ceo",
       "description": "Autonomous CEO agent. Reads Obsidian vault, dispatches 6 specialized subagents, proposes actions by authority tier, learns from corrections.",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "author": {
         "name": "nhangen"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ceo",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Autonomous CEO agent for Claude Code. Reads your Obsidian vault, prioritizes work, dispatches 6 specialized subagents, and learns from corrections via playbooks and training files.",
   "author": {
     "name": "nhangen"


### PR DESCRIPTION
Minor bump for new `value-tracker` playbook (PR #40, merge `6ae5591`).

Now 8 playbooks total: blessings, brief, ceo-config, inbox, scan, token-intake, **value-tracker**, weekly.