### PR TITLE
fix(test): harness silently counts set -u aborts as passing tests

### DIFF
--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -257,6 +257,7 @@ test_resolve_real_home_falls_back_to_dscl_when_getent_returns_empty() {
   # the dscl branch was unreachable once command -v getent succeeded.
   if [ "$(uname)" != "Darwin" ]; then
     printf "  SKIP [%s] non-Darwin\n" "$CURRENT_TEST"
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
     return 0
   fi
   local stub_dir="$TEST_HOME/stubs"

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -7,16 +7,7 @@ set -uo pipefail  # no -e — tests handle their own failures
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="$SCRIPT_DIR/ceo-config.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -35,6 +26,7 @@ test_load_config_returns_nonzero_when_unresolved() {
     ceo_load_config
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "ceo_load_config must return 1 when no source resolves CEO_VAULT"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_load_config_honors_env_bypass() {
@@ -46,6 +38,7 @@ test_load_config_honors_env_bypass() {
     [ \"\$CEO_VAULT\" = \"$TEST_HOME/explicit\" ]
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "explicit CEO_VAULT in env must short-circuit discovery"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_load_config_finds_legacy_candidate() {
@@ -59,6 +52,7 @@ test_load_config_finds_legacy_candidate() {
   " 2>/dev/null) || rc=$?
   assert_eq "$rc" "0" "ceo_load_config must succeed when a candidate vault exists"
   assert_eq "$vault_path" "$TEST_HOME/Documents/Obsidian" "must export the discovered vault path"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_require_vault_exits_when_unresolved() {
@@ -69,6 +63,7 @@ test_require_vault_exits_when_unresolved() {
     ceo_require_vault
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "ceo_require_vault must exit 1 when no source resolves CEO_VAULT"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_require_vault_returns_zero_when_resolved() {
@@ -79,6 +74,7 @@ test_require_vault_returns_zero_when_resolved() {
     ceo_require_vault
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ceo_require_vault must return 0 when CEO_VAULT resolves"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_report_fails_loud_on_unresolved_vault() {
@@ -93,6 +89,7 @@ test_ceo_report_fails_loud_on_unresolved_vault() {
     printf '  FAIL [%s] silent provision under default path\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_callers_fail_loud_on_unresolved_vault() {
@@ -108,12 +105,14 @@ test_ceo_callers_fail_loud_on_unresolved_vault() {
     esac
   done
   CURRENT_TEST="$_outer_test"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_help_works_on_fresh_host() {
   local rc=0
   env -i HOME="$TEST_HOME/empty" PATH="$PATH" bash "$SCRIPT_DIR/ceo" help >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ceo help must exit 0 on a host with no CEO_VAULT"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_registry_validate_accepts_integer_current_schema() {
@@ -127,6 +126,7 @@ test_registry_validate_accepts_integer_current_schema() {
     ceo_registry_validate '$registry'
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "integer schema_version at current version must validate"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_registry_validate_rejects_non_integer_schema() {
@@ -140,6 +140,7 @@ test_registry_validate_rejects_non_integer_schema() {
     ceo_registry_validate '$registry'
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "2" "float schema_version must reject instead of falling through"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_registry_validate_rejects_string_schema() {
@@ -153,6 +154,7 @@ test_registry_validate_rejects_string_schema() {
     ceo_registry_validate '$registry'
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "2" "string schema_version must reject instead of coercing"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # ceo_inbox_has_unchecked — preflight helper that scans both the legacy
@@ -173,6 +175,7 @@ test_inbox_has_unchecked_returns_nonzero_when_no_files_exist() {
   mkdir -p "$TEST_HOME/CEO"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "1" "no inbox files anywhere → nothing to do"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_has_unchecked_finds_legacy_inbox_md() {
@@ -181,6 +184,7 @@ test_inbox_has_unchecked_finds_legacy_inbox_md() {
   printf -- '- [ ] something\n' > "$TEST_HOME/CEO/inbox.md"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "0" "unchecked item in legacy inbox.md must trigger preflight"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_has_unchecked_skips_legacy_when_all_checked() {
@@ -189,6 +193,7 @@ test_inbox_has_unchecked_skips_legacy_when_all_checked() {
   printf -- '- [x] done\n' > "$TEST_HOME/CEO/inbox.md"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "1" "all-checked legacy inbox.md must not trigger preflight"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_has_unchecked_finds_per_host_shadow_file() {
@@ -197,6 +202,7 @@ test_inbox_has_unchecked_finds_per_host_shadow_file() {
   printf -- '- [ ] from-mac\n' > "$TEST_HOME/CEO/inbox/mac-mini.md"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "0" "unchecked item in per-host shadow must trigger preflight"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_has_unchecked_skips_per_host_when_all_checked() {
@@ -206,6 +212,7 @@ test_inbox_has_unchecked_skips_per_host_when_all_checked() {
   printf -- '- [x] done-on-wsl\n' > "$TEST_HOME/CEO/inbox/wsl-host.md"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "1" "all-checked per-host shadow files must not trigger preflight"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty() {
@@ -215,6 +222,7 @@ test_inbox_has_unchecked_with_legacy_clean_and_shadow_dirty() {
   printf -- '- [ ] shadow-pending\n' > "$TEST_HOME/CEO/inbox/host-b.md"
   _inbox_check "$TEST_HOME/CEO" || rc=$?
   assert_eq "$rc" "0" "must find unchecked items even when legacy is clean"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_real_home_ignores_env_HOME() {
@@ -239,6 +247,7 @@ test_resolve_real_home_ignores_env_HOME() {
     ceo_resolve_real_home
   ")
   assert_eq "$got" "$expected" "ceo_resolve_real_home must use passwd, not \$HOME"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_real_home_falls_back_to_dscl_when_getent_returns_empty() {
@@ -275,6 +284,7 @@ EOF
     ceo_resolve_real_home
   ")
   assert_eq "$got" "$expected" "must fall through to dscl when getent on PATH returns empty"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pin_home_or_warn_emits_warn_on_resolver_failure() {
@@ -296,6 +306,7 @@ test_pin_home_or_warn_emits_warn_on_resolver_failure() {
     *) printf '  FAIL [%s] expected WARN line on stderr, got: %q\n' "$CURRENT_TEST" "$stderr"
        FAILS=$((FAILS + 1)) ;;
   esac
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_plugin_cli_returns_runtime_and_abs_path() {
@@ -316,6 +327,7 @@ test_resolve_plugin_cli_returns_runtime_and_abs_path() {
   assert_eq "$line1" "bun" "default runtime should be bun"
   assert_eq "$line2" "$TEST_HOME/.claude/plugins/cache/nhangen-tools/token-scope/1.3.1/src/cli.ts" \
     "second line should be absolute entry path"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_plugin_cli_picks_latest_version() {
@@ -335,6 +347,7 @@ test_resolve_plugin_cli_picks_latest_version() {
   local picked
   picked=$(printf '%s\n' "$out" | sed -n '2p')
   assert_eq "$picked" "$base/1.3.1/src/cli.ts" "resolver must pick the highest version via sort -V"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_plugin_cli_fails_when_plugin_absent() {
@@ -345,6 +358,7 @@ test_resolve_plugin_cli_fails_when_plugin_absent() {
     ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "resolver must return 1 when no cache directory exists"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_plugin_cli_fails_when_entry_missing() {
@@ -358,6 +372,7 @@ test_resolve_plugin_cli_fails_when_entry_missing() {
     ceo_resolve_plugin_cli 'nhangen-tools/token-scope' 'src/cli.ts'
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "resolver must return 1 when entry file is missing"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_resolve_plugin_cli_honors_runtime_override() {
@@ -375,6 +390,7 @@ test_resolve_plugin_cli_honors_runtime_override() {
   local runtime
   runtime=$(printf '%s\n' "$out" | sed -n '1p')
   assert_eq "$runtime" "node" "runtime arg must override the bun default"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # --- ceo_write_alert_frontmatter / ceo_read_alert_field ---
@@ -405,6 +421,7 @@ test_write_alert_frontmatter_emits_required_fields() {
     *) printf '  FAIL [%s] missing host\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)) ;;
   esac
   assert_eq "$(printf '%s\n' "$out" | tail -n 1)" "---" "last line must be closing delimiter"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_alert_frontmatter_rejects_invalid_status() {
@@ -420,6 +437,7 @@ test_write_alert_frontmatter_rejects_invalid_status() {
     *) printf '  FAIL [%s] expected error on stderr, got: %q\n' "$CURRENT_TEST" "$stderr"
        FAILS=$((FAILS + 1)) ;;
   esac
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_alert_frontmatter_accepts_clear_and_firing() {
@@ -432,6 +450,7 @@ test_write_alert_frontmatter_accepts_clear_and_firing() {
     " >/dev/null 2>&1 || rc=$?
     assert_eq "$rc" "0" "status=$s must be accepted"
   done
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_alert_frontmatter_rejects_unknown_status() {
@@ -442,6 +461,7 @@ test_write_alert_frontmatter_rejects_unknown_status() {
     ceo_write_alert_frontmatter --status=unknown --since=t --host=h --last-check=t
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "status=unknown is reserved as a consumer-side corruption sentinel and must not be writable"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_alert_frontmatter_requires_since_and_host() {
@@ -459,6 +479,7 @@ test_write_alert_frontmatter_requires_since_and_host() {
     ceo_write_alert_frontmatter --status=clear --since=t --last-check=t
   " >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "missing --host must return 1"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_alert_frontmatter_emits_extra_fields() {
@@ -470,12 +491,9 @@ test_write_alert_frontmatter_emits_extra_fields() {
       --field dump_folder_gb=20 --field c_free_gb=999 --field measurement_failed=0
   ")
   for kv in "dump_folder_gb: 20" "c_free_gb: 999" "measurement_failed: 0"; do
-    case "$out" in
-      *"$kv"*) ;;
-      *) printf '  FAIL [%s] missing %q in output\n' "$CURRENT_TEST" "$kv"
-         FAILS=$((FAILS + 1)) ;;
-    esac
+    assert_contains "$out" "$kv" "missing $kv in output"
   done
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_alert_field_parses_timestamps_with_colons() {
@@ -495,6 +513,7 @@ EOF
     ceo_read_alert_field '$f' since
   ")
   assert_eq "$got" "2026-01-01T00:00:00-0500" "since must round-trip including colons (regression: -F': *' bug)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_alert_field_rc1_for_missing_field() {
@@ -512,6 +531,7 @@ EOF
   ") || rc=$?
   assert_eq "$got" "" "missing field must print empty"
   assert_eq "$rc"  "1" "missing field must return rc=1 so callers distinguish corruption from absence"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_alert_field_rc2_for_missing_file() {
@@ -523,6 +543,7 @@ test_read_alert_field_rc2_for_missing_file() {
   ") || rc=$?
   assert_eq "$got" "" "missing file must print empty"
   assert_eq "$rc"  "2" "missing file must return rc=2 (legitimate first-run, distinct from corruption)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_alert_field_anchored_match() {
@@ -542,6 +563,7 @@ EOF
   ") || rc=$?
   assert_eq "$rc"  "1" "field 'host' must not match line 'hostname:' (anchored match)"
   assert_eq "$got" "" "no spurious value when only a prefix-named field is present"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_alert_field_rc0_for_present_empty_value() {
@@ -555,6 +577,7 @@ test_read_alert_field_rc0_for_present_empty_value() {
   ") || rc=$?
   assert_eq "$rc"  "0" "field present with empty value is rc=0 (not rc=1) — value-empty != field-absent"
   assert_eq "$got" "" "empty value prints empty"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_write_and_read_roundtrip() {
@@ -579,6 +602,7 @@ test_write_and_read_roundtrip() {
   assert_eq "$since" "2026-01-01T00:00:00-0500" "round-trip since (colons preserved)"
   assert_eq "$host" "ml1" "round-trip host"
   assert_eq "$dump" "20" "round-trip extra field"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_require_vault_rejects_empty_home() {
@@ -591,14 +615,16 @@ test_require_vault_rejects_empty_home() {
     source '$LIB'
     ceo_require_vault
   " 2>&1) || rc=$?
+  
+  # Manual assertion count for the custom rc check
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
   if [ "$rc" -eq 0 ]; then
     printf '  FAIL [%s] ceo_require_vault must exit non-zero when HOME is empty (got 0)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
-  case "$out" in
-    *HOME*) ;;
-    *) printf '  FAIL [%s] empty-HOME error must mention HOME\n    got: %q\n' "$CURRENT_TEST" "$out"; FAILS=$((FAILS + 1)) ;;
-  esac
+  
+  assert_contains "$out" "HOME" "empty-HOME error must mention HOME"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback() {
@@ -628,12 +654,14 @@ test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback() {
   " >/dev/null 2>&1 || true
   fails_value=$(cat "$counter_file" 2>/dev/null || echo missing)
   assert_eq "$fails_value" "1" "corrupted counter must reset to 1 on next failure"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_path_uses_home() {
   local got
   got=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_path")
   assert_eq "$got" "$TEST_HOME/.ceo/pr-sources.json" "pr-sources path must be under \$HOME/.ceo"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_path_rejects_empty_home() {
@@ -642,6 +670,7 @@ test_pr_sources_path_rejects_empty_home() {
   env -i HOME="" PATH="$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_path" >/dev/null 2>&1 || rc=$?
   [ "$rc" -ne 0 ] && rc=1
   assert_eq "$rc" "1" "ceo_pr_sources_path must reject empty HOME (mirrors sibling :?: guard)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_github_accounts_reads_config() {
@@ -650,6 +679,7 @@ test_pr_sources_github_accounts_reads_config() {
   local got
   got=$(bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$cfg'" | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "nhangenam,nhangen" "must list both configured accounts in order"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_github_accounts_empty_array_returns_empty_when_no_gh() {
@@ -659,6 +689,7 @@ test_pr_sources_github_accounts_empty_array_returns_empty_when_no_gh() {
   # PATH stripped so gh discovery fallback can't fire.
   got=$(env -i PATH="/usr/bin:/bin" HOME="$TEST_HOME" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$cfg'")
   assert_eq "$got" "" "empty accounts array with no gh available → empty stdout"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_exclude_orgs() {
@@ -667,12 +698,14 @@ test_pr_sources_exclude_orgs() {
   local got
   got=$(bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_exclude_orgs '$cfg'" | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "dependabot,copilot" "exclude_orgs must round-trip"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_dedupe_default_true() {
   local rc=0
   bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_dedupe '$TEST_HOME/missing.json'" || rc=$?
   assert_eq "$rc" "0" "missing config defaults dedupe=true (rc=0)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_dedupe_explicit_false() {
@@ -681,6 +714,7 @@ test_pr_sources_dedupe_explicit_false() {
   local rc=0
   bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_dedupe '$cfg'" || rc=$?
   assert_eq "$rc" "1" "explicit dedupe:false returns rc=1"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_malformed_json_falls_through() {
@@ -689,6 +723,7 @@ test_pr_sources_malformed_json_falls_through() {
   local got
   got=$(env -i PATH="/usr/bin:/bin" HOME="$TEST_HOME" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$cfg'" 2>/dev/null)
   assert_eq "$got" "" "malformed JSON must not crash; falls through to empty when no gh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # Stub-gh tests: place a fake `gh` on PATH that emits a known `gh auth status`
@@ -740,6 +775,7 @@ test_pr_sources_github_accounts_discovers_via_gh_when_config_missing() {
   stub_dir=$(_setup_stub_gh "$TEST_HOME" auth-multi)
   got=$(env -i HOME="$TEST_HOME" PATH="$stub_dir:/usr/bin:/bin" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$TEST_HOME/missing.json'" 2>/dev/null | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "stubuser1,stubuser2" "missing config must fall through to gh discovery"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_github_accounts_empty_array_triggers_discovery() {
@@ -751,6 +787,7 @@ test_pr_sources_github_accounts_empty_array_triggers_discovery() {
   stub_dir=$(_setup_stub_gh "$TEST_HOME" auth-multi)
   got=$(env -i HOME="$TEST_HOME" PATH="$stub_dir:/usr/bin:/bin" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$cfg'" 2>/dev/null | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "stubuser1,stubuser2" "empty accounts array must fall through to gh discovery"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_github_accounts_malformed_triggers_discovery() {
@@ -760,6 +797,7 @@ test_pr_sources_github_accounts_malformed_triggers_discovery() {
   stub_dir=$(_setup_stub_gh "$TEST_HOME" auth-multi)
   got=$(env -i HOME="$TEST_HOME" PATH="$stub_dir:/usr/bin:/bin" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$cfg'" 2>/dev/null | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "stubuser1,stubuser2" "malformed JSON must trigger gh discovery (not silently return empty)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_github_accounts_gh_auth_failure_returns_empty() {
@@ -768,6 +806,7 @@ test_pr_sources_github_accounts_gh_auth_failure_returns_empty() {
   got=$(env -i HOME="$TEST_HOME" PATH="$stub_dir:/usr/bin:/bin" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_accounts '$TEST_HOME/missing.json'" 2>/dev/null) || rc=$?
   assert_eq "$got" "" "gh auth status failure → empty stdout, no crash"
   assert_eq "$rc" "0" "gh auth failure must not propagate non-zero rc"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_gitlab_usernames_reads_config() {
@@ -775,6 +814,7 @@ test_pr_sources_gitlab_usernames_reads_config() {
   printf '%s\n' '{"gitlab":{"usernames":["nhangen","alt-user"]}}' > "$cfg"
   got=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_gitlab_usernames '$cfg'" | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "nhangen,alt-user" "gitlab usernames must round-trip from config"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_exclude_orgs_rejects_garbage() {
@@ -787,6 +827,7 @@ test_pr_sources_exclude_orgs_rejects_garbage() {
   printf '%s\n' '{"github":{"exclude_orgs":["dependabot","valid-org","bad org with space","invalid!chars"]}}' > "$cfg"
   got=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_pr_sources_github_exclude_orgs '$cfg'" | tr '\n' ',' | sed 's/,$//')
   assert_eq "$got" "dependabot,valid-org" "exclude_orgs validator must drop garbage entries"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_setup_skips_non_tty() {
@@ -805,6 +846,7 @@ test_pr_sources_setup_skips_non_tty() {
     accounts=0
   fi
   assert_eq "${accounts:-0}" "0" "non-tty stdin must not silently select any accounts"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_setup_writes_valid_json_when_no_sources() {
@@ -816,24 +858,7 @@ test_pr_sources_setup_writes_valid_json_when_no_sources() {
     jq empty "$TEST_HOME/.ceo/pr-sources.json" 2>/dev/null || rc=$?
   fi
   assert_eq "$rc" "0" "setup must either skip cleanly or write valid JSON"
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -8,32 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CEO_CLI="$SCRIPT_DIR/ceo"
 CRON="$SCRIPT_DIR/ceo-cron.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_file_exists() {
-  local path="$1" msg="${2:-}"
-  if [[ ! -f "$path" ]]; then
-    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -146,6 +121,7 @@ SH
   fi
 
   rm -f "$SCRIPT_DIR/fake-intake.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_default_invokes_claude() {
@@ -166,6 +142,7 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_VERBOSE=1 bash "$CRON" fake-claude >/dev/null 2>&1 || true
   assert_file_exists "$HOME/claude-invoked.txt" "default runner must invoke claude"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_tier_posts_full_report_to_discord_report_webhook() {
@@ -233,6 +210,7 @@ STUB
     "Discord payload must include the parsed LOG_ENTRY body"
 
   unset CURL_CAPTURE_DIR
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_v_safe_under_set_e() {
@@ -264,6 +242,7 @@ SH
     "script must run end-to-end with CEO_VERBOSE unset (regression guard for a528fde)"
 
   rm -f "$SCRIPT_DIR/v-test.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_script_stderr_redirected_to_log() {
@@ -297,6 +276,7 @@ SH
     "script stderr must be appended to cron-stderr.log"
 
   rm -f "$SCRIPT_DIR/stderr-intake.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_script_failure_increments_fail_count() {
@@ -328,6 +308,7 @@ SH
   assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after one script failure"
 
   rm -f "$SCRIPT_DIR/fail-intake.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_script_success_resets_fail_count() {
@@ -360,6 +341,7 @@ SH
   assert_eq "$fails" "0" "FAIL_COUNT_FILE must be 0 after a successful script run"
 
   rm -f "$SCRIPT_DIR/ok-intake.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_script_success_appends_runs_log() {
@@ -391,6 +373,7 @@ SH
   assert_contains "$runs_log" "log-intake completed" "cron-runs.log must record successful script run"
 
   rm -f "$SCRIPT_DIR/log-intake.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_disk_monitor_success_suppresses_success_notification() {
@@ -425,6 +408,7 @@ SH
   fi
 
   rm -f "$SCRIPT_DIR/disk-monitor-test.sh"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_read_tier_failure_increments_fail_count() {
@@ -461,6 +445,7 @@ PB
       "$CURRENT_TEST" "$runs_log"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_phase3_failure_does_not_log_completed() {
@@ -507,6 +492,7 @@ PB
       "$CURRENT_TEST" "$runs_log"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_unknown_value_skipped_at_scan() {
@@ -531,6 +517,7 @@ PB
   local entry
   entry=$(jq -r '.playbooks[] | select(.name=="typo-runner")' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
   assert_eq "$entry" "" "skipped playbook must not appear in registry.json"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_unknown_value_rejected_at_dispatch() {
@@ -560,6 +547,7 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Unknown runner 'scrpt'" "skips log must record unknown-runner rejection"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_accepted_at_scan() {
@@ -587,6 +575,7 @@ PB
   local entry
   entry=$(jq -r '.playbooks[] | select(.name=="ollama-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
   assert_eq "$entry" "ollama" "ollama playbook must be registered with runner:ollama"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_invokes_ollama_and_skips_claude() {
@@ -619,6 +608,7 @@ PB
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "mistral-small3.2:24b" "runner:ollama default must be mistral-small3.2:24b"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_think_uses_gpt_oss_default() {
@@ -644,6 +634,7 @@ PB
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "gpt-oss:20b" "runner:ollama-think default must be gpt-oss:20b"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_explicit_model_overrides_default() {
@@ -670,6 +661,7 @@ PB
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "qwen3:14b" "explicit model: tag must override runner default"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_failure_increments_fail_count() {
@@ -716,6 +708,7 @@ STUB
   local stderr_log
   stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
   assert_contains "$stderr_log" "ollama-error-sentinel" "ollama stderr must be appended to cron-stderr.log"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_think_accepted_at_scan() {
@@ -743,6 +736,7 @@ PB
   local entry
   entry=$(jq -r '.playbooks[] | select(.name=="ollama-think-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
   assert_eq "$entry" "ollama-think" "ollama-think playbook must be registered with runner:ollama-think"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_model_sonnet_passes_literal() {
@@ -767,6 +761,7 @@ PB
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to mistral default)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_daemon_unreachable_records_failure() {
@@ -801,6 +796,7 @@ STUB
     printf '  FAIL [%s] ollama must NOT be invoked when daemon probe fails\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_empty_output_records_failure() {
@@ -838,6 +834,7 @@ STUB
       "$CURRENT_TEST" "$runs_log"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_works_under_stripped_path() {
@@ -861,6 +858,7 @@ PB
   PATH=/usr/bin:/bin bash "$CRON" ollama-strip >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ollama branch must resolve ollama via ceo_augment_path under stripped PATH"
   assert_file_exists "$HOME/ollama-invoked-model.txt" "ollama stub must fire under stripped PATH"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_skips_preamble_files() {
@@ -901,6 +899,7 @@ PB
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$prompt" "my-playbook-body" "ollama prompt must contain the playbook body"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_read_tier_includes_pre_gathered_data() {
@@ -941,6 +940,7 @@ PB
   # of the SINGLE_PROMPT_BODY split (so ollama got only the playbook file)
   # would not surface PENDING_COUNT — the literal "3 pending" disappears.
   assert_contains "$prompt" "3 pending" "pre-gathered PENDING_COUNT (sentinel: 3) must reach ollama prompt"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_prompt_exceeds_budget_fails() {
@@ -980,6 +980,7 @@ PB
   local raw_log
   raw_log=$(cat "$CEO_DIR/log/cron-raw.log" 2>/dev/null || echo "")
   assert_contains "$raw_log" "Prompt exceeds budget" "cron-raw.log must capture budget-exceeded events"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_rejects_non_read_tier() {
@@ -1014,6 +1015,7 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "ollama runner requires tier:read" "skips log must record reject reason"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_think_rejects_non_read_tier() {
@@ -1045,6 +1047,7 @@ PB
     printf '  FAIL [%s] ollama-think must NOT be invoked for non-read tier\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_success_routes_through_ceo_report_intake() {
@@ -1135,6 +1138,7 @@ STUB
   local payload
   payload=$(cat "$CURL_CAPTURE_DIR/payload.json" 2>/dev/null || echo "")
   assert_contains "$payload" "ollama-intake-sentinel" "Discord side-channel must fire on ollama success"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_ollama_self_reported_failed_records_failure() {
@@ -1186,6 +1190,7 @@ STUB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "self-reported" "cron-skips.log must record self-reported-failure reason"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_claude_self_reported_failed_records_failure() {
@@ -1231,6 +1236,7 @@ STUB
   local fails
   fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
   assert_eq "$fails" "1" "claude path: model self-reporting **Status:** failed must increment FAIL_COUNT_FILE"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_production_morning_brief_registers_with_ollama_runner() {
@@ -1257,6 +1263,7 @@ test_production_morning_brief_registers_with_ollama_runner() {
   assert_eq "$runner" "ollama" "production morning-brief.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-brief.md must declare tier: read"
   assert_eq "$model" "mistral-small3.2:24b" "production morning-brief.md must declare model: mistral-small3.2:24b"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_production_morning_scan_registers_with_ollama_runner() {
@@ -1278,6 +1285,7 @@ test_production_morning_scan_registers_with_ollama_runner() {
   assert_eq "$runner" "ollama" "production morning-scan.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-scan.md must declare tier: read"
   assert_eq "$model" "mistral-small3.2:24b" "production morning-scan.md must declare model: mistral-small3.2:24b"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_augment_path_prepends_user_tool_prefixes() {
@@ -1298,6 +1306,7 @@ test_ceo_augment_path_prepends_user_tool_prefixes() {
 
   local first_segment="${out%%:*}"
   assert_eq "$first_segment" "/fake/.bun/bin" "augmented prefix must be FIRST on PATH"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_augment_path_idempotent() {
@@ -1312,6 +1321,7 @@ test_ceo_augment_path_idempotent() {
     [ "$first" = "$second" ] && echo idempotent || echo diverged
   ')
   assert_eq "$out" "idempotent" "ceo_augment_path must not drift PATH on repeated calls"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_augment_path_empty_home_aborts() {
@@ -1320,10 +1330,12 @@ test_ceo_augment_path_empty_home_aborts() {
     source '"$SCRIPT_DIR"'/ceo-config.sh
     ceo_augment_path
   ' >/dev/null 2>&1 || rc=$?
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
   if [ "$rc" = "0" ]; then
     printf '  FAIL [%s] expected non-zero rc with HOME="", got 0\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_cron_invokes_ceo_augment_path_at_dispatch() {
@@ -1345,6 +1357,7 @@ PB
   PATH=/usr/bin:/bin bash "$CRON" path-strip >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ceo-cron must invoke ceo_augment_path so dispatcher resolves binaries under stripped PATH"
   assert_file_exists "$HOME/claude-invoked.txt" "claude stub must fire (proves PATH augmentation reached dispatcher)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_writes_schema_version_2() {
@@ -1365,6 +1378,7 @@ PB
   local v
   v=$(jq -r '.schema_version // "missing"' "$CEO_DIR/registry.json")
   assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_refuses_newer_schema_version() {
@@ -1392,6 +1406,7 @@ PB
   local after
   after=$(cat "$CEO_DIR/registry.json")
   assert_eq "$after" "$before" "newer registry content must remain unchanged"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cron_skips_on_missing_schema_version() {
@@ -1428,6 +1443,7 @@ PB
     printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cron_skips_on_old_schema_version() {
@@ -1464,6 +1480,7 @@ PB
     printf '  FAIL [%s] claude must NOT fire when schema gate trips\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_list_rejects_old_schema_version() {
@@ -1486,6 +1503,7 @@ PB
   local rc=0
   bash "$CEO_CLI" playbook list >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "playbook list must reject old registry schema"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_info_rejects_old_schema_version() {
@@ -1508,6 +1526,7 @@ PB
   local rc=0
   bash "$CEO_CLI" playbook info example >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "playbook info must reject old registry schema"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cmd_chat_rejects_old_schema_version() {
@@ -1530,6 +1549,7 @@ PB
   local rc=0
   bash "$CEO_CLI" chat example >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "cmd_chat must reject old registry schema"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cmd_preflight_rejects_old_schema_version() {
@@ -1552,6 +1572,7 @@ PB
   local rc=0
   bash "$CEO_CLI" preflight >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "cmd_preflight must reject old registry schema"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_script_missing_script_field_fails() {
@@ -1577,6 +1598,7 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "runner:script but no script field" "missing-script error must be logged"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_blocks_non_primary_host() {
@@ -1602,6 +1624,7 @@ PB
     printf '  FAIL [%s] non-primary host wrote registry.json (must not)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_succeeds_on_primary_host() {
@@ -1623,6 +1646,7 @@ PB
   CEO_HOSTNAME=alpha bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "primary host must be allowed to scan"
   assert_file_exists "$CEO_DIR/registry.json" "registry must be written by primary host"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_unrestricted_when_primary_host_unset() {
@@ -1644,6 +1668,7 @@ PB
   CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "no primary_host setting → backward-compatible (any host can scan)"
   assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_typoed_primary_host_field_emits_warning() {
@@ -1666,6 +1691,7 @@ PB
   assert_eq "$rc" "0" "typo'd key falls through to no-gate (backward-compat) but must warn"
   assert_contains "$out" "unknown key 'promary_host'" "typo'd key must surface a warning so operator notices"
   assert_file_exists "$CEO_DIR/registry.json" "scan continues despite typo (gate is not configured from parser's view)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_malformed_settings_json_fails_loud() {
@@ -1691,6 +1717,7 @@ PB
     printf '  FAIL [%s] registry written despite malformed settings.json\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_missing_jq_with_settings_fails_loud() {
@@ -1717,6 +1744,7 @@ PB
     printf '  FAIL [%s] registry written despite missing-jq error\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_preserves_user_installed_bins() {
@@ -1745,6 +1773,7 @@ PB
     printf '  FAIL [%s] playbook scan removed user-installed ceo symlink\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_creates_and_prunes_declared_bin() {
@@ -1786,6 +1815,7 @@ PB
     printf '  FAIL [%s] previously-managed bin should be pruned when playbook drops it\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_scan_prunes_dropped_bin_but_keeps_user_bins() {
@@ -1833,6 +1863,7 @@ PB
     printf '  FAIL [%s] user-installed ceo symlink should survive prune\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 _write_pending_drip_registry() {
@@ -1895,6 +1926,7 @@ test_pending_drip_success_appends_host_inbox_not_report() {
     printf '  FAIL [%s] successful pending-drip must not append to daily report\n    report: %q\n' "$CURRENT_TEST" "$report"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pending_drip_rerun_is_idempotent() {
@@ -1908,6 +1940,7 @@ test_pending_drip_rerun_is_idempotent() {
   local count
   count=$(grep -c -F "<!-- pending-drip:" "$CEO_DIR/inbox/testhost.md" 2>/dev/null || echo 0)
   assert_eq "$count" "1" "same-day pending-drip rerun must not append duplicate inbox item"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pending_drip_append_preserves_task_start_after_missing_newline() {
@@ -1922,6 +1955,7 @@ test_pending_drip_append_preserves_task_start_after_missing_newline() {
   local task_count
   task_count=$(grep -c '^- \[ \] Review pending drip' "$CEO_DIR/inbox/testhost.md" 2>/dev/null || echo 0)
   assert_eq "$task_count" "1" "pending-drip append must start on a new line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pending_drip_failed_entry_uses_report_not_inbox() {
@@ -1940,6 +1974,7 @@ test_pending_drip_failed_entry_uses_report_not_inbox() {
   assert_file_exists "$report" "failed pending-drip must use normal report path"
   report_body=$(cat "$report" 2>/dev/null)
   assert_contains "$report_body" "Something failed" "failed pending-drip report must include failure output"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pending_drip_no_relevant_questions_suppresses_inbox() {
@@ -1952,6 +1987,7 @@ test_pending_drip_no_relevant_questions_suppresses_inbox() {
     printf '  FAIL [%s] no-relevant pending-drip must not create inbox task\n    inbox: %q\n' "$CURRENT_TEST" "$(cat "$CEO_DIR/inbox/testhost.md")"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # --- inputs: per-playbook injection filter (0.11.0) ---
@@ -1995,6 +2031,7 @@ PB
   assert_contains "$prompt" "PRs requesting review:" "default-all: pr_data line present"
   assert_contains "$prompt" "Briefing-specific training" "default-all: briefings_training block present"
   assert_contains "$prompt" "Active Domains priority order" "default-all: active_domains block present"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inputs_empty_array_excludes_all_blocks() {
@@ -2030,6 +2067,7 @@ PB
     printf '  FAIL [%s] inputs:[] should suppress pr_data lines\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inputs_subset_includes_only_listed() {
@@ -2068,6 +2106,7 @@ PB
     printf '  FAIL [%s] subset: active_domains must be absent\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inputs_unknown_key_warns_at_scan() {
@@ -2091,6 +2130,7 @@ PB
   out=$(bash "$CEO_CLI" playbook scan 2>&1)
   assert_contains "$out" "unknown key" "scan must warn on typo'd input key"
   assert_contains "$out" "bogus_key" "warning must name the offending key"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inputs_non_array_warns_and_defaults_to_all() {
@@ -2119,6 +2159,7 @@ PB
   prompt=$(cat "$HOME/claude-stdin.txt" 2>/dev/null)
   assert_contains "$prompt" "Briefing-specific training" "non-array inputs must default to all (briefings present)"
   assert_contains "$prompt" "PRs requesting review:" "non-array inputs must default to all (pr_data present)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_repo_playbook_auto_registers_with_absolute_file_path() {
@@ -2147,6 +2188,7 @@ PB
   file_field=$(jq -r '.playbooks[] | select(.name=="_test-repo-pb") | .file' "$CEO_DIR/registry.json")
   assert_eq "${file_field:0:1}" "/" "repo playbook .file must be absolute"
   assert_contains "$file_field" "_test-repo-pb.md" "repo playbook .file must point at repo path"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_vault_playbook_shadows_repo_playbook_with_same_name() {
@@ -2187,6 +2229,7 @@ PB
   status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$CEO_DIR/registry.json")
   assert_eq "$desc" "Vault override" "vault entry must win on collision"
   assert_eq "$status" "inactive" "vault status must override repo status"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_repo_internal_duplicate_logs_dup_not_shadow() {
@@ -2224,6 +2267,7 @@ PB
     printf '  FAIL [%s] repo-internal dup must NOT log SHADOW (no vault override exists)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_claude_rate_limit_falls_back_to_ollama_on_read_tier() {
@@ -2260,6 +2304,7 @@ STUB
   local ollama_invoked
   ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_contains "$ollama_invoked" "mistral-small" "ollama must be invoked with default model during fallback"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_claude_rate_limit_fallback_ignores_claude_model_frontmatter() {
@@ -2297,6 +2342,7 @@ STUB
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "mistral-small3.2:24b" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_ceo_cron_skips_read_tier_on_failed_gather() {
@@ -2328,6 +2374,7 @@ PB
   local report
   report=$(cat "$CEO_DIR/reports/$(date +%Y-%m-%d).md" 2>/dev/null || echo "")
   assert_contains "$report" "skipped: gather-empty" "report must show skipped status"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_located_and_success() {
@@ -2368,6 +2415,7 @@ EOF
   local content
   content=$(cat "$expected_out" 2>/dev/null || echo "")
   assert_contains "$content" "test-skill output" "runner:skill must capture skill stdout"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_missing_skill_records_failure() {
@@ -2392,6 +2440,7 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Skill script not found" "skips log must record missing skill script"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_missing_credential_records_failure() {
@@ -2418,6 +2467,7 @@ PB
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "missing credential(s) MISSING_TEST_VAR" "skips log must record missing credential"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_no_output_file_records_failure() {
@@ -2449,6 +2499,7 @@ EOF
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Skill produced no output file" "skips log must record missing output file failure"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_empty_output_records_failure() {
@@ -2486,6 +2537,7 @@ EOF
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "Skill produced empty output" "skips log must record empty output failure"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_runner_skill_workload_report_stub_produces_output() {
@@ -2523,27 +2575,7 @@ EOF
   local expected_out
   expected_out="$CEO_DIR/reports/workload/$(date +%Y-%m-%d)-$(hostname -s).md"
   assert_file_exists "$expected_out" "workload-report must produce correct interpolated file"
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
-      continue
-    fi
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-discord-report.test.sh
+++ b/scripts/ceo-discord-report.test.sh
@@ -6,24 +6,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPORT="$SCRIPT_DIR/ceo-discord-report.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TMP=$(mktemp -d)
@@ -66,6 +49,7 @@ test_silent_without_report_webhook() {
   printf 'hello' | "$REPORT" morning-brief >/dev/null 2>&1
   assert_eq "$(find "$CURL_CAPTURE_DIR" -type f | wc -l | tr -d ' ')" "0" \
     "no webhook means no curl call"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_missing_settings_defaults_to_morning_brief_only() {
@@ -74,6 +58,7 @@ test_missing_settings_defaults_to_morning_brief_only() {
 
   assert_eq "$(find "$CURL_CAPTURE_DIR" -type f | wc -l | tr -d ' ')" "0" \
     "missing settings must still default to morning-brief only"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_uses_dedicated_report_webhook_from_file() {
@@ -84,6 +69,7 @@ test_uses_dedicated_report_webhook_from_file() {
   payload=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
   assert_contains "$payload" "CEO full report: morning-brief" "first payload must identify report"
   assert_contains "$payload" "full report body" "payload must contain body"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_trigger_allowlist_filters_other_reports() {
@@ -93,6 +79,7 @@ test_trigger_allowlist_filters_other_reports() {
 
   assert_eq "$(find "$CURL_CAPTURE_DIR" -type f | wc -l | tr -d ' ')" "0" \
     "non-allowlisted trigger must not post"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_splits_large_report() {
@@ -110,24 +97,7 @@ test_splits_large_report() {
       "$CURRENT_TEST" "$count"
     FAILS=$((FAILS + 1))
   fi
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-disk-monitor.test.sh
+++ b/scripts/ceo-disk-monitor.test.sh
@@ -7,40 +7,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MONITOR="$SCRIPT_DIR/ceo-disk-monitor.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_file_exists() {
-  local path="$1" msg="${2:-}"
-  if [[ ! -f "$path" ]]; then
-    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_not_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    forbidden: %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -125,6 +92,7 @@ test_first_run_clear_creates_state_file() {
     printf '  FAIL [%s] clear first run must not write inbox\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_first_run_firing_appends_one_inbox_task() {
@@ -133,6 +101,7 @@ test_first_run_firing_appends_one_inbox_task() {
   local count
   count=$(grep -c -F "Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
   assert_eq "$count" "1" "first firing run must append exactly one task"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_steady_state_firing_does_not_re_append() {
@@ -143,6 +112,7 @@ test_steady_state_firing_does_not_re_append() {
   local count
   count=$(grep -c -F "Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
   assert_eq "$count" "1" "steady-state firing must not re-append"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_firing_to_clear_flips_task_and_appends_resolution() {
@@ -157,6 +127,7 @@ test_firing_to_clear_flips_task_and_appends_resolution() {
     printf '  FAIL [%s] original unchecked task must no longer be present\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_measurement_failure_preserves_prior_firing() {
@@ -169,6 +140,7 @@ test_measurement_failure_preserves_prior_firing() {
   local inbox_after
   inbox_after=$(cat "$CEO_DIR/inbox/testhost.md")
   assert_eq "$inbox_after" "$inbox_before" "measurement failure must not mutate inbox"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_measurement_failure_on_clear_does_not_flip_to_firing() {
@@ -179,6 +151,7 @@ test_measurement_failure_on_clear_does_not_flip_to_firing() {
     printf '  FAIL [%s] measurement-failed run after clear must not write inbox\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_missing_wsl_crashes_path_is_measurement_failure() {
@@ -190,6 +163,7 @@ test_missing_wsl_crashes_path_is_measurement_failure() {
     printf '  FAIL [%s] missing measurement path must not escalate inbox\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_corrupted_prior_status_does_not_mutate_inbox() {
@@ -208,6 +182,7 @@ EOF
     printf '  FAIL [%s] unknown prior status must not trigger inbox flip\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_corrupted_prior_status_emits_warning() {
@@ -223,6 +198,7 @@ EOF
   local stderr
   stderr=$(bash "$MONITOR" 2>&1 >/dev/null) || true
   assert_contains "$stderr" "unrecognized prior status" "unrecognized enum value must log to stderr"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_sustained_firing_re_pokes_after_user_checkoff() {
@@ -238,6 +214,7 @@ test_sustained_firing_re_pokes_after_user_checkoff() {
   local count
   count=$(grep -c -F -- "- [ ] Clean wsl-crashes on testhost" "$CEO_DIR/inbox/testhost.md")
   assert_eq "$count" "1" "sustained firing past 24h after checkoff must re-append one task"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_two_hosts_write_disjoint_state_files() {
@@ -250,6 +227,7 @@ test_two_hosts_write_disjoint_state_files() {
   beta_status=$(awk '/^status:/ { sub(/^status:[[:space:]]*/, ""); print; exit }' "$CEO_DIR/alerts/disk-beta.md" | tr -d '[:space:]')
   assert_eq "$alpha_status" "firing" "alpha must be firing"
   assert_eq "$beta_status" "clear" "beta must be clear (no overwrite from alpha)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_user_reformat_does_not_duplicate_task() {
@@ -268,6 +246,7 @@ test_user_reformat_does_not_duplicate_task() {
     printf '  FAIL [%s] reformat was overwritten — original wording reappeared\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_log_append_failure_emits_warning() {
@@ -282,6 +261,7 @@ test_log_append_failure_emits_warning() {
   stderr=$(DUMP_GB_STUB="0" bash "$MONITOR" 2>&1 >/dev/null) || true
   chmod 0600 "$log_file"
   assert_contains "$stderr" "failed to append log line" "read-only log file must surface a warning to stderr"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_inbox_rewrite_handles_host_with_regex_chars() {
@@ -294,24 +274,7 @@ test_inbox_rewrite_handles_host_with_regex_chars() {
   local body
   body=$(cat "$CEO_DIR/inbox/odd.host[1].md")
   assert_contains "$body" "[done] Cleaned wsl-crashes on odd.host[1]" "host with regex chars must flip cleanly"
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-notify.test.sh
+++ b/scripts/ceo-notify.test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Tests for ceo-notify.sh — exercises the helper without posting to Discord
 # by routing curl at a local responder served from a tempdir socket.
+#
+# shellcheck disable=SC2034
+# CURRENT_TEST is set per-test here and read by assertion helpers in test-harness.sh.
 
 set -uo pipefail
 

--- a/scripts/ceo-notify.test.sh
+++ b/scripts/ceo-notify.test.sh
@@ -7,32 +7,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NOTIFY="$SCRIPT_DIR/ceo-notify.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_no_match() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack contained forbidden needle: %q\n' "$CURRENT_TEST" "$msg" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TMP=$(mktemp -d)
@@ -57,6 +32,7 @@ test_silent_when_no_webhook_configured() {
   assert_eq "$rc" "0" "exit 0 when no webhook"
   assert_eq "$out" "" "no output when no webhook"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_silent_when_events_off() {
@@ -69,6 +45,7 @@ test_silent_when_events_off() {
   assert_eq "$rc" "0" "exit 0 when events=off"
   assert_eq "$out" "" "no output when events=off"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_silent_on_success_when_events_failures() {
@@ -82,6 +59,7 @@ test_silent_on_success_when_events_failures() {
   assert_eq "$rc" "0" "exit 0 when events=failures and status=success"
   assert_eq "$out" "" "no output when filtered"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_invalid_status_no_op() {
@@ -93,6 +71,7 @@ test_invalid_status_no_op() {
   assert_eq "$rc" "0" "exit 0 on unknown status"
   assert_contains "$out" "unknown status" "stderr explains"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_missing_args_no_op() {
@@ -102,6 +81,7 @@ test_missing_args_no_op() {
   rc=$?
   assert_eq "$rc" "0" "exit 0 on missing args (must not break cron)"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_unknown_events_warns_and_defaults_to_failures() {
@@ -114,6 +94,7 @@ test_unknown_events_warns_and_defaults_to_failures() {
   assert_eq "$rc" "0" "exit 0 with typo'd events"
   assert_contains "$out" "unknown notify_events 'typoed'" "must warn on unknown value (enum-config-typo-fallback rule)"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_curl_unreachable_does_not_break() {
@@ -126,6 +107,7 @@ test_curl_unreachable_does_not_break() {
   rc=$?
   assert_eq "$rc" "0" "exit 0 even when curl fails"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_env_var_overrides_secrets_file() {
@@ -141,6 +123,7 @@ test_env_var_overrides_secrets_file() {
   assert_no_match "$trace" "from-file" "secrets-file URL must NOT be selected when env var is set"
   assert_eq "$rc" "0" "helper rc=0 even with unreachable host"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_does_not_log_webhook_url() {
@@ -155,6 +138,7 @@ test_does_not_log_webhook_url() {
   assert_eq "$rc" "0" "rc=0"
   assert_no_match "$out" "SECRET-TOKEN-12345" "webhook URL must not appear in script output"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_jq_argjson_color_no_injection() {
@@ -168,6 +152,7 @@ test_jq_argjson_color_no_injection() {
   rc=$?
   assert_eq "$rc" "0" "special chars in reason must not crash helper"
   teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # --- Run all tests ---

--- a/scripts/ceo-playbook-diff.test.sh
+++ b/scripts/ceo-playbook-diff.test.sh
@@ -7,32 +7,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CEO_CLI="$SCRIPT_DIR/ceo"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_not_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    forbidden:%q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -62,6 +37,7 @@ test_clean_returns_0_and_says_no_drift() {
   out=$(bash "$CEO_CLI" playbook diff); rc=$?
   assert_eq "$rc" "0" "clean → exit 0"
   assert_contains "$out" "No drift detected" "clean → no-drift message"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_clean_quiet_silent() {
@@ -70,6 +46,7 @@ test_clean_quiet_silent() {
   out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1); rc=$?
   assert_eq "$rc" "0" "clean --quiet → exit 0"
   assert_eq "$out" "" "clean --quiet → empty stdout+stderr"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_vault_only_drift() {
@@ -78,6 +55,7 @@ test_vault_only_drift() {
   out=$(bash "$CEO_CLI" playbook diff); rc=$?
   assert_eq "$rc" "1" "vault-only → exit 1"
   assert_contains "$out" "Vault only: only-in-vault.md" "drift message"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_repo_only_drift() {
@@ -86,6 +64,7 @@ test_repo_only_drift() {
   out=$(bash "$CEO_CLI" playbook diff); rc=$?
   assert_eq "$rc" "1" "repo-only → exit 1"
   assert_contains "$out" "Repo only: only-in-repo.md" "drift message"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_differs_shows_unified_diff() {
@@ -96,6 +75,7 @@ test_differs_shows_unified_diff() {
   assert_eq "$rc" "1" "differs → exit 1"
   assert_contains "$out" "Differs: foo.md" "differs label"
   assert_contains "$out" "+++" "unified diff header present"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_quiet_on_drift_silent_but_nonzero() {
@@ -104,6 +84,7 @@ test_quiet_on_drift_silent_but_nonzero() {
   out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1); rc=$?
   assert_eq "$rc" "1" "quiet drift → exit 1"
   assert_eq "$out" "" "quiet drift → no output"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_quiet_arg_forwarded_from_dispatcher() {
@@ -113,6 +94,7 @@ test_quiet_arg_forwarded_from_dispatcher() {
   local out
   out=$(bash "$CEO_CLI" playbook diff --quiet 2>&1 || true)
   assert_not_contains "$out" "Vault only" "dispatcher must forward --quiet flag"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_missing_vault_dir_returns_2_not_1() {
@@ -120,6 +102,7 @@ test_missing_vault_dir_returns_2_not_1() {
   local rc=0
   bash "$CEO_CLI" playbook diff --quiet >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "2" "missing vault dir → exit 2 (distinct from drift's 1)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_missing_repo_dir_returns_2() {
@@ -127,6 +110,7 @@ test_missing_repo_dir_returns_2() {
   local rc=0
   bash "$CEO_CLI" playbook diff --quiet >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "2" "missing repo dir → exit 2"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_unset_vault_fails_loudly() {
@@ -140,6 +124,7 @@ test_unset_vault_fails_loudly() {
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$out" "CEO_VAULT" "error must name the missing variable"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_both_dirs_empty_no_drift() {
@@ -147,27 +132,7 @@ test_both_dirs_empty_no_drift() {
   out=$(bash "$CEO_CLI" playbook diff); rc=$?
   assert_eq "$rc" "0" "both empty → exit 0"
   assert_contains "$out" "No drift detected" "both empty → no drift"
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
-      continue
-    fi
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-schedule.test.sh
+++ b/scripts/ceo-schedule.test.sh
@@ -12,32 +12,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CEO_CLI="$SCRIPT_DIR/ceo"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_no_match() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    forbidden in haystack: %q\n' "$CURRENT_TEST" "$msg" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 # Source the helpers from `ceo` via the CEO_LIB_ONLY guard, which skips the
 # dispatch table at the bottom of the file. Required because `ceo`'s dispatch
@@ -78,39 +53,28 @@ teardown() {
 # --- Tests ---
 
 test_no_overrides_file_returns_unchanged_registry() {
-  CURRENT_TEST="no_overrides_file_returns_unchanged"
-  setup
   out=$(_playbook_apply_schedule_overrides "$REGISTRY")
   assert_eq "$(echo "$out" | jq -r '.playbooks[] | select(.name=="morning-scan") | .schedule')" \
     "57 8 * * 1-5" "frontmatter schedule preserved when no overrides"
-  teardown
 }
 
 test_override_replaces_frontmatter() {
-  CURRENT_TEST="override_replaces_frontmatter"
-  setup
   echo '{"morning-scan": "50 8 * * 1-5"}' > "$CEO_DIR/schedules.json"
   out=$(_playbook_apply_schedule_overrides "$REGISTRY")
   assert_eq "$(echo "$out" | jq -r '.playbooks[] | select(.name=="morning-scan") | .schedule')" \
     "50 8 * * 1-5" "override replaces frontmatter"
   assert_eq "$(echo "$out" | jq -r '.playbooks[] | select(.name=="morning-brief") | .schedule')" \
     "57 8 * * 1-5" "non-overridden playbook keeps frontmatter"
-  teardown
 }
 
 test_unknown_playbook_in_overrides_warns_and_ignored() {
-  CURRENT_TEST="unknown_playbook_warns"
-  setup
   echo '{"nonexistent-playbook": "0 0 * * *"}' > "$CEO_DIR/schedules.json"
   out=$(_playbook_apply_schedule_overrides "$REGISTRY" 2>&1 >/dev/null)
   assert_contains "$out" "unknown playbook" "must warn on unknown playbook name (enum-config-typo-fallback)"
   assert_contains "$out" "nonexistent-playbook" "must name the offending key"
-  teardown
 }
 
 test_invalid_cron_expr_warns_and_ignored() {
-  CURRENT_TEST="invalid_cron_expr_warns"
-  setup
   echo '{"morning-scan": "not a cron expression"}' > "$CEO_DIR/schedules.json"
   out=$(_playbook_apply_schedule_overrides "$REGISTRY" 2>&1)
   registry_only=$(_playbook_apply_schedule_overrides "$REGISTRY" 2>/dev/null)
@@ -118,45 +82,35 @@ test_invalid_cron_expr_warns_and_ignored() {
   # Schedule should fall back to frontmatter
   assert_eq "$(echo "$registry_only" | jq -r '.playbooks[] | select(.name=="morning-scan") | .schedule')" \
     "57 8 * * 1-5" "schedule falls back to frontmatter when override is invalid"
-  teardown
 }
 
 test_malformed_overrides_json_warns_and_ignored() {
-  CURRENT_TEST="malformed_overrides_json"
-  setup
   echo '{not json' > "$CEO_DIR/schedules.json"
   out=$(_playbook_apply_schedule_overrides "$REGISTRY" 2>&1 >/dev/null)
   assert_contains "$out" "not valid JSON" "must warn on malformed override file"
-  teardown
 }
 
 test_validate_cron_expr_accepts_valid_forms() {
-  CURRENT_TEST="validate_cron_accepts_valid"
-  setup
   for expr in "0 0 * * *" "57 8 * * 1-5" "*/5 * * * *" "0 9,13,17 * * 1-5"; do
     if ! _validate_cron_expr "$expr" >/dev/null 2>&1; then
       printf '  FAIL [%s] valid expr rejected: %q\n' "$CURRENT_TEST" "$expr"
       FAILS=$((FAILS + 1))
     fi
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
   done
-  teardown
 }
 
 test_validate_cron_expr_rejects_bad_forms() {
-  CURRENT_TEST="validate_cron_rejects_bad"
-  setup
   for expr in "0 0 * *" "0 0 * * * *" "abc def ghi jkl mno" ""; do
     if _validate_cron_expr "$expr" >/dev/null 2>&1; then
       printf '  FAIL [%s] invalid expr accepted: %q\n' "$CURRENT_TEST" "$expr"
       FAILS=$((FAILS + 1))
     fi
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
   done
-  teardown
 }
 
 test_collision_detection_blocks_crontab_write() {
-  CURRENT_TEST="collision_blocks_crontab"
-  setup
   # Default REGISTRY has morning-scan and morning-brief at the same schedule.
   # _playbook_update_crontab should refuse to write.
   # shellcheck disable=SC2034
@@ -167,12 +121,9 @@ test_collision_detection_blocks_crontab_write() {
   assert_contains "$out" "collision" "must mention collision in error"
   assert_contains "$out" "morning-scan" "must name first colliding playbook"
   assert_contains "$out" "morning-brief" "must name second colliding playbook"
-  teardown
 }
 
 test_collision_resolved_after_override() {
-  CURRENT_TEST="collision_resolved_after_override"
-  setup
   # shellcheck disable=SC2034
   CEO_CRON="/tmp/fake-cron.sh"
   echo '{"morning-scan": "50 8 * * 1-5"}' > "$CEO_DIR/schedules.json"
@@ -192,12 +143,9 @@ EOF
   assert_no_match "$out" "collision" "no collision message after override"
   assert_contains "$out" "Crontab:" "must reach 'installed' message"
   assert_contains "$(cat "$capture" 2>/dev/null)" "ceo:morning-scan" "fake crontab received the install"
-  teardown
 }
 
 test_crontab_install_failure_returns_nonzero() {
-  CURRENT_TEST="crontab_install_failure_returns_nonzero"
-  setup
   # Fake crontab that simulates a real failure (locked spool, quota, etc).
   cat > "$TMP/failing-crontab" <<'EOF'
 #!/bin/bash
@@ -212,12 +160,9 @@ EOF
   assert_eq "$rc" "1" "crontab failure must propagate as rc=1"
   assert_contains "$out" "crontab install failed" "must surface failure to caller"
   assert_no_match "$out" "Crontab:.*installed" "must NOT print success message on failure"
-  teardown
 }
 
 test_validate_cron_inside_schedule_one_blocks_bad_input() {
-  CURRENT_TEST="validate_cron_inside_schedule_one_blocks_bad_input"
-  setup
   # Build a real registry so _schedule_one sees a known playbook.
   echo "$REGISTRY" | jq '.' > "$CEO_DIR/registry.json"
   # Drive _schedule_one with a deliberately invalid expression on stdin.
@@ -230,56 +175,23 @@ test_validate_cron_inside_schedule_one_blocks_bad_input() {
     written=$(jq -r '."morning-scan" // ""' "$CEO_DIR/schedules.json")
     assert_eq "$written" "" "schedules.json must not contain rejected value"
   fi
-  teardown
 }
 
 test_schedule_source_returns_frontmatter_when_no_overrides() {
-  CURRENT_TEST="source_frontmatter_no_overrides"
-  setup
   src=$(_schedule_source "morning-scan")
   assert_eq "$src" "frontmatter" "no overrides file → frontmatter"
-  teardown
 }
 
 test_schedule_source_returns_override_when_present() {
-  CURRENT_TEST="source_override_when_present"
-  setup
   echo '{"morning-scan": "50 8 * * 1-5"}' > "$CEO_DIR/schedules.json"
   src=$(_schedule_source "morning-scan")
   assert_eq "$src" "override" "override present → override"
   src2=$(_schedule_source "morning-brief")
   assert_eq "$src2" "frontmatter" "playbook not in overrides → frontmatter"
-  teardown
 }
 
 # --- Run all tests ---
 
 _load_ceo_helpers
 
-TESTS=(
-  test_no_overrides_file_returns_unchanged_registry
-  test_override_replaces_frontmatter
-  test_unknown_playbook_in_overrides_warns_and_ignored
-  test_invalid_cron_expr_warns_and_ignored
-  test_malformed_overrides_json_warns_and_ignored
-  test_validate_cron_expr_accepts_valid_forms
-  test_validate_cron_expr_rejects_bad_forms
-  test_collision_detection_blocks_crontab_write
-  test_collision_resolved_after_override
-  test_crontab_install_failure_returns_nonzero
-  test_validate_cron_inside_schedule_one_blocks_bad_input
-  test_schedule_source_returns_frontmatter_when_no_overrides
-  test_schedule_source_returns_override_when_present
-)
-
-for t in "${TESTS[@]}"; do
-  "$t"
-done
-
-if [ "$FAILS" -eq 0 ]; then
-  echo "All tests passed. (${#TESTS[@]} tests)"
-  exit 0
-else
-  echo "$FAILS test(s) failed."
-  exit 1
-fi
+run_tests

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -7,32 +7,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTAKE="$SCRIPT_DIR/ceo-token-intake.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_file_exists() {
-  local path="$1" msg="${2:-}"
-  if [[ ! -f "$path" ]]; then
-    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -96,6 +71,7 @@ test_creates_host_suffixed_report_and_appends_per_host_inbox_line() {
   local count
   count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "per-host inbox must contain wikilink to host-suffixed report"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_does_not_write_to_shared_inbox_md() {
@@ -105,6 +81,7 @@ test_does_not_write_to_shared_inbox_md() {
       "$CURRENT_TEST" "$(cat "$CEO_DIR/inbox.md")"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_idempotent_same_day() {
@@ -115,6 +92,7 @@ test_idempotent_same_day() {
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
   count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "two runs must leave exactly one inbox line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_does_not_re_append_after_inbox_checkoff() {
@@ -129,6 +107,7 @@ test_does_not_re_append_after_inbox_checkoff() {
   local count
   count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
   assert_eq "$count" "1" "checked-off line must not trigger re-append"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_two_hosts_write_disjoint_files() {
@@ -144,6 +123,7 @@ test_two_hosts_write_disjoint_files() {
     printf '  FAIL [%s] beta inbox shadow must not reference alpha\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_invokes_ceo_augment_path() {
@@ -158,6 +138,7 @@ test_invokes_ceo_augment_path() {
   assert_file_exists "$report" "report file must exist"
   body=$(cat "$report")
   assert_contains "$body" "rtk-stub:" "report must contain stub rtk output (proves ceo_augment_path resolved \$HOME/.bun/bin)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pins_home_to_resolved_user_home_before_capture() {
@@ -198,6 +179,7 @@ EOF
   body=$(cat "$report")
   assert_contains "$body" "rtk-saw-HOME=$pinned" \
     "rtk must see HOME=$pinned (resolver target), not the sandbox HOME the caller passed"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_exits_nonzero_when_capture_command_missing() {
@@ -219,6 +201,7 @@ test_exits_nonzero_when_capture_command_missing() {
     printf '  FAIL [%s] report must record the missing-binary sentinel for forensics\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_exits_nonzero_when_capture_command_fails() {
@@ -238,6 +221,7 @@ STUB
     printf '  FAIL [%s] inbox must NOT have a line when capture failed\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_augment_path_branches_per_os() {
@@ -265,6 +249,7 @@ test_augment_path_branches_per_os() {
   assert_contains "$got" "$HOME/.bun/bin" "macos branch must include \$HOME/.bun/bin"
   unset _CEO_PATH_AUGMENTED
   unset -f ceo_detect_os
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_aborts_on_unwritable_report_dir() {
@@ -283,6 +268,7 @@ test_aborts_on_unwritable_report_dir() {
     printf '  FAIL [%s] per-host inbox must NOT have an inbox line when the report write failed\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_prefers_plugin_cache_over_path_for_token_scope() {
@@ -336,24 +322,7 @@ STUB
     printf '  FAIL [%s] bun stub received wrong entry path (runtime+path pair mismatched)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -8,32 +8,7 @@ TRACKER="$SCRIPT_DIR/ceo-value-tracker.sh"
 
 WIKILINK_PREFIX="[[Projects/Development/nhangen/claude-ceo/value-tracker"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_file_exists() {
-  local path="$1" msg="${2:-}"
-  if [[ ! -f "$path" ]]; then
-    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -99,6 +74,7 @@ test_appends_inbox_line_and_invokes_bun() {
   assert_contains "$output" "bun-stub:" "script must invoke bun"
   assert_contains "$output" "--since $yesterday" "bun invocation must pass --since with yesterday's date"
   assert_contains "$output" "--obsidian-vault $CEO_VAULT" "bun invocation must pass obsidian-vault"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_idempotent_inbox_append() {
@@ -111,6 +87,7 @@ test_idempotent_inbox_append() {
 
   count=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$inbox" || true)
   assert_eq "$count" "1" "two runs must leave exactly one inbox line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_idempotent_preserves_checked_off_line() {
@@ -130,6 +107,7 @@ test_idempotent_preserves_checked_off_line() {
   unchecked=$(grep -c -F -- "- [ ] Review daily value-tracker report $WIKILINK_PREFIX/$today]]" "$inbox" || true)
   assert_eq "$checked" "1" "checked-off line must survive re-run"
   assert_eq "$unchecked" "0" "must not re-append an unchecked line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_exits_with_bun_exit_code_when_bun_fails() {
@@ -148,6 +126,7 @@ STUB
     printf '  FAIL [%s] inbox must NOT have a line when bun failed\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_fails_when_home_is_empty() {
@@ -158,6 +137,7 @@ test_fails_when_home_is_empty() {
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$stderr" "HOME" "stderr must mention HOME (got: $stderr)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_fails_when_ceo_vault_is_unset() {
@@ -167,6 +147,7 @@ test_fails_when_ceo_vault_is_unset() {
     printf '  FAIL [%s] unset CEO_VAULT must fail\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_fails_when_bun_missing_from_path() {
@@ -180,6 +161,7 @@ test_fails_when_bun_missing_from_path() {
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$stderr" "bun" "stderr must mention bun (got: $stderr)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_fails_when_entry_missing() {
@@ -190,6 +172,7 @@ test_fails_when_entry_missing() {
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$stderr" "entry not found" "stderr must mention entry not found (got: $stderr)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_two_hosts_write_to_disjoint_files() {
@@ -206,28 +189,7 @@ test_two_hosts_write_to_disjoint_files() {
   h2=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$CEO_DIR/inbox/otherhost.md" || true)
   assert_eq "$h1" "1" "host1 must have its own line"
   assert_eq "$h2" "1" "host2 must have its own line"
-}
-
-run_tests() {
-  local count=0
-  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
-    CURRENT_TEST="$fn"
-    setup
-    "$fn"
-    teardown
-    count=$((count + 1))
-  done
-  echo ""
-  if [ "$count" -eq 0 ]; then
-    echo "ERROR: no tests discovered" >&2
-    exit 1
-  fi
-  if [ "$FAILS" -eq 0 ]; then
-    echo "All tests passed. ($count tests)"
-  else
-    echo "FAILED: $FAILS"
-    exit 1
-  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 run_tests

--- a/scripts/count-blessings.test.sh
+++ b/scripts/count-blessings.test.sh
@@ -7,32 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLI="$SCRIPT_DIR/count-blessings.sh"
 LIB="$SCRIPT_DIR/blessings-lib.sh"
 
-FAILS=0
-CURRENT_TEST=""
-
-assert_eq() {
-  local got="$1" want="$2" msg="${3:-}"
-  if [[ "$got" != "$want" ]]; then
-    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" msg="${3:-}"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
-    FAILS=$((FAILS + 1))
-  fi
-}
-
-assert_fails() {
-  local msg="$1"; shift
-  if "$@" >/dev/null 2>&1; then
-    printf '  FAIL [%s] %s (expected non-zero exit)\n' "$CURRENT_TEST" "$msg"
-    FAILS=$((FAILS + 1))
-  fi
-}
+source "$SCRIPT_DIR/test-harness.sh"
 
 setup() {
   TEST_HOME=$(mktemp -d)
@@ -48,6 +23,7 @@ teardown() {
 
 test_harness_works() {
   assert_eq "1" "1" "arithmetic still works"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_writes_bullet_to_blessings_file() {
@@ -56,6 +32,7 @@ test_add_writes_bullet_to_blessings_file() {
   content=$(cat "$CEO_DIR/blessings.md")
   assert_contains "$content" "- family" "bullet written"
   assert_contains "$content" "type: ea-blessings" "frontmatter created"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_bootstraps_missing_ceo_dir() {
@@ -65,6 +42,7 @@ test_add_bootstraps_missing_ceo_dir() {
   bash "$CLI" add "first-blessing" >/dev/null
   [[ -d "$CEO_DIR" ]] || { printf '  FAIL [%s] CEO_DIR was not created\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)); return; }
   assert_contains "$(cat "$CEO_DIR/blessings.md")" "- first-blessing" "bullet landed"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_appends_without_overwriting() {
@@ -74,20 +52,24 @@ test_add_appends_without_overwriting() {
   content=$(cat "$CEO_DIR/blessings.md")
   assert_contains "$content" "- first" "first preserved"
   assert_contains "$content" "- second" "second appended"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_rejects_empty_argument() {
   assert_fails "empty add should fail" bash "$CLI" add ""
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_rejects_newline_in_argument() {
   assert_fails "newline smuggling rejected" bash "$CLI" add $'line1\nline2'
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_rejects_overlong_argument() {
   local long
   long=$(printf 'x%.0s' {1..501})
   assert_fails "501-char entry rejected" bash "$CLI" add "$long"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_handles_shell_metacharacters_literally() {
@@ -95,6 +77,7 @@ test_add_handles_shell_metacharacters_literally() {
   local content
   content=$(cat "$CEO_DIR/blessings.md")
   assert_contains "$content" '$(rm -rf /tmp/should-not-happen); echo pwned' "metachars stored verbatim"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_ensures_trailing_newline_before_append() {
@@ -104,12 +87,14 @@ test_add_ensures_trailing_newline_before_append() {
   local lines
   lines=$(grep -c '^- ' "$CEO_DIR/blessings.md")
   assert_eq "$lines" "2" "both bullets present on their own lines"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_add_prints_confirmation() {
   local out
   out=$(bash "$CLI" add "gratitude")
   assert_contains "$out" "Added: gratitude" "confirmation printed to stdout"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_list_shows_numbered_bullets() {
@@ -122,6 +107,7 @@ test_list_shows_numbered_bullets() {
   assert_contains "$out" "- second" "second present"
   assert_contains "$out" "- third" "third present"
   assert_contains "$out" "     1	" "numbered"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_list_strips_frontmatter() {
@@ -132,6 +118,7 @@ test_list_strips_frontmatter() {
     printf '  FAIL [%s] frontmatter leaked into list output\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   }
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_list_on_missing_file_is_empty() {
@@ -139,6 +126,7 @@ test_list_on_missing_file_is_empty() {
   out=$(bash "$CLI" list 2>&1 || true)
   # Missing file is not an error — just empty output.
   assert_eq "$out" "" "empty output on missing file"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_list_on_empty_body_is_empty() {
@@ -149,6 +137,7 @@ test_list_on_empty_body_is_empty() {
   local rc=$?
   assert_eq "$rc" "0" "exit 0 on empty body"
   assert_eq "$out" "" "empty output on empty body"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_picks_three_when_many_available() {
@@ -171,6 +160,7 @@ test_cache_picks_three_when_many_available() {
   local bullet_count
   bullet_count=$(grep -c '^- ' "$cache")
   assert_eq "$bullet_count" "3" "exactly three picks"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_picks_all_when_fewer_than_three() {
@@ -182,6 +172,7 @@ test_cache_picks_all_when_fewer_than_three() {
   local count
   count=$(grep -c '^- ' "$CEO_DIR/cache/blessings-today.md")
   assert_eq "$count" "1" "one-entry file yields one pick"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_no_op_when_already_today() {
@@ -194,6 +185,7 @@ test_cache_no_op_when_already_today() {
   ensure_blessings_cache
   # sentinel must still be present — helper skipped regen
   assert_contains "$(cat "$CEO_DIR/cache/blessings-today.md")" "cached-sentinel" "cache preserved"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_regenerates_when_stale() {
@@ -209,6 +201,7 @@ test_cache_regenerates_when_stale() {
     printf '  FAIL [%s] stale cache was not replaced\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   }
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_handles_missing_source_file() {
@@ -220,6 +213,7 @@ test_cache_handles_missing_source_file() {
   local bullet_count
   bullet_count=$(grep -c '^- ' "$cache" 2>/dev/null || true)
   assert_eq "$bullet_count" "0" "no bullets when source missing"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_cache_strips_frontmatter_before_picking() {
@@ -238,6 +232,7 @@ test_cache_strips_frontmatter_before_picking() {
     FAILS=$((FAILS + 1))
   }
   assert_contains "$content" "- real-entry" "real entry picked"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_show_outputs_cache_file() {
@@ -249,12 +244,14 @@ test_show_outputs_cache_file() {
   out=$(bash "$CLI" show)
   local today; today=$(date +%Y-%m-%d)
   assert_contains "$out" "date: $today" "cache date visible"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_show_on_missing_cache_is_empty() {
   local out
   out=$(bash "$CLI" show 2>&1 || true)
   assert_eq "$out" "" "empty on no cache"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_repick_prints_todays_picks() {
@@ -265,6 +262,7 @@ test_repick_prints_todays_picks() {
   out=$(bash "$CLI" repick)
   assert_contains "$out" "Repicked" "confirmation line present"
   assert_contains "$out" "- " "picks listed in output"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_repick_forces_regeneration() {
@@ -282,6 +280,7 @@ test_repick_forces_regeneration() {
     printf '  FAIL [%s] repick did not regenerate\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   }
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 # --- runner ---

--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -66,7 +66,8 @@ _record_test_abort() {
 
 run_tests() {
   local count=0
-  export TEST_FAILS_TMP=$(mktemp)
+  export TEST_FAILS_TMP
+  TEST_FAILS_TMP=$(mktemp)
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
     if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
       continue
@@ -87,7 +88,7 @@ run_tests() {
     
     if [ -s "$TEST_FAILS_TMP" ]; then
       FAILS=$((FAILS + $(wc -l < "$TEST_FAILS_TMP")))
-      > "$TEST_FAILS_TMP"
+      true > "$TEST_FAILS_TMP"
     fi
     
     if [ -f "${TEST_FAILS_TMP}.assertions" ]; then

--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# test-harness.sh
+# Shared test harness for all claude-ceo test suites.
+
+FAILS=0
+CURRENT_TEST=""
+ASSERTION_COUNT=0
+
+assert_eq() {
+  local got="$1" want="$2" msg="${3:-}"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [[ "$got" != "$want" ]]; then
+    printf '  FAIL [%s] %s\n    got:  %q\n    want: %q\n' "$CURRENT_TEST" "$msg" "$got" "$want"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1" msg="${2:-}"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [[ ! -f "$path" ]]; then
+    printf '  FAIL [%s] %s\n    expected file: %q\n' "$CURRENT_TEST" "$msg" "$path"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    needle:   %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  FAIL [%s] %s\n    haystack: %q\n    forbidden: %q\n' "$CURRENT_TEST" "$msg" "$haystack" "$needle"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+# Alias for backwards compatibility
+assert_no_match() {
+  assert_not_contains "$@"
+}
+
+assert_fails() {
+  local msg="$1"; shift
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if "$@" >/dev/null 2>&1; then
+    printf '  FAIL [%s] %s (expected non-zero exit)\n' "$CURRENT_TEST" "$msg"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+_record_test_abort() {
+  local test_name="$1" rc="$2"
+  if [ "$rc" -ne 0 ]; then
+    printf '  FAIL [%s] test body aborted or exited with non-zero code (%d)\n' "$test_name" "$rc"
+    echo 1 >> "$TEST_FAILS_TMP"
+  fi
+}
+
+run_tests() {
+  local count=0
+  export TEST_FAILS_TMP=$(mktemp)
+  for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
+    if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
+      continue
+    fi
+    CURRENT_TEST="$fn"
+    
+    if type setup >/dev/null 2>&1; then
+      setup
+    fi
+    
+    local assertions_before=$ASSERTION_COUNT
+    
+    (
+      trap 'rc=$?; [ $rc -ne 0 ] && _record_test_abort "$CURRENT_TEST" $rc' EXIT
+      "$fn"
+      echo "$ASSERTION_COUNT" > "${TEST_FAILS_TMP}.assertions"
+    )
+    
+    if [ -s "$TEST_FAILS_TMP" ]; then
+      FAILS=$((FAILS + $(wc -l < "$TEST_FAILS_TMP")))
+      > "$TEST_FAILS_TMP"
+    fi
+    
+    if [ -f "${TEST_FAILS_TMP}.assertions" ]; then
+      ASSERTION_COUNT=$(cat "${TEST_FAILS_TMP}.assertions")
+    fi
+    
+    if [ "$ASSERTION_COUNT" -eq "$assertions_before" ]; then
+      printf '  FAIL [%s] NO ASSERTIONS RAN (test body exited early or had no assertions)\n' "$CURRENT_TEST"
+      FAILS=$((FAILS + 1))
+    fi
+    
+    if type teardown >/dev/null 2>&1; then
+      teardown
+    fi
+    count=$((count + 1))
+  done
+  rm -f "$TEST_FAILS_TMP" "${TEST_FAILS_TMP}.assertions"
+  
+  echo ""
+  if [ "$FAILS" -eq 0 ]; then
+    echo "All tests passed. ($count tests)"
+  else
+    echo "FAILED: $FAILS"
+    exit 1
+  fi
+}


### PR DESCRIPTION
## Description
Fixes #79

Refactors the test harness to accurately report failures when tests abort prematurely (e.g., due to `set -u` or unhandled errors).

- Extracted `assert_*` and `run_tests` to a shared `scripts/test-harness.sh`
- Wrapped each test in a subshell with a trap to catch non-zero exits
- Tracked `ASSERTION_COUNT` across the boundary to detect tests that exit 0 without running assertions
- Cleaned up manual assertions in existing tests