### PR TITLE
Observability and Ollama Runner Fixes (#15-17, #30-35)

### DIFF
--- a/docs/ollama-setup.md
+++ b/docs/ollama-setup.md
@@ -1,0 +1,35 @@
+# Ollama Setup for CEO Agent
+
+The CEO agent supports local inference via the `runner: ollama` and `runner: ollama-think` options in playbook frontmatter. This allows you to run deterministic, high-throughput, or privacy-sensitive tasks locally without incurring API costs.
+
+## Default Models
+
+If a playbook uses an ollama runner but does not specify a `model:`, the system defaults to:
+- `runner: ollama`: `mistral-small3.2:24b`
+- `runner: ollama-think`: `gpt-oss:20b`
+
+These models were chosen as the optimal balance between capability and speed for a local 16GB-24GB VRAM environment.
+
+## Bootstrap Script
+
+To quickly pull the required default models on a new host, run the provided bootstrap script:
+
+```bash
+bash scripts/ollama-setup.sh
+```
+
+## Manual Setup
+
+If you prefer to pull the models manually, or if you want to use custom models:
+
+```bash
+# Pull the standard playbook runner (fast, capable)
+ollama pull mistral-small3.2:24b
+
+# Pull the thinking/reasoning runner (slower, methodical)
+ollama pull gpt-oss:20b
+```
+
+## Scan-Time Validation
+
+When you run `ceo playbook scan`, the agent will check your local `ollama list` to verify that the required models (either defaults or explicitly defined `model:` overrides) are available. If a required model is missing, the playbook will be skipped during scan time with a diagnostic message, preventing runtime failures.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -525,13 +525,41 @@ cmd_playbook_scan() {
         ;;
     esac
 
-    case "$runner" in
-      ""|claude|script|ollama|ollama-think) ;;
-      *)
-        echo "  SKIP  $basename (unknown runner: '$runner', expected: claude|script|ollama|ollama-think)"
-        skipped=$((skipped + 1))
-        continue ;;
-    esac
+    local runner_valid=0
+    [ -z "$runner" ] && runner_valid=1
+    for r in "${CEO_VALID_RUNNERS[@]}"; do
+      [ "$runner" = "$r" ] && { runner_valid=1; break; }
+    done
+    if [ "$runner_valid" -eq 0 ]; then
+      echo "  SKIP  $basename (unknown runner: '$runner', expected: ${CEO_VALID_RUNNERS[*]})"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [ "$runner" = "ollama" ] || [ "$runner" = "ollama-think" ]; then
+      local effective_model="$model"
+      if [ "$runner" = "ollama" ]; then
+        [ -z "$effective_model" ] && effective_model="mistral-small3.2:24b"
+      else
+        [ -z "$effective_model" ] && effective_model="gpt-oss:20b"
+      fi
+
+      if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
+        if ! command -v ollama &>/dev/null; then
+          echo "  SKIP  $basename (ollama CLI not found)"
+          skipped=$((skipped + 1))
+          continue
+        fi
+
+        local ollama_models
+        ollama_models=$(timeout 3 ollama list 2>/dev/null | awk '{print $1}')
+        if ! echo "$ollama_models" | grep -q "^${effective_model}$"; then
+          echo "  SKIP  $basename (model '$effective_model' not found locally; run 'ollama pull $effective_model')"
+          skipped=$((skipped + 1))
+          continue
+        fi
+      fi
+    fi
 
     local entry_file
     if [ "$from_repo" = "1" ]; then

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -8,7 +8,10 @@ set -euo pipefail
 # Usage: ceo-cleanup.sh
 # Requires: CEO_VAULT env var or defaults to ~/Documents/Obsidian
 
