### PR TITLE
Follow-up fixes for #49 (Locks, regex, state paths)

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -553,7 +553,7 @@ cmd_playbook_scan() {
 
         local ollama_models
         ollama_models=$(timeout 3 ollama list 2>/dev/null | awk '{print $1}')
-        if ! echo "$ollama_models" | grep -q "^${effective_model}$"; then
+        if ! echo "$ollama_models" | grep -Fxq -- "$effective_model"; then
           echo "  SKIP  $basename (model '$effective_model' not found locally; run 'ollama pull $effective_model')"
           skipped=$((skipped + 1))
           continue

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -551,8 +551,20 @@ cmd_playbook_scan() {
           continue
         fi
 
-        local ollama_models
-        ollama_models=$(timeout 3 ollama list 2>/dev/null | awk '{print $1}')
+        ceo_resolve_timeout_bin
+        local ollama_models ollama_rc
+        if [ -n "$CEO_TIMEOUT_BIN" ]; then
+          ollama_models=$("$CEO_TIMEOUT_BIN" 3 ollama list 2>/dev/null | awk 'NR>1 {print $1}')
+          ollama_rc=${PIPESTATUS[0]}
+        else
+          ollama_models=$(ollama list 2>/dev/null | awk 'NR>1 {print $1}')
+          ollama_rc=${PIPESTATUS[0]}
+        fi
+        case "$ollama_rc" in
+          0) : ;;
+          124) echo "  SKIP  $basename (ollama daemon hung — 'ollama list' timed out)"; skipped=$((skipped + 1)); continue ;;
+          *)   echo "  SKIP  $basename (ollama list failed rc=$ollama_rc — daemon down? run 'ollama serve')"; skipped=$((skipped + 1)); continue ;;
+        esac
         if ! echo "$ollama_models" | grep -Fxq -- "$effective_model"; then
           echo "  SKIP  $basename (model '$effective_model' not found locally; run 'ollama pull $effective_model')"
           skipped=$((skipped + 1))

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -101,16 +101,31 @@ ceo_load_config() {
 # `return 1` on failure (exit would kill the caller's shell).
 # ---------------------------------------------------------------------------
 ceo_require_vault() {
+  local fail_file="$HOME/.claude/ceo-cron-config-fails"
   if ceo_load_config; then
-    rm -f "/tmp/ceo-cron-config-fails" 2>/dev/null || true
+    rm -f "$fail_file" 2>/dev/null || true
     return 0
   fi
   echo "FATAL — CEO_VAULT unresolved. Run 'ceo setup' to initialize." >&2
-  local fail_file="/tmp/ceo-cron-config-fails"
+  
+  mkdir -p "$HOME/.claude" 2>/dev/null || true
+  local lock_file="${fail_file}.lock"
+  
+  if command -v flock &>/dev/null; then
+    exec 202>"$lock_file"
+    flock -x 202
+  fi
+  
   local fails
   fails=$(cat "$fail_file" 2>/dev/null || echo 0)
   fails=$((fails + 1))
   echo "$fails" > "$fail_file"
+  
+  if command -v flock &>/dev/null; then
+    flock -u 202
+    exec 202>&-
+  fi
+
   if [ "$fails" -ge 3 ]; then
     if command -v osascript &>/dev/null; then
       osascript -e 'display notification "CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." with title "Claude CEO FATAL"' &>/dev/null || true

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -96,6 +96,23 @@ ceo_load_config() {
 }
 
 # ---------------------------------------------------------------------------
+# ceo_resolve_timeout_bin — sets CEO_TIMEOUT_BIN to "timeout" / "gtimeout" / "".
+# Empty value means no portable timeout available; callers must handle that.
+# Mirrors the resolver in ceo-cron.sh:85-107; promoted here so non-cron scripts
+# (e.g. `ceo playbook scan`'s ollama probe) can share the same shim.
+# ---------------------------------------------------------------------------
+ceo_resolve_timeout_bin() {
+  if command -v timeout &>/dev/null; then
+    CEO_TIMEOUT_BIN="timeout"
+  elif command -v gtimeout &>/dev/null; then
+    CEO_TIMEOUT_BIN="gtimeout"
+  else
+    CEO_TIMEOUT_BIN=""
+  fi
+  export CEO_TIMEOUT_BIN
+}
+
+# ---------------------------------------------------------------------------
 # ceo_require_vault — load config; exit 1 with operator guidance if unresolved.
 # For executed scripts only. Sourced scripts must call ceo_load_config and
 # `return 1` on failure (exit would kill the caller's shell).

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -118,36 +118,66 @@ ceo_resolve_timeout_bin() {
 # `return 1` on failure (exit would kill the caller's shell).
 # ---------------------------------------------------------------------------
 ceo_require_vault() {
+  : "${HOME:?HOME must be set before ceo_require_vault}"
   local fail_file="$HOME/.claude/ceo-cron-config-fails"
   if ceo_load_config; then
     rm -f "$fail_file" 2>/dev/null || true
     return 0
   fi
   echo "FATAL — CEO_VAULT unresolved. Run 'ceo setup' to initialize." >&2
-  
+
   mkdir -p "$HOME/.claude" 2>/dev/null || true
   local lock_file="${fail_file}.lock"
-  
-  if command -v flock &>/dev/null; then
-    exec 202>"$lock_file"
-    flock -x 202
+  local lock_dir="${fail_file}.lock.d"
+  local locked=false
+
+  # Atomic increment: prefer flock (Linux), fall back to mkdir directory-lock
+  # (macOS where flock isn't installed). Bounded wait so a stale lock doesn't
+  # block the cron tick indefinitely; on timeout we log and skip the increment
+  # rather than race on the read-modify-write.
+  if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
+    if exec 202>"$lock_file" && flock -w 5 -x 202; then
+      locked=true
+    else
+      echo "WARN — could not acquire flock on $lock_file; skipping fail-counter increment" >&2
+      exec 202>&- 2>/dev/null || true
+    fi
+  else
+    local _i
+    for _i in $(seq 1 5); do
+      if mkdir "$lock_dir" 2>/dev/null; then
+        locked=true
+        break
+      fi
+      sleep 1
+    done
+    if ! $locked; then
+      echo "WARN — could not acquire mkdir lock on $lock_dir; skipping fail-counter increment" >&2
+    fi
   fi
-  
-  local fails
-  fails=$(cat "$fail_file" 2>/dev/null || echo 0)
-  fails=$((fails + 1))
-  echo "$fails" > "$fail_file"
-  
-  if command -v flock &>/dev/null; then
-    flock -u 202
-    exec 202>&-
+
+  local fails=0
+  if $locked; then
+    fails=$(cat "$fail_file" 2>/dev/null || echo 0)
+    case "$fails" in (''|*[!0-9]*) fails=0 ;; esac
+    fails=$((fails + 1))
+    echo "$fails" > "$fail_file"
+    if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
+      flock -u 202 2>/dev/null || true
+      exec 202>&- 2>/dev/null || true
+    else
+      rmdir "$lock_dir" 2>/dev/null || true
+    fi
   fi
 
   if [ "$fails" -ge 3 ]; then
+    # Sentinel file alongside the notification channels so observability sees
+    # the escalation even if osascript (locked session) and logger both fail.
+    : > "$HOME/.claude/ceo-fatal-alerted" 2>/dev/null || true
     if command -v osascript &>/dev/null; then
       osascript -e 'display notification "CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." with title "Claude CEO FATAL"' &>/dev/null || true
     else
-      logger "Claude CEO FATAL: CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." || true
+      logger "Claude CEO FATAL: CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." 2>/dev/null || true
     fi
   fi
   exit 1

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -95,6 +95,19 @@ test_ceo_report_fails_loud_on_unresolved_vault() {
   fi
 }
 
+test_ceo_callers_fail_loud_on_unresolved_vault() {
+  local rc=0 out
+  for script in "ceo-log.sh" "ceo-cleanup.sh" "ceo-scan.sh" "ceo-gather.sh" "count-blessings.sh"; do
+    rc=0
+    out=$(env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/$script" 2>&1) || rc=$?
+    assert_eq "$rc" "1" "$script must exit 1 when no vault resolves"
+    case "$out" in
+      *FATAL*) ;;
+      *) printf '  FAIL [%s] %s stderr missing FATAL\n    got: %q\n' "$CURRENT_TEST" "$script" "$out"; FAILS=$((FAILS + 1)) ;;
+    esac
+  done
+}
+
 test_ceo_help_works_on_fresh_host() {
   local rc=0
   env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/ceo" help >/dev/null 2>&1 || rc=$?

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -96,16 +96,18 @@ test_ceo_report_fails_loud_on_unresolved_vault() {
 }
 
 test_ceo_callers_fail_loud_on_unresolved_vault() {
-  local rc=0 out
+  local rc=0 out _outer_test="$CURRENT_TEST"
   for script in "ceo-log.sh" "ceo-cleanup.sh" "ceo-scan.sh" "ceo-gather.sh" "count-blessings.sh"; do
+    CURRENT_TEST="${_outer_test}::${script}"
     rc=0
     out=$(env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/$script" 2>&1) || rc=$?
     assert_eq "$rc" "1" "$script must exit 1 when no vault resolves"
     case "$out" in
       *FATAL*) ;;
-      *) printf '  FAIL [%s] %s stderr missing FATAL\n    got: %q\n' "$CURRENT_TEST" "$script" "$out"; FAILS=$((FAILS + 1)) ;;
+      *) printf '  FAIL [%s] stderr missing FATAL\n    got: %q\n' "$CURRENT_TEST" "$out"; FAILS=$((FAILS + 1)) ;;
     esac
   done
+  CURRENT_TEST="$_outer_test"
 }
 
 test_ceo_help_works_on_fresh_host() {
@@ -577,6 +579,55 @@ test_write_and_read_roundtrip() {
   assert_eq "$since" "2026-01-01T00:00:00-0500" "round-trip since (colons preserved)"
   assert_eq "$host" "ml1" "round-trip host"
   assert_eq "$dump" "20" "round-trip extra field"
+}
+
+test_require_vault_rejects_empty_home() {
+  # F10 fail-on-revert: removing the ${HOME:?...} guard at the top of
+  # ceo_require_vault lets the fail-counter write fall through to /.claude/...
+  # under empty HOME. set -u alone does not catch set-but-empty.
+  local rc=0 out
+  out=$(env -i HOME="" CEO_VAULT="" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_require_vault
+  " 2>&1) || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] ceo_require_vault must exit non-zero when HOME is empty (got 0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  case "$out" in
+    *HOME*) ;;
+    *) printf '  FAIL [%s] empty-HOME error must mention HOME\n    got: %q\n' "$CURRENT_TEST" "$out"; FAILS=$((FAILS + 1)) ;;
+  esac
+}
+
+test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback() {
+  # F3 fail-on-revert: with CEO_TEST_FORCE_MKDIR_LOCK=1 the mkdir directory-lock
+  # path runs even on hosts with flock. Three sequential failures must yield a
+  # counter value of 3 — reverting the lock-gated write to an unguarded one
+  # would still increment correctly here, but reverting the validator
+  # ($fails fallthrough to "0" on non-numeric) would crash arithmetic on a
+  # pre-corrupted file.
+  local counter_file="$TEST_HOME/.claude/ceo-cron-config-fails"
+  local fails_value
+  for _i in 1 2 3; do
+    env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 PATH="$PATH" bash -c "
+      set -uo pipefail
+      source '$LIB'
+      ceo_require_vault
+    " >/dev/null 2>&1 || true
+  done
+  fails_value=$(cat "$counter_file" 2>/dev/null || echo missing)
+  assert_eq "$fails_value" "3" "fail counter must reach 3 after three calls under mkdir-fallback"
+  # Pre-corrupt the counter and verify the numeric validator resets to 0+1=1.
+  echo "garbage" > "$counter_file"
+  env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_require_vault
+  " >/dev/null 2>&1 || true
+  fails_value=$(cat "$counter_file" 2>/dev/null || echo missing)
+  assert_eq "$fails_value" "1" "corrupted counter must reset to 1 on next failure"
 }
 
 run_tests() {

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -173,22 +173,36 @@ REPORT_DIR="$CEO_DIR/reports"
 mkdir -p "$REPORT_DIR"
 
 # --- Exclusive lock (prevents overlapping cron runs) ---
-if command -v flock &>/dev/null; then
+if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
   exec 200>"$LOCK_FILE"
   if ! flock -w 30 200; then
     echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 30s)" >> "$LOG_DIR/cron-skips.log"
     exit 0
   fi
-  trap "rm -f '$LOCK_FILE' 2>/dev/null" EXIT
+  # No rm trap: flock releases on FD close. Unlinking the inode while another
+  # process still holds it open lets a third process create a new inode at the
+  # same path and acquire its own flock — both run concurrently.
 else
-  # macOS fallback: mkdir-based lock with retry
+  # macOS fallback: mkdir-based lock with retry + stale-PID detection.
+  # A SIGKILL'd cron leaves $LOCK_DIR orphaned; without stale detection every
+  # subsequent tick loops 30s and falsely reports "another CEO cron is running".
   LOCK_DIR="${LOCK_FILE}.d"
   _lock_acquired=false
   trap '$_lock_acquired && rmdir "$LOCK_DIR" 2>/dev/null' EXIT
   for _i in $(seq 1 30); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo "$$" > "$LOCK_DIR/pid"
       _lock_acquired=true
       break
+    fi
+    # Stale check: if the recorded PID is gone, reclaim the lock.
+    if [ -f "$LOCK_DIR/pid" ]; then
+      _holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo "")
+      if [ -n "$_holder" ] && ! kill -0 "$_holder" 2>/dev/null; then
+        echo "$(date): Reclaiming stale lock from dead PID $_holder" >> "$LOG_DIR/cron-skips.log"
+        rmdir "$LOCK_DIR" 2>/dev/null || true
+        continue
+      fi
     fi
     sleep 1
   done

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -29,7 +29,7 @@ LOG_DIR="$CEO_DIR/log"
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
 LOG_FILE="$LOG_DIR/$TODAY.md"
-LOCK_FILE="${CEO_LOCK_FILE:-"$CEO_DIR/log/ceo-cron.lock"}"
+LOCK_FILE="${CEO_LOCK_FILE:-$CEO_DIR/log/ceo-cron.lock}"
 LAST_RUN_FILE="$LOG_DIR/.last-run-${TRIGGER}"
 FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
 
@@ -45,8 +45,9 @@ _record_success() {
   date +%s > "$LAST_RUN_FILE"
   [ "$TRIGGER" = "morning-scan" ] && touch "$LOG_DIR/.last-scan"
   echo "$(date): $TRIGGER completed" >> "$LOG_DIR/cron-runs.log"
-  if [ "$TRIGGER" != "disk-monitor" ]; then
-    [ -x "$SCRIPT_DIR/ceo-notify.sh" ] && "$SCRIPT_DIR/ceo-notify.sh" success "$TRIGGER" >/dev/null 2>&1 || true
+  if [ "$TRIGGER" != "disk-monitor" ] && [ -x "$SCRIPT_DIR/ceo-notify.sh" ]; then
+    "$SCRIPT_DIR/ceo-notify.sh" success "$TRIGGER" >/dev/null 2>&1 || \
+      echo "$(date): WARN — ceo-notify.sh success exited non-zero for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
   fi
 }
 
@@ -69,7 +70,10 @@ _record_failure() {
 ALERTEOF
   fi
   date +%s > "$LAST_RUN_FILE"
-  [ -x "$SCRIPT_DIR/ceo-notify.sh" ] && "$SCRIPT_DIR/ceo-notify.sh" failure "$TRIGGER" "$reason" >/dev/null 2>&1 || true
+  if [ -x "$SCRIPT_DIR/ceo-notify.sh" ]; then
+    "$SCRIPT_DIR/ceo-notify.sh" failure "$TRIGGER" "$reason" >/dev/null 2>&1 || \
+      echo "$(date): WARN — ceo-notify.sh failure exited non-zero for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
+  fi
 }
 
 # --- Require jq ---
@@ -214,7 +218,8 @@ fi
 
 # --- Per-trigger runaway protection (skip with --force) ---
 if [ "${CEO_FORCE:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then
-  LAST_RUN=$(cat "$LAST_RUN_FILE")
+  LAST_RUN=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo 0)
+  case "$LAST_RUN" in (''|*[!0-9]*) LAST_RUN=0 ;; esac
   NOW_EPOCH=$(date +%s)
   COOLDOWN=$(_cfg '.cooldown_seconds' '1800')
   if [ $((NOW_EPOCH - LAST_RUN)) -lt "$COOLDOWN" ]; then
@@ -433,7 +438,7 @@ if [ "$RUNNER" = "script" ]; then
   _v "Runner: script — exec $SCRIPT_PATH"
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
   SCRIPT_EXIT=0
-  "$SCRIPT_FULL" 2>>"$LOG_DIR/cron-stderr.log" || SCRIPT_EXIT=$?
+  "$SCRIPT_FULL" >>"$LOG_DIR/cron-stdout.log" 2>>"$LOG_DIR/cron-stderr.log" || SCRIPT_EXIT=$?
   if [ "$SCRIPT_EXIT" -ne 0 ]; then
     _v "FAILED (exit: $SCRIPT_EXIT)"
     _record_failure "Script exited $SCRIPT_EXIT for $TRIGGER"

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -29,7 +29,7 @@ LOG_DIR="$CEO_DIR/log"
 TODAY=$(date +%Y-%m-%d)
 NOW=$(date +%H:%M)
 LOG_FILE="$LOG_DIR/$TODAY.md"
-LOCK_FILE="/tmp/ceo-cron.lock"
+LOCK_FILE="${CEO_LOCK_FILE:-"$CEO_DIR/log/ceo-cron.lock"}"
 LAST_RUN_FILE="$LOG_DIR/.last-run-${TRIGGER}"
 FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
 
@@ -175,8 +175,8 @@ mkdir -p "$REPORT_DIR"
 # --- Exclusive lock (prevents overlapping cron runs) ---
 if command -v flock &>/dev/null; then
   exec 200>"$LOCK_FILE"
-  if ! flock -w 300 200; then
-    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 300s)" >> "$LOG_DIR/cron-skips.log"
+  if ! flock -w 30 200; then
+    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 30s)" >> "$LOG_DIR/cron-skips.log"
     exit 0
   fi
   trap "rm -f '$LOCK_FILE' 2>/dev/null" EXIT
