### PR TITLE
fix(cron): Persist runner:skill fields to registry (Retry)

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -563,7 +563,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -610,6 +610,17 @@ cmd_playbook_scan() {
     bin=$(yq --front-matter=extract '.bin // ""' "$f" 2>/dev/null || echo "")
     runner=$(yq --front-matter=extract '.runner // ""' "$f" 2>/dev/null || echo "")
     script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
+    skill=$(yq --front-matter=extract '.skill // ""' "$f" 2>/dev/null || echo "")
+    out_pattern=$(yq --front-matter=extract '.out_pattern // ""' "$f" 2>/dev/null || echo "")
+    requires=$(yq --front-matter=extract --output-format=json '.requires // null' "$f" 2>/dev/null || echo "null")
+    case "$requires" in
+      "null"|"") requires="null" ;;
+      \[*\]) ;;
+      *)
+        echo "  WARN  $basename: 'requires' must be an array (got: $(echo "$requires" | head -c 60)) — defaulting to none" >&2
+        requires="null"
+        ;;
+    esac
     # `inputs` is an optional array of pre-gather keys to inject into the prompt.
     # Absent → all keys (backward-compatible default). [] → none. Non-array →
     # warn and treat as absent (per enum-config-typo-fallback rule). yq emits
@@ -705,9 +716,12 @@ cmd_playbook_scan() {
       --arg bin "$bin" \
       --arg runner "$runner" \
       --arg script "$script" \
+      --arg skill "$skill" \
+      --arg out_pattern "$out_pattern" \
       --argjson inputs "$inputs" \
+      --argjson requires "$requires" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, inputs:$inputs, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, inputs:$inputs, requires:$requires, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2379,7 +2379,7 @@ PB
 
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
-  assert_contains "$skips_log" "missing credential MISSING_TEST_VAR" "skips log must record missing credential"
+  assert_contains "$skips_log" "missing credential(s) MISSING_TEST_VAR" "skips log must record missing credential"
 }
 
 test_runner_skill_no_output_file_records_failure() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2325,7 +2325,8 @@ EOF
   PATH=/usr/bin:/bin bash "$CRON" skill-success >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "runner:skill must exit 0 on success"
 
-  local expected_out="$CEO_DIR/reports/test/$(date +%Y-%m-%d)-$(hostname -s).md"
+  local expected_out
+  expected_out="$CEO_DIR/reports/test/$(date +%Y-%m-%d)-$(hostname -s).md"
   assert_file_exists "$expected_out" "runner:skill must write to interpolated out_pattern"
   local content
   content=$(cat "$expected_out" 2>/dev/null || echo "")
@@ -2482,7 +2483,8 @@ EOF
   PATH=/usr/bin:/bin bash "$CRON" workload-report >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "workload-report skill runner must exit 0"
 
-  local expected_out="$CEO_DIR/reports/workload/$(date +%Y-%m-%d)-$(hostname -s).md"
+  local expected_out
+  expected_out="$CEO_DIR/reports/workload/$(date +%Y-%m-%d)-$(hostname -s).md"
   assert_file_exists "$expected_out" "workload-report must produce correct interpolated file"
 }
 


### PR DESCRIPTION
Re-submitting the fixes for the registry scan bug where `skill`, `out_pattern`, and `requires` fields were parsed but dropped from the `jq -n` payload builder. The previous PR (#77) was mistakenly merged before you could review it, which has now been reverted on `main`. This restores those exact same fixes for proper review.