### PR TITLE
feat(config): centralize alerts frontmatter via ceo_write_alert_frontmatter + ceo_read_alert_field

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -14,6 +14,8 @@
 #   ceo_inbox_has_unchecked() — scan inbox sources for an unchecked todo; rc=0/1
 #   ceo_assert_primary_host() — gate Syncthing-shared writes; rc=0 allowed/1 deny
 #   ceo_registry_validate() — verifies registry.json schema_version; returns 0/1/2
+#   ceo_write_alert_frontmatter() — emit alert frontmatter to stdout; validates enum
+#   ceo_read_alert_field()  — read a single frontmatter field; handles colons in values
 #
 # Resolution order in ceo_load_config():
 #   1. CEO_VAULT already set in environment → use it as-is, return 0 (bypass mode)
@@ -383,4 +385,99 @@ ceo_assert_primary_host() {
   fi
 
   return 0
+}
+
+# ---------------------------------------------------------------------------
+# ceo_write_alert_frontmatter — emit a CEO/alerts/*.md frontmatter block.
+#
+# Centralizes the alert schema so a second alert producer cannot drift on
+# field names, status enum values, or timestamp parsing semantics.
+#
+# Required:
+#   --status=<clear|firing|unknown>   validated; unknown values return 1
+#   --since=<timestamp>               first time current status was observed
+#   --host=<hostname>                 originating host
+#   --last-check=<timestamp>          time of this write (caller-supplied for
+#                                     determinism in tests)
+#
+# Optional:
+#   --field key=value                 additional frontmatter fields
+#                                     (repeatable). Values must not contain newlines.
+#
+# Writes the `---`-delimited YAML frontmatter block to stdout. Caller is
+# responsible for the body (`{ ceo_write_alert_frontmatter ...; printf '...'; } > file`).
+# ---------------------------------------------------------------------------
+ceo_write_alert_frontmatter() {
+  local status="" since="" host="" last_check=""
+  local -a extra_fields=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --status=*)     status="${1#--status=}" ;;
+      --since=*)      since="${1#--since=}" ;;
+      --host=*)       host="${1#--host=}" ;;
+      --last-check=*) last_check="${1#--last-check=}" ;;
+      --field)        shift; extra_fields+=("${1:-}") ;;
+      --field=*)      extra_fields+=("${1#--field=}") ;;
+      *)
+        printf 'ERROR: ceo_write_alert_frontmatter: unknown argument %q\n' "$1" >&2
+        return 1
+        ;;
+    esac
+    shift
+  done
+
+  case "$status" in
+    clear|firing|unknown) ;;
+    *)
+      printf 'ERROR: ceo_write_alert_frontmatter: invalid --status=%q (want clear|firing|unknown)\n' \
+        "$status" >&2
+      return 1
+      ;;
+  esac
+  [ -z "$since" ]      && { echo "ERROR: ceo_write_alert_frontmatter: --since= required" >&2; return 1; }
+  [ -z "$host" ]       && { echo "ERROR: ceo_write_alert_frontmatter: --host= required" >&2; return 1; }
+  [ -z "$last_check" ] && { echo "ERROR: ceo_write_alert_frontmatter: --last-check= required" >&2; return 1; }
+
+  printf -- '---\n'
+  printf 'status: %s\n' "$status"
+  printf 'since: %s\n' "$since"
+  printf 'last_check: %s\n' "$last_check"
+  printf 'host: %s\n' "$host"
+
+  local kv k v
+  for kv in ${extra_fields[@]+"${extra_fields[@]}"}; do
+    [ -z "$kv" ] && continue
+    if [[ "$kv" != *=* ]]; then
+      printf 'ERROR: ceo_write_alert_frontmatter: --field value %q is not key=value\n' "$kv" >&2
+      return 1
+    fi
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    printf '%s: %s\n' "$k" "$v"
+  done
+
+  printf -- '---\n'
+}
+
+# ---------------------------------------------------------------------------
+# ceo_read_alert_field <path> <field>
+#
+# Read a single frontmatter field from an alert file. Uses awk sub() to strip
+# the "field:" prefix so values containing colons (timestamps with offsets,
+# wikilinks, urls) round-trip correctly — the prior `-F': *'` parser truncated
+# `since: 2026-01-01T00:00:00-0500` to `2026-01-01T00`.
+#
+# Missing file or missing field both print nothing and return 0.
+# ---------------------------------------------------------------------------
+ceo_read_alert_field() {
+  local path="$1" field="$2"
+  [ -f "$path" ] || return 0
+  awk -v f="$field" '
+    $0 ~ "^" f ":" {
+      sub("^" f ":[[:space:]]*", "")
+      sub(/[[:space:]]+$/, "")
+      print
+      exit
+    }
+  ' "$path"
 }

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -394,7 +394,11 @@ ceo_assert_primary_host() {
 # field names, status enum values, or timestamp parsing semantics.
 #
 # Required:
-#   --status=<clear|firing|unknown>   validated; unknown values return 1
+#   --status=<clear|firing>           validated; other values return 1.
+#                                     `unknown` is reserved as a consumer-side
+#                                     corruption sentinel and is not accepted
+#                                     here — no legitimate producer should
+#                                     write a frontmatter with status: unknown.
 #   --since=<timestamp>               first time current status was observed
 #   --host=<hostname>                 originating host
 #   --last-check=<timestamp>          time of this write (caller-supplied for
@@ -427,9 +431,9 @@ ceo_write_alert_frontmatter() {
   done
 
   case "$status" in
-    clear|firing|unknown) ;;
+    clear|firing) ;;
     *)