@@ -184,7 +184,8 @@ else
   # macOS fallback: mkdir-based lock with retry
   LOCK_DIR="${LOCK_FILE}.d"
   _lock_acquired=false
-  for _i in $(seq 1 300); do
+  trap '$_lock_acquired && rmdir "$LOCK_DIR" 2>/dev/null' EXIT
+  for _i in $(seq 1 30); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       _lock_acquired=true
       break
@@ -192,10 +193,9 @@ else
     sleep 1
   done
   if ! $_lock_acquired; then
-    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 300s)" >> "$LOG_DIR/cron-skips.log"
+    echo "$(date): Skipping $TRIGGER — another CEO cron is running (timed out after 30s)" >> "$LOG_DIR/cron-skips.log"
     exit 0
   fi
-  trap "rmdir '$LOCK_DIR' 2>/dev/null" EXIT
 fi
 
 # --- Per-trigger runaway protection (skip with --force) ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -46,8 +46,8 @@ setup() {
   # has no daemon backing it). Production runs leave this unset.
   export CEO_OLLAMA_SKIP_PROBE=1
 
-  # Prevent test pollution from leaked cron locks
-  rm -rf /tmp/ceo-cron.lock /tmp/ceo-cron.lock.d 2>/dev/null || true
+  # Isolate cron lock to this test invocation
+  export CEO_LOCK_FILE="$TEST_HOME/ceo-cron.lock"
 
   mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports"
   : > "$CEO_DIR/AGENTS.md"
