### PR TITLE
feat: backfill playbooks and add drift detector

### DIFF
--- a/docs/playbooks/auto-review.md
+++ b/docs/playbooks/auto-review.md
@@ -1,0 +1,68 @@
+---
+name: auto-review
+description: Scan team PRs, dispatch 2-round review pipeline, write drafts to Obsidian
+trigger: cron
+schedule: "17 9,13 * * 1-5"
+model: sonnet
+preflight: has_auto_review_prs
+tier: read
+status: active
+---
+
+# Auto PR Review
+
+Scan all team repos for qualifying PRs, run the 2-round review pipeline (Agent A verify + Agent B independent + expert panel), write actionable drafts to Obsidian. Never posts comments — that's a separate interactive action.
+
+## Steps
+
+1. Read `CEO/TRAINING.md` and `CEO/training/pr-review.md` for review rules.
+
+2. The preflight has already run `scan-prs.sh` and saved the qualifying PR JSON to `/tmp/auto-review-scan.json`. Read it now to confirm there is work:
+
+   ```bash
+   QUALIFYING=$(jq 'length' /tmp/auto-review-scan.json)
+   ```
+
+   If `$QUALIFYING == 0`, log "no qualifying PRs" and exit (this should never happen — preflight gates on > 0).
+
+3. **Invoke the `/auto-review` skill** with mode `process-prefetched`:
+   - The skill should NOT re-scan; it should read `/tmp/auto-review-scan.json` directly
+   - For each qualifying PR, run the 2-round pipeline: Agent A (verify existing review comments), Agent B (independent review), Expert panel (reconcile)
+   - Write the consolidated report to `~/Documents/Obsidian/Awesome Motive/reviews/<date>-<HHMM>-auto-review.md`
+   - Update `~/.config/auto-review/reviewed.json`
+
+4. After the skill completes, output the LOG_ENTRY summary:
+
+   ```
+   **Auto Review:**
+   - Scanned: N PRs across M repos
+   - Qualifying: N
+   - Reviewed: N
+   - Skipped: N
+   - Report: <path>
+   - PRs needing your action: <list of repo#number with recommendation>
+   ```
+
+5. If any PR has recommendation `Changes requested` or unresolved decisions, note it as a suggested follow-up — the human acts on the draft via "show me the draft for PR #NNN" in a separate session.
+
+## Constraints
+
+- **Read-only tier.** This playbook NEVER posts comments, approves, or modifies any PR. All it does is write a Markdown file to Obsidian and update a local JSON state file.
+- The skill handles all the AI work (agent dispatch, synthesis). The playbook is a thin wrapper.
+- Never run `gh` directly — the skill does it.
+- If the skill fails or times out on a single PR, that PR is added to the skipped list with a reason. Other PRs continue.
+- No Slack, email, or external notifications. The Obsidian write is the only output.
+
+## Token Budget
+
+- Preflight scan: 0 AI tokens (pure shell).
+- Per qualifying PR: ~50-100k tokens (Agent A + Agent B + 3 experts + synthesis).
+- Typical run with 2-3 qualifying PRs: ~200-300k tokens.
+- High-water mark with 5+ PRs: ~500k+ tokens — log a warning and consider extending the cron interval.
+
+## Failure Modes
+
+- **`gh auth` failed:** Preflight returns no-work. Log "scan-prs.sh exit 2: auth failure" and skip.
+- **Zero qualifying PRs:** Preflight returns no-work. No log entry needed (already common).
+- **Skill error mid-run:** Some PRs may be partially reviewed. The reviewed.json is only updated for PRs that completed successfully — others retry on next cron.
+- **Obsidian vault unreachable:** Skill writes to `/tmp` as fallback and logs the alternate path.

