### PR TITLE
feat: disk-monitor playbook with state-machine semantics

### DIFF
--- a/docs/playbooks/disk-monitor.md
+++ b/docs/playbooks/disk-monitor.md
@@ -29,7 +29,7 @@ Written May 11 2026 by a Claude Code session on ML-1 as a follow-up to a 1.126 T
 | `CEO/log/disk-monitor/YYYY-MM.md` | append | Every run. One line per check. Forensic history. |
 | `CEO/inbox/<host>.md` | append `- [ ]` line | On `clear → firing` transition. Idempotent — does not re-append the same task line. Per-host file (`<host>` = `hostname -s`, lowercase). |
 
-The sustained-firing re-poke appends a fresh `- [ ]` line only when the prior task has been checked off (`- [x]`) but the alert continues to fire past 24 hours — `grep -qF` matches the literal unchecked form, so a still-unchecked line is never duplicated.
+Dedupe is gated by an HTML-comment marker (`<!-- disk-monitor:<host> -->`) embedded in every task line. The marker survives user reformats (translating the message, editing wording) so the same alert never produces two active task lines. The sustained-firing re-poke appends a fresh `- [ ]` only when no unchecked line carries the marker — i.e., the prior task has been checked off — and the alert continues to fire past 24 hours.
 
 When state transitions `firing → clear`, the playbook flips the matching `- [ ]` task in `CEO/inbox/<host>.md` to `- [done]` and appends a one-line resolution note. The rewrite is exact-string match (no regex), so hosts with regex metacharacters in their names rewrite correctly.
 

--- a/docs/playbooks/disk-monitor.md
+++ b/docs/playbooks/disk-monitor.md
@@ -1,0 +1,45 @@
+---
+name: disk-monitor
+description: Hourly disk/wsl-crashes check on ML-1; writes state to alerts/disk.md, escalates to inbox on sustained firing
+trigger: cron
+schedule: "0 * * * *"
+preflight: none
+tier: low-stakes write
+status: active
+runner: script
+script: ceo-disk-monitor.sh
+---
+
+# Disk Monitor (ML-1)
+
+Shell-only playbook. Runs hourly on ML-1 (WSL2). Checks:
+
+- C: drive free space — alert if < 50 GB
+- `C:\Users\nhang\AppData\Local\Temp\wsl-crashes\` folder size — alert if > 5 GB
+
+## Origin
+
+Written May 11 2026 by a Claude Code session on ML-1 as a follow-up to a 1.126 TB WSL node crash-dump cleanup (see `Projects/Development/nhangen/claude-ceo/2026-05-11-c-drive-exhaustion-wsl-crash-dump.md`). The first version was an append-on-every-fire signal generator, which spammed `CEO/inbox/disk-alert.md` after a May 11 CARLA crash dropped a 14 GB dump into `wsl-crashes/`. This version is a state machine.
+
+## Outputs
+
+| File | Mode | When |
+|---|---|---|
+| `CEO/alerts/disk.md` | overwrite | Every run. One entry, current state. Frontmatter: `status: firing\|clear`, `since:`, `last_check:`, `dump_folder_gb:`, `c_free_gb:`. |
+| `CEO/log/disk-monitor/YYYY-MM.md` | append | Every run. One line per check. Forensic history. |
+| `CEO/inbox/ML-1.md` | append `- [ ]` line | Only on state transition clear→firing, OR sustained firing past 24 hours. Idempotent — does not re-append if the same task line already exists. |
+
+When state transitions firing→clear, the playbook flips the matching `- [ ]` task in `CEO/inbox/ML-1.md` to `- [done]` and appends a one-line resolution note.
+
+## Documented gaps
+
+- `.wslconfig`'s `crashDumpFolder=` only suppresses WSL-guest-side dumps. Windows-native binaries running Linux builds *under* WSL (e.g. CARLA's Linux UE4 binary) still write to `wsl-crashes/` via Windows Error Reporting. The monitor can detect this but does not clean it up — cleanup is human work via the inbox task.
+- Hourly cadence is intentional (early detection). Suppress duplicate inbox tasks via idempotency, not by lengthening the schedule.
+
+## Install
+
+Registered automatically by `ceo playbook scan`. Repo playbooks under `docs/playbooks/` are picked up alongside vault playbooks. Cron lines bake in `$INSTALL_DIR` at scan time; re-run `ceo playbook scan` if the repo moves.
+
+## Disable
+
+Set `status: inactive` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/disk-monitor.md`) and re-scan.

--- a/docs/playbooks/disk-monitor.md
+++ b/docs/playbooks/disk-monitor.md
@@ -25,7 +25,7 @@ Written May 11 2026 by a Claude Code session on ML-1 as a follow-up to a 1.126 T
 
 | File | Mode | When |
 |---|---|---|
-| `CEO/alerts/disk.md` | overwrite | Every run. One entry, current state. Frontmatter: `status: firing\|clear\|unknown`, `since:`, `last_check:`, `dump_folder_gb:`, `c_free_gb:`, `measurement_failed:`. |
+| `CEO/alerts/disk-<host>.md` | overwrite | Every run. One entry per host, current state. Frontmatter: `status: firing\|clear\|unknown`, `since:`, `last_check:`, `host:`, `dump_folder_gb:`, `c_free_gb:`, `measurement_failed:`. Per-host so a synced vault with multiple monitors does not race. |
 | `CEO/log/disk-monitor/YYYY-MM.md` | append | Every run. One line per check. Forensic history. |
 | `CEO/inbox/<host>.md` | append `- [ ]` line | On `clear → firing` transition. Idempotent — does not re-append the same task line. Per-host file (`<host>` = `hostname -s`, lowercase). |
 

--- a/docs/playbooks/disk-monitor.md
+++ b/docs/playbooks/disk-monitor.md
@@ -25,11 +25,17 @@ Written May 11 2026 by a Claude Code session on ML-1 as a follow-up to a 1.126 T
 
 | File | Mode | When |
 |---|---|---|
-| `CEO/alerts/disk.md` | overwrite | Every run. One entry, current state. Frontmatter: `status: firing\|clear`, `since:`, `last_check:`, `dump_folder_gb:`, `c_free_gb:`. |
+| `CEO/alerts/disk.md` | overwrite | Every run. One entry, current state. Frontmatter: `status: firing\|clear\|unknown`, `since:`, `last_check:`, `dump_folder_gb:`, `c_free_gb:`, `measurement_failed:`. |
 | `CEO/log/disk-monitor/YYYY-MM.md` | append | Every run. One line per check. Forensic history. |
-| `CEO/inbox/ML-1.md` | append `- [ ]` line | Only on state transition clear→firing, OR sustained firing past 24 hours. Idempotent — does not re-append if the same task line already exists. |
+| `CEO/inbox/<host>.md` | append `- [ ]` line | On `clear → firing` transition. Idempotent — does not re-append the same task line. Per-host file (`<host>` = `hostname -s`, lowercase). |
 
