### PR TITLE
fix: gracefully skip read-tier playbooks on empty gather

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -626,8 +626,8 @@ if [ "$TIER" = "read" ]; then
   _v "Read-tier playbook — single call (no plan/filter phases)"
   _v "Using model: $MODEL"
 
-  # Override failed status if vault changes exist (for morning-scan)
-  if [ "${CEO_GATHER_STATUS:-ok}" = "failed" ] && [ "${VAULT_CHANGES_COUNT:-0}" -gt 0 ]; then
+  # Override failed/empty status if vault changes exist (for morning-scan)
+  if [[ "${CEO_GATHER_STATUS:-ok}" == "failed" || "${CEO_GATHER_STATUS:-ok}" == "empty" ]] && [ "${VAULT_CHANGES_COUNT:-0}" -gt 0 ]; then
     CEO_GATHER_STATUS="partial"
     CEO_GATHER_REASONS="Primary data empty, but vault changes present"
   fi
@@ -636,11 +636,11 @@ if [ "$TIER" = "read" ]; then
     echo "$(date) [$TRIGGER] WARN — Gather phase $CEO_GATHER_STATUS: $CEO_GATHER_REASONS" >> "$LOG_DIR/cron-skips.log"
     _v "WARN: Gather phase $CEO_GATHER_STATUS — $CEO_GATHER_REASONS"
     
-    if [ "$CEO_GATHER_STATUS" = "failed" ]; then
-      _v "SKIPPED (gather phase failed)"
-      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** skipped: gather-failed
+    if [ "$CEO_GATHER_STATUS" = "failed" ] || [ "$CEO_GATHER_STATUS" = "empty" ]; then
+      _v "SKIPPED (gather phase $CEO_GATHER_STATUS)"
+      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** skipped: gather-$CEO_GATHER_STATUS
 **Playbook:** $PLAYBOOK_REL
-**Note:** All primary data sources empty or missing. Skipping run to prevent empty confident brief."
+**Note:** $CEO_GATHER_REASONS. Skipping run to prevent empty confident brief."
       exit 0
     fi
   fi

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -626,6 +626,25 @@ if [ "$TIER" = "read" ]; then
   _v "Read-tier playbook — single call (no plan/filter phases)"
   _v "Using model: $MODEL"
 
+  # Override failed status if vault changes exist (for morning-scan)
+  if [ "${CEO_GATHER_STATUS:-ok}" = "failed" ] && [ "${VAULT_CHANGES_COUNT:-0}" -gt 0 ]; then
+    CEO_GATHER_STATUS="partial"
+    CEO_GATHER_REASONS="Primary data empty, but vault changes present"
+  fi
+
+  if [ "${CEO_GATHER_STATUS:-ok}" != "ok" ]; then
+    echo "$(date) [$TRIGGER] WARN — Gather phase $CEO_GATHER_STATUS: $CEO_GATHER_REASONS" >> "$LOG_DIR/cron-skips.log"
+    _v "WARN: Gather phase $CEO_GATHER_STATUS — $CEO_GATHER_REASONS"
+    
+    if [ "$CEO_GATHER_STATUS" = "failed" ]; then
+      _v "SKIPPED (gather phase failed)"
+      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** skipped: gather-failed
+**Playbook:** $PLAYBOOK_REL
+**Note:** All primary data sources empty or missing. Skipping run to prevent empty confident brief."
+      exit 0
+    fi
+  fi
+
   # Build pre-gathered data block conditionally based on the playbook's
   # `inputs:` frontmatter (or default-all if absent). Each line/block is
   # included only when _inputs_includes returns 0 for its canonical key.

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -54,6 +54,7 @@ setup() {
   : > "$CEO_DIR/IDENTITY.md"
   : > "$CEO_DIR/TRAINING.md"
   : > "$CEO_DIR/inbox.md"
+  echo "- [ ] test task" > "$CEO_DIR/approvals/pending.md"
 
   # Stub crontab so playbook scan's cron install can't touch the user's real crontab.
   mkdir -p "$TEST_HOME/.bun/bin"
@@ -2259,6 +2260,37 @@ STUB
   local ollama_invoked
   ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_contains "$ollama_invoked" "mistral-small" "ollama must be invoked with default model during fallback"
+}
+
+test_ceo_cron_skips_read_tier_on_failed_gather() {
+  cat > "$CEO_DIR/playbooks/morning-brief.md" << 'PB'
+---
+name: morning-brief
+description: briefing
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  # Force gather phase to fail by emptying pending tasks
+  : > "$CEO_DIR/approvals/pending.md"
+
+  local rc=0
+  bash "$CRON" morning-brief >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "cron must exit 0 on failed gather"
+  
+  local skip_log
+  skip_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skip_log" "Gather phase failed" "cron-skips.log must mention gather phase failed"
+  
+  local report
+  report=$(cat "$CEO_DIR/reports/$(date +%Y-%m-%d).md" 2>/dev/null || echo "")
+  assert_contains "$report" "skipped: gather-failed" "report must show skipped status"
 }
 
 run_tests() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2286,11 +2286,11 @@ PB
   
   local skip_log
   skip_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
