### PR TITLE
feat(ollama): inject pre-gathered data + switch morning-brief / morning-scan to local mistral

### DIFF
--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -3,7 +3,8 @@ name: morning-brief
 description: Generate a prioritized overview of the day's work
 trigger: cron
 schedule: "57 8 * * 1-5"
-model: sonnet
+runner: ollama
+model: mistral-small3.2:24b
 preflight: none
 tier: read
 status: active

--- a/docs/playbooks/morning-scan.md
+++ b/docs/playbooks/morning-scan.md
@@ -3,7 +3,8 @@ name: morning-scan
 description: Scan vault for overnight changes, new notes, unresolved items, carryover
 trigger: cron
 schedule: "50 8 * * 1-5"
-model: haiku
+runner: ollama
+model: mistral-small3.2:24b
 preflight: none
 tier: read
 status: active

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -76,6 +76,55 @@ ALERTEOF
   fi
 }
 
+# Single source of truth for routing read-tier model output. Both runner
+# branches (claude single-call, ollama) feed their raw stdout here so report
+# intake, Discord side-channel, and model-self-reported-status handling can't
+# drift between them. Returns 1 (caller exits) if the model self-reported
+# **Status:** failed inside its LOG_ENTRY block; otherwise records success.
+# Arguments: $1 trigger, $2 raw model stdout, $3 model_label (for log lines).
+_dispatch_single_output() {
+  local trigger="$1"
+  local output="$2"
+  local model_label="$3"
+
+  local log_entry
+  log_entry=$(printf '%s\n' "$output" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
+
+  if [ -z "$log_entry" ]; then
+    _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
+    "$SCRIPT_DIR/ceo-report.sh" action "$trigger" "**Status:** completed (unparseable output)
+**Playbook:** $PLAYBOOK_REL
+**Note:** Execution succeeded but log format could not be parsed ($model_label)."
+    printf '%s [%s] Unparseable output (%s):\n%s\n---\n' "$(date)" "$trigger" "$model_label" "$output" >> "$LOG_DIR/cron-raw.log"
+    _record_success
+    return 0
+  fi
+
+  _v ""
+  _v "--- Output ---"
+  [ "${CEO_VERBOSE:-}" = "1" ] && echo "$log_entry"
+  _v "--- End ---"
+  _v ""
+
+  local self_reported_failed=0
+  if printf '%s\n' "$log_entry" | grep -q '^\*\*Status:\*\* failed'; then
+    self_reported_failed=1
+  fi
+
+  if [ "$trigger" = "pending-drip" ] && [ "$self_reported_failed" -eq 0 ]; then
+    _append_pending_drip_to_inbox "$log_entry"
+  else
+    "$SCRIPT_DIR/ceo-report.sh" intake "$trigger" "$log_entry"
+  fi
+
+  if [ "$self_reported_failed" -eq 1 ]; then
+    _record_failure "$trigger self-reported **Status:** failed ($model_label)"
+    return 1
+  fi
+  _record_success
+  return 0
+}
+
 # --- Require jq ---
 if ! command -v jq &>/dev/null; then
   echo "$(date): FATAL — jq not installed. Run: sudo apt install jq" >&2
@@ -640,6 +689,7 @@ END_LOG_ENTRY"
       fi
     else
       _v "NOTE: CEO_OLLAMA_SKIP_PROBE set, skipping daemon probe"
+      echo "$(date): NOTE — $TRIGGER skipping ollama daemon probe (CEO_OLLAMA_SKIP_PROBE set)" >> "$LOG_DIR/cron-skips.log"
     fi
     if [ -z "$MODEL_FROM_FRONTMATTER" ]; then
       case "$RUNNER" in
@@ -654,11 +704,14 @@ END_LOG_ENTRY"
     OLLAMA_PROMPT="$SINGLE_PROMPT_BODY"
     # mistral-small3.2:24b has a 32K context window. Reserve ~8K for output
     # and overhead; the rest is the prompt budget. Override via env when a
-    # larger-context model is selected.
+    # larger-context model is selected. `wc -c` measures bytes — `${#var}`
+    # would return character count under a UTF-8 locale and undercount.
     : "${CEO_OLLAMA_MAX_PROMPT_BYTES:=24576}"
-    OLLAMA_PROMPT_BYTES=${#OLLAMA_PROMPT}
+    OLLAMA_PROMPT_BYTES=$(printf '%s' "$OLLAMA_PROMPT" | wc -c | tr -d ' ')
     if [ "$OLLAMA_PROMPT_BYTES" -gt "$CEO_OLLAMA_MAX_PROMPT_BYTES" ]; then
       _v "FAILED (prompt exceeds budget: $OLLAMA_PROMPT_BYTES > $CEO_OLLAMA_MAX_PROMPT_BYTES bytes)"
+      printf '%s [%s] Prompt exceeds budget (%s bytes > %s) for model: %s\n---\n' \
+        "$(date)" "$TRIGGER" "$OLLAMA_PROMPT_BYTES" "$CEO_OLLAMA_MAX_PROMPT_BYTES" "$OLLAMA_MODEL" >> "$LOG_DIR/cron-raw.log"
       _record_failure "ollama prompt exceeds budget ($OLLAMA_PROMPT_BYTES > $CEO_OLLAMA_MAX_PROMPT_BYTES bytes) for $TRIGGER (model: $OLLAMA_MODEL)"
       exit 1
     fi
@@ -667,16 +720,18 @@ END_LOG_ENTRY"
     OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | ollama run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
     if [ "$OLLAMA_EXIT" -ne 0 ]; then
       _v "FAILED (exit: $OLLAMA_EXIT)"
+      printf '%s [%s] ollama non-zero exit %s (model: %s):\n%s\n---\n' \
+        "$(date)" "$TRIGGER" "$OLLAMA_EXIT" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_DIR/cron-raw.log"
       _record_failure "ollama exited $OLLAMA_EXIT for $TRIGGER (model: $OLLAMA_MODEL)"
       exit "$OLLAMA_EXIT"
     fi
     if [ -z "$(printf '%s' "$OLLAMA_OUT" | tr -d '[:space:]')" ]; then
       _v "FAILED (empty output)"
+      printf '%s [%s] Empty ollama output (model: %s)\n---\n' "$(date)" "$TRIGGER" "$OLLAMA_MODEL" >> "$LOG_DIR/cron-raw.log"
       _record_failure "ollama returned empty output for $TRIGGER (model: $OLLAMA_MODEL)"
       exit 1
     fi
-    printf '\n## %s — %s (model: %s)\n\n%s\n' "$NOW" "$TRIGGER" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_FILE"
-    _record_success
+    _dispatch_single_output "$TRIGGER" "$OLLAMA_OUT" "model: $OLLAMA_MODEL" || exit 1
     exit 0
   fi
 
@@ -699,29 +754,7 @@ END_LOG_ENTRY"
     exit "$SINGLE_EXIT"
   fi
 
-  LOG_ENTRY=$(echo "$SINGLE_OUTPUT" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
-  if [ -n "$LOG_ENTRY" ]; then
-    _v ""
-    _v "--- Output ---"
-    [ "${CEO_VERBOSE:-}" = "1" ] && echo "$LOG_ENTRY"
-    _v "--- End ---"
-    _v ""
-    if [ "$TRIGGER" = "pending-drip" ] && ! printf '%s\n' "$LOG_ENTRY" | grep -q '^\*\*Status:\*\* failed'; then
-      _append_pending_drip_to_inbox "$LOG_ENTRY"
-    else
-      "$SCRIPT_DIR/ceo-report.sh" intake "$TRIGGER" "$LOG_ENTRY"
-    fi
-  else
-    _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
-    "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** completed (unparseable output)
-**Playbook:** $PLAYBOOK_REL
-**Note:** Execution succeeded but log format could not be parsed."
-    echo "$(date) [$TRIGGER] Unparseable output:" >> "$LOG_DIR/cron-raw.log"
-    echo "$SINGLE_OUTPUT" >> "$LOG_DIR/cron-raw.log"
-    echo "---" >> "$LOG_DIR/cron-raw.log"
-  fi
-
-  _record_success
+  _dispatch_single_output "$TRIGGER" "$SINGLE_OUTPUT" "model: $MODEL" || exit 1
   exit 0
 fi
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -339,6 +339,9 @@ fi
 
 PLAYBOOK_REL=$(echo "$ENTRY" | jq -r '.file')
 MODEL=$(echo "$ENTRY" | jq -r '.model // ""')
+# Preserves "did the playbook declare an explicit model?" across the
+# claude-default fallback below. Empty string = no override.
+MODEL_FROM_FRONTMATTER="$MODEL"
 PREFLIGHT=$(echo "$ENTRY" | jq -r '.preflight // "none"')
 STATUS=$(echo "$ENTRY" | jq -r '.status // "active"')
 TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
@@ -450,53 +453,13 @@ if [ "$RUNNER" = "script" ]; then
   exit 0
 fi
 
-# --- Ollama-runner branch: route playbook body to a local ollama model ---
-# One-shot prompt-in / text-out; no AGENTS.md / IDENTITY.md / TRAINING.md preamble.
-if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
-  if ! command -v ollama >/dev/null 2>&1; then
-    _record_failure "ollama binary not found on PATH (playbook: $TRIGGER)"
-    exit 1
-  fi
-  if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
-    if ! command -v curl >/dev/null 2>&1; then
-      _record_failure "curl not available — cannot probe ollama daemon (playbook: $TRIGGER)"
-      exit 1
-    fi
-    if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>>"$LOG_DIR/cron-stderr.log"; then
-      _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
-      exit 1
-    fi
-  else
-    _v "NOTE: CEO_OLLAMA_SKIP_PROBE set, skipping daemon probe"
-  fi
-  if [ -z "$MODEL" ]; then
-    case "$RUNNER" in
-      ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
-      ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
-    esac
-  else
-    OLLAMA_MODEL="$MODEL"
-  fi
-  _v "Runner: $RUNNER — model: $OLLAMA_MODEL"
-  OLLAMA_PROMPT=$(safe_read "$PLAYBOOK_FILE" "$MAX_FILE_SIZE")
-  OLLAMA_EXIT=0
-  OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | ollama run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
-  if [ "$OLLAMA_EXIT" -ne 0 ]; then
-    _v "FAILED (exit: $OLLAMA_EXIT)"
-    _record_failure "ollama exited $OLLAMA_EXIT for $TRIGGER (model: $OLLAMA_MODEL)"
-    exit "$OLLAMA_EXIT"
-  fi
-  if [ -z "$(printf '%s' "$OLLAMA_OUT" | tr -d '[:space:]')" ]; then
-    _v "FAILED (empty output)"
-    _record_failure "ollama returned empty output for $TRIGGER (model: $OLLAMA_MODEL)"
-    exit 1
-  fi
-  printf '\n## %s — %s (model: %s)\n\n%s\n' "$NOW" "$TRIGGER" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_FILE"
-  _record_success
-  exit 0
+# --- Ollama runners only support tier:read ---
+# The three-phase pipeline (PLAN → FILTER → EXECUTE) requires tool calls and
+# strict ACTION:-line output that ollama can't reliably produce. Reject early.
+if { [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; } && [ "$TIER" != "read" ]; then
+  _record_failure "ollama runner requires tier:read ($TRIGGER is tier:$TIER)"
+  exit 1
 fi
-
-MODEL="${MODEL:-sonnet}"
 
 # --- Read context files (with size limits for injection safety) ---
 AGENTS_CONTENT=$(safe_read "$CEO_DIR/AGENTS.md" "$MAX_FILE_SIZE")
@@ -621,7 +584,10 @@ $(_escape_tag "$PENDING_ASK_QUESTIONS")
   BLESSINGS_BLOCK_OUT=""
   _inputs_includes blessings && BLESSINGS_BLOCK_OUT="$BLESSINGS_DATA"
 
-  SINGLE_PROMPT="You are the CEO agent. Read the context and execute the playbook.
+  # Prompt is built in two halves so the ollama runner can drop the AGENTS /
+  # IDENTITY / TRAINING preamble while still receiving the playbook body and
+  # pre-gathered data. The claude path concatenates both halves.
+  SINGLE_PROMPT_PREAMBLE="You are the CEO agent. Read the context and execute the playbook.
 
 GLOBAL AGENT RULES:
 $AGENTS_CONTENT
@@ -634,7 +600,9 @@ $TRAINING_CONTENT
 
 $DOMAIN_TRAINING
 
-PLAYBOOK ($TRIGGER):
+"
+
+  SINGLE_PROMPT_BODY="PLAYBOOK ($TRIGGER):
 $PLAYBOOK_CONTENT
 
 PRE-GATHERED DATA (from shell — do not re-fetch; the answer must be derived from this block alone, do not call Read/Grep/Glob):
@@ -655,6 +623,65 @@ LOG_ENTRY:
 **Errors:**
 - {any errors, or 'none'}
 END_LOG_ENTRY"
+
+  if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
+    if ! command -v ollama >/dev/null 2>&1; then
+      _record_failure "ollama binary not found on PATH (playbook: $TRIGGER)"
+      exit 1
+    fi
+    if [ -z "${CEO_OLLAMA_SKIP_PROBE:-}" ]; then
+      if ! command -v curl >/dev/null 2>&1; then
+        _record_failure "curl not available — cannot probe ollama daemon (playbook: $TRIGGER)"
+        exit 1
+      fi
+      if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>>"$LOG_DIR/cron-stderr.log"; then
+        _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
+        exit 1
+      fi
+    else
+      _v "NOTE: CEO_OLLAMA_SKIP_PROBE set, skipping daemon probe"
+    fi
+    if [ -z "$MODEL_FROM_FRONTMATTER" ]; then
+      case "$RUNNER" in
+        ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
+        ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
+      esac
+    else
+      OLLAMA_MODEL="$MODEL_FROM_FRONTMATTER"
+    fi
+    _v "Runner: $RUNNER — model: $OLLAMA_MODEL"
+
+    OLLAMA_PROMPT="$SINGLE_PROMPT_BODY"
+    # mistral-small3.2:24b has a 32K context window. Reserve ~8K for output
+    # and overhead; the rest is the prompt budget. Override via env when a
+    # larger-context model is selected.
+    : "${CEO_OLLAMA_MAX_PROMPT_BYTES:=24576}"
+    OLLAMA_PROMPT_BYTES=${#OLLAMA_PROMPT}
+    if [ "$OLLAMA_PROMPT_BYTES" -gt "$CEO_OLLAMA_MAX_PROMPT_BYTES" ]; then
+      _v "FAILED (prompt exceeds budget: $OLLAMA_PROMPT_BYTES > $CEO_OLLAMA_MAX_PROMPT_BYTES bytes)"
+      _record_failure "ollama prompt exceeds budget ($OLLAMA_PROMPT_BYTES > $CEO_OLLAMA_MAX_PROMPT_BYTES bytes) for $TRIGGER (model: $OLLAMA_MODEL)"
+      exit 1
+    fi
+
+    OLLAMA_EXIT=0
+    OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | ollama run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
+    if [ "$OLLAMA_EXIT" -ne 0 ]; then
+      _v "FAILED (exit: $OLLAMA_EXIT)"
+      _record_failure "ollama exited $OLLAMA_EXIT for $TRIGGER (model: $OLLAMA_MODEL)"
+      exit "$OLLAMA_EXIT"
+    fi
+    if [ -z "$(printf '%s' "$OLLAMA_OUT" | tr -d '[:space:]')" ]; then
+      _v "FAILED (empty output)"
+      _record_failure "ollama returned empty output for $TRIGGER (model: $OLLAMA_MODEL)"
+      exit 1
+    fi
+    printf '\n## %s — %s (model: %s)\n\n%s\n' "$NOW" "$TRIGGER" "$OLLAMA_MODEL" "$OLLAMA_OUT" >> "$LOG_FILE"
+    _record_success
+    exit 0
+  fi
+
+  MODEL="${MODEL:-sonnet}"
+  SINGLE_PROMPT="${SINGLE_PROMPT_PREAMBLE}${SINGLE_PROMPT_BODY}"
 
   SINGLE_EXIT=0
   SINGLE_OUTPUT=$(cd "$VAULT" && echo "$SINGLE_PROMPT" | CLAUDE_MEM_INTERNAL=1 $(_with_timeout 300) claude --print --max-turns 5 \
@@ -699,6 +726,7 @@ END_LOG_ENTRY"
 fi
 
 # --- Three-phase pipeline (low-stakes write and above) ---
+MODEL="${MODEL:-sonnet}"
 
 # --- Phase 1: PLAN (read-only, no tool execution) ---
 PLAN_PROMPT="You are the CEO agent running in PLANNING MODE. You CANNOT execute any actions.

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -903,6 +903,17 @@ PB
 }
 
 test_runner_ollama_read_tier_includes_pre_gathered_data() {
+  # Seed approvals/pending.md with three unchecked items so PENDING_COUNT=3
+  # (per ceo-gather.sh's `grep -c "^- \[ \]" approvals/pending.md`). The
+  # sentinel value lets us prove the gathered count reached the ollama prompt.
+  cat > "$CEO_DIR/approvals/pending.md" << 'PENDING'
+# Pending
+
+- [ ] sentinel-pending-item-A
+- [ ] sentinel-pending-item-B
+- [ ] sentinel-pending-item-C
+PENDING
+
   cat > "$CEO_DIR/playbooks/ollama-pregather.md" << 'PB'
 ---
 name: ollama-pregather
@@ -925,6 +936,10 @@ PB
   assert_contains "$prompt" "PRE-GATHERED DATA" "ollama+tier:read prompt must include PRE-GATHERED DATA section"
   assert_contains "$prompt" "ollama-pregather-playbook-body" "ollama prompt must include playbook body"
   assert_contains "$prompt" "PLAYBOOK (ollama-pregather)" "ollama prompt must label the playbook"
+  # Sentinel pin: the seeded inbox count must reach the prompt body. A revert
+  # of the SINGLE_PROMPT_BODY split (so ollama got only the playbook file)
+  # would not surface PENDING_COUNT — the literal "3 pending" disappears.
+  assert_contains "$prompt" "3 pending" "pre-gathered PENDING_COUNT (sentinel: 3) must reach ollama prompt"
 }
 
 test_runner_ollama_prompt_exceeds_budget_fails() {
@@ -956,7 +971,14 @@ PB
 
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
-  assert_contains "$skips_log" "exceeds budget" "skips log must record oversized-prompt reason"
+  assert_contains "$skips_log" "exceeds budget (" "skips log must record oversized-prompt reason with byte counts"
+
+  # Forensic capture: the offending prompt context lands in cron-raw.log so a
+  # human investigating "why is morning-brief over budget on Tuesdays" has an
+  # artifact to inspect (mirrors the claude failure-path capture).
+  local raw_log
+  raw_log=$(cat "$CEO_DIR/log/cron-raw.log" 2>/dev/null || echo "")
+  assert_contains "$raw_log" "Prompt exceeds budget" "cron-raw.log must capture budget-exceeded events"
 }
 
 test_runner_ollama_rejects_non_read_tier() {
@@ -967,7 +989,7 @@ description: ollama on non-read tier must reject before any dispatch
 trigger: cron
 schedule: "0 9 * * *"
 preflight: none
-tier: low-stakes write
+tier: low-stakes-write
 status: active
 runner: ollama
 ---
@@ -991,6 +1013,269 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "ollama runner requires tier:read" "skips log must record reject reason"
+}
+
+test_runner_ollama_think_rejects_non_read_tier() {
+  # Sibling pin for runner:ollama-think — the guard at ceo-cron.sh:459 covers
+  # both ollama variants, so a regression that drops one side would leak.
+  cat > "$CEO_DIR/playbooks/ollama-think-writetier.md" << 'PB'
+---
+name: ollama-think-writetier
+description: ollama-think on non-read tier must reject
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: low-stakes-write
+status: active
+runner: ollama-think
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" ollama-think-writetier >/dev/null 2>&1 || rc=$?
+
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] ollama-think with non-read tier must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ -f "$HOME/ollama-invoked-model.txt" ]; then
+    printf '  FAIL [%s] ollama-think must NOT be invoked for non-read tier\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+test_runner_ollama_success_routes_through_ceo_report_intake() {
+  # Pins Finding 1 of the panel review: morning-brief / morning-scan after the
+  # ollama switch must still land in CEO/reports/<date>.md and trigger the
+  # Discord side-channel — same as the claude path. Regression-test for the
+  # bug where the ollama branch wrote directly to LOG_FILE and bypassed
+  # ceo-report.sh entirely.
+
+  cat > "$CEO_DIR/playbooks/ollama-intake.md" << 'PB'
+---
+name: ollama-intake
+description: ollama success must route through ceo-report.sh intake
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  # ollama stub emits a parseable LOG_ENTRY block — the helper extracts and
+  # routes through ceo-report.sh intake, which writes to REPORT_FILE and
+  # fires the Discord side-channel via curl. We capture curl to assert the
+  # side-channel fired (same shape as test_read_tier_posts_full_report).
+  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+#!/bin/bash
+if [ "${1:-}" = "run" ]; then
+  echo "$2" > "$HOME/ollama-invoked-model.txt"
+  cat > "$HOME/ollama-invoked-prompt.txt"
+  cat << 'OUT'
+LOG_ENTRY:
+## 09:00 — ollama-intake
+**Status:** completed
+**Playbook:** playbooks/ollama-intake.md
+**Output:**
+Hello from ollama-intake-sentinel.
+**Errors:**
+- none
+END_LOG_ENTRY
+OUT
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/ollama"
+
+  mkdir -p "$TEST_HOME/curl"
+  export CURL_CAPTURE_DIR="$TEST_HOME/curl"
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+out="$CURL_CAPTURE_DIR/payload.json"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d) shift; printf '%s' "$1" > "$out" ;;
+  esac
+  shift || true
+done
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
+
+  mkdir -p "$HOME/.config/claude-ceo"
+  echo '{"discord_report_webhook":"http://127.0.0.1/report-channel"}' \
+    > "$HOME/.config/claude-ceo/secrets.json"
+  # ceo-discord-report.sh defaults the trigger allowlist to ["morning-brief"];
+  # extend it so this test playbook is allowed to fire the side channel.
+  echo '{"discord_report_triggers": ["ollama-intake"]}' \
+    > "$CEO_DIR/settings.json"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-intake >/dev/null 2>&1 || true
+
+  # REPORT_FILE must exist with the intake entry — this is the canonical
+  # write that breaks if the ollama branch skips ceo-report.sh.
+  local report_file="$CEO_DIR/reports/$(date +%Y-%m-%d).md"
+  assert_file_exists "$report_file" "ollama success must write to CEO/reports/<date>.md via ceo-report.sh intake"
+  local report
+  report=$(cat "$report_file" 2>/dev/null || echo "")
+  assert_contains "$report" "ollama-intake-sentinel" "report file must contain the LOG_ENTRY body"
+  assert_contains "$report" "ollama-intake [intake]" "report header must be intake-tagged"
+
+  # Discord side-channel fires (proves intake routing is reached, not just
+  # report-file append — they're separate concerns inside ceo-report.sh).
+  local payload
+  payload=$(cat "$CURL_CAPTURE_DIR/payload.json" 2>/dev/null || echo "")
+  assert_contains "$payload" "ollama-intake-sentinel" "Discord side-channel must fire on ollama success"
+}
+
+test_runner_ollama_self_reported_failed_records_failure() {
+  # Pins Finding 1 second facet: a model that emits **Status:** failed inside
+  # its LOG_ENTRY block must increment FAIL_COUNT_FILE — not silently record
+  # success because the exit code was 0 and stdout was non-empty.
+
+  cat > "$CEO_DIR/playbooks/ollama-selffail.md" << 'PB'
+---
+name: ollama-selffail
+description: ollama self-reports failed → must increment fail count
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+#!/bin/bash
+if [ "${1:-}" = "run" ]; then
+  cat << 'OUT'
+LOG_ENTRY:
+## 09:00 — ollama-selffail
+**Status:** failed
+**Playbook:** playbooks/ollama-selffail.md
+**Output:**
+Simulated playbook failure.
+**Errors:**
+- something broke during synthesis
+END_LOG_ENTRY
+OUT
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/ollama"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-selffail >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "model self-reporting **Status:** failed must increment FAIL_COUNT_FILE (silent-success invariant)"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "self-reported" "cron-skips.log must record self-reported-failure reason"
+}
+
+test_runner_claude_self_reported_failed_records_failure() {
+  # Sibling invariant: the same shape on the claude path. Before the
+  # _dispatch_single_output helper consolidation, claude swallowed
+  # model-self-reported failures and recorded success. The helper now gates
+  # both runners through the same check.
+
+  cat > "$CEO_DIR/playbooks/claude-selffail.md" << 'PB'
+---
+name: claude-selffail
+description: claude self-reports failed → must increment fail count
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+cat << 'OUT'
+LOG_ENTRY:
+## 09:00 — claude-selffail
+**Status:** failed
+**Playbook:** playbooks/claude-selffail.md
+**Output:**
+Simulated claude failure.
+**Errors:**
+- broken
+END_LOG_ENTRY
+OUT
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/claude"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" claude-selffail >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "claude path: model self-reporting **Status:** failed must increment FAIL_COUNT_FILE"
+}
+
+test_production_morning_brief_registers_with_ollama_runner() {
+  # Pins Finding 2 of the panel review: the actual docs/playbooks/morning-brief.md
+  # in the repo must register with runner: ollama + tier: read after this PR.
+  # A typo in the frontmatter (e.g. `runner: olllama`) would silently ship
+  # green without this test — the unit tests above use synthetic playbooks.
+
+  local repo_playbook="$SCRIPT_DIR/../docs/playbooks/morning-brief.md"
+  if [ ! -f "$repo_playbook" ]; then
+    printf '  FAIL [%s] cannot find production playbook at %q\n' \
+      "$CURRENT_TEST" "$repo_playbook"
+    FAILS=$((FAILS + 1))
+    return
+  fi
+  cp "$repo_playbook" "$CEO_DIR/playbooks/morning-brief.md"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local runner tier model
+  runner=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  tier=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .tier' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  model=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  assert_eq "$runner" "ollama" "production morning-brief.md must declare runner: ollama"
+  assert_eq "$tier" "read" "production morning-brief.md must declare tier: read"
+  assert_eq "$model" "mistral-small3.2:24b" "production morning-brief.md must declare model: mistral-small3.2:24b"
+}
+
+test_production_morning_scan_registers_with_ollama_runner() {
+  local repo_playbook="$SCRIPT_DIR/../docs/playbooks/morning-scan.md"
+  if [ ! -f "$repo_playbook" ]; then
+    printf '  FAIL [%s] cannot find production playbook at %q\n' \
+      "$CURRENT_TEST" "$repo_playbook"
+    FAILS=$((FAILS + 1))
+    return
+  fi
+  cp "$repo_playbook" "$CEO_DIR/playbooks/morning-scan.md"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  local runner tier model
+  runner=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  tier=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .tier' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  model=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  assert_eq "$runner" "ollama" "production morning-scan.md must declare runner: ollama"
+  assert_eq "$tier" "read" "production morning-scan.md must declare tier: read"
+  assert_eq "$model" "mistral-small3.2:24b" "production morning-scan.md must declare model: mistral-small3.2:24b"
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -902,6 +902,97 @@ PB
   assert_contains "$prompt" "my-playbook-body" "ollama prompt must contain the playbook body"
 }
 
+test_runner_ollama_read_tier_includes_pre_gathered_data() {
+  cat > "$CEO_DIR/playbooks/ollama-pregather.md" << 'PB'
+---
+name: ollama-pregather
+description: Verify pre-gathered data injection on ollama+tier:read
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# ollama-pregather-playbook-body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-pregather >/dev/null 2>&1 || true
+
+  local prompt
+  prompt=$(cat "$HOME/ollama-invoked-prompt.txt" 2>/dev/null || echo "")
+  assert_contains "$prompt" "PRE-GATHERED DATA" "ollama+tier:read prompt must include PRE-GATHERED DATA section"
+  assert_contains "$prompt" "ollama-pregather-playbook-body" "ollama prompt must include playbook body"
+  assert_contains "$prompt" "PLAYBOOK (ollama-pregather)" "ollama prompt must label the playbook"
+}
+
+test_runner_ollama_prompt_exceeds_budget_fails() {
+  cat > "$CEO_DIR/playbooks/ollama-toolarge.md" << 'PB'
+---
+name: ollama-toolarge
+description: Tests CEO_OLLAMA_MAX_PROMPT_BYTES budget enforcement
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# ollama-toolarge-body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_OLLAMA_MAX_PROMPT_BYTES=100 CEO_VERBOSE=1 bash "$CRON" ollama-toolarge >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "oversized prompt must increment FAIL_COUNT_FILE"
+
+  if [ -f "$HOME/ollama-invoked-model.txt" ]; then
+    printf '  FAIL [%s] ollama must NOT be invoked when prompt exceeds budget\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "exceeds budget" "skips log must record oversized-prompt reason"
+}
+
+test_runner_ollama_rejects_non_read_tier() {
+  cat > "$CEO_DIR/playbooks/ollama-writetier.md" << 'PB'
+---
+name: ollama-writetier
+description: ollama on non-read tier must reject before any dispatch
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: low-stakes write
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" ollama-writetier >/dev/null 2>&1 || rc=$?
+
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] ollama with non-read tier must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+
+  if [ -f "$HOME/ollama-invoked-model.txt" ]; then
+    printf '  FAIL [%s] ollama must NOT be invoked for non-read tier\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "ollama runner requires tier:read" "skips log must record reject reason"
+}
+
 test_ceo_augment_path_prepends_user_tool_prefixes() {
   local out
   out=$(env HOME=/fake bash -c '

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1121,7 +1121,8 @@ STUB
 
   # REPORT_FILE must exist with the intake entry — this is the canonical
   # write that breaks if the ollama branch skips ceo-report.sh.
-  local report_file="$CEO_DIR/reports/$(date +%Y-%m-%d).md"
+  local report_file
+  report_file="$CEO_DIR/reports/$(date +%Y-%m-%d).md"
   assert_file_exists "$report_file" "ollama success must write to CEO/reports/<date>.md via ceo-report.sh intake"
   local report
   report=$(cat "$report_file" 2>/dev/null || echo "")


### PR DESCRIPTION
Closes #68

## Description (Issue Fixed & New Behavior)

Issue #67: morning-brief failed 2026-05-22 because the 03:20 EDT cron fired inside an Anthropic session-limit window. Recurred 4+ times in the prior month. Issue #68 proposed routing pre-gathered read-tier synthesis playbooks (morning-brief, morning-scan) to the local ollama runner introduced in PR #29.

While implementing the flip I found the dispatcher gap: the ollama branch in `scripts/ceo-cron.sh` (PR #29) sent **only** the raw playbook body to the local model. Read-tier playbooks declare "This playbook is fully pre-gathered. Do NOT call Read, Grep, or Glob" and expect the shell to inject a PRE-GATHERED DATA block plus several `<external-data>` blocks (PR counts, daily note, blessings, pending questions, scan results). Without those, mistral would have received the recipe with no ingredients.

This PR closes that gap:

1. **Splits the read-tier prompt into preamble + body.** The preamble (AGENTS / IDENTITY / TRAINING / domain training) stays claude-only — preserving PR #29's "skip the 30KB preamble" benefit. The body (playbook + PRE-GATHERED DATA + external-data blocks + LOG_ENTRY output format) is shared.
2. **Moves the ollama dispatch inside the read-tier block.** It now reuses the shared body. The early ollama dispatch above the tier check is removed.
3. **Rejects ollama on non-read tiers.** The three-phase pipeline (PLAN → FILTER → EXECUTE) relies on tool calls and strict `ACTION:` line format ollama can't reliably produce. Guard added right after the script-runner branch.
4. **Adds a prompt-length budget** (`CEO_OLLAMA_MAX_PROMPT_BYTES`, default 24576 bytes). Mistral-small3.2:24b has a 32K context; 8K reserved for response + overhead leaves 24K for the prompt. The auditor flagged this as the single biggest risk — a busy-day SCAN_DATA could silently truncate without it. Fails loud (`_record_failure`) instead of truncating.
5. **`MODEL_FROM_FRONTMATTER` capture** so the ollama default-model resolution doesn't see the claude `sonnet` fallback (preserves `test_runner_ollama_model_sonnet_passes_literal`'s invariant).
6. **Switches `morning-brief.md` and `morning-scan.md`** to `runner: ollama` + `model: mistral-small3.2:24b`. `pending-drip` and `eod-summary` stay on claude — their bodies still tell the agent to `Read` files (not pre-gathered yet — worth a future issue).

## Testing Procedure

1. Check out `nh/feature/ollama-read-tier-playbooks` and `cd scripts/`.
2. Run the full suite: `bash ceo-cron.test.sh`. Expect: `All tests passed. (62 tests)` — 3 new ollama tests on top of PR #29's 12.
3. Inspect the 3 new tests:
   - `test_runner_ollama_read_tier_includes_pre_gathered_data` — pins the dispatcher fix; the ollama prompt now contains `PRE-GATHERED DATA` and `PLAYBOOK ($TRIGGER)` headers.
   - `test_runner_ollama_prompt_exceeds_budget_fails` — sets `CEO_OLLAMA_MAX_PROMPT_BYTES=100`, runs, asserts ollama was NOT invoked, FAIL_COUNT_FILE incremented, skips log records "exceeds budget".
   - `test_runner_ollama_rejects_non_read_tier` — playbook with `tier: low-stakes write` + `runner: ollama` exits non-zero, ollama never invoked, skips log records "ollama runner requires tier:read".
4. Revert verification: temporarily delete the `if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then ... fi` block from the read-tier branch and re-run — the 3 new tests fail. Same for deleting the early-reject guard or the budget check. Each test pins exactly one change.
5. Optional smoke test on ML-1 WSL after merge:
   - `git pull` in `/mnt/c/Projects/claude-ceo/claude-ceo`
   - `ceo playbook scan` — confirm morning-brief and morning-scan re-register with `runner: ollama`
   - `bash scripts/ceo-cron.sh morning-brief` — confirm completion in `cron-runs.log` and a `## HH:MM — morning-brief (model: mistral-small3.2:24b)` entry in today's CEO log

## Additional Notes

- Auditor flagged context truncation as the single biggest risk. Mitigated with the `CEO_OLLAMA_MAX_PROMPT_BYTES` budget check that fails loud rather than silently passing a truncated prompt to ollama.
- Cold-load timing verified on ML-1: `ollama stop mistral-small3.2:24b && time ollama run mistral-small3.2:24b` against a representative pre-gathered prompt completed in ~13s. Well inside `flock -w 30`. morning-scan (08:50) and morning-brief (08:57) are 7 min apart in cron — no concurrent-lock risk.
- `pending-drip` and `eod-summary` left on claude. Their playbook bodies still say "Read CEO/TRAINING.md", "Read Pending.md", etc. Switching them to ollama is a separate PR that needs to either pre-gather those files in `ceo-gather.sh` or accept that ollama runners can't follow Read instructions.
- Open question from #68 about `gpt-oss:20b` (runner: ollama-think) remains untouched. No current playbook screams "diagnostic reasoning"; if one shows up later it can opt in via frontmatter.

## Reference

- Issue #67: https://github.com/nhangen/claude-ceo/issues/67 (root cause + classifier-side proposal)
- Issue #68: https://github.com/nhangen/claude-ceo/issues/68 (this PR)
- PR #29: https://github.com/nhangen/claude-ceo/pull/29 (ollama runner introduction)