@@ -108,10 +108,9 @@ STUB
 
 teardown() {
   rm -rf "$TEST_HOME"
-  rm -rf /tmp/ceo-cron.lock /tmp/ceo-cron.lock.d 2>/dev/null || true
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR CEO_OLLAMA_SKIP_PROBE
+  unset CEO_VAULT CEO_DIR TEST_HOME HOME_BACKUP PATH_BACKUP CEO_REPO_PLAYBOOK_DIR CEO_OLLAMA_SKIP_PROBE CEO_LOCK_FILE
 }
 
 test_runner_script_execs_named_script_and_skips_claude() {

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -8,7 +8,7 @@
 # Replaces the prior /home/nhang/disk-monitor.sh which appended to
 # CEO/inbox/disk-alert.md unconditionally every hour.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=ceo-config.sh
@@ -162,7 +162,11 @@ if ! {
       printf '## Reasons\n\n'
       for r in "${REASONS[@]}"; do printf -- '- %s\n' "$r"; done
       printf '\n## Largest dumps\n\n```\n'
-      [ -d "$WSL_CRASHES_PATH" ] && (ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10 || echo "(unable to list)")
+      if [ -d "$WSL_CRASHES_PATH" ]; then
+        if ! ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10; then
+          echo "(unable to list)"
+        fi
+      fi
       printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm /mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes/*.dmp\n```\n'
     fi
   elif [ "$CURRENT_STATUS" = "clear" ]; then
@@ -213,13 +217,20 @@ if [ "$MEASUREMENT_FAILED" -eq 0 ] && [ "$PRIOR_STATUS" != "unknown" ] && [ "$CU
     fi
   fi
 
+  _append_inbox() {
+    if ! printf '%s\n' "$1" >> "$INBOX_FILE"; then
+      echo "ERROR: ceo-disk-monitor: failed to append to $INBOX_FILE" >&2
+      exit 1
+    fi
+  }
+
   if [ "$PRIOR_STATUS" = "clear" ] && [ "$CURRENT_STATUS" = "firing" ]; then
-    active_task_present || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+    active_task_present || _append_inbox "$TASK_LINE"
   elif [ "$SUSTAINED" -eq 1 ]; then
     # Re-poke fires only if the prior unchecked task has been checked off
     # — `active_task_present` is false once the `[ ]` becomes `[x]` or
     # `[done]`, allowing the append.
-    active_task_present || printf '%s\n' "$TASK_LINE" >> "$INBOX_FILE"
+    active_task_present || _append_inbox "$TASK_LINE"
   elif [ "$PRIOR_STATUS" = "firing" ] && [ "$CURRENT_STATUS" = "clear" ]; then
     if active_task_present; then
       tmpfile=$(mktemp) || { echo "ERROR: ceo-disk-monitor: mktemp failed for inbox rewrite" >&2; exit 1; }
@@ -232,7 +243,7 @@ if [ "$MEASUREMENT_FAILED" -eq 0 ] && [ "$PRIOR_STATUS" != "unknown" ] && [ "$CU
         exit 1
       fi
       trap - EXIT
-      printf '%s\n' "$DONE_NOTE" >> "$INBOX_FILE"
+      _append_inbox "$DONE_NOTE"
     fi
   fi
 fi

--- a/scripts/ollama-setup.sh
+++ b/scripts/ollama-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # ollama-setup.sh — Bootstrap script to pull default local models for the CEO agent
-set -e
+set -euo pipefail
+trap 'echo "ERROR: ollama-setup failed at line $LINENO" >&2' ERR
 
 if ! command -v ollama &>/dev/null; then
   echo "ERROR: ollama CLI not found. Please install Ollama first:"
@@ -12,9 +13,11 @@ echo "Pulling default models for CEO agent runners..."
 
 echo "1/2: Pulling mistral-small3.2:24b (default for 'runner: ollama')..."
 ollama pull mistral-small3.2:24b
+echo "1/2: OK"
 
 echo "2/2: Pulling gpt-oss:20b (default for 'runner: ollama-think')..."
 ollama pull gpt-oss:20b
+echo "2/2: OK"
 
 echo ""
 echo "Setup complete. The CEO agent is ready to dispatch local playbooks."


### PR DESCRIPTION
This PR resolves the follow-up issues generated by the mini panel review on PR #49.

Resolves #50
Resolves #51
Resolves #52
Resolves #53
Resolves #54
Resolves #55

Changes:
- Moves lock state off world-writable /tmp paths to private ~/.claude and CEO_DIR/log.
- Wraps config fail counter in flock for atomic updates.
- Lowers the global cron lock wait from 300s to 30s.
- Corrects trap installation order for macOS mkdir fallback locks.
- Uses strict string matching (grep -Fxq) for ollama model verification.
- Adds call-site smoke tests for ceo_require_vault.
- Scopes test cron lock via CEO_LOCK_FILE to prevent live tick clobbering.