-When state transitions firing→clear, the playbook flips the matching `- [ ]` task in `CEO/inbox/ML-1.md` to `- [done]` and appends a one-line resolution note.
+The sustained-firing re-poke appends a fresh `- [ ]` line only when the prior task has been checked off (`- [x]`) but the alert continues to fire past 24 hours — `grep -qF` matches the literal unchecked form, so a still-unchecked line is never duplicated.
+
+When state transitions `firing → clear`, the playbook flips the matching `- [ ]` task in `CEO/inbox/<host>.md` to `- [done]` and appends a one-line resolution note. The rewrite is exact-string match (no regex), so hosts with regex metacharacters in their names rewrite correctly.
+
+## Measurement-failure invariant
+
+If `du`, `df`, or either measured path is unavailable, the run is treated as measurement-failed: `status:` is preserved from the prior run (`firing` stays firing; `clear` stays clear), inbox is never mutated, and `measurement_failed: 1` is recorded in the alert frontmatter. A transient read error cannot silently clear an active alert.
 
 ## Documented gaps
 

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# ceo-disk-monitor.sh — Hourly disk-state check on ML-1 (WSL2).
+# State machine, not signal generator. Writes one state file (overwrite),
+# one log line (append), and only touches the inbox on state transitions
+# or sustained firing.
+#
+# Invoked by ceo-cron.sh when the disk-monitor playbook (runner:script) fires.
+# Replaces the prior /home/nhang/disk-monitor.sh which appended to
+# CEO/inbox/disk-alert.md unconditionally every hour.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+ceo_pin_home_or_warn || true
+ceo_augment_path
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+
+ALERTS_DIR="$CEO_DIR/alerts"
+LOG_DIR="$CEO_DIR/log/disk-monitor"
+INBOX_DIR="$CEO_DIR/inbox"
+STATE_FILE="$ALERTS_DIR/disk.md"
+LOG_FILE="$LOG_DIR/$(date +%Y-%m).md"
+INBOX_FILE="$INBOX_DIR/$HOST.md"
+
+mkdir -p "$ALERTS_DIR" "$LOG_DIR" "$INBOX_DIR"
+
+# Thresholds
+WSL_CRASHES_PATH="/mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes"
+DUMP_THRESHOLD_GB=5
+FREE_THRESHOLD_GB=50
+
+NOW=$(date +%Y-%m-%dT%H:%M:%S%z)
+TODAY=$(date +%Y-%m-%d)
+
+# --- Measure current state ---
+# Use safe defaults so a read error doesn't false-clear an alert.
+DUMP_GB=0
+if [ -d "$WSL_CRASHES_PATH" ]; then
+  DUMP_GB=$(du -sBG "$WSL_CRASHES_PATH" 2>/dev/null | awk '{sub(/G$/, "", $1); print int($1)}') || DUMP_GB=0
+fi
+
+C_FREE_GB=999
+if [ -d "/mnt/c" ]; then
+  C_FREE_GB=$(df -BG /mnt/c 2>/dev/null | awk 'NR==2 {sub(/G$/, "", $4); print int($4)}') || C_FREE_GB=999
+fi
+
+REASONS=()
+[ "$DUMP_GB" -gt "$DUMP_THRESHOLD_GB" ] && REASONS+=("wsl-crashes ${DUMP_GB}G > ${DUMP_THRESHOLD_GB}G")
+[ "$C_FREE_GB" -lt "$FREE_THRESHOLD_GB" ] && REASONS+=("C: free ${C_FREE_GB}G < ${FREE_THRESHOLD_GB}G")
+
+if [ "${#REASONS[@]}" -gt 0 ]; then
+  CURRENT_STATUS="firing"
+else
+  CURRENT_STATUS="clear"
+fi
+
+# --- Read prior state from state file frontmatter ---
+PRIOR_STATUS="clear"
+PRIOR_SINCE=""
+if [ -f "$STATE_FILE" ]; then
+  PRIOR_STATUS=$(awk -F': *' '/^status:/ {print $2; exit}' "$STATE_FILE" | tr -d '[:space:]')
+  PRIOR_SINCE=$(awk -F': *' '/^since:/ {print $2; exit}' "$STATE_FILE" | tr -d '[:space:]')
+  [ -z "$PRIOR_STATUS" ] && PRIOR_STATUS="clear"
+fi
+
+if [ "$CURRENT_STATUS" = "firing" ]; then
+  SINCE="${PRIOR_SINCE:-$NOW}"
+  [ "$PRIOR_STATUS" = "clear" ] && SINCE="$NOW"
+else
+  SINCE="$NOW"
+fi
+
+# --- Write state file (overwrite) ---
+{
+  printf -- '---\n'
+  printf 'status: %s\n' "$CURRENT_STATUS"
+  printf 'since: %s\n' "$SINCE"
+  printf 'last_check: %s\n' "$NOW"
+  printf 'host: %s\n' "$HOST"
+  printf 'dump_folder_gb: %s\n' "$DUMP_GB"
+  printf 'c_free_gb: %s\n' "$C_FREE_GB"
+  printf -- '---\n\n'
+  printf '# Disk Monitor — %s\n\n' "$HOST"
+  if [ "$CURRENT_STATUS" = "firing" ]; then
+    printf 'Firing since %s.\n\n' "$SINCE"
+    printf '## Reasons\n\n'
+    for r in "${REASONS[@]}"; do printf -- '- %s\n' "$r"; done
+    printf '\n## Largest dumps\n\n```\n'
+    if [ -d "$WSL_CRASHES_PATH" ]; then
+      ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10 || echo "(unable to list)"
+    fi
+    printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm /mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes/*.dmp\n```\n'
+  else
+    printf 'No active disk pressure. C: free %sG, wsl-crashes %sG.\n' "$C_FREE_GB" "$DUMP_GB"
+  fi
+} > "$STATE_FILE"
+
+# --- Append log line ---
+printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
+  "$NOW" "$CURRENT_STATUS" "$DUMP_GB" "$C_FREE_GB" "${REASONS[*]:-}" >> "$LOG_FILE"
+
+# --- Inbox escalation rules ---
+TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk]]"
+DONE_NOTE="- [done] disk monitor cleared $(date +%Y-%m-%d) — wsl-crashes ${DUMP_GB}G, C: ${C_FREE_GB}G free"
+
+touch "$INBOX_FILE"
+
+# Sustained-firing check: if firing for >24h AND task line not present, append it.
+SUSTAINED=0
+if [ "$CURRENT_STATUS" = "firing" ]; then
+  if [ -n "$PRIOR_SINCE" ]; then
+    SINCE_EPOCH=$(date -d "$PRIOR_SINCE" +%s 2>/dev/null || echo 0)
+    NOW_EPOCH=$(date +%s)
+    if [ "$SINCE_EPOCH" -gt 0 ] && [ $((NOW_EPOCH - SINCE_EPOCH)) -gt 86400 ]; then
+      SUSTAINED=1
+    fi
+  fi
+fi
+
+if [ "$PRIOR_STATUS" = "clear" ] && [ "$CURRENT_STATUS" = "firing" ]; then
+  # Transition: clear → firing. Idempotent — only append if not already there.
+  if ! grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
+    printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+  fi
+elif [ "$SUSTAINED" -eq 1 ]; then
+  # Sustained firing — same idempotency.
+  if ! grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
+    printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+  fi
+elif [ "$PRIOR_STATUS" = "firing" ] && [ "$CURRENT_STATUS" = "clear" ]; then
+  # Transition: firing → clear. Flip the task and append a resolution note.
+  if grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
+    # Replace the - [ ] task with - [done]. Use a temp file because sed -i differs across platforms.
+    tmpfile=$(mktemp)
+    sed "s|^- \[ \] Clean wsl-crashes on $HOST.*|- [done] Cleaned wsl-crashes on $HOST $(date +%Y-%m-%d)|" "$INBOX_FILE" > "$tmpfile"
+    mv "$tmpfile" "$INBOX_FILE"
+    printf '%s\n' "$DONE_NOTE" >> "$INBOX_FILE"
+  fi
+fi
+
+exit 0

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -26,7 +26,7 @@ HOST="${CEO_HOSTNAME:-$(hostname -s)}"
 ALERTS_DIR="$CEO_DIR/alerts"
 LOG_DIR="$CEO_DIR/log/disk-monitor"
 INBOX_DIR="$CEO_DIR/inbox"
-STATE_FILE="$ALERTS_DIR/disk.md"
+STATE_FILE="$ALERTS_DIR/disk-$HOST.md"
 LOG_FILE="$LOG_DIR/$(date +%Y-%m).md"
 INBOX_FILE="$INBOX_DIR/$HOST.md"
 
@@ -128,6 +128,7 @@ fi
   printf 'measurement_failed: %s\n' "$MEASUREMENT_FAILED"
   printf -- '---\n\n'
   printf '# Disk Monitor — %s\n\n' "$HOST"
+  printf '<!-- alert: [[CEO/alerts/disk-%s]] -->\n\n' "$HOST"
   if [ "$CURRENT_STATUS" = "firing" ]; then
     printf 'Firing since %s.\n\n' "$SINCE"
     if [ "$MEASUREMENT_FAILED" -eq 1 ]; then
@@ -152,7 +153,7 @@ printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
 # Inbox escalation. Unknown prior or current status, or any measurement
 # failure, suppresses all inbox mutation — we never escalate or clear on
 # uncertain state.
-TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk]]"
+TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk-$HOST]]"
 DONE_NOTE="- [done] disk monitor cleared $(date +%Y-%m-%d) — wsl-crashes ${DUMP_GB}G, C: ${C_FREE_GB}G free"
 
 touch "$INBOX_FILE"

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -147,8 +147,10 @@ fi
   fi
 } > "$STATE_FILE"
 
-printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
-  "$NOW" "$CURRENT_STATUS" "$DUMP_GB" "$C_FREE_GB" "${REASONS[*]:-}" >> "$LOG_FILE"
+if ! printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
+    "$NOW" "$CURRENT_STATUS" "$DUMP_GB" "$C_FREE_GB" "${REASONS[*]:-}" >> "$LOG_FILE" 2>/dev/null; then
+  printf 'WARN: ceo-disk-monitor: failed to append log line to %s\n' "$LOG_FILE" >&2
+fi
 
 # Inbox escalation. Unknown prior or current status, or any measurement
 # failure, suppresses all inbox mutation — we never escalate or clear on

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -8,7 +8,7 @@
 # Replaces the prior /home/nhang/disk-monitor.sh which appended to
 # CEO/inbox/disk-alert.md unconditionally every hour.
 
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=ceo-config.sh
@@ -32,53 +32,91 @@ INBOX_FILE="$INBOX_DIR/$HOST.md"
 
 mkdir -p "$ALERTS_DIR" "$LOG_DIR" "$INBOX_DIR"
 
-# Thresholds
-WSL_CRASHES_PATH="/mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes"
+# Paths are overridable so the test harness can drive without a real /mnt/c.
+WSL_CRASHES_PATH="${CEO_DISK_WSL_CRASHES_PATH:-/mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes}"
+C_MOUNT="${CEO_DISK_C_MOUNT:-/mnt/c}"
 DUMP_THRESHOLD_GB=5
 FREE_THRESHOLD_GB=50
 
 NOW=$(date +%Y-%m-%dT%H:%M:%S%z)
-TODAY=$(date +%Y-%m-%d)
 
-# --- Measure current state ---
-# Use safe defaults so a read error doesn't false-clear an alert.
-DUMP_GB=0
+# Read prior state from state file frontmatter.
+# Empty status = first run (no state file) = "clear".
+# Unknown status = corrupted state file = log + refuse to mutate inbox.
+PRIOR_STATUS=""
+PRIOR_SINCE=""
+if [ -f "$STATE_FILE" ]; then
+  PRIOR_STATUS=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$STATE_FILE" | tr -d '[:space:]')
+  PRIOR_SINCE=$(awk '/^since:/ { sub(/^since:[[:space:]]*/, ""); print; exit }' "$STATE_FILE" | tr -d '[:space:]')
+fi
+case "$PRIOR_STATUS" in
+  clear|firing) ;;
+  '') PRIOR_STATUS="clear" ;;
+  *)
+    printf 'WARN: ceo-disk-monitor: unknown prior status %q in %s; refusing inbox mutation\n' \
+      "$PRIOR_STATUS" "$STATE_FILE" >&2
+    PRIOR_STATUS="unknown"
+    ;;
+esac
+
+# Measure. Any unreadable path or non-zero exit from du/df is
+# MEASUREMENT_FAILED — we must NOT silently downgrade to clear.
+MEASUREMENT_FAILED=0
+DUMP_GB="?"
+C_FREE_GB="?"
+
 if [ -d "$WSL_CRASHES_PATH" ]; then
