### PR TITLE
feat(workload-report): twice-weekly Zenhub team workload playbook

### DIFF
--- a/docs/playbooks/workload-report.md
+++ b/docs/playbooks/workload-report.md
@@ -47,6 +47,12 @@ Registered automatically by `ceo playbook scan`. Cron entries for repo playbooks
 
 Files accumulate forever by design — explicitly chose history over overwrite for trend analysis. Add a retention sweep later if `CEO/reports/workload/` gets unwieldy.
 
+## Troubleshooting
+
+- **No output or empty report:** check `cron-stderr.log` for the skill's stderr. Common cause: `~/.cursor/mcp.json` missing or `ZENHUB_TOKEN` resolved to the literal string `"null"`.
+- **`WARN: no assignee rows`:** auth succeeded but Zenhub returned zero items — likely a wrong `ZENHUB_WORKSPACE_ID` or the gh user has no access to the workspace.
+- **Wrong host in filename:** `CEO_HOSTNAME` overrides `hostname -s` if set.
+
 ## Disable
 
 Set `status: inactive` in this frontmatter or remove the file, then re-run `ceo playbook scan`.

--- a/docs/playbooks/workload-report.md
+++ b/docs/playbooks/workload-report.md
@@ -1,0 +1,52 @@
+---
+name: workload-report
+description: Twice-weekly Zenhub team workload report — current sprint, next sprint, other, by assignee and pipeline with story-point totals
+trigger: cron
+schedule: "0 7 * * 1,3"
+preflight: none
+tier: read
+status: active
+runner: script
+script: ceo-workload-report.sh
+---
+
+# Workload Report
+
+Shell-only playbook. The dispatcher invokes `scripts/ceo-workload-report.sh` directly — no LLM call.
+
+## What it does
+
+Runs the `workload-report` Claude Code skill (`~/.claude/skills/workload-report/scripts/run-report.sh`) and lands the markdown report at:
+
+```
+CEO/reports/workload/<YYYY-MM-DD>-<host>.md
+```
+
+Each fire writes a fresh dated snapshot so trends across sprints stay diffable. The skill itself queries Zenhub GraphQL + GitHub: per-assignee, per-pipeline counts and story-point totals, bucketed into Current Sprint / Next Sprint / Other.
+
+No inbox line. Workload is reference material, not a `- [ ]` task — surfaced via `ceo report` or direct file open.
+
+## Schedule
+
+Monday and Wednesday, 07:00 local. Monday seeds the week's starting picture post-weekend; Wednesday is a mid-sprint pulse before the typical Thursday/Friday sprint flip.
+
+## Credentials
+
+Resolved at runtime from the user's environment:
+
+- `GITHUB_TOKEN` ← `gh auth token`
+- `ZENHUB_TOKEN` + `ZENHUB_WORKSPACE_ID` ← `~/.cursor/mcp.json` (Zenhub MCP config)
+
+Both are user-scoped — the playbook is host-local (Mac), not portable to ML-1 unless those credentials are mirrored.
+
+## Install
+
+Registered automatically by `ceo playbook scan`. Cron entries for repo playbooks bake in `$INSTALL_DIR` at scan time. If the claude-ceo repo moves (re-clone, worktree shuffle), re-run `ceo playbook scan` to refresh the crontab.
+
+## Output retention
+
+Files accumulate forever by design — explicitly chose history over overwrite for trend analysis. Add a retention sweep later if `CEO/reports/workload/` gets unwieldy.
+
+## Disable
+
+Set `status: inactive` in this frontmatter or remove the file, then re-run `ceo playbook scan`.

--- a/scripts/ceo-workload-report.sh
+++ b/scripts/ceo-workload-report.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# ceo-workload-report.sh — Twice-weekly Zenhub team workload report.
+# Writes a dated snapshot to CEO/reports/workload/<TODAY>-<host>.md.
+# Per-host filenames keep two Syncthing peers from racing on the same path.
+# No inbox line — workload is reference, not an actionable task.
+#
+# Invoked by ceo-cron.sh when the workload-report playbook (runner:script) fires.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+
+# The skill script reads gh auth and ~/.cursor/mcp.json from $HOME.
+ceo_pin_home_or_warn || true
+ceo_augment_path
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+WORKLOAD_DIR="$CEO_DIR/reports/workload"
+TODAY=$(date +%Y-%m-%d)
+REPORT_FILE="$WORKLOAD_DIR/$TODAY-$HOST.md"
+
+mkdir -p "$WORKLOAD_DIR"
+
+SKILL="$HOME/.claude/skills/workload-report/scripts/run-report.sh"
+if [ ! -x "$SKILL" ]; then
+  echo "ERROR: workload-report skill not found at $SKILL" >&2
+  exit 1
+fi
+
+# Skill writes <date>-team.md into --out. Rename to include host so two
+# peers (Mac + ML-1) can run independently without clobbering each other.
+TMP_OUT=$(mktemp -d)
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+if ! "$SKILL" --out "$TMP_OUT" >/dev/null 2>&1; then
+  echo "ERROR: workload-report skill failed" >&2
+  exit 1
+fi
+
+SRC="$TMP_OUT/$TODAY-team.md"
+if [ ! -s "$SRC" ]; then
+  echo "ERROR: skill produced no output at $SRC" >&2
+  exit 1
+fi
+
+mv "$SRC" "$REPORT_FILE"
+echo "Wrote $REPORT_FILE"

