### PR TITLE
fix(cron): gate pending-drip preflight on Pending.md ask markers

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -362,7 +362,11 @@ preflight_has_prs_to_review() {
 }
 
 preflight_has_pending_items() {
-  [ "${PENDING_COUNT:-0}" -gt 0 ]
+  # pending-drip surfaces [ask] markers from $VAULT/Pending.md, not the
+  # CEO/approvals/pending.md queue that PENDING_COUNT measures. Gate on the
+  # gathered ask-question lines so an empty Pending.md skips instead of firing
+  # an LLM call that reports failure for lack of input.
+  [ -n "${PENDING_ASK_QUESTIONS:-}" ]
 }
 
 preflight_has_log_entries_after_4pm() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1978,6 +1978,31 @@ test_pending_drip_failed_entry_uses_report_not_inbox() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_pending_drip_skips_when_pending_md_empty() {
+  _write_pending_drip_registry
+  # Setup line 32 + helper line 1885 leave $CEO_DIR/approvals/pending.md
+  # populated (PENDING_COUNT > 0). Remove Pending.md so PENDING_ASK_QUESTIONS
+  # is empty — this is the literal bug shape that motivated the fix at
+  # scripts/ceo-cron.sh:369. Reverting that gate must make this test fail.
+  rm -f "$CEO_VAULT/Pending.md"
+  _stub_claude_log_entry "completed" "should never run"
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$CRON" pending-drip >/dev/null 2>&1 || true
+
+  local skip_log="$CEO_DIR/log/cron-skips.log"
+  assert_file_exists "$skip_log" "preflight skip must write cron-skips.log"
+  local skip_body
+  skip_body=$(cat "$skip_log" 2>/dev/null)
+  assert_contains "$skip_body" "preflight 'has_pending_items' returned no-work" \
+    "empty Pending.md must trigger preflight no-work skip even when approvals/pending.md is populated"
+
+  if [ -s "$CEO_DIR/inbox/testhost.md" ]; then
+    printf '  FAIL [%s] empty Pending.md must not produce inbox entry\n    inbox: %q\n' "$CURRENT_TEST" "$(cat "$CEO_DIR/inbox/testhost.md")"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_pending_drip_no_relevant_questions_suppresses_inbox() {
   _write_pending_drip_registry
   _stub_claude_log_entry "completed" "No relevant [ask] questions today."

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1883,6 +1883,7 @@ PB
 {"schema_version":2,"playbooks":[{"name":"pending-drip","file":"$CEO_DIR/playbooks/pending-drip.md","model":"haiku","preflight":"has_pending_items","trigger":"cron","tier":"read","status":"active"}]}
 JSON
   printf -- '- [ ] pending approval sentinel\n' > "$CEO_DIR/approvals/pending.md"
+  printf -- '- [ ] **file:** sentinel.md **question:** sentinel ask?\n' > "$CEO_VAULT/Pending.md"
 }
 
 _stub_claude_log_entry() {


### PR DESCRIPTION
## Summary

\`preflight_has_pending_items\` checked \`PENDING_COUNT\`, which is sourced from \`CEO/approvals/pending.md\` (the approval queue). But the \`pending-drip\` playbook surfaces \`[ask]\` markers from \`\$VAULT/Pending.md\` — a different file with different semantics.

When the approval queue had items but \`Pending.md\` was empty (or the gather extracted no \`- [ ]\` lines for any reason), the preflight passed and the LLM fired against pre-gathered data that contained only a count — no actual questions — and self-reported \`**Status:** failed\`.

This is the root cause of the recurring \`pending-drip self-reported **Status:** failed\` lines in \`cron-skips.log\` (May 24, May 26, May 27).

## Change

- \`scripts/ceo-cron.sh\`: \`preflight_has_pending_items\` now gates on \`PENDING_ASK_QUESTIONS\` (the actual lines extracted from \`\$VAULT/Pending.md\` at gather time) instead of \`PENDING_COUNT\`.
- \`scripts/ceo-cron.test.sh\`: pending-drip fixture seeds \`\$VAULT/Pending.md\` so the test mirrors production.

\`has_pending_items\` is only referenced by the pending-drip playbook (confirmed with grep across \`CEO/playbooks/\` and \`skills/\`), so the semantic shift is contained.

## Test plan

- [x] Run \`bash scripts/ceo-cron.test.sh\` — exit 0, all assertions pass.
- [ ] Wait one cron cycle and verify the next \`pending-drip\` run either lands cleanly in inbox/report or is skipped via \`preflight ... returned no-work\` (depending on whether \`Pending.md\` has \`- [ ]\` items at the time).
- [ ] Confirm no other playbook reaches \`preflight: has_pending_items\` in \`registry.json\`.