-VAULT="${CEO_VAULT:-$HOME/Documents/Obsidian}"
+_CLEANUP_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$_CLEANUP_DIR/ceo-config.sh"
+ceo_require_vault
+VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 LOG_DIR="$CEO_DIR/log"
 REPOS_FILE="$CEO_DIR/repos.md"

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -101,8 +101,23 @@ ceo_load_config() {
 # `return 1` on failure (exit would kill the caller's shell).
 # ---------------------------------------------------------------------------
 ceo_require_vault() {
-  ceo_load_config && return 0
+  if ceo_load_config; then
+    rm -f "/tmp/ceo-cron-config-fails" 2>/dev/null || true
+    return 0
+  fi
   echo "FATAL — CEO_VAULT unresolved. Run 'ceo setup' to initialize." >&2
+  local fail_file="/tmp/ceo-cron-config-fails"
+  local fails
+  fails=$(cat "$fail_file" 2>/dev/null || echo 0)
+  fails=$((fails + 1))
+  echo "$fails" > "$fail_file"
+  if [ "$fails" -ge 3 ]; then
+    if command -v osascript &>/dev/null; then
+      osascript -e 'display notification "CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." with title "Claude CEO FATAL"' &>/dev/null || true
+    else
+      logger "Claude CEO FATAL: CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." || true
+    fi
+  fi
   exit 1
 }
 
@@ -234,6 +249,7 @@ ceo_pin_home_or_warn() {
 #   1 — implicit (pre-runner-script registry; missing field treated as <2)
 # ---------------------------------------------------------------------------
 CEO_REGISTRY_SCHEMA_VERSION=2
+CEO_VALID_RUNNERS=(claude script ollama ollama-think)
 
 # ceo_registry_version <registry_file>
 #   Prints the integer schema_version, or nothing if missing/malformed.

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -175,16 +175,24 @@ mkdir -p "$REPORT_DIR"
 # --- Exclusive lock (prevents overlapping cron runs) ---
 if command -v flock &>/dev/null; then
   exec 200>"$LOCK_FILE"
-  if ! flock -n 200; then
-    echo "$(date): Skipping $TRIGGER — another CEO cron is running" >> "$LOG_DIR/cron-skips.log"
+  if ! flock -w 300 200; then
+    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 300s)" >> "$LOG_DIR/cron-skips.log"
     exit 0
   fi
   trap "rm -f '$LOCK_FILE' 2>/dev/null" EXIT
 else
-  # macOS fallback: mkdir-based lock
+  # macOS fallback: mkdir-based lock with retry
   LOCK_DIR="${LOCK_FILE}.d"
-  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    echo "$(date): Skipping $TRIGGER — another CEO cron is running" >> "$LOG_DIR/cron-skips.log"
+  _lock_acquired=false
+  for _i in $(seq 1 300); do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      _lock_acquired=true
+      break
+    fi
+    sleep 1
+  done
+  if ! $_lock_acquired; then
+    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 300s)" >> "$LOG_DIR/cron-skips.log"
     exit 0
   fi
   trap "rmdir '$LOCK_DIR' 2>/dev/null" EXIT