-  DUMP_GB=$(du -sBG "$WSL_CRASHES_PATH" 2>/dev/null | awk '{sub(/G$/, "", $1); print int($1)}') || DUMP_GB=0
+  _du_out=$(du -sBG "$WSL_CRASHES_PATH" 2>/dev/null) && _du_rc=0 || _du_rc=$?
+  if [ "$_du_rc" -eq 0 ] && [ -n "$_du_out" ]; then
+    DUMP_GB=$(printf '%s\n' "$_du_out" | awk '{sub(/G$/, "", $1); print int($1); exit}')
+    [ -z "$DUMP_GB" ] && { MEASUREMENT_FAILED=1; DUMP_GB="?"; }
+  else
+    MEASUREMENT_FAILED=1
+  fi
+else
+  MEASUREMENT_FAILED=1
 fi
 
-C_FREE_GB=999
-if [ -d "/mnt/c" ]; then
-  C_FREE_GB=$(df -BG /mnt/c 2>/dev/null | awk 'NR==2 {sub(/G$/, "", $4); print int($4)}') || C_FREE_GB=999
+if [ -d "$C_MOUNT" ]; then
+  _df_out=$(df -BG "$C_MOUNT" 2>/dev/null) && _df_rc=0 || _df_rc=$?
+  if [ "$_df_rc" -eq 0 ] && [ -n "$_df_out" ]; then
+    C_FREE_GB=$(printf '%s\n' "$_df_out" | awk 'NR==2 {sub(/G$/, "", $4); print int($4); exit}')
+    [ -z "$C_FREE_GB" ] && { MEASUREMENT_FAILED=1; C_FREE_GB="?"; }
+  else
+    MEASUREMENT_FAILED=1
+  fi
+else
+  MEASUREMENT_FAILED=1
 fi
 
 REASONS=()
-[ "$DUMP_GB" -gt "$DUMP_THRESHOLD_GB" ] && REASONS+=("wsl-crashes ${DUMP_GB}G > ${DUMP_THRESHOLD_GB}G")
-[ "$C_FREE_GB" -lt "$FREE_THRESHOLD_GB" ] && REASONS+=("C: free ${C_FREE_GB}G < ${FREE_THRESHOLD_GB}G")
+if [ "$MEASUREMENT_FAILED" -eq 0 ]; then
+  [ "$DUMP_GB" -gt "$DUMP_THRESHOLD_GB" ] && REASONS+=("wsl-crashes ${DUMP_GB}G > ${DUMP_THRESHOLD_GB}G")
+  [ "$C_FREE_GB" -lt "$FREE_THRESHOLD_GB" ] && REASONS+=("C: free ${C_FREE_GB}G < ${FREE_THRESHOLD_GB}G")
+fi
 