--- a/docs/playbooks/bug-fix.md
+++ b/docs/playbooks/bug-fix.md
@@ -1,0 +1,62 @@
+---
+name: bug-fix
+description: Investigate and fix a reported bug following structured workflow
+trigger: both
+model: opus
+preflight: none
+tier: low-stakes write
+status: active
+---
+
+# Bug Fix
+
+Investigate and fix a bug in a repo. Delegated via /ceo:delegate.
+
+## Input
+
+A bug description — either a GitHub issue number, a PR with failing tests, or a free-text description.
+
+## Steps
+
+1. Read CEO/TRAINING.md and CEO/training/repos.md for repo-specific rules.
+2. **Identify the repo** — parse the issue/PR reference or ask if unclear.
+3. **Clone if needed** — if the repo isn't cloned:
+   ```bash
+   git clone git@github.com:<org>/<repo>.git ~/repos/<org>/<repo>
+   ```
+   Add entry to CEO/repos.md.
+4. **Create a worktree** — from the repo:
+   ```bash
+   git fetch origin master
+   git worktree add ../repo-<slug> -b ceo/bug/<issue>-<short-desc> origin/master
+   ```
+5. **Read the issue/PR** — gather context:
+   ```bash
+   gh issue view <number> --json title,body,labels,comments
+   ```
+
+6. **Dispatch Implementer** — delegate the investigation and fix to an Implementer subagent (vault-mediated):
+   - Task: "Fix <bug description> in <org>/<repo>. Issue: #<number>."
+   - Context: issue body from step 5, repo path, CEO/training/repos.md, worktree path from step 4
+   - The Implementer will return: status, fix summary, files changed, test results, commit hash, recommendations
+
+7. **Review the result** — read the Implementer's output.
+   - If STATUS is "completed": proceed to propose push + PR
+   - If STATUS is "failed" or "needs-help": log the failure, escalate to Nathan
+   - If tests failed: do NOT proceed. Log and stop.
+
+8. **Propose push + PR** — pushing and creating a PR are high-stakes actions. Write to CEO/approvals/pending.md:
+    ```
+    - [ ] **Push and create PR for bug fix**
+      - repo: <org>/<repo>
+      - branch: ceo/bug/<issue>-<short-desc>
+      - playbook: bug-fix
+      - reasoning: <what the fix does, test results>
+    ```
+9. **Log result** — append to CEO/log/YYYY-MM-DD.md.
+
+## Constraints
+
+- Do NOT push code or create PRs — those are high-stakes. Always write a proposal.
+- If the fix is too complex or touches too many files, escalate to the user.
+- If tests fail after the fix, log the failure and stop — do not push broken code.

--- a/docs/playbooks/cleanup.md
+++ b/docs/playbooks/cleanup.md
@@ -1,0 +1,50 @@
+---
+name: cleanup
+description: Clean merged branches, detect orphans, resolve sync conflicts
+trigger: cron
+schedule: "7 3 * * 0"
+model: haiku
+preflight: has_ceo_branches
+tier: low-stakes write
+status: active
+---
+
+# Cleanup
+
+Weekly maintenance: clean up branches, worktrees, and review CEO log history.
+
+## Steps
+
+1. Read CEO/TRAINING.md and CEO/training/repos.md for repo-specific rules.
+2. **Run cleanup script** — execute the shell script that handles all deterministic cleanup:
+   ```bash
+   bash <plugin-path>/scripts/ceo-cleanup.sh
+   ```
+   The script:
+   - Reads CEO/repos.md for cloned repos
+   - Lists CEO branches and worktrees per repo
+   - Removes merged branches and their worktrees automatically
+   - Identifies orphaned branches (no PR, >7 days old)
+   - Counts sync conflict files
+   - Counts old log files (>30 days)
+   - Reports whether AI judgment is needed
+
+3. **If AI_NEEDED: yes** — review the orphaned branches listed in ORPHAN_SUMMARY. For each:
+   - If the branch name suggests abandoned work, propose deletion in CEO/approvals/pending.md
+   - If the branch might have unsaved work, log it as "needs review" but do not propose deletion
+
+4. **If sync conflicts found** — log them as errors. These indicate Syncthing write-domain violations.
+
+5. **Output cleanup summary** in the LOG_ENTRY Output section — the shell will write it to CEO/log/YYYY-MM-DD.md:
+   ```
+   - N worktrees removed (merged)
+   - N orphaned branches found (N proposals written)
+   - N sync conflicts detected
+   - N log files older than 30 days
+   ```
+
+## Constraints
+
+- Do NOT delete remote branches — that's high-stakes. Only clean up local branches and worktrees.
+- Do NOT delete log files — only report age.
+- Propose remote branch deletion via CEO/approvals/pending.md if needed.