-  assert_contains "$skip_log" "Gather phase failed" "cron-skips.log must mention gather phase failed"
+  assert_contains "$skip_log" "Gather phase empty" "cron-skips.log must mention gather phase empty"
   
   local report
   report=$(cat "$CEO_DIR/reports/$(date +%Y-%m-%d).md" 2>/dev/null || echo "")
-  assert_contains "$report" "skipped: gather-failed" "report must show skipped status"
+  assert_contains "$report" "skipped: gather-empty" "report must show skipped status"
 }
 
 run_tests() {

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -278,3 +278,23 @@ PENDING_ASK_QUESTIONS=$(grep -n '\[ask\]' "$PENDING_FILE" 2>/dev/null | head -20
 else
   export PENDING_ASK_QUESTIONS=""
 fi
+
+# --- Evaluate Gather Status ---
+export CEO_GATHER_STATUS="ok"
+export CEO_GATHER_REASONS=""
+
+_has_data=0
+[ "${PENDING_COUNT:-0}" -gt 0 ] && _has_data=1
+[ "${PR_REVIEW_COUNT:-0}" -gt 0 ] && _has_data=1
+[ "${PR_AUTHORED_COUNT:-0}" -gt 0 ] && _has_data=1
+[ -n "${DAILY_NOTE_TOP3:-}" ] && _has_data=1
+[ -n "${PENDING_ASK_QUESTIONS:-}" ] && _has_data=1
+
+if [ "$_has_data" -eq 0 ]; then
+  CEO_GATHER_STATUS="failed"
+  CEO_GATHER_REASONS="All primary data sources (pending, PRs, daily note, questions) are empty or missing"
+elif [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ]; then
+  CEO_GATHER_STATUS="partial"
+  # Replace newlines with spaces for single-line logging
+  CEO_GATHER_REASONS="PR gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
+fi

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -291,8 +291,13 @@ _has_data=0
 [ -n "${PENDING_ASK_QUESTIONS:-}" ] && _has_data=1
 
 if [ "$_has_data" -eq 0 ]; then
-  CEO_GATHER_STATUS="failed"
-  CEO_GATHER_REASONS="All primary data sources (pending, PRs, daily note, questions) are empty or missing"
+  if [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ]; then
+    CEO_GATHER_STATUS="failed"
+    CEO_GATHER_REASONS="All primary data sources empty, and PR gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
+  else
+    CEO_GATHER_STATUS="empty"
+    CEO_GATHER_REASONS="All APIs succeeded, but zero active items found (quiet day)"
+  fi
 elif [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ]; then
   CEO_GATHER_STATUS="partial"
   # Replace newlines with spaces for single-line logging


### PR DESCRIPTION
Resolves #70.

Implements the "stronger fix" by evaluating primary inputs at the end of `ceo-gather.sh` and exporting `CEO_GATHER_STATUS=failed` when all primary data sources (pending, PRs, daily note, questions) are empty. 

Gates read-tier dispatch on this status. If the status is failed, it skips execution with a clean log and a `skipped: gather-failed` report, completely preventing the model from hallucinating a confident-but-empty brief.