-if [ "${#REASONS[@]}" -gt 0 ]; then
+# Resolve CURRENT_STATUS.
+# Measurement failure preserves PRIOR_STATUS so a transient du/df error
+# cannot flip a firing alert to clear.
+if [ "$MEASUREMENT_FAILED" -eq 1 ]; then
+  printf 'WARN: ceo-disk-monitor: measurement failed; preserving prior status %q\n' "$PRIOR_STATUS" >&2
+  case "$PRIOR_STATUS" in
+    firing|clear) CURRENT_STATUS="$PRIOR_STATUS" ;;
+    *)            CURRENT_STATUS="unknown" ;;
+  esac
+elif [ "${#REASONS[@]}" -gt 0 ]; then
   CURRENT_STATUS="firing"
 else
   CURRENT_STATUS="clear"
 fi
 
-# --- Read prior state from state file frontmatter ---
-PRIOR_STATUS="clear"
-PRIOR_SINCE=""
-if [ -f "$STATE_FILE" ]; then
-  PRIOR_STATUS=$(awk -F': *' '/^status:/ {print $2; exit}' "$STATE_FILE" | tr -d '[:space:]')
-  PRIOR_SINCE=$(awk -F': *' '/^since:/ {print $2; exit}' "$STATE_FILE" | tr -d '[:space:]')
-  [ -z "$PRIOR_STATUS" ] && PRIOR_STATUS="clear"
-fi
-
-if [ "$CURRENT_STATUS" = "firing" ]; then
-  SINCE="${PRIOR_SINCE:-$NOW}"
-  [ "$PRIOR_STATUS" = "clear" ] && SINCE="$NOW"
+# SINCE only resets on a real transition into firing.
+if [ "$CURRENT_STATUS" = "firing" ] && [ "$PRIOR_STATUS" = "firing" ] && [ -n "$PRIOR_SINCE" ]; then
+  SINCE="$PRIOR_SINCE"
 else
   SINCE="$NOW"
 fi
 