--- a/docs/playbooks/eod-summary.md
+++ b/docs/playbooks/eod-summary.md
@@ -1,0 +1,42 @@
+---
+name: eod-summary
+description: End of day summary — what was done, what carries over
+trigger: cron
+schedule: "47 17 * * 1-5"
+model: sonnet
+preflight: has_log_entries_after_4pm
+tier: read
+status: active
+---
+
+# End of Day Summary
+
+Summarize the day's CEO activity and carryover items.
+
+## Steps
+
+1. Read CEO/TRAINING.md and CEO/training/briefings.md for summary rules.
+2. Read CEO/log/YYYY-MM-DD.md — gather all entries from today.
+3. Read CEO/approvals/pending.md — count outstanding items.
+4. Read today's daily note if it exists — check Tasks for incomplete items.
+5. Output the summary in the LOG_ENTRY Output section — the shell will write it to CEO/log/YYYY-MM-DD.md:
+   ```
+   **Today's activity:**
+   - N actions executed (N completed, N failed, N partial)
+   - N proposals written to pending approvals
+   - N audibles logged
+   
+   **Pending approvals:** N items awaiting Nathan's review
+   
+   **Carryover for tomorrow:**
+   - [items from daily note Tasks still unchecked]
+   - [any failed actions that need retry]
+   - [pending questions not yet answered]
+   
+   **Errors:** [any unresolved errors, or "none"]
+   ```
+
+## Constraints
+
+- Read-only. The shell handles all log writes from your LOG_ENTRY block.
+- Keep the summary under 15 lines.

