### PR TITLE
fix(gather): match Pending.md unchecked items instead of stale [ask] marker

### DIFF
--- a/docs/playbooks/pending-drip.md
+++ b/docs/playbooks/pending-drip.md
@@ -11,7 +11,7 @@ status: active
 
 # Pending Drip
 
-Surface 1-2 outstanding [ask] questions from Pending.md, matched to the current context.
+Surface 1-2 outstanding `- [ ]` questions from Pending.md, matched to the current context.
 
 ## Steps
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -784,7 +784,7 @@ $(_escape_tag "$ACTIVE_DOMAINS_CONTENT")
   if _inputs_includes pending_ask; then
     PENDING_ASK_BLOCK="
 <external-data>
-Pending [ask] questions (Pending.md, top 20):
+Pending questions (Pending.md unchecked items, top 20):
 $(_escape_tag "$PENDING_ASK_QUESTIONS")
 </external-data>"
   fi

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -268,13 +268,14 @@ else
   export ACTIVE_DOMAINS_CONTENT=""
 fi
 
-# --- Pending.md [ask] questions (top entries only) ---
-# Morning brief asks Claude to "pick 1-2 [ask] questions". Pre-extract them
-# so Claude doesn't need to read the full file. Cap at 20 lines to bound cost.
+# --- Pending.md outstanding questions (top entries only) ---
+# Pre-extract unchecked items so Claude doesn't need to read the full file.
+# Matches the same pattern PENDING_COUNT uses (line 38). Cap at 20 lines to
+# bound cost.
 PENDING_FILE="$VAULT/Pending.md"
 if [ -f "$PENDING_FILE" ]; then
 export PENDING_ASK_QUESTIONS
-PENDING_ASK_QUESTIONS=$(grep -n '\[ask\]' "$PENDING_FILE" 2>/dev/null | head -20)
+PENDING_ASK_QUESTIONS=$(grep -n '^- \[ \]' "$PENDING_FILE" 2>/dev/null | head -20)
 else
   export PENDING_ASK_QUESTIONS=""
 fi


### PR DESCRIPTION
Closes #81

## Description (Issue Fixed & New Behavior)

`scripts/ceo-gather.sh:277` pre-gathered pending questions by greping `Pending.md` for the literal string `[ask]`. The current vault format doesn't use that marker — items are `- [ ] **file:** X **field:** Y **question:** Z`. The only `[ask]` match was a descriptive header line, so `PENDING_ASK_QUESTIONS` ended up with one noise line and zero real questions.

`PENDING_COUNT` (line 38) was correctly populated via `^- \[ \]`, so the empty-gather detector added in #72 didn't fire — `pending-drip` ran with count-only input, couldn't see question content, and self-reported `**Status:** failed` (2026-05-24 "unparseable", 2026-05-26 explicit `Status: failed` from haiku).

Fix:
- `ceo-gather.sh:277` — switch grep to `^- \[ \]`, matching the same pattern `PENDING_COUNT` already uses (line 38) and matching what the playbook's step 3 already says to scan.
- `ceo-cron.sh:787` — rename prompt block label from "Pending [ask] questions" to "Pending questions (Pending.md unchecked items, top 20)" so the model sees framing that matches the data.
- `docs/playbooks/pending-drip.md:14` — drop stale `[ask]` wording from the description; the rest of the playbook already references `- [ ]` entries correctly.

## Testing Procedure

1. Check out branch: `git checkout nh/fix/81-pending-drip-gather`.
2. Verify shellcheck passes: `shellcheck -S warning scripts/ceo-gather.sh scripts/ceo-cron.sh` — exit 0.
3. Run repo test suite: `for t in scripts/*.test.sh; do bash "$t" || exit 1; done` — all pass.
4. Run the new grep against the actual `Pending.md` and confirm output structure:
   ```
   grep -n '^- \[ \]' /path/to/vault/Pending.md | head -20
   ```
   Expected: lines like ``13:- [ ] **file:** `Profile.md` **field:** communication preferences **question:** …``. Verified against ML-1 vault — old pattern returned only the header noise line, new pattern returns the two real questions.
5. Wait for next `pending-drip` cron fire (03:30 EDT) or trigger manually with `ceo run pending-drip`. Confirm `CEO/log/cron-skips.log` no longer records `pending-drip self-reported **Status:** failed` and the model's LOG_ENTRY output references the actual question text from Pending.md.

## Additional Notes / HelpScout Tickets

- Failure history (from `CEO/log/cron-skips.log`): repeated failures across May 22, May 24, May 25, May 26.
- Vault memo from 2026-05-20 ("Pending-drip blocked (pre-gather count-only)") documented the same diagnosis 6 days before the fix landed.
- Sibling issue #70 / PR #72 added the `CEO_GATHER_STATUS=empty` detector for the all-empty case; this PR addresses the orthogonal "one input shaped wrong" case that detector can't catch by design.