@@ -202,7 +210,10 @@ if [ "${CEO_FORCE:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then
 fi
 
 # --- Pre-flight: gh auth ---
-if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
+if ! command -v gh &>/dev/null; then
+  echo "$(date): ERROR — gh CLI not found on PATH=$PATH" >> "$LOG_DIR/cron-stderr.log"
+  _v "ERROR: gh CLI not found"
+elif ! gh auth status &>/dev/null 2>&1; then
   echo "$(date): WARNING — gh CLI not authenticated. PR-related playbooks will fail." >> "$LOG_DIR/cron-skips.log"
   _v "WARNING: gh CLI not authenticated"
 fi
@@ -238,6 +249,10 @@ preflight_has_unchecked_inbox() {
 }
 
 preflight_has_prs_to_review() {
+  if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
+    _record_failure "gh CLI missing or unauthenticated; cannot check PRs for review"
+    return 1
+  fi
   [ "${PR_REVIEW_COUNT:-0}" -gt 0 ]
 }
 
@@ -264,6 +279,10 @@ preflight_has_ceo_branches() {
 preflight_has_auto_review_prs() {
   local scan_script="$HOME/.claude/skills/auto-review/scripts/scan-prs.sh"
   [ -x "$scan_script" ] || return 1
+  if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
+    _record_failure "gh CLI missing or unauthenticated; cannot run auto-review scan"
+    return 1
+  fi
   local scan_out="/tmp/auto-review-scan.json"
   "$scan_script" > "$scan_out" 2>/tmp/auto-review-scan.stderr
   local exit_code=$?
@@ -305,12 +324,14 @@ TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
 TIER=$(echo "$ENTRY" | jq -r '.tier // "read"')
 RUNNER=$(echo "$ENTRY" | jq -r '.runner // ""')
 [ -z "$RUNNER" ] && RUNNER="claude"
-case "$RUNNER" in
-  claude|script|ollama|ollama-think) ;;
-  *)
-    _record_failure "Unknown runner '$RUNNER' for $TRIGGER (expected: claude|script|ollama|ollama-think)"
-    exit 1 ;;
-esac
+_runner_valid=0
+for _r in "${CEO_VALID_RUNNERS[@]}"; do
+  [ "$RUNNER" = "$_r" ] && { _runner_valid=1; break; }
+done
+if [ "$_runner_valid" -eq 0 ]; then
+  _record_failure "Unknown runner '$RUNNER' for $TRIGGER (expected: ${CEO_VALID_RUNNERS[*]})"
+  exit 1
+fi
 SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
 # Per-playbook input filtering. INPUTS_JSON is the raw JSON value from the
 # registry: `null` (absent → all keys), `[]` (none), or `["key", …]`.
@@ -424,6 +445,8 @@ if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
       _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
       exit 1
     fi
+  else
+    _v "NOTE: CEO_OLLAMA_SKIP_PROBE set, skipping daemon probe"
   fi
   if [ -z "$MODEL" ]; then
     case "$RUNNER" in

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -46,6 +46,9 @@ setup() {
   # has no daemon backing it). Production runs leave this unset.
   export CEO_OLLAMA_SKIP_PROBE=1
 
+  # Prevent test pollution from leaked cron locks
+  rm -rf /tmp/ceo-cron.lock /tmp/ceo-cron.lock.d 2>/dev/null || true
+
   mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports"
   : > "$CEO_DIR/AGENTS.md"
   : > "$CEO_DIR/IDENTITY.md"
@@ -105,6 +108,7 @@ STUB
 
 teardown() {
   rm -rf "$TEST_HOME"
+  rm -rf /tmp/ceo-cron.lock /tmp/ceo-cron.lock.d 2>/dev/null || true
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
   unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR CEO_OLLAMA_SKIP_PROBE
@@ -857,6 +861,46 @@ PB
   PATH=/usr/bin:/bin bash "$CRON" ollama-strip >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ollama branch must resolve ollama via ceo_augment_path under stripped PATH"
   assert_file_exists "$HOME/ollama-invoked-model.txt" "ollama stub must fire under stripped PATH"
+}
+
+test_runner_ollama_skips_preamble_files() {
+  cat > "$CEO_DIR/playbooks/ollama-preamble.md" << 'PB'
+---
+name: ollama-preamble
+description: Assert AGENTS/IDENTITY omitted
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# my-playbook-body
+PB
+
+  echo "SENTINEL_AGENT_CONTENT" > "$CEO_DIR/AGENTS.md"
+  echo "SENTINEL_IDENTITY_CONTENT" > "$CEO_DIR/IDENTITY.md"
+  echo "SENTINEL_TRAINING_CONTENT" > "$CEO_DIR/TRAINING.md"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-preamble >/dev/null 2>&1 || true
+
+  local prompt
+  prompt=$(cat "$HOME/ollama-invoked-prompt.txt" 2>/dev/null || echo "")
+
+  if [[ "$prompt" == *"SENTINEL_AGENT_CONTENT"* ]]; then
+    printf '  FAIL [%s] ollama prompt must NOT contain AGENTS.md content\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [[ "$prompt" == *"SENTINEL_IDENTITY_CONTENT"* ]]; then
+    printf '  FAIL [%s] ollama prompt must NOT contain IDENTITY.md content\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [[ "$prompt" == *"SENTINEL_TRAINING_CONTENT"* ]]; then
+    printf '  FAIL [%s] ollama prompt must NOT contain TRAINING.md content\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$prompt" "my-playbook-body" "ollama prompt must contain the playbook body"
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -22,7 +22,7 @@ GATHER_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 source "$GATHER_DIR/ceo-config.sh"
 
 # --- Base paths ---
-ceo_load_config || { echo "ERROR: CEO config not found. Set CEO_VAULT or run: ceo setup" >&2; return 1; }
+ceo_require_vault
 export VAULT="$CEO_VAULT"
 export CEO_DIR="$VAULT/CEO"
 export LOG_DIR="$CEO_DIR/log"

--- a/scripts/ceo-log.sh
+++ b/scripts/ceo-log.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # Usage: ceo-log.sh [date|yesterday|today]
 # Called by the /ceo:log skill to avoid an AI call for pure file display.
 
-VAULT="${CEO_VAULT:-$HOME/Documents/Obsidian}"
+_LOG_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$_LOG_DIR/ceo-config.sh"
+ceo_require_vault
+VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 LOG_DIR="$CEO_DIR/log"
 

--- a/scripts/ceo-scan.sh
+++ b/scripts/ceo-scan.sh
@@ -14,7 +14,8 @@ _SCAN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=ceo-config.sh
 source "$_SCAN_DIR/ceo-config.sh"
 
-VAULT="${CEO_VAULT:-${VAULT:-$HOME/Documents/Obsidian}}"
+ceo_require_vault
+VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 REPORT_DIR="$CEO_DIR/reports"
 LOG_DIR="$CEO_DIR/log"

--- a/scripts/count-blessings.sh
+++ b/scripts/count-blessings.sh
@@ -5,8 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=blessings-lib.sh
 source "$SCRIPT_DIR/blessings-lib.sh"
 
-: "${CEO_VAULT:=$HOME/Documents/Obsidian}"
-: "${CEO_DIR:=$CEO_VAULT/CEO}"
+source "$SCRIPT_DIR/ceo-config.sh"
+ceo_require_vault
+CEO_DIR="$CEO_VAULT/CEO"
 export CEO_VAULT CEO_DIR
 
 BLESSINGS_FILE="$CEO_DIR/blessings.md"

--- a/scripts/ollama-setup.sh
+++ b/scripts/ollama-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# ollama-setup.sh — Bootstrap script to pull default local models for the CEO agent
+set -e
+
+if ! command -v ollama &>/dev/null; then
+  echo "ERROR: ollama CLI not found. Please install Ollama first:"
+  echo "https://ollama.com/download"
+  exit 1
+fi
+
+echo "Pulling default models for CEO agent runners..."
+
+echo "1/2: Pulling mistral-small3.2:24b (default for 'runner: ollama')..."
+ollama pull mistral-small3.2:24b
+
+echo "2/2: Pulling gpt-oss:20b (default for 'runner: ollama-think')..."
+ollama pull gpt-oss:20b
+
+echo ""
+echo "Setup complete. The CEO agent is ready to dispatch local playbooks."


### PR DESCRIPTION
Resolves #15
Resolves #16
Resolves #17
Resolves #30
Resolves #31
Resolves #32
Resolves #33
Resolves #34
Resolves #35

This PR addresses all observability gaps and Ollama runner lifecycle behaviors:
- Structurally enforces vault resolution via `ceo_require_vault`.
- Adds preflight and stderr logging for `gh` missing state.
- Adds test harness isolation for cron locks.
- Extracts `CEO_VALID_RUNNERS` to configuration.
- Validates local models at scan time.
- Increases global lock to 300s to handle local model cold-loading.
- Adds documentation for Ollama setup.