--- a/docs/playbooks/inbox.md
+++ b/docs/playbooks/inbox.md
@@ -1,0 +1,47 @@
+---
+name: inbox
+description: Check CEO/inbox.md for new tasks and process them
+trigger: chat
+model: haiku
+preflight: has_unchecked_inbox
+tier: read
+status: active
+---
+
+# Inbox Processing
+
+Check CEO/inbox.md for new tasks and process them.
+
+## Steps
+
+1. Read CEO/TRAINING.md for general rules.
+2. Read CEO/inbox.md.
+3. Find all unchecked items (`- [ ]`). Skip items marked `[x]` (user cancelled) or `[done]` (already processed).
+4. If no unchecked items: log "inbox empty" and stop.
+5. For each unchecked item, in order:
+   a. Match to a playbook via CEO/SKILLS.md dispatch table (same keyword matching as /ceo:delegate).
+   b. If matched: dispatch per the playbook (may involve subagent dispatch).
+   c. If no match: attempt the task without a playbook using authority tiers. For read-only tasks, execute directly. For write tasks, propose in approvals/pending.md.
+   d. After completion: format the item as `- [done] <task> — <brief result> (<YYYY-MM-DD>)`, remove it from `CEO/inbox.md`, and append it to `CEO/inbox-archive.md` (create a `## YYYY-MM-DD` header if it's the first item of the day).
+   e. On failure: replace `- [ ]` with `- [failed] ` and append the error.
+6. Output the inbox results in the LOG_ENTRY Output section — the shell will write it to CEO/log/YYYY-MM-DD.md:
+   ```
+   **Items processed:** N
+   **Results:**
+   - <task> — completed | failed | proposed
+   ```
+
+## Inbox Item Format After Processing
+
+```markdown
+- [done] Review PR #7010 in optin-monster-app — reviewed, draft posted to approvals (2026-04-15)
+- [failed] Check NRX inventory — gh auth expired (2026-04-15)
+- [x] Draft LinkedIn post — cancelled by user
+```
+
+## Constraints
+
+- Process items in order (top to bottom).
+- When an item is completed successfully, remove it from `CEO/inbox.md` and move it to `CEO/inbox-archive.md`. Leave `[failed]` and `[x]` items in `CEO/inbox.md` so the user sees what happened.
+- Respect authority tiers. High-stakes actions from inbox items go to approvals/pending.md.
+- If inbox has more than 5 unchecked items, process only the first 5 per cycle to stay within budget.

--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -1,0 +1,52 @@
+---
+name: morning-brief
+description: Generate a prioritized overview of the day's work
+trigger: cron
+schedule: "57 8 * * 1-5"
+model: sonnet
+preflight: none
+tier: read
+status: active
+---
+
+# Morning Brief
+
+Generate a prioritized overview of the day's work.
+
+## Steps
+
+**This playbook is fully pre-gathered. Do NOT call Read, Grep, or Glob.**
+Every input below is already injected into the prompt by the shell. Synthesize the brief from those values; the cap is `--max-turns 5` and tool calls burn turns.
+
+1. Apply the briefing-specific rules from `<external-data>` `Briefing-specific training`.
+2. Use the priority order in `<external-data>` `Active Domains priority order`.
+3. Use pre-gathered PR data: `PR_REVIEW_COUNT`, `PR_AUTHORED_COUNT`, `PR_REVIEW_REQUESTED`, `PR_AUTHORED`.
+4. Use `Pending approvals: N pending` from PRE-GATHERED DATA for the outstanding count.
+5. Pick 1–2 questions from `<external-data>` `Pending [ask] questions` relevant to today's likely focus domain.
+6. Use `Yesterday's log summary` for carryover items.
+7. Use `Daily note Top 3` and `Daily note Tasks` if non-empty.
+8. Output the brief in the LOG_ENTRY Output section — the shell will write it to CEO/log/YYYY-MM-DD.md.
+
+## Output Format
+
+Max 10 bullet points:
+- Open PR count and oldest PR age
+- PRs needing your review (count + list top 3)
+- Pending approvals count
+- Top 3 priorities (from daily note or inferred from PR urgency + domain priority)
+- 1-2 questions from Pending.md if relevant to today's focus
+- Carryover items from yesterday
+
+Then append a Personal section sourced from the `<external-data>` `Blessings today:` field. If the field is empty, omit the entire section.
+
+## Personal
+
+### Blessings
+<reproduce each bullet from `Blessings today:` verbatim>
+
+_Add one?_ Run `count-blessings add "your blessing"` from a terminal.
+
+## Constraints
+
+- This is a read-only playbook. Do not execute any write actions.
+- All GitHub data comes from pre-gathered shell variables — never run `gh` directly.

--- a/docs/playbooks/morning-scan.md
+++ b/docs/playbooks/morning-scan.md
@@ -1,0 +1,47 @@
+---
+name: morning-scan
+description: Scan vault for overnight changes, new notes, unresolved items, carryover
+trigger: cron
+schedule: "50 8 * * 1-5"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+
+# Morning Scan
+
+Read everything that changed since your last scan. Understand the full picture. Present findings by urgency:
+
+- **Needs decision** — new items requiring Nathan's input
+- **Needs attention** — items aging or approaching deadlines
+- **FYI** — status updates on known items, no action needed
+
+For repeat items (things you've surfaced before that haven't been addressed), mention them briefly under FYI unless their urgency has escalated. Don't nag.
+
+If today's daily note has no priorities set, note that for the triage conversation.
+If there are carryover items from yesterday, cross-reference them against today's data (e.g., open PR counts). Do not surface resolved items (like a PR that is no longer in the open list) as carryover. Only flag items that are verifiably still unresolved and relevant.
+
+## Data Available
+
+The shell has pre-gathered the following data and injected it into your prompt. Do not re-fetch any of this.
+
+- Vault file changes since last scan (grouped by domain). Excludes `CEO/log/`, `CEO/reports/`, `CEO/alerts/`, and `CEO/inbox/` — those have dedicated surfacing rules below.
+- Yesterday's daily note (full content)
+- Today's daily note (full content)
+- Pending questions (from Pending.md)
+- Pending approvals (unchecked items)
+- Yesterday's CEO report (full content, including any carryover)
+- Failed actions from yesterday
+- PR counts and details (from ceo-gather.sh)
+- **Currently firing alerts** (`ALERTS_FIRING`) — list of monitor state files in `CEO/alerts/` with `status: firing`, plus host and `since:` timestamp. Surface these under **Needs attention** with the firing duration; do not surface clear alerts.
+
+## Output rules for alerts
+
+- **First firing** (since < 24h ago): surface under FYI with the alert name and host.
+- **Sustained firing** (since >= 24h ago): surface under Needs attention; the responsible playbook will have already appended a `- [ ]` task to `CEO/inbox/<host>.md`, so flag that the inbox has the action.
+- Do not surface clear alerts. Do not surface state-file mutations as generic vault changes.
+
+## Output
+
+Write your findings as the content for an [intake] report entry. The shell will write it to the daily report file. Focus on what Nathan needs to know, not on being comprehensive.

--- a/docs/playbooks/pending-drip.md
+++ b/docs/playbooks/pending-drip.md
@@ -1,0 +1,40 @@
+---
+name: pending-drip
+description: Check pending approvals and surface items needing attention
+trigger: cron
+schedule: "33 9 * * *"
+model: haiku
+preflight: has_pending_items
+tier: read
+status: active
+---
+
+# Pending Drip
+
+Surface 1-2 outstanding [ask] questions from Pending.md, matched to the current context.
+
+## Steps
+
+1. Read CEO/TRAINING.md and CEO/training/communication.md for communication rules.
+2. Read Profile.md Active Domains to determine priority domains.
+3. Read Pending.md - scan all outstanding `- [ ]` entries.
+4. Match entries to today's likely focus:
+   - If today's daily note has a Top 3, match pending questions to those domains.
+   - If no daily note, use the highest-priority domain from Profile.md.
+5. Pick 1-2 relevant questions. Prefer questions that:
+   - Relate to active work (same domain as today's focus)
+   - Are quick to answer (role, title, date - not essay questions)
+   - Haven't been surfaced recently (check CEO/log/ for last 3 days)
+6. Output in the LOG_ENTRY Output section. For `pending-drip`, the shell will turn this into one unchecked item in `CEO/inbox/<host>.md` instead of appending it to the daily CEO report:
+   ```
+   **Questions to ask Nathan:**
+   - [from People/slava.md] What is Slava's exact title at OM?
+   - [from Profile.md] Expected MS graduation date?
+   ```
+
+## Constraints
+
+- Read-only. Do not answer questions or modify Pending.md.
+- Max 2 questions per drip. Don't overwhelm.
+- If no questions match the current context, log "No relevant pending questions today" and stop.
+- Write only the questions Nathan should answer; the cron wrapper owns the inbox append.

--- a/docs/playbooks/pr-review.md
+++ b/docs/playbooks/pr-review.md
@@ -1,0 +1,66 @@
+---
+name: pr-review
+description: Review a specific PR — read diff, analyze changes, draft review
+trigger: both
+model: opus
+preflight: none
+tier: low-stakes write
+status: active
+---
+
+# PR Review
+
+Review a pull request: read the diff, check tests, post a review comment.
+
+## Input
+
+A PR identifier — either a number (#6980) or a full repo reference (org/repo#6980).
+
+## Steps
+
+1. **Identify the repo** — parse the PR reference. If no repo specified, check CEO/repos.md for recently used repos, or ask.
+
+2. **Clone if needed** — if the repo isn't cloned on this machine:
+   - `git clone git@github.com:<org>/<repo>.git ~/repos/<org>/<repo>`
+   - Add entry to CEO/repos.md
+
+3. **Checkout PR** — from the repo directory:
+   ```bash
+   gh pr checkout <number>
+   ```
+
+4. **Read the PR** — gather context:
+   ```bash
+   gh pr view <number> --json title,body,labels,reviewRequests,statusCheckRollup
+   gh pr diff <number>
+   ```
+
+5. **Read training** — read CEO/TRAINING.md for general rules, then CEO/training/pr-review.md for review-specific rules.
+
+6. **Dispatch Code Reviewer** — delegate the review analysis to a Code Reviewer subagent (vault-mediated):
+   - Task: "Review PR #<number> in <org>/<repo>. PR title: <title>."
+   - Context: the PR diff output from step 4, CEO/training/pr-review.md, CI status
+   - The Code Reviewer will return: verdict, summary, issues, draft review body
+
+7. **Review the draft** — read the Code Reviewer's result.
+   - In interactive mode: present the draft to Nathan for approval/editing
+   - In cron mode: write to CEO/approvals/pending.md with the draft body (all review posting is high-stakes)
+
+8. **Log result** — append to CEO/log/YYYY-MM-DD.md:
+    ```markdown
+    ## HH:MM — pr-review
+
+    **Status:** completed
+    **Playbook:** playbooks/pr-review.md
+    **PR:** <org>/<repo>#<number> — <title>
+    **Verdict:** approved | requested changes | commented
+    **Actions:**
+    - Cloned <repo> (if applicable)
+    - Posted review comment
+    ```
+
+## Constraints
+
+- Do NOT merge the PR — that's a high-stakes action. If the PR should be merged, write a proposal to CEO/approvals/pending.md.
+- Do NOT push any code changes — review only.
+- If the PR is too large or complex to review confidently, say so and escalate to the user.

--- a/docs/playbooks/pr-triage.md
+++ b/docs/playbooks/pr-triage.md
@@ -1,0 +1,40 @@
+---
+name: pr-triage
+description: Scan open PRs and prioritize review queue
+trigger: cron
+schedule: "3 10 * * 1-5"
+model: sonnet
+preflight: has_prs_to_review
+tier: read
+status: active
+---
+
+# PR Triage
+
+Scan open PRs across repos, categorize by urgency, surface stale or blocked PRs.
+
+## Steps
+
+1. Read CEO/TRAINING.md and CEO/training/pr-review.md for review rules.
+2. Use the pre-gathered PR data injected by the shell (PR_REVIEW_REQUESTED, PR_AUTHORED — JSON arrays per repo). Do NOT run `gh` yourself — the shell already fetched this data.
+3. Categorize each PR using the JSON fields available (number, title, createdAt, repository, statusCheckRollup):
+   - **Urgent:** review requested from @me (any PR in PR_REVIEW_REQUESTED), or open > 7 days
+   - **Needs attention:** CI failing (statusCheckRollup) or stale (createdAt > 3 days)
+   - **On track:** everything else
+4. Output the triage in the LOG_ENTRY Output section (the shell will write it to the log):
+   ```
+   **Urgent (N):**
+   - repo#number — title (age, status)
+
+   **Needs attention (N):**
+   - repo#number — title (reason)
+
+   **On track (N):**
+   - repo#number — title
+   ```
+
+## Constraints
+
+- Read-only. Do not post comments, review, or modify PRs.
+- All GitHub data comes from pre-gathered shell variables — never run `gh` directly.
+- If a PR is urgent and would benefit from full review, note it as a suggested delegation to pr-review.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -243,13 +243,30 @@ cmd_doctor() {
     fi
   fi
 
-  # playbook drift
-  if cmd_playbook_diff --quiet >/dev/null 2>&1; then
+  # playbook drift — only meaningful when both trees exist
+  local alert_file="$CEO_DIR/alerts/playbook-drift.md"
+  if [ ! -d "$CEO_DIR/playbooks" ] || [ ! -d "${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}" ]; then
+    echo "  ? Playbook drift check skipped (vault or repo playbooks dir missing)"
+    warn=$((warn + 1))
+  elif cmd_playbook_diff --quiet >/dev/null 2>&1; then
     echo "  ✓ Playbooks in sync (no vault/repo drift)"
     ok=$((ok + 1))
+    [ -f "$alert_file" ] && rm -f "$alert_file"
   else
-    echo "  ! Playbook drift detected — run: ceo playbook diff"
-    warn=$((warn + 1))
+    echo "  ✗ Playbook drift detected — run: ceo playbook diff"
+    fail=$((fail + 1))
+    mkdir -p "$(dirname "$alert_file")"
+    {
+      echo "---"
+      echo "status: drift"
+      echo "since: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      echo "last_check: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      echo "---"
+      echo ""
+      echo "# Playbook drift"
+      echo ""
+      echo "Vault and repo playbook trees diverged. Run \`ceo playbook diff\` for details."
+    } > "$alert_file"
   fi
 
   echo ""
@@ -380,14 +397,14 @@ cmd_playbook() {
     scan) cmd_playbook_scan ;;
     list) cmd_playbook_list ;;
     info) cmd_playbook_info "$@" ;;
-    diff) cmd_playbook_diff ;;
+    diff) cmd_playbook_diff "$@" ;;
     help|--help|-h)
       echo "Usage: ceo playbook <scan|list|info|diff>"
       echo ""