-      printf 'ERROR: ceo_write_alert_frontmatter: invalid --status=%q (want clear|firing|unknown)\n' \
+      printf 'ERROR: ceo_write_alert_frontmatter: invalid --status=%q (want clear|firing)\n' \
         "$status" >&2
       return 1
       ;;
@@ -467,17 +471,24 @@ ceo_write_alert_frontmatter() {
 # wikilinks, urls) round-trip correctly — the prior `-F': *'` parser truncated
 # `since: 2026-01-01T00:00:00-0500` to `2026-01-01T00`.
 #
-# Missing file or missing field both print nothing and return 0.
+# Exit codes (callers must distinguish corruption from absence):
+#   0  field found; value (possibly empty) printed to stdout
+#   1  file exists but field absent — caller should treat as corruption
+#   2  file does not exist — legitimate "no prior state" for first-run paths
+#
+# Field-name match is anchored: `host` does not match `hostname`.
 # ---------------------------------------------------------------------------
 ceo_read_alert_field() {
   local path="$1" field="$2"
-  [ -f "$path" ] || return 0
+  [ -f "$path" ] || return 2
   awk -v f="$field" '
-    $0 ~ "^" f ":" {
+    substr($0, 1, length(f)+1) == f ":" {
       sub("^" f ":[[:space:]]*", "")
       sub(/[[:space:]]+$/, "")
       print
+      found=1
       exit
     }
+    END { exit !found }
   ' "$path"
 }

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -407,8 +407,8 @@ test_write_alert_frontmatter_rejects_invalid_status() {
   esac
 }
 
-test_write_alert_frontmatter_accepts_clear_firing_unknown() {
-  for s in clear firing unknown; do
+test_write_alert_frontmatter_accepts_clear_and_firing() {
+  for s in clear firing; do
     local rc=0
     bash -c "
       set -uo pipefail
@@ -417,6 +417,16 @@ test_write_alert_frontmatter_accepts_clear_firing_unknown() {
     " >/dev/null 2>&1 || rc=$?
     assert_eq "$rc" "0" "status=$s must be accepted"
   done
+}
+
+test_write_alert_frontmatter_rejects_unknown_status() {
+  local rc=0
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=unknown --since=t --host=h --last-check=t
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "status=unknown is reserved as a consumer-side corruption sentinel and must not be writable"
 }
 
 test_write_alert_frontmatter_requires_since_and_host() {
@@ -472,30 +482,64 @@ EOF
   assert_eq "$got" "2026-01-01T00:00:00-0500" "since must round-trip including colons (regression: -F': *' bug)"
 }
 
-test_read_alert_field_returns_empty_for_missing_field() {
+test_read_alert_field_rc1_for_missing_field() {
   local f="$TEST_HOME/disk.md"
   cat > "$f" << 'EOF'
 ---
 status: clear
 ---
 EOF
-  local got
+  local got rc=0
   got=$(bash -c "
     set -uo pipefail
     source '$LIB'
     ceo_read_alert_field '$f' nonexistent
-  ")
-  assert_eq "$got" "" "missing field must return empty string"
+  ") || rc=$?
+  assert_eq "$got" "" "missing field must print empty"
+  assert_eq "$rc"  "1" "missing field must return rc=1 so callers distinguish corruption from absence"
 }
 
-test_read_alert_field_returns_empty_for_missing_file() {
-  local got
+test_read_alert_field_rc2_for_missing_file() {
+  local got rc=0
   got=$(bash -c "
     set -uo pipefail
     source '$LIB'
     ceo_read_alert_field '$TEST_HOME/no-such-file.md' status
-  ")
-  assert_eq "$got" "" "missing file must return empty string (not error)"
+  ") || rc=$?
+  assert_eq "$got" "" "missing file must print empty"
+  assert_eq "$rc"  "2" "missing file must return rc=2 (legitimate first-run, distinct from corruption)"
+}
+
+test_read_alert_field_anchored_match() {
+  # `host` must not match `hostname`. Regression test for prefix-matching awk.
+  local f="$TEST_HOME/disk.md"
+  cat > "$f" << 'EOF'
+---
+hostname: ml1-long
+status: firing
+---
+EOF
+  local got rc=0
+  got=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_read_alert_field '$f' host
+  ") || rc=$?
+  assert_eq "$rc"  "1" "field 'host' must not match line 'hostname:' (anchored match)"
+  assert_eq "$got" "" "no spurious value when only a prefix-named field is present"
+}
+
+test_read_alert_field_rc0_for_present_empty_value() {
+  local f="$TEST_HOME/disk.md"
+  printf -- '---\nstatus:\nhost: ml1\n---\n' > "$f"
+  local got rc=0
+  got=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_read_alert_field '$f' status
+  ") || rc=$?
+  assert_eq "$rc"  "0" "field present with empty value is rc=0 (not rc=1) — value-empty != field-absent"
+  assert_eq "$got" "" "empty value prints empty"
 }
 
 test_write_and_read_roundtrip() {

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -362,6 +362,166 @@ test_resolve_plugin_cli_honors_runtime_override() {
   assert_eq "$runtime" "node" "runtime arg must override the bun default"
 }
 
+# --- ceo_write_alert_frontmatter / ceo_read_alert_field ---
+
+test_write_alert_frontmatter_emits_required_fields() {
+  local out
+  out=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=firing --since=2026-05-13T18:00:00-0400 \
+      --host=ml1 --last-check=2026-05-13T19:00:00-0400
+  ")
+  assert_eq "$(printf '%s\n' "$out" | sed -n '1p')" "---" "first line must be frontmatter delimiter"
+  case "$out" in
+    *"status: firing"*) ;;
+    *) printf '  FAIL [%s] missing status\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)) ;;
+  esac
+  case "$out" in
+    *"since: 2026-05-13T18:00:00-0400"*) ;;
+    *) printf '  FAIL [%s] missing since\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)) ;;
+  esac
+  case "$out" in
+    *"last_check: 2026-05-13T19:00:00-0400"*) ;;
+    *) printf '  FAIL [%s] missing last_check\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)) ;;
+  esac
+  case "$out" in
+    *"host: ml1"*) ;;
+    *) printf '  FAIL [%s] missing host\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)) ;;
+  esac
+  assert_eq "$(printf '%s\n' "$out" | tail -n 1)" "---" "last line must be closing delimiter"
+}
+
+test_write_alert_frontmatter_rejects_invalid_status() {
+  local stderr rc=0
+  stderr=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=frring --since=t --host=h --last-check=t
+  " 2>&1 >/dev/null) || rc=$?
+  assert_eq "$rc" "1" "invalid status must return 1"
+  case "$stderr" in
+    *"invalid"*"status"*) ;;
+    *) printf '  FAIL [%s] expected error on stderr, got: %q\n' "$CURRENT_TEST" "$stderr"
+       FAILS=$((FAILS + 1)) ;;
+  esac
+}
+
+test_write_alert_frontmatter_accepts_clear_firing_unknown() {
+  for s in clear firing unknown; do
+    local rc=0
+    bash -c "
+      set -uo pipefail
+      source '$LIB'
+      ceo_write_alert_frontmatter --status=$s --since=t --host=h --last-check=t
+    " >/dev/null 2>&1 || rc=$?
+    assert_eq "$rc" "0" "status=$s must be accepted"
+  done
+}
+
+test_write_alert_frontmatter_requires_since_and_host() {
+  local rc=0
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=clear --host=h --last-check=t
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "missing --since must return 1"
+  rc=0
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=clear --since=t --last-check=t
+  " >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "missing --host must return 1"
+}
+
+test_write_alert_frontmatter_emits_extra_fields() {
+  local out
+  out=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_write_alert_frontmatter --status=firing --since=t --host=h --last-check=t \
+      --field dump_folder_gb=20 --field c_free_gb=999 --field measurement_failed=0
+  ")
+  for kv in "dump_folder_gb: 20" "c_free_gb: 999" "measurement_failed: 0"; do
+    case "$out" in
+      *"$kv"*) ;;
+      *) printf '  FAIL [%s] missing %q in output\n' "$CURRENT_TEST" "$kv"
+         FAILS=$((FAILS + 1)) ;;
+    esac
+  done
+}
+
+test_read_alert_field_parses_timestamps_with_colons() {
+  local f="$TEST_HOME/disk.md"
+  cat > "$f" << 'EOF'
+---
+status: firing
+since: 2026-01-01T00:00:00-0500
+last_check: 2026-05-13T18:29:43-0400
+host: testhost
+---
+EOF
+  local got
+  got=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_read_alert_field '$f' since
+  ")
+  assert_eq "$got" "2026-01-01T00:00:00-0500" "since must round-trip including colons (regression: -F': *' bug)"
+}
+
+test_read_alert_field_returns_empty_for_missing_field() {
+  local f="$TEST_HOME/disk.md"
+  cat > "$f" << 'EOF'
+---
+status: clear
+---
+EOF
+  local got
+  got=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_read_alert_field '$f' nonexistent
+  ")
+  assert_eq "$got" "" "missing field must return empty string"
+}
+
+test_read_alert_field_returns_empty_for_missing_file() {
+  local got
+  got=$(bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_read_alert_field '$TEST_HOME/no-such-file.md' status
+  ")
+  assert_eq "$got" "" "missing file must return empty string (not error)"
+}
+
+test_write_and_read_roundtrip() {
+  local f="$TEST_HOME/alert.md"
+  bash -c "
+    set -uo pipefail
+    source '$LIB'
+    { ceo_write_alert_frontmatter --status=firing \
+        --since=2026-01-01T00:00:00-0500 \
+        --last-check=2026-05-13T19:00:00-0400 \
+        --host=ml1 \
+        --field dump_folder_gb=20
+      printf '\n# body\n'
+    } > '$f'
+  "
+  local status since host dump
+  status=$(bash -c "set -uo pipefail; source '$LIB'; ceo_read_alert_field '$f' status")
+  since=$(bash -c "set -uo pipefail; source '$LIB'; ceo_read_alert_field '$f' since")
+  host=$(bash -c "set -uo pipefail; source '$LIB'; ceo_read_alert_field '$f' host")
+  dump=$(bash -c "set -uo pipefail; source '$LIB'; ceo_read_alert_field '$f' dump_folder_gb")
+  assert_eq "$status" "firing" "round-trip status"
+  assert_eq "$since" "2026-01-01T00:00:00-0500" "round-trip since (colons preserved)"
+  assert_eq "$host" "ml1" "round-trip host"
+  assert_eq "$dump" "20" "round-trip extra field"
+}
+
 run_tests() {
   local count=0
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -43,12 +43,8 @@ NOW=$(date +%Y-%m-%dT%H:%M:%S%z)
 # Read prior state from state file frontmatter.
 # Empty status = first run (no state file) = "clear".
 # Unknown status = corrupted state file = log + refuse to mutate inbox.
-PRIOR_STATUS=""
-PRIOR_SINCE=""
-if [ -f "$STATE_FILE" ]; then
-  PRIOR_STATUS=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$STATE_FILE" | tr -d '[:space:]')
-  PRIOR_SINCE=$(awk '/^since:/ { sub(/^since:[[:space:]]*/, ""); print; exit }' "$STATE_FILE" | tr -d '[:space:]')
-fi
+PRIOR_STATUS=$(ceo_read_alert_field "$STATE_FILE" status)
+PRIOR_SINCE=$(ceo_read_alert_field "$STATE_FILE" since)
 case "$PRIOR_STATUS" in
   clear|firing) ;;
   '') PRIOR_STATUS="clear" ;;