-# --- Write state file (overwrite) ---
 {
   printf -- '---\n'
   printf 'status: %s\n' "$CURRENT_STATUS"
@@ -87,62 +125,75 @@ fi
   printf 'host: %s\n' "$HOST"
   printf 'dump_folder_gb: %s\n' "$DUMP_GB"
   printf 'c_free_gb: %s\n' "$C_FREE_GB"
+  printf 'measurement_failed: %s\n' "$MEASUREMENT_FAILED"
   printf -- '---\n\n'
   printf '# Disk Monitor — %s\n\n' "$HOST"
   if [ "$CURRENT_STATUS" = "firing" ]; then
     printf 'Firing since %s.\n\n' "$SINCE"
-    printf '## Reasons\n\n'
-    for r in "${REASONS[@]}"; do printf -- '- %s\n' "$r"; done
-    printf '\n## Largest dumps\n\n```\n'
-    if [ -d "$WSL_CRASHES_PATH" ]; then
-      ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10 || echo "(unable to list)"
+    if [ "$MEASUREMENT_FAILED" -eq 1 ]; then
+      printf 'Status preserved from prior run (measurement failed).\n\n'
+    else
+      printf '## Reasons\n\n'
+      for r in "${REASONS[@]}"; do printf -- '- %s\n' "$r"; done
+      printf '\n## Largest dumps\n\n```\n'
+      [ -d "$WSL_CRASHES_PATH" ] && (ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10 || echo "(unable to list)")
+      printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm /mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes/*.dmp\n```\n'
     fi
-    printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm /mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes/*.dmp\n```\n'
-  else
+  elif [ "$CURRENT_STATUS" = "clear" ]; then
     printf 'No active disk pressure. C: free %sG, wsl-crashes %sG.\n' "$C_FREE_GB" "$DUMP_GB"
+  else
+    printf 'Status unknown — measurement failed and no prior state available.\n'
   fi
 } > "$STATE_FILE"
 
-# --- Append log line ---
 printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
   "$NOW" "$CURRENT_STATUS" "$DUMP_GB" "$C_FREE_GB" "${REASONS[*]:-}" >> "$LOG_FILE"
 
-# --- Inbox escalation rules ---
+# Inbox escalation. Unknown prior or current status, or any measurement
+# failure, suppresses all inbox mutation — we never escalate or clear on
+# uncertain state.
 TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk]]"
 DONE_NOTE="- [done] disk monitor cleared $(date +%Y-%m-%d) — wsl-crashes ${DUMP_GB}G, C: ${C_FREE_GB}G free"
 
 touch "$INBOX_FILE"
 
-# Sustained-firing check: if firing for >24h AND task line not present, append it.
-SUSTAINED=0
-if [ "$CURRENT_STATUS" = "firing" ]; then
-  if [ -n "$PRIOR_SINCE" ]; then
-    SINCE_EPOCH=$(date -d "$PRIOR_SINCE" +%s 2>/dev/null || echo 0)
+if [ "$MEASUREMENT_FAILED" -eq 0 ] && [ "$PRIOR_STATUS" != "unknown" ] && [ "$CURRENT_STATUS" != "unknown" ]; then
+  SUSTAINED=0
+  if [ "$CURRENT_STATUS" = "firing" ] && [ "$PRIOR_STATUS" = "firing" ] && [ -n "$PRIOR_SINCE" ]; then
+    SINCE_EPOCH=$(date -d "$PRIOR_SINCE" +%s 2>/dev/null \
+      || date -j -f '%Y-%m-%dT%H:%M:%S%z' "$PRIOR_SINCE" +%s 2>/dev/null \
+      || echo 0)
     NOW_EPOCH=$(date +%s)
     if [ "$SINCE_EPOCH" -gt 0 ] && [ $((NOW_EPOCH - SINCE_EPOCH)) -gt 86400 ]; then
       SUSTAINED=1
     fi
   fi
-fi
 
-if [ "$PRIOR_STATUS" = "clear" ] && [ "$CURRENT_STATUS" = "firing" ]; then
-  # Transition: clear → firing. Idempotent — only append if not already there.
-  if ! grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
-    printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
-  fi
-elif [ "$SUSTAINED" -eq 1 ]; then
-  # Sustained firing — same idempotency.
-  if ! grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
-    printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
-  fi
-elif [ "$PRIOR_STATUS" = "firing" ] && [ "$CURRENT_STATUS" = "clear" ]; then
-  # Transition: firing → clear. Flip the task and append a resolution note.
-  if grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
-    # Replace the - [ ] task with - [done]. Use a temp file because sed -i differs across platforms.
-    tmpfile=$(mktemp)
-    sed "s|^- \[ \] Clean wsl-crashes on $HOST.*|- [done] Cleaned wsl-crashes on $HOST $(date +%Y-%m-%d)|" "$INBOX_FILE" > "$tmpfile"
-    mv "$tmpfile" "$INBOX_FILE"
-    printf '%s\n' "$DONE_NOTE" >> "$INBOX_FILE"
+  if [ "$PRIOR_STATUS" = "clear" ] && [ "$CURRENT_STATUS" = "firing" ]; then
+    grep -qF -- "$TASK_LINE" "$INBOX_FILE" || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+  elif [ "$SUSTAINED" -eq 1 ]; then
+    # Re-poke only fires after the user has checked off the prior task line
+    # — `grep -qF` matches only the literal "- [ ]" form, not "- [x]".
+    grep -qF -- "$TASK_LINE" "$INBOX_FILE" || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+  elif [ "$PRIOR_STATUS" = "firing" ] && [ "$CURRENT_STATUS" = "clear" ]; then
+    if grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
+      tmpfile=$(mktemp) || { echo "ERROR: mktemp failed for inbox rewrite" >&2; exit 1; }
+      trap 'rm -f "$tmpfile"' EXIT
+      _done_replacement="- [done] Cleaned wsl-crashes on $HOST $(date +%Y-%m-%d)"
+      while IFS= read -r line || [ -n "$line" ]; do
+        if [ "$line" = "$TASK_LINE" ]; then
+          printf '%s\n' "$_done_replacement"
+        else
+          printf '%s\n' "$line"
+        fi
+      done < "$INBOX_FILE" > "$tmpfile"
+      if ! mv "$tmpfile" "$INBOX_FILE"; then
+        echo "ERROR: failed to rewrite $INBOX_FILE" >&2
+        exit 1
+      fi
+      trap - EXIT
+      printf '%s\n' "$DONE_NOTE" >> "$INBOX_FILE"
+    fi
   fi
 fi
 

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -153,10 +153,20 @@ printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
 # Inbox escalation. Unknown prior or current status, or any measurement
 # failure, suppresses all inbox mutation — we never escalate or clear on
 # uncertain state.
-TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk-$HOST]]"
-DONE_NOTE="- [done] disk monitor cleared $(date +%Y-%m-%d) — wsl-crashes ${DUMP_GB}G, C: ${C_FREE_GB}G free"
+#
+# Dedupe and rewrite key off TASK_MARKER, an HTML comment embedded in the
+# task line. The marker survives user reformats (translating the message,
+# editing wording, adding context) so the same alert never produces two
+# active task lines.
+TASK_MARKER="<!-- disk-monitor:$HOST -->"
+TASK_LINE="- [ ] Clean wsl-crashes on $HOST — see [[CEO/alerts/disk-$HOST]] $TASK_MARKER"
+DONE_NOTE="- [done] disk monitor cleared $(date +%Y-%m-%d) — wsl-crashes ${DUMP_GB}G, C: ${C_FREE_GB}G free $TASK_MARKER"
 
 touch "$INBOX_FILE"
+
+active_task_present() {
+  awk -v m="$TASK_MARKER" '/^- \[ \]/ && index($0, m) { found=1; exit } END { exit !found }' "$INBOX_FILE"
+}
 
 if [ "$MEASUREMENT_FAILED" -eq 0 ] && [ "$PRIOR_STATUS" != "unknown" ] && [ "$CURRENT_STATUS" != "unknown" ]; then
   SUSTAINED=0
@@ -171,25 +181,21 @@ if [ "$MEASUREMENT_FAILED" -eq 0 ] && [ "$PRIOR_STATUS" != "unknown" ] && [ "$CU
   fi
 
   if [ "$PRIOR_STATUS" = "clear" ] && [ "$CURRENT_STATUS" = "firing" ]; then
-    grep -qF -- "$TASK_LINE" "$INBOX_FILE" || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+    active_task_present || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
   elif [ "$SUSTAINED" -eq 1 ]; then
-    # Re-poke only fires after the user has checked off the prior task line
-    # — `grep -qF` matches only the literal "- [ ]" form, not "- [x]".
-    grep -qF -- "$TASK_LINE" "$INBOX_FILE" || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+    # Re-poke fires only if the prior unchecked task has been checked off
+    # — `active_task_present` is false once the `[ ]` becomes `[x]` or
+    # `[done]`, allowing the append.
+    active_task_present || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
   elif [ "$PRIOR_STATUS" = "firing" ] && [ "$CURRENT_STATUS" = "clear" ]; then
-    if grep -qF -- "$TASK_LINE" "$INBOX_FILE"; then
-      tmpfile=$(mktemp) || { echo "ERROR: mktemp failed for inbox rewrite" >&2; exit 1; }
+    if active_task_present; then
+      tmpfile=$(mktemp) || { echo "ERROR: ceo-disk-monitor: mktemp failed for inbox rewrite" >&2; exit 1; }
       trap 'rm -f "$tmpfile"' EXIT
-      _done_replacement="- [done] Cleaned wsl-crashes on $HOST $(date +%Y-%m-%d)"
-      while IFS= read -r line || [ -n "$line" ]; do
-        if [ "$line" = "$TASK_LINE" ]; then
-          printf '%s\n' "$_done_replacement"
-        else
-          printf '%s\n' "$line"
-        fi
-      done < "$INBOX_FILE" > "$tmpfile"
+      _done_replacement="- [done] Cleaned wsl-crashes on $HOST $(date +%Y-%m-%d) $TASK_MARKER"
+      awk -v m="$TASK_MARKER" -v r="$_done_replacement" \
+        '/^- \[ \]/ && index($0, m) { print r; next } { print }' "$INBOX_FILE" > "$tmpfile"
       if ! mv "$tmpfile" "$INBOX_FILE"; then
-        echo "ERROR: failed to rewrite $INBOX_FILE" >&2
+        echo "ERROR: ceo-disk-monitor: failed to rewrite $INBOX_FILE" >&2
         exit 1
       fi
       trap - EXIT

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -270,6 +270,19 @@ test_user_reformat_does_not_duplicate_task() {
   fi
 }
 
+test_log_append_failure_emits_warning() {
+  if [ "$(id -u)" = "0" ]; then
+    return 0
+  fi
+  DUMP_GB_STUB="0" run_monitor
+  local log_file="$CEO_DIR/log/disk-monitor/$(date +%Y-%m).md"
+  chmod 0400 "$log_file"
+  local stderr
+  stderr=$(DUMP_GB_STUB="0" bash "$MONITOR" 2>&1 >/dev/null) || true
+  chmod 0600 "$log_file"
+  assert_contains "$stderr" "failed to append log line" "read-only log file must surface a warning to stderr"
+}
+
 test_inbox_rewrite_handles_host_with_regex_chars() {
   # HOST is interpolated into inbox-rewrite logic — must not break on regex
   # metacharacters or shell special chars.

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -112,14 +112,14 @@ run_monitor() {
 }
 
 state_field() {
-  awk -F': *' "/^$1:/ {print \$2; exit}" "$CEO_DIR/alerts/disk.md" | tr -d '[:space:]'
+  awk "/^$1:/ { sub(/^$1:[[:space:]]*/, \"\"); print; exit }" "$CEO_DIR/alerts/disk-$CEO_HOSTNAME.md" | tr -d '[:space:]'
 }
 
 # ---------- tests ----------
 
 test_first_run_clear_creates_state_file() {
   DUMP_GB_STUB="0" C_FREE_GB_STUB="999" run_monitor
-  assert_file_exists "$CEO_DIR/alerts/disk.md" "state file should exist"
+  assert_file_exists "$CEO_DIR/alerts/disk-$CEO_HOSTNAME.md" "state file should exist"
   assert_eq "$(state_field status)" "clear" "first run with low usage should be clear"
   if [ -f "$CEO_DIR/inbox/testhost.md" ] && [ -s "$CEO_DIR/inbox/testhost.md" ]; then
     printf '  FAIL [%s] clear first run must not write inbox\n' "$CURRENT_TEST"
@@ -195,7 +195,7 @@ test_missing_wsl_crashes_path_is_measurement_failure() {
 test_corrupted_prior_status_does_not_mutate_inbox() {
   # Write a state file with an unknown status value.
   mkdir -p "$CEO_DIR/alerts"
-  cat > "$CEO_DIR/alerts/disk.md" << 'EOF'
+  cat > "$CEO_DIR/alerts/disk-$CEO_HOSTNAME.md" << 'EOF'
 ---
 status: frring
 since: 2026-05-12T00:00:00-0400
@@ -212,7 +212,7 @@ EOF
 
 test_corrupted_prior_status_emits_warning() {
   mkdir -p "$CEO_DIR/alerts"
-  cat > "$CEO_DIR/alerts/disk.md" << 'EOF'
+  cat > "$CEO_DIR/alerts/disk-$CEO_HOSTNAME.md" << 'EOF'
 ---
 status: frring
 since: 2026-05-12T00:00:00-0400
@@ -232,12 +232,24 @@ test_sustained_firing_re_pokes_after_user_checkoff() {
   sed -i.bak 's/^- \[ \]/- [x]/' "$CEO_DIR/inbox/testhost.md"
   rm -f "$CEO_DIR/inbox/testhost.md.bak"
   # Force prior since to >24h ago so the SUSTAINED branch fires.
-  sed -i.bak "s/^since: .*/since: 2026-01-01T00:00:00-0500/" "$CEO_DIR/alerts/disk.md"
+  sed -i.bak "s/^since: .*/since: 2026-01-01T00:00:00-0500/" "$CEO_DIR/alerts/disk-$CEO_HOSTNAME.md"
   rm -f "$CEO_DIR/alerts/disk.md.bak"
   DUMP_GB_STUB="20" run_monitor
   local count
   count=$(grep -c -F -- "- [ ] Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
   assert_eq "$count" "1" "sustained firing past 24h after checkoff must re-append one task"
+}
+
+test_two_hosts_write_disjoint_state_files() {
+  CEO_HOSTNAME="alpha" DUMP_GB_STUB="20" run_monitor
+  CEO_HOSTNAME="beta"  DUMP_GB_STUB="0"  run_monitor
+  assert_file_exists "$CEO_DIR/alerts/disk-alpha.md" "alpha state file"
+  assert_file_exists "$CEO_DIR/alerts/disk-beta.md"  "beta state file"
+  local alpha_status beta_status
+  alpha_status=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$CEO_DIR/alerts/disk-alpha.md" | tr -d '[:space:]')
+  beta_status=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$CEO_DIR/alerts/disk-beta.md" | tr -d '[:space:]')
+  assert_eq "$alpha_status" "firing" "alpha must be firing"
+  assert_eq "$beta_status" "clear" "beta must be clear (no overwrite from alpha)"
 }
 
 test_inbox_rewrite_handles_host_with_regex_chars() {

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -252,6 +252,24 @@ test_two_hosts_write_disjoint_state_files() {
   assert_eq "$beta_status" "clear" "beta must be clear (no overwrite from alpha)"
 }
 
+test_user_reformat_does_not_duplicate_task() {
+  # User reformats the task line text but leaves the HTML-comment marker.
+  # Steady-state firing must NOT append a second active task.
+  DUMP_GB_STUB="20" run_monitor
+  local marker="<!-- disk-monitor:testhost -->"
+  # Reformat the line: keep marker, change everything else.
+  sed -i.bak "s|^- \[ \] Clean wsl-crashes.*|- [ ] custom translated message $marker|" "$CEO_DIR/inbox/testhost.md"
+  rm -f "$CEO_DIR/inbox/testhost.md.bak"
+  DUMP_GB_STUB="20" run_monitor
+  local count
+  count=$(grep -c -F -- "$marker" "$CEO_DIR/inbox/testhost.md")
+  assert_eq "$count" "1" "reformatted line with marker must not be duplicated"
+  if grep -qF -- "Clean wsl-crashes on testhost — see" "$CEO_DIR/inbox/testhost.md"; then
+    printf '  FAIL [%s] reformat was overwritten — original wording reappeared\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
 test_inbox_rewrite_handles_host_with_regex_chars() {
   # HOST is interpolated into inbox-rewrite logic — must not break on regex
   # metacharacters or shell special chars.

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Self-contained test harness for ceo-disk-monitor.sh — verifies the state
+# machine, idempotency, and measurement/parse failure invariants.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MONITOR="$SCRIPT_DIR/ceo-disk-monitor.sh"
+
+FAILS=0
+CURRENT_TEST=""
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1" msg="${2:-}"
+  if [[ ! -f "$path" ]]; then
+    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    forbidden: %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="testhost"
+  mkdir -p "$CEO_DIR"
+  touch "$CEO_DIR/inbox.md"  # satisfy ceo_validate_vault
+
+  # Stub paths the script measures. Inject via env so the script does not
+  # require a real /mnt/c.
+  export CEO_DISK_WSL_CRASHES_PATH="$TEST_HOME/fake-crashes"
+  export CEO_DISK_C_MOUNT="$TEST_HOME/fake-c-mount"
+  mkdir -p "$CEO_DISK_WSL_CRASHES_PATH" "$CEO_DISK_C_MOUNT"
+
+  # Stubs for du, df, getent. Tests override DUMP_GB_STUB / C_FREE_GB_STUB
+  # before calling the script.
+  mkdir -p "$TEST_HOME/stubs"
+  cat > "$TEST_HOME/stubs/du" << 'STUB'
+#!/bin/bash
+if [ -n "${DUMP_GB_STUB_FAIL:-}" ]; then
+  exit 1
+fi
+printf '%sG\t%s\n' "${DUMP_GB_STUB:-0}" "${@: -1}"
+STUB
+  cat > "$TEST_HOME/stubs/df" << 'STUB'
+#!/bin/bash
+if [ -n "${C_FREE_GB_STUB_FAIL:-}" ]; then
+  exit 1
+fi
+printf 'Filesystem 1G-blocks Used Available Use%% Mounted on\n'
+printf '/dev/sda 100G 0G %sG 0%% /\n' "${C_FREE_GB_STUB:-999}"
+STUB
+  chmod +x "$TEST_HOME/stubs/du" "$TEST_HOME/stubs/df"
+
+  local user
+  user=$(id -un)
+  cat > "$TEST_HOME/stubs/getent" << EOF
+#!/bin/bash
+if [ "\$1" = "passwd" ] && [ "\$2" = "$user" ]; then
+  printf '%s:x:0:0::%s:/bin/bash\n' "$user" "$TEST_HOME"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$TEST_HOME/stubs/getent"
+
+  export PATH="$TEST_HOME/stubs:$PATH"
+  # Defaults — tests override per-case.
+  export DUMP_GB_STUB="0"
+  export C_FREE_GB_STUB="999"
+  unset DUMP_GB_STUB_FAIL C_FREE_GB_STUB_FAIL
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP
+  unset CEO_DISK_WSL_CRASHES_PATH CEO_DISK_C_MOUNT
+  unset DUMP_GB_STUB C_FREE_GB_STUB DUMP_GB_STUB_FAIL C_FREE_GB_STUB_FAIL
+}
+
+run_monitor() {
+  bash "$MONITOR" >/dev/null 2>&1
+}
+
+state_field() {
+  awk -F': *' "/^$1:/ {print \$2; exit}" "$CEO_DIR/alerts/disk.md" | tr -d '[:space:]'
+}
+
+# ---------- tests ----------
+
+test_first_run_clear_creates_state_file() {
+  DUMP_GB_STUB="0" C_FREE_GB_STUB="999" run_monitor
+  assert_file_exists "$CEO_DIR/alerts/disk.md" "state file should exist"
+  assert_eq "$(state_field status)" "clear" "first run with low usage should be clear"
+  if [ -f "$CEO_DIR/inbox/testhost.md" ] && [ -s "$CEO_DIR/inbox/testhost.md" ]; then
+    printf '  FAIL [%s] clear first run must not write inbox\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_first_run_firing_appends_one_inbox_task() {
+  DUMP_GB_STUB="20" C_FREE_GB_STUB="999" run_monitor
+  assert_eq "$(state_field status)" "firing" "high dump should fire"
+  local count
+  count=$(grep -c -F "Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
+  assert_eq "$count" "1" "first firing run must append exactly one task"
+}
+
+test_steady_state_firing_does_not_re_append() {
+  # The regression this PR fixes: 64 identical appends. Two firing runs
+  # with no transition must leave exactly one task line.
+  DUMP_GB_STUB="20" run_monitor
+  DUMP_GB_STUB="20" run_monitor
+  local count
+  count=$(grep -c -F "Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
+  assert_eq "$count" "1" "steady-state firing must not re-append"
+}
+
+test_firing_to_clear_flips_task_and_appends_resolution() {
+  DUMP_GB_STUB="20" run_monitor
+  DUMP_GB_STUB="0" run_monitor
+  assert_eq "$(state_field status)" "clear" "second run with clear measurement should be clear"
+  local body
+  body=$(cat "$CEO_DIR/inbox/testhost.md")
+  assert_contains "$body" "- [done] Cleaned wsl-crashes on testhost" "task line must be flipped to [done]"
+  assert_contains "$body" "disk monitor cleared" "resolution note must be appended"
+  if grep -qF -- "- [ ] Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md"; then
+    printf '  FAIL [%s] original unchecked task must no longer be present\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_measurement_failure_preserves_prior_firing() {
+  # Invariant: du/df failure must NOT silently clear a firing alert.
+  DUMP_GB_STUB="20" run_monitor   # firing
+  local inbox_before
+  inbox_before=$(cat "$CEO_DIR/inbox/testhost.md")
+  DUMP_GB_STUB_FAIL=1 run_monitor # measurement fails
+  assert_eq "$(state_field status)" "firing" "measurement failure must preserve prior firing"
+  local inbox_after
+  inbox_after=$(cat "$CEO_DIR/inbox/testhost.md")
+  assert_eq "$inbox_after" "$inbox_before" "measurement failure must not mutate inbox"
+}
+
+test_measurement_failure_on_clear_does_not_flip_to_firing() {
+  DUMP_GB_STUB="0" run_monitor    # clear
+  DUMP_GB_STUB_FAIL=1 run_monitor # measurement fails
+  assert_eq "$(state_field status)" "clear" "measurement failure on clear stays clear"
+  if [ -f "$CEO_DIR/inbox/testhost.md" ] && [ -s "$CEO_DIR/inbox/testhost.md" ]; then
+    printf '  FAIL [%s] measurement-failed run after clear must not write inbox\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_missing_wsl_crashes_path_is_measurement_failure() {
+  rm -rf "$CEO_DISK_WSL_CRASHES_PATH"
+  DUMP_GB_STUB="20" run_monitor  # would fire if measurement succeeded
+  DUMP_GB_STUB="20" run_monitor  # second run to ensure no transition triggered
+  # Path missing on a firing measurement should not flip clear→firing.
+  if [ -f "$CEO_DIR/inbox/testhost.md" ] && [ -s "$CEO_DIR/inbox/testhost.md" ]; then
+    printf '  FAIL [%s] missing measurement path must not escalate inbox\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_corrupted_prior_status_does_not_mutate_inbox() {
+  # Write a state file with an unknown status value.
+  mkdir -p "$CEO_DIR/alerts"
+  cat > "$CEO_DIR/alerts/disk.md" << 'EOF'
+---
+status: frring
+since: 2026-05-12T00:00:00-0400
+last_check: 2026-05-12T00:00:00-0400
+host: testhost
+---
+EOF
+  DUMP_GB_STUB="0" run_monitor  # would clear, but prior is unknown → refuse to mutate inbox
+  if [ -f "$CEO_DIR/inbox/testhost.md" ] && [ -s "$CEO_DIR/inbox/testhost.md" ]; then
+    printf '  FAIL [%s] unknown prior status must not trigger inbox flip\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_corrupted_prior_status_emits_warning() {
+  mkdir -p "$CEO_DIR/alerts"
+  cat > "$CEO_DIR/alerts/disk.md" << 'EOF'
+---
+status: frring
+since: 2026-05-12T00:00:00-0400
+last_check: 2026-05-12T00:00:00-0400
+host: testhost
+---
+EOF
+  local stderr
+  stderr=$(bash "$MONITOR" 2>&1 >/dev/null) || true
+  assert_contains "$stderr" "unknown prior status" "unknown enum value must log to stderr"
+}
+
+test_sustained_firing_re_pokes_after_user_checkoff() {
+  # Sustained-firing branch fires only when the [ ] task line has been
+  # checked off but the alert still fires.
+  DUMP_GB_STUB="20" run_monitor                    # clear→firing, task appended
+  sed -i.bak 's/^- \[ \]/- [x]/' "$CEO_DIR/inbox/testhost.md"
+  rm -f "$CEO_DIR/inbox/testhost.md.bak"
+  # Force prior since to >24h ago so the SUSTAINED branch fires.
+  sed -i.bak "s/^since: .*/since: 2026-01-01T00:00:00-0500/" "$CEO_DIR/alerts/disk.md"
+  rm -f "$CEO_DIR/alerts/disk.md.bak"
+  DUMP_GB_STUB="20" run_monitor
+  local count
+  count=$(grep -c -F -- "- [ ] Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
+  assert_eq "$count" "1" "sustained firing past 24h after checkoff must re-append one task"
+}
+
+test_inbox_rewrite_handles_host_with_regex_chars() {
+  # HOST is interpolated into inbox-rewrite logic — must not break on regex
+  # metacharacters or shell special chars.
+  CEO_HOSTNAME='odd.host[1]'
+  DUMP_GB_STUB="20" run_monitor
+  DUMP_GB_STUB="0" run_monitor
+  assert_eq "$(state_field status)" "clear" "regex-meta host must still resolve"
+  local body
+  body=$(cat "$CEO_DIR/inbox/odd.host[1].md")
+  assert_contains "$body" "[done] Cleaned wsl-crashes on odd.host[1]" "host with regex chars must flip cleanly"
+}
+
+run_tests() {
+  local count=0
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    CURRENT_TEST="$fn"
+    setup
+    "$fn"
+    teardown
+    count=$((count + 1))
+  done
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}
+
+run_tests

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -23,10 +23,18 @@ if [ ! -f "$LAST_SCAN_MARKER" ]; then
 fi
 
 # --- 1. Vault file changes since last scan ---
+# Excludes:
+#   .obsidian/    — editor metadata
+#   CEO/log/      — append-only forensic history (per output-locations.md)
+#   CEO/reports/  — CEO-generated reports
+#   CEO/alerts/   — monitor state files (surfaced separately via ALERTS_FIRING below)
+#   CEO/inbox/    — per-host task files; the inbox playbook handles these directly
 VAULT_CHANGES_RAW=$(find "$VAULT" -newer "$LAST_SCAN_MARKER" -type f -name "*.md" \
   -not -path "*/.obsidian/*" \
   -not -path "*/CEO/log/*" \
   -not -path "*/CEO/reports/*" \
+  -not -path "*/CEO/alerts/*" \
+  -not -path "*/CEO/inbox/*" \
   -not -name "*.sync-conflict-*" \
   2>/dev/null || true)
 
@@ -93,3 +101,23 @@ if [ -f "$YESTERDAY_REPORT_FILE" ]; then
 else
   export FAILED_ACTIONS="none"
 fi
+
+# --- 6. Alerts (state files with status: firing|clear) ---
+# Surface only alerts whose status is "firing". Pull host + reason summary
+# from frontmatter. Sustained-firing surfacing is the playbook's job — this
+# block just reports the current state of each alert file.
+ALERTS_DIR="$CEO_DIR/alerts"
+ALERTS_FIRING=""
+if [ -d "$ALERTS_DIR" ]; then
+  for alert in "$ALERTS_DIR"/*.md; do
+    [ -f "$alert" ] || continue
+    status=$(awk -F': *' '/^status:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
+    if [ "$status" = "firing" ]; then
+      name=$(basename "$alert" .md)
+      host=$(awk -F': *' '/^host:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
+      since=$(awk -F': *' '/^since:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
+      ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
+    fi
+  done
+fi
+export ALERTS_FIRING

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -8,6 +8,7 @@
 #   YESTERDAY_DAILY_NOTE, TODAY_DAILY_NOTE
 #   PENDING_QUESTIONS, PENDING_APPROVALS_UNCHECKED
 #   YESTERDAY_REPORT, FAILED_ACTIONS
+#   ALERTS_FIRING
 
 VAULT="${CEO_VAULT:-${VAULT:-$HOME/Documents/Obsidian}}"
 CEO_DIR="$VAULT/CEO"
@@ -103,21 +104,30 @@ else
 fi
 
 # --- 6. Alerts (state files with status: firing|clear) ---
-# Surface only alerts whose status is "firing". Pull host + reason summary
-# from frontmatter. Sustained-firing surfacing is the playbook's job — this
-# block just reports the current state of each alert file.
+# Surface only alerts whose `status:` frontmatter is "firing". Pulls host and
+# transition timestamp from the same frontmatter; full reasons live in the
+# alert body. Unknown status values are logged so a corrupt or typo'd alert
+# file does not silently disappear from the morning scan.
 ALERTS_DIR="$CEO_DIR/alerts"
 ALERTS_FIRING=""
 if [ -d "$ALERTS_DIR" ]; then
   for alert in "$ALERTS_DIR"/*.md; do
     [ -f "$alert" ] || continue
-    status=$(awk -F': *' '/^status:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
-    if [ "$status" = "firing" ]; then
-      name=$(basename "$alert" .md)
-      host=$(awk -F': *' '/^host:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
-      since=$(awk -F': *' '/^since:/ {print $2; exit}' "$alert" | tr -d '[:space:]')
-      ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
-    fi
+    status=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
+    case "$status" in
+      firing)
+        name=$(basename "$alert" .md)
+        host=$(awk '/^host:/ { sub(/^host:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
+        since=$(awk '/^since:/ { sub(/^since:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
+        ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
+        ;;
+      clear|'')
+        ;;
+      *)
+        printf 'WARN: ceo-scan: unknown alert status %q in %s; treating as not firing\n' \
+          "$status" "$alert" >&2
+        ;;
+    esac
   done
 fi
 export ALERTS_FIRING

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -103,7 +103,6 @@ else
   export FAILED_ACTIONS="none"
 fi
 
-# --- 6. Alerts (state files with status: firing|clear) ---
 # Surface only alerts whose `status:` frontmatter is "firing". Pulls host and
 # transition timestamp from the same frontmatter; full reasons live in the
 # alert body. Unknown status values are logged so a corrupt or typo'd alert


### PR DESCRIPTION
## Summary

Converts the ad-hoc `/home/nhang/disk-monitor.sh` on ML-1 (written May 11 as a follow-up to the WSL crash-dump cleanup, with no registry entry, no playbook doc, and no state-machine logic) into a registered CEO playbook. Replaces append-on-every-fire signal generation with a state machine.

Context: between May 12 01:00 and May 13 17:00 the prior monitor appended 64 identical alert blocks to `CEO/inbox/disk-alert.md` after a May 11 CARLA crash dropped a 14 GB dump into `wsl-crashes/`. Morning-scan saw the file changing every hour but had no resolution path because (a) the inbox playbook only reads `CEO/inbox.md` (singular) and (b) the script had no clear-state logic.

## What changed

- **`scripts/ceo-disk-monitor.sh`** (new, +x) — state machine:
  - Reads prior `status:` and `since:` from `CEO/alerts/disk.md` frontmatter.
  - Measures wsl-crashes folder size (alert > 5 GB) and C: free (alert < 50 GB). Safe defaults so a read error doesn't false-clear.
  - Writes current state (overwrite) to `CEO/alerts/disk.md` with frontmatter (`status`, `since`, `last_check`, `host`, `dump_folder_gb`, `c_free_gb`).
  - Appends one line per check to `CEO/log/disk-monitor/YYYY-MM.md`.
  - Escalates to `CEO/inbox/<host>.md` ONLY on `clear → firing` transition or sustained firing (>24h since `since`). Idempotent (`grep -qF` dedupe).
  - On `firing → clear`: flips the task to `- [done]` and appends a resolution note.
- **`docs/playbooks/disk-monitor.md`** (new) — declared outputs, origin, documented gaps (`.wslconfig` only suppresses WSL-guest-side dumps; Windows-native binaries like CARLA bypass it).
- **`scripts/ceo-scan.sh`** (edited) — excludes `CEO/alerts/` and `CEO/inbox/` from generic vault-change diff; new section 6 (`ALERTS_FIRING`) reads `alerts/*.md` frontmatter and surfaces only entries with `status: firing`.

## Companion changes (vault side, not in this repo)

- `CEO/registry.json` — `disk-monitor` registered (`runner: script`, hourly, `file:` → `/mnt/c/Projects/claude-ceo/claude-ceo/docs/playbooks/disk-monitor.md`).
- `CEO/playbooks/morning-scan.md` — surfacing rules updated.
- `CEO/rules/output-locations.md` — four-location contract written.
- Global rule `ceo-automated-writers-are-playbooks` added at `~/.claude/rules/` + `~/.cursor/rules/` + `~/.claude/CLAUDE.md`.

## Test plan

- [ ] Bash syntax check (`bash -n`) on both scripts — passes locally.
- [ ] After merge: pull on ML-1; run `ceo playbook scan` and confirm new cron line installed.
- [ ] Manual fire: `ceo run disk-monitor` (or invoke the script directly); verify `CEO/alerts/disk.md` written with current state, `CEO/log/disk-monitor/2026-05.md` line appended.
- [ ] Verify state transition: with `wsl-crashes/` cleared (Phase 0b on ML-1), confirm `status: clear` and no inbox task. Drop a dummy 6G file under `wsl-crashes/`, re-fire, confirm `status: firing` and a single `- [ ]` task appended to `CEO/inbox/ML-1.md`. Re-fire — task should not duplicate.
- [ ] Verify clear transition: delete the dummy file, re-fire; the task in `inbox/ML-1.md` should flip to `- [done]` with a resolution note appended.
- [ ] Remove the bare `# ceo:disk-monitor` cron line from the old crontab on ML-1 (replaced by `ceo playbook scan`'s install).

## Session note

Full design + audit findings at `~/Documents/Obsidian/Projects/Development/nhangen/claude-ceo/2026-05-13-tighten-ceo-inbox-boundary.md`.