-      echo "  scan        Discover playbooks, update registry + crontab"
-      echo "  list        Show all registered playbooks"
-      echo "  info <name> Show details for one playbook"
-      echo "  diff        Detect drift between vault and repo playbooks"
+      echo "  scan          Discover playbooks, update registry + crontab"
+      echo "  list          Show all registered playbooks"
+      echo "  info <name>   Show details for one playbook"
+      echo "  diff [--quiet] Detect drift between vault and repo playbooks"
       ;;
     *)
       echo "Unknown playbook command: $subcmd"
@@ -398,17 +415,23 @@ cmd_playbook() {
 }
 
 cmd_playbook_diff() {
+  : "${CEO_VAULT:?CEO_VAULT must be set before ceo playbook diff}"
   local vault_dir="$CEO_DIR/playbooks"
   local repo_dir="${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}"
-  local quiet="${1:-}"
+  local quiet=""
+  for arg in "$@"; do
+    case "$arg" in
+      --quiet) quiet="--quiet" ;;
+    esac
+  done
 
   if [ ! -d "$vault_dir" ]; then
     [ "$quiet" != "--quiet" ] && echo "ERROR: Vault playbooks directory not found at $vault_dir" >&2
-    return 1
+    return 2
   fi
   if [ ! -d "$repo_dir" ]; then
     [ "$quiet" != "--quiet" ] && echo "ERROR: Repo playbooks directory not found at $repo_dir" >&2