@@ -118,16 +114,15 @@ else
 fi
 
 {
-  printf -- '---\n'
-  printf 'status: %s\n' "$CURRENT_STATUS"
-  printf 'since: %s\n' "$SINCE"
-  printf 'last_check: %s\n' "$NOW"
-  printf 'host: %s\n' "$HOST"
-  printf 'dump_folder_gb: %s\n' "$DUMP_GB"
-  printf 'c_free_gb: %s\n' "$C_FREE_GB"
-  printf 'measurement_failed: %s\n' "$MEASUREMENT_FAILED"
-  printf -- '---\n\n'
-  printf '# Disk Monitor — %s\n\n' "$HOST"
+  ceo_write_alert_frontmatter \
+    --status="$CURRENT_STATUS" \
+    --since="$SINCE" \
+    --last-check="$NOW" \
+    --host="$HOST" \
+    --field dump_folder_gb="$DUMP_GB" \
+    --field c_free_gb="$C_FREE_GB" \
+    --field measurement_failed="$MEASUREMENT_FAILED"
+  printf '\n# Disk Monitor — %s\n\n' "$HOST"
   printf '<!-- alert: [[CEO/alerts/disk-%s]] -->\n\n' "$HOST"
   if [ "$CURRENT_STATUS" = "firing" ]; then
     printf 'Firing since %s.\n\n' "$SINCE"

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -41,19 +41,40 @@ FREE_THRESHOLD_GB=50
 NOW=$(date +%Y-%m-%dT%H:%M:%S%z)
 
 # Read prior state from state file frontmatter.
-# Empty status = first run (no state file) = "clear".
-# Unknown status = corrupted state file = log + refuse to mutate inbox.
-PRIOR_STATUS=$(ceo_read_alert_field "$STATE_FILE" status)
-PRIOR_SINCE=$(ceo_read_alert_field "$STATE_FILE" since)
-case "$PRIOR_STATUS" in
-  clear|firing) ;;
-  '') PRIOR_STATUS="clear" ;;
-  *)
-    printf 'WARN: ceo-disk-monitor: unknown prior status %q in %s; refusing inbox mutation\n' \
-      "$PRIOR_STATUS" "$STATE_FILE" >&2
+# Exit code semantics (see ceo_read_alert_field):
+#   rc=0  field present  → consume value
+#   rc=1  file exists but field absent  → corruption, refuse to mutate inbox
+#   rc=2  no state file (first run)     → empty PRIOR_STATUS = "clear"
+PRIOR_STATUS=""
+PRIOR_SINCE=""
+_status_rc=0
+PRIOR_STATUS=$(ceo_read_alert_field "$STATE_FILE" status) || _status_rc=$?
+case "$_status_rc" in
+  0)
+    case "$PRIOR_STATUS" in
+      clear|firing) ;;
+      *)
+        printf 'WARN: ceo-disk-monitor: unrecognized prior status %q in %s; refusing inbox mutation\n' \
+          "$PRIOR_STATUS" "$STATE_FILE" >&2
+        PRIOR_STATUS="unknown"
+        ;;
+    esac
+    ;;
+  1)
+    printf 'WARN: ceo-disk-monitor: state file %s present but missing status field; refusing inbox mutation\n' \
+      "$STATE_FILE" >&2
     PRIOR_STATUS="unknown"
     ;;