--- a/scripts/ceo-workload-report.sh
+++ b/scripts/ceo-workload-report.sh
@@ -39,7 +39,7 @@ fi
 TMP_OUT=$(mktemp -d)
 trap 'rm -rf "$TMP_OUT"' EXIT
 
-if ! "$SKILL" --out "$TMP_OUT" >/dev/null 2>&1; then
+if ! "$SKILL" --out "$TMP_OUT" >/dev/null; then
   echo "ERROR: workload-report skill failed" >&2
   exit 1
 fi

--- a/scripts/ceo-workload-report.sh
+++ b/scripts/ceo-workload-report.sh
@@ -62,5 +62,12 @@ if [ ! -s "$SRC" ]; then
   exit 1
 fi
 
+# The skill emits frontmatter + headers unconditionally, so -s passes even
+# when Zenhub returned zero items (wrong workspace ID, auth-OK-no-data, etc).
+# Bullet rows start with "- **" — absence means a header-only report.
+if ! grep -q '^- \*\*' "$SRC"; then
+  echo "WARN: skill produced report with no assignee rows — auth/workspace misconfig?" >&2
+fi
+
 mv "$SRC" "$REPORT_FILE"
 echo "Wrote $REPORT_FILE"

--- a/scripts/ceo-workload-report.sh
+++ b/scripts/ceo-workload-report.sh
@@ -14,10 +14,22 @@ source "$SCRIPT_DIR/ceo-config.sh"
 
 ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
 
+# `set -u` does not catch HOME="" (set-but-empty); guard before any helper
+# that reads $HOME. Same shape as ceo-value-tracker.sh (PR #11 fix).
+: "${HOME:?HOME must be set}"
+
 # The skill script reads gh auth and ~/.cursor/mcp.json from $HOME.
 ceo_pin_home_or_warn || true
 ceo_augment_path
 
+# Verify $HOME actually resolves to a directory holding the MCP config the
+# skill will need. Catches launchd's $HOME=/var/root and cron-stripped env.
+if [ ! -f "$HOME/.cursor/mcp.json" ]; then
+  echo "ERROR: $HOME/.cursor/mcp.json not found — \$HOME may be wrong" >&2
+  exit 1
+fi
+
+: "${CEO_VAULT:?CEO_VAULT must be set}"
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 HOST="${CEO_HOSTNAME:-$(hostname -s)}"

--- a/scripts/ceo-workload-report.sh
+++ b/scripts/ceo-workload-report.sh
@@ -56,9 +56,19 @@ if ! "$SKILL" --out "$TMP_OUT" >/dev/null; then
   exit 1
 fi
 
-SRC="$TMP_OUT/$TODAY-team.md"
+# Don't hardcode the skill's filename — across-midnight TZ skew between
+# wrapper $TODAY and the skill's own `date` call would leave the file under
+# yesterday's name and make us bail as if no output existed. Glob instead.
+shopt -s nullglob
+MD_FILES=("$TMP_OUT"/*.md)
+shopt -u nullglob
+if [ "${#MD_FILES[@]}" -ne 1 ]; then
+  echo "ERROR: expected exactly one .md in $TMP_OUT, got ${#MD_FILES[@]}" >&2
+  exit 1
+fi
+SRC="${MD_FILES[0]}"
 if [ ! -s "$SRC" ]; then
-  echo "ERROR: skill produced no output at $SRC" >&2
+  echo "ERROR: skill produced empty output at $SRC" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds a script-runner playbook that writes a dated team workload snapshot to `CEO/reports/workload/<date>-<host>.md` every Mon/Wed at 07:00 local.
- Wrapper invokes the new `workload-report` Claude Code skill (`~/.claude/skills/workload-report/scripts/run-report.sh`), which queries Zenhub GraphQL for open issues across all pipelines, groups by assignee × sprint bucket (current/next/other) × pipeline, and totals story points.
- No inbox line — workload is reference material, not an actionable task. Surfaced via `ceo report` or direct file open.
- Per-host filename (`<date>-<host>.md`) prevents two Syncthing peers from racing on the same path.

## Files

- `scripts/ceo-workload-report.sh` — shell-only wrapper, follows the token-intake pattern (`ceo_load_config`, `ceo_pin_home_or_warn`, `ceo_augment_path`, `set -euo pipefail`).
- `docs/playbooks/workload-report.md` — playbook frontmatter with `runner: script`, `schedule: "0 7 * * 1,3"`, `tier: read`.

## Testing

- [x] Skill end-to-end: `bash ~/.claude/skills/workload-report/scripts/run-report.sh --no-save` returns a full team report against the OptinMonster workspace.
- [x] Wrapper end-to-end: `bash scripts/ceo-workload-report.sh` wrote a 27 KB report to `CEO/reports/workload/2026-05-19-MacBook-Pro-190.md`.
- [ ] After merge: run `ceo playbook scan` from `~/code/claude-ceo` to update `CEO/registry.json` and install the crontab line. First scheduled fire: Mon 2026-05-25 07:00.

## Notes

- Credentials are user-scoped (gh CLI + `~/.cursor/mcp.json`). Mac-only for now; ML-1 would need both mirrored.
- History accumulates by design (snapshot per fire). Add a retention sweep later if `reports/workload/` gets unwieldy.