-    return 1
+    return 2
   fi
 
   local drift=0
@@ -420,12 +443,21 @@ cmd_playbook_diff() {
     if [ ! -f "$repo_dir/$base" ]; then
       [ "$quiet" != "--quiet" ] && echo "Vault only: $base"
       drift=$((drift + 1))
-    elif ! cmp -s "$f" "$repo_dir/$base"; then
-      [ "$quiet" != "--quiet" ] && echo "Differs: $base"
-      if [ "$quiet" != "--quiet" ]; then
-        diff -u "$repo_dir/$base" "$f" || true
+    else
+      local cmp_rc=0
+      cmp -s "$f" "$repo_dir/$base" || cmp_rc=$?
+      if [ "$cmp_rc" -eq 0 ]; then
+        :
+      elif [ "$cmp_rc" -eq 1 ]; then
+        [ "$quiet" != "--quiet" ] && echo "Differs: $base"
+        if [ "$quiet" != "--quiet" ]; then
+          diff -u "$repo_dir/$base" "$f" || true
+        fi
+        drift=$((drift + 1))
+      else
+        echo "ERROR: cmp failed (rc=$cmp_rc) comparing $f vs $repo_dir/$base — treating as drift" >&2
+        drift=$((drift + 1))
       fi
-      drift=$((drift + 1))
     fi
   done
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -243,6 +243,15 @@ cmd_doctor() {
     fi
   fi
 
+  # playbook drift
+  if cmd_playbook_diff --quiet >/dev/null 2>&1; then
+    echo "  ✓ Playbooks in sync (no vault/repo drift)"
+    ok=$((ok + 1))
+  else
+    echo "  ! Playbook drift detected — run: ceo playbook diff"
+    warn=$((warn + 1))
+  fi
+
   echo ""
   echo "Result: $ok ok, $warn warnings, $fail failures"
   [ "$fail" -gt 0 ] && return 1
@@ -371,12 +380,14 @@ cmd_playbook() {
     scan) cmd_playbook_scan ;;
     list) cmd_playbook_list ;;
     info) cmd_playbook_info "$@" ;;