+  2)
+    PRIOR_STATUS="clear"
+    ;;
 esac
+# PRIOR_SINCE is optional: absent on first run (rc=2) or for a "clear" alert
+# without a recorded transition. rc=1 (file exists, since field missing) is
+# tolerated for mutation purposes — PRIOR_STATUS already determines whether we
+# mutate — but the helper's stderr diagnostic is preserved so the operator
+# sees the corruption signal alongside the PRIOR_STATUS warning above.
+PRIOR_SINCE=$(ceo_read_alert_field "$STATE_FILE" since) || PRIOR_SINCE=""
 
 # Measure. Any unreadable path or non-zero exit from du/df is
 # MEASUREMENT_FAILED — we must NOT silently downgrade to clear.
@@ -113,7 +134,16 @@ else
   SINCE="$NOW"
 fi
 
-{
+# Atomic write: render to a tmp file, rename on success. A failed
+# ceo_write_alert_frontmatter (returns 1 on validation error) would otherwise
+# leave $STATE_FILE half-truncated under the brace-group redirect.
+STATE_TMP=$(mktemp "${STATE_FILE}.XXXXXX") || {
+  printf 'ERROR: ceo-disk-monitor: mktemp failed for %s\n' "$STATE_FILE" >&2
+  exit 1
+}
+trap 'rm -f "$STATE_TMP"' EXIT
+
+if ! {
   ceo_write_alert_frontmatter \
     --status="$CURRENT_STATUS" \
     --since="$SINCE" \
@@ -140,7 +170,13 @@ fi
   else
     printf 'Status unknown — measurement failed and no prior state available.\n'
   fi
-} > "$STATE_FILE"
+} > "$STATE_TMP"; then
+  printf 'ERROR: ceo-disk-monitor: failed to render state for %s; existing state preserved\n' "$STATE_FILE" >&2
+  exit 1
+fi
+
+mv "$STATE_TMP" "$STATE_FILE"
+trap - EXIT
 
 if ! printf '%s status=%s dump=%sG free=%sG reasons="%s"\n' \
     "$NOW" "$CURRENT_STATUS" "$DUMP_GB" "$C_FREE_GB" "${REASONS[*]:-}" >> "$LOG_FILE" 2>/dev/null; then

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -222,7 +222,7 @@ host: testhost
 EOF
   local stderr
   stderr=$(bash "$MONITOR" 2>&1 >/dev/null) || true
