### PR TITLE
fix(cron): rate-limit fallback ignores claude-tier model frontmatter

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -754,7 +754,13 @@ END_LOG_ENTRY"
       _v "NOTE: CEO_OLLAMA_SKIP_PROBE set, skipping daemon probe"
       echo "$(date): NOTE — $TRIGGER skipping ollama daemon probe (CEO_OLLAMA_SKIP_PROBE set)" >> "$LOG_DIR/cron-skips.log"
     fi
-    if [ -z "$MODEL_FROM_FRONTMATTER" ]; then
+    # Rate-limit fallback (CEO_CRON_OLLAMA_FALLBACK=1) flips RUNNER=ollama at
+    # runtime for a claude-tier playbook whose frontmatter `model:` is a Claude
+    # name (sonnet/haiku/opus). On that path, ignore frontmatter and use the
+    # runner-default ollama model — passing a Claude name to `ollama run` fails
+    # with "pull model manifest: file does not exist". Native runner:ollama
+    # playbooks still honor `model:` for explicit ollama-model overrides.
+    if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
       case "$RUNNER" in
         ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
         ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2262,6 +2262,43 @@ STUB
   assert_contains "$ollama_invoked" "mistral-small" "ollama must be invoked with default model during fallback"
 }
 
+test_claude_rate_limit_fallback_ignores_claude_model_frontmatter() {
+  # Regression: a runner:claude playbook with model:haiku|sonnet (Claude tier
+  # name) must NOT pass that name through to `ollama run` when the rate-limit
+  # fallback flips RUNNER to ollama. The invariant is "rate-limit fallback is
+  # 100% ollama-mapped"; frontmatter model overrides apply only to native
+  # runner:ollama playbooks, not to a runtime-flipped runner.
+  cat > "$CEO_DIR/playbooks/ratelimit-haiku.md" << 'PB'
+---
+name: ratelimit-haiku
+description: claude-tier playbook that declares model:haiku
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+echo "You've hit your session limit · resets 5:10am (America/New_York)"
+exit 1
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/claude"
+
+  local rc=0
+  bash "$CRON" ratelimit-haiku >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "cron must exit 0 after falling back to ollama"
+
+  local model
+  model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$model" "mistral-small3.2:24b" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
+}
+
 test_ceo_cron_skips_read_tier_on_failed_gather() {
   cat > "$CEO_DIR/playbooks/morning-brief.md" << 'PB'
 ---


### PR DESCRIPTION
## Description

Three CEO playbooks on ML-1 failed this morning (2026-05-25) — `morning-scan`, `morning-brief`, `pending-drip`. All three Claude-rate-limited, all three fell back to ollama, all three failed with `Error: pull model manifest: file does not exist`. Root cause was in the model-resolution block, not the ollama install (`mistral-small3.2:24b` and `gpt-oss:20b` are pulled and working).

The fallback path in `ceo-cron.sh` flips `RUNNER=ollama` at runtime when Claude returns rate-limit text, but the model-resolution block then honored the playbook's frontmatter `model:` — which for these playbooks is a Claude-tier name (`haiku` / `sonnet`). The Claude name went straight into `ollama run sonnet`, which has no such manifest.

The intent at the time PR #69 landed was: a *native* `runner: ollama` playbook can override the runner default with `model: mistral-small3.2:24b` (or other ollama model) in frontmatter. PR #71 later added the rate-limit fallback (`CEO_CRON_OLLAMA_FALLBACK=1`), which flips RUNNER but didn't reset `MODEL_FROM_FRONTMATTER`. The two PRs each made sense in isolation but composed to a bug that broke the invariant "rate-limit fallback is 100% ollama-mapped."

Fix: on the fallback path, fall through to the runner-default ollama model. Native `runner: ollama` playbooks (including the existing `test_runner_ollama_model_sonnet_passes_literal` test case where `model: sonnet` is *deliberately* misconfigured by the user) still honor frontmatter exactly as before.

## Testing Procedure

1. `cd scripts && bash ceo-cron.test.sh` — all 71 tests pass.
2. `TEST_FILTER=claude_rate_limit_fallback_ignores bash scripts/ceo-cron.test.sh` — new regression test passes. Revert the `||` clause in `ceo-cron.sh:757` and rerun → the new test fails with `got: haiku, want: mistral-small3.2:24b`.
3. `TEST_FILTER=runner_ollama bash scripts/ceo-cron.test.sh` — all 17 native-ollama-runner tests still pass (including `test_runner_ollama_model_sonnet_passes_literal`, which pins the deliberate-misconfig path).

## Additional Notes

This bug had been live since PR #71 merged. ML-1's three morning playbooks would have failed silently on every rate-limit fallback since then; the failures only became visible today because the broader morning sweep was rate-limited simultaneously and the cron-skips log was tailed. No production data was lost — fallback returns exit 1 and the rate-limit notification fires either way.

Companion gap (different issue, not in scope here): the `workload-report` playbook on ML-1 fails for a separate reason — secondary llm-tools clone was stale, and the skill itself hard-codes \`~/.cursor/mcp.json\` as a credential source. Tracked at nhangen/llm-tools#35.