+    diff) cmd_playbook_diff ;;
     help|--help|-h)
-      echo "Usage: ceo playbook <scan|list|info>"
+      echo "Usage: ceo playbook <scan|list|info|diff>"
       echo ""
       echo "  scan        Discover playbooks, update registry + crontab"
       echo "  list        Show all registered playbooks"
       echo "  info <name> Show details for one playbook"
+      echo "  diff        Detect drift between vault and repo playbooks"
       ;;
     *)
       echo "Unknown playbook command: $subcmd"
@@ -384,6 +395,56 @@ cmd_playbook() {
       exit 1
       ;;
   esac
+}
+
+cmd_playbook_diff() {
+  local vault_dir="$CEO_DIR/playbooks"
+  local repo_dir="${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}"
+  local quiet="${1:-}"
+
+  if [ ! -d "$vault_dir" ]; then
+    [ "$quiet" != "--quiet" ] && echo "ERROR: Vault playbooks directory not found at $vault_dir" >&2
+    return 1
+  fi
+  if [ ! -d "$repo_dir" ]; then
+    [ "$quiet" != "--quiet" ] && echo "ERROR: Repo playbooks directory not found at $repo_dir" >&2
+    return 1
+  fi
+
+  local drift=0
+
+  # Check vault vs repo
+  for f in "$vault_dir"/*.md; do
+    [ -f "$f" ] || continue
+    local base="${f##*/}"
+    if [ ! -f "$repo_dir/$base" ]; then
+      [ "$quiet" != "--quiet" ] && echo "Vault only: $base"
+      drift=$((drift + 1))
+    elif ! cmp -s "$f" "$repo_dir/$base"; then
+      [ "$quiet" != "--quiet" ] && echo "Differs: $base"
+      if [ "$quiet" != "--quiet" ]; then
+        diff -u "$repo_dir/$base" "$f" || true
+      fi
+      drift=$((drift + 1))
+    fi
+  done
+
+  # Check repo vs vault
+  for f in "$repo_dir"/*.md; do
+    [ -f "$f" ] || continue
+    local base="${f##*/}"
+    if [ ! -f "$vault_dir/$base" ]; then
+      [ "$quiet" != "--quiet" ] && echo "Repo only: $base"
+      drift=$((drift + 1))
+    fi
+  done
+
+  if [ "$drift" -gt 0 ]; then
+    return 1
+  else
+    [ "$quiet" != "--quiet" ] && echo "No drift detected between $vault_dir and $repo_dir"
+    return 0
+  fi
 }
 
 cmd_playbook_scan() {

--- a/scripts/ceo-playbook-diff.test.sh
+++ b/scripts/ceo-playbook-diff.test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Self-contained test harness for `ceo playbook diff`.
+# Mirrors ceo-cron.test.sh / ceo-config.test.sh shape.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+FAILS=0
+CURRENT_TEST=""
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    forbidden:%q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_REPO_PLAYBOOK_DIR="$TEST_HOME/repo-pb"
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_REPO_PLAYBOOK_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  unset CEO_VAULT CEO_DIR CEO_REPO_PLAYBOOK_DIR TEST_HOME HOME_BACKUP
+}
+
+write_pair() {
+  local name="$1" body="$2"
+  printf '%s' "$body" > "$CEO_DIR/playbooks/$name"
+  printf '%s' "$body" > "$CEO_REPO_PLAYBOOK_DIR/$name"
+}
+
+test_clean_returns_0_and_says_no_drift() {
+  write_pair "foo.md" "hello"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff); rc=$?
+  assert_eq "$rc" "0" "clean → exit 0"
+  assert_contains "$out" "No drift detected" "clean → no-drift message"
+}
+
+test_clean_quiet_silent() {
+  write_pair "foo.md" "hello"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1); rc=$?
+  assert_eq "$rc" "0" "clean --quiet → exit 0"
+  assert_eq "$out" "" "clean --quiet → empty stdout+stderr"
+}
+
+test_vault_only_drift() {
+  echo "alpha" > "$CEO_DIR/playbooks/only-in-vault.md"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff); rc=$?
+  assert_eq "$rc" "1" "vault-only → exit 1"
+  assert_contains "$out" "Vault only: only-in-vault.md" "drift message"
+}
+
+test_repo_only_drift() {
+  echo "alpha" > "$CEO_REPO_PLAYBOOK_DIR/only-in-repo.md"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff); rc=$?
+  assert_eq "$rc" "1" "repo-only → exit 1"
+  assert_contains "$out" "Repo only: only-in-repo.md" "drift message"
+}
+
+test_differs_shows_unified_diff() {
+  echo "alpha" > "$CEO_DIR/playbooks/foo.md"
+  echo "beta"  > "$CEO_REPO_PLAYBOOK_DIR/foo.md"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff); rc=$?
+  assert_eq "$rc" "1" "differs → exit 1"
+  assert_contains "$out" "Differs: foo.md" "differs label"
+  assert_contains "$out" "+++" "unified diff header present"
+}
+
+test_quiet_on_drift_silent_but_nonzero() {
+  echo "x" > "$CEO_DIR/playbooks/only-vault.md"
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1); rc=$?
+  assert_eq "$rc" "1" "quiet drift → exit 1"
+  assert_eq "$out" "" "quiet drift → no output"
+}
+
+test_quiet_arg_forwarded_from_dispatcher() {
+  echo "x" > "$CEO_DIR/playbooks/only-vault.md"
+  # Subcommand-positional form: `ceo playbook diff --quiet`. Before the fix,
+  # the dispatcher dropped "$@" so this leaked verbose output.
+  local out
+  out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1 || true)
+  assert_not_contains "$out" "Vault only" "dispatcher must forward --quiet flag"
+}
+
+test_missing_vault_dir_returns_2_not_1() {
+  rm -rf "$CEO_DIR/playbooks"
+  local rc=0
+  bash "$CEO_CLI" playbook diff --quiet >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "missing vault dir → exit 2 (distinct from drift's 1)"
+}
+
+test_missing_repo_dir_returns_2() {
+  rm -rf "$CEO_REPO_PLAYBOOK_DIR"
+  local rc=0
+  bash "$CEO_CLI" playbook diff --quiet >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "missing repo dir → exit 2"
+}
+
+test_unset_vault_fails_loudly() {
+  unset CEO_VAULT
+  unset CEO_DIR
+  local out rc=0
+  out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1) || rc=$?
+  # `${VAR:?msg}` causes the shell to print the message and exit non-zero.
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] unset CEO_VAULT should fail loudly, got rc=0\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$out" "CEO_VAULT" "error must name the missing variable"
+}
+
+test_both_dirs_empty_no_drift() {
+  local out rc
+  out=$(bash "$CEO_CLI" playbook diff); rc=$?
+  assert_eq "$rc" "0" "both empty → exit 0"
+  assert_contains "$out" "No drift detected" "both empty → no drift"
+}
+
+run_tests() {
+  local count=0
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
+      continue
+    fi
+    CURRENT_TEST="$fn"
+    setup
+    "$fn"
+    teardown
+    count=$((count + 1))
+  done
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}
+
+run_tests


### PR DESCRIPTION
Resolves #57, #58, #59, and #60. Backfilled 10 vault-only playbooks into docs/playbooks, making the repo a comprehensive seed. Added 'ceo playbook diff' command to detect drift between the vault and repo playbooks, and wired it into 'ceo doctor'.