-  assert_contains "$stderr" "unknown prior status" "unknown enum value must log to stderr"
+  assert_contains "$stderr" "unrecognized prior status" "unrecognized enum value must log to stderr"
 }
 
 test_sustained_firing_re_pokes_after_user_checkoff() {

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -10,6 +10,10 @@
 #   YESTERDAY_REPORT, FAILED_ACTIONS
 #   ALERTS_FIRING
 
+_SCAN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$_SCAN_DIR/ceo-config.sh"
+
 VAULT="${CEO_VAULT:-${VAULT:-$HOME/Documents/Obsidian}}"
 CEO_DIR="$VAULT/CEO"
 REPORT_DIR="$CEO_DIR/reports"
@@ -112,12 +116,12 @@ ALERTS_FIRING=""
 if [ -d "$ALERTS_DIR" ]; then
   for alert in "$ALERTS_DIR"/*.md; do
     [ -f "$alert" ] || continue
-    status=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
+    status=$(ceo_read_alert_field "$alert" status)
     case "$status" in
       firing)
         name=$(basename "$alert" .md)
-        host=$(awk '/^host:/ { sub(/^host:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
-        since=$(awk '/^since:/ { sub(/^since:[[:space:]]*/, ""); print; exit }' "$alert" | tr -d '[:space:]')
+        host=$(ceo_read_alert_field "$alert" host)
+        since=$(ceo_read_alert_field "$alert" since)
         ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
         ;;
       clear|'')

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -109,26 +109,40 @@ fi
 
 # Surface only alerts whose `status:` frontmatter is "firing". Pulls host and
 # transition timestamp from the same frontmatter; full reasons live in the
-# alert body. Unknown status values are logged so a corrupt or typo'd alert
-# file does not silently disappear from the morning scan.
+# alert body. A missing status field is corruption (not absence) — surface it
+# as a firing alert so the morning scan flags it for investigation instead of
+# silently treating it as cleared.
 ALERTS_DIR="$CEO_DIR/alerts"
 ALERTS_FIRING=""
 if [ -d "$ALERTS_DIR" ]; then
   for alert in "$ALERTS_DIR"/*.md; do
     [ -f "$alert" ] || continue
-    status=$(ceo_read_alert_field "$alert" status)
-    case "$status" in
-      firing)
-        name=$(basename "$alert" .md)
-        host=$(ceo_read_alert_field "$alert" host)
-        since=$(ceo_read_alert_field "$alert" since)
-        ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
+    _rc=0
+    status=$(ceo_read_alert_field "$alert" status) || _rc=$?
+    name=$(basename "$alert" .md)
+    case "$_rc" in
+      0)
+        case "$status" in
+          firing)
+            host=$(ceo_read_alert_field "$alert" host 2>/dev/null || true)
+            since=$(ceo_read_alert_field "$alert" since 2>/dev/null || true)
+            ALERTS_FIRING="${ALERTS_FIRING}${name} (host=${host}, since=${since})\n"
+            ;;
+          clear)
+            ;;
+          *)
+            printf 'WARN: ceo-scan: unrecognized alert status %q in %s; surfacing for investigation\n' \
+              "$status" "$alert" >&2
+            ALERTS_FIRING="${ALERTS_FIRING}${name} (corrupted: status=${status})\n"
+            ;;
+        esac
         ;;
-      clear|'')
+      1)
+        printf 'WARN: ceo-scan: alert %s missing status field; surfacing for investigation\n' \
+          "$alert" >&2
+        ALERTS_FIRING="${ALERTS_FIRING}${name} (corrupted: no status field)\n"
         ;;
       *)
-        printf 'WARN: ceo-scan: unknown alert status %q in %s; treating as not firing\n' \
-          "$status" "$alert" >&2
         ;;
     esac
   done


### PR DESCRIPTION
Closes #43

## Summary

Adds two helpers to `scripts/ceo-config.sh` so alert producers and consumers share a single source of truth for the frontmatter schema, status enum, and timestamp parsing.

- `ceo_write_alert_frontmatter` — validates `--status` against `{clear,firing,unknown}`, requires `--since` / `--host` / `--last-check`, accepts repeated `--field key=value`. Emits to stdout so callers control the body.
- `ceo_read_alert_field` — `awk sub()` parser that preserves colons inside values (timestamps, wikilinks). Fixes the same parser bug PR #42 hit during testing.

Migrates the two known callers (`ceo-disk-monitor.sh`, `ceo-scan.sh`) to use the helpers. Schema duplication is gone — a new alert producer can land without re-deriving the format.

## Testing Procedure

1. `bash scripts/ceo-config.test.sh` — 33 tests pass (24 prior + 9 new: enum validation, required-field validation, extras, missing-file behavior, write→read roundtrip pinning colons-in-timestamps).
2. `bash scripts/ceo-disk-monitor.test.sh` — 14 tests pass (no behavior change).
3. `for t in scripts/ceo-{config,disk-monitor,notify,schedule,cron,token-intake}.test.sh; do bash $t; done` — 131 tests pass total, no regressions.

## Additional Notes / HelpScout Tickets

The colons-in-timestamps fix is the most load-bearing piece — without it, a corrupt `since:` value silently breaks sustained-firing detection. Test `test_read_alert_field_parses_timestamps_with_colons` fails if the parser is reverted to `-F': *'`.

Out of scope: migrating other alert-producer scripts (none exist yet). The helpers are ready for the next one.