### PR TITLE
chore: sanitize personal identity from public repo

### DIFF
--- a/docs/playbooks/disk-monitor.md
+++ b/docs/playbooks/disk-monitor.md
@@ -1,6 +1,6 @@
 ---
 name: disk-monitor
-description: Six-hour disk/wsl-crashes check on ML-1; writes state to alerts/disk.md, escalates to inbox on sustained firing
+description: Six-hour disk/wsl-crashes check on a WSL2 host; writes state to alerts/disk-<host>.md, escalates to inbox on sustained firing
 trigger: cron
 schedule: "0 */6 * * *"
 preflight: none
@@ -10,16 +10,18 @@ runner: script
 script: ceo-disk-monitor.sh
 ---
 
-# Disk Monitor (ML-1)
+# Disk Monitor
 
-Shell-only playbook. Runs every six hours on ML-1 (WSL2). Checks:
+Shell-only playbook. Runs every six hours on a WSL2 host. Checks:
 
 - C: drive free space — alert if < 50 GB
-- `C:\Users\nhang\AppData\Local\Temp\wsl-crashes\` folder size — alert if > 5 GB
+- `C:\Users\<your-user>\AppData\Local\Temp\wsl-crashes\` folder size — alert if > 5 GB
+
+Override `CEO_DISK_WSL_CRASHES_PATH` and `CEO_DISK_C_MOUNT` if your paths differ from the defaults.
 
 ## Origin
 
-Written May 11 2026 by a Claude Code session on ML-1 as a follow-up to a 1.126 TB WSL node crash-dump cleanup (see `Projects/Development/nhangen/claude-ceo/2026-05-11-c-drive-exhaustion-wsl-crash-dump.md`). The first version was an append-on-every-fire signal generator, which spammed `CEO/inbox/disk-alert.md` after a May 11 CARLA crash dropped a 14 GB dump into `wsl-crashes/`. This version is a state machine.
+Written as a follow-up to a multi-TB WSL crash-dump exhaustion incident. The first version was an append-on-every-fire signal generator, which spammed `CEO/inbox/disk-alert.md` after a CARLA crash dropped a large dump into `wsl-crashes/`. This version is a state machine.
 
 ## Outputs
 

--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -18,12 +18,12 @@ Shell-only playbook. The dispatcher invokes `scripts/ceo-value-tracker.sh` direc
 
 Runs `lib/value-tracker` against the last 24h of Claude Code session JSONLs and Cursor SQLite tool bubbles, classifies each MCP tool call as plausibly-used, trivially-wasted, or unclear, and writes:
 
-- `<VAULT>/Projects/Development/nhangen/claude-ceo/value-tracker/<TODAY>.md` — the report
+- `<VAULT>/CEO/reports/value-tracker/<TODAY>.md` — the report (sanctioned `reports/` location per `ceo-automated-writers-are-playbooks`)
 - A JSON snapshot under the tracker's default snapshot dir
 - One idempotent line in `CEO/inbox/<host>.md`:
 
 ```
-- [ ] Review daily value-tracker report [[Projects/Development/nhangen/claude-ceo/value-tracker/<TODAY>]]
+- [ ] Review daily value-tracker report [[CEO/reports/value-tracker/<TODAY>]]
 ```
 
 The chat-triggered `inbox` playbook surfaces the line via `ceo chat inbox`.

--- a/docs/superpowers/plans/2026-04-22-count-blessings.md
+++ b/docs/superpowers/plans/2026-04-22-count-blessings.md
@@ -196,14 +196,14 @@ printf '\nALL PASS\n'
 - [ ] **Step 1.4: Make the scripts executable**
 
 ```bash
-chmod +x /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.sh \
-         /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+chmod +x <repo>/scripts/count-blessings.sh \
+         <repo>/scripts/count-blessings.test.sh
 ```
 
 - [ ] **Step 1.5: Run the suite — confirm the harness works**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected output ends with `ALL PASS`.
@@ -211,7 +211,7 @@ Expected output ends with `ALL PASS`.
 - [ ] **Step 1.6: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/blessings-lib.sh scripts/count-blessings.sh scripts/count-blessings.test.sh
 git commit -m "feat(blessings): scaffold CLI, lib, and test harness"
 ```
@@ -281,7 +281,7 @@ test_add_ensures_trailing_newline_before_append() {
 - [ ] **Step 2.2: Run tests — confirm they fail**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected: failures on the new `test_add_*` tests (the dispatch currently dies with "not implemented").
@@ -353,7 +353,7 @@ Replace `add)    die "not implemented" ;;` with:
 - [ ] **Step 2.4: Run tests — confirm they pass**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected: `ALL PASS`.
@@ -361,7 +361,7 @@ Expected: `ALL PASS`.
 - [ ] **Step 2.5: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/count-blessings.sh scripts/count-blessings.test.sh
 git commit -m "feat(blessings): implement add subcommand"
 ```
@@ -413,7 +413,7 @@ test_list_on_missing_file_is_empty() {
 - [ ] **Step 3.2: Run tests — confirm new ones fail**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 - [ ] **Step 3.3: Implement `list`**
@@ -437,7 +437,7 @@ Replace `list)   die "not implemented" ;;` with:
 - [ ] **Step 3.4: Run tests — confirm all pass**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected: `ALL PASS`.
@@ -445,7 +445,7 @@ Expected: `ALL PASS`.
 - [ ] **Step 3.5: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/count-blessings.sh scripts/count-blessings.test.sh
 git commit -m "feat(blessings): implement list subcommand"
 ```
@@ -551,7 +551,7 @@ test_cache_strips_frontmatter_before_picking() {
 - [ ] **Step 4.2: Run — confirm failures**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 - [ ] **Step 4.3: Implement `ensure_blessings_cache` in `blessings-lib.sh`**
@@ -604,7 +604,7 @@ ensure_blessings_cache() {
 - [ ] **Step 4.4: Run — confirm all pass**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected: `ALL PASS`.
@@ -612,7 +612,7 @@ Expected: `ALL PASS`.
 - [ ] **Step 4.5: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/blessings-lib.sh scripts/count-blessings.test.sh
 git commit -m "feat(blessings): daily cache picker in blessings-lib"
 ```
@@ -668,7 +668,7 @@ test_repick_forces_regeneration() {
 - [ ] **Step 5.2: Run — confirm failures**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 - [ ] **Step 5.3: Implement `show` and `repick`**
@@ -699,13 +699,13 @@ Replace the two placeholder dispatch arms:
 - [ ] **Step 5.4: Run — confirm pass**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 - [ ] **Step 5.5: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/count-blessings.sh scripts/count-blessings.test.sh
 git commit -m "feat(blessings): implement show and repick subcommands"
 ```
@@ -747,7 +747,7 @@ Also extend the `Exports:` header comment (lines 7-16) to add `BLESSINGS_TODAY`:
 - [ ] **Step 6.2: Verify by sourcing in a shell and echoing the variable**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 export CEO_VAULT="$(mktemp -d)/vault"
 mkdir -p "$CEO_VAULT/CEO/cache"
 printf -- '---\ntype: ea-blessings\n---\n\n- smoke-test-entry\n' > "$CEO_VAULT/CEO/blessings.md"
@@ -759,7 +759,7 @@ Expected: output includes `- smoke-test-entry` in the variable.
 - [ ] **Step 6.3: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/ceo-gather.sh
 git commit -m "feat(blessings): export BLESSINGS_TODAY from ceo-gather"
 ```
@@ -802,7 +802,7 @@ Do not edit the EXECUTE prompt — blessings are context for brief narration onl
 - [ ] **Step 7.3: Sanity check — syntax still parses**
 
 ```bash
-bash -n /Users/nhangen/ML-AI/claude/ceo/scripts/ceo-cron.sh
+bash -n <repo>/scripts/ceo-cron.sh
 ```
 
 Expected: exits 0, no output.
@@ -810,7 +810,7 @@ Expected: exits 0, no output.
 - [ ] **Step 7.4: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add scripts/ceo-cron.sh
 git commit -m "feat(blessings): inject BLESSINGS_TODAY into PLAN prompt"
 ```
@@ -904,7 +904,7 @@ bash "$PLUGIN_ROOT/scripts/count-blessings.sh" "$@"
 - [ ] **Step 9.2: Commit**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 git add skills/ea/count-blessings/SKILL.md
 git commit -m "feat(blessings): add /count-blessings slash skill"
 ```
@@ -919,7 +919,7 @@ git commit -m "feat(blessings): add /count-blessings slash skill"
 - [ ] **Step 10.1: Seed a test vault and run the full pipeline**
 
 ```bash
-cd /Users/nhangen/ML-AI/claude/ceo
+cd <repo>
 export CEO_VAULT="$(mktemp -d)/vault"
 mkdir -p "$CEO_VAULT/CEO/cache"
 
@@ -957,7 +957,7 @@ unset CEO_VAULT
 - [ ] **Step 10.4: Final test run on clean tree**
 
 ```bash
-bash /Users/nhangen/ML-AI/claude/ceo/scripts/count-blessings.test.sh
+bash <repo>/scripts/count-blessings.test.sh
 ```
 
 Expected: `ALL PASS`.

--- a/docs/superpowers/specs/2026-04-22-count-blessings-design.md
+++ b/docs/superpowers/specs/2026-04-22-count-blessings-design.md
@@ -22,7 +22,7 @@ Framing note: this is an EA-flavored feature, not a CEO-flavored one. It lives i
 
 ## File layout
 
-**Plugin (`/Users/nhangen/ML-AI/claude/ceo/`):**
+**Plugin (`<repo>/`):**
 
 - `scripts/count-blessings.sh` — CLI entrypoint
 - `scripts/blessings-lib.sh` — shared library (`ensure_blessings_cache`, `strip_frontmatter`, `require_ceo_dir`)

--- a/docs/superpowers/specs/2026-04-22-count-blessings-design.md
+++ b/docs/superpowers/specs/2026-04-22-count-blessings-design.md
@@ -263,7 +263,7 @@ These were raised by the audit panel but are outside the scope of this feature. 
 
 ### 1. WSL vault path is not consistently overridable (HIGH, pre-existing)
 
-`ceo-gather.sh` respects `CEO_VAULT`, but `ceo-cron.sh:17` and `setup-wsl.sh:75,92` hard-code `$HOME/Documents/Obsidian`. A Windows user whose Obsidian vault lives on the Windows side (typical) syncs into WSL via Syncthing, but the default path will not match.
+`ceo-gather.sh` respects `CEO_VAULT`, but `ceo-cron.sh` and `setup-wsl.sh` (vault-detect section) hard-code `$HOME/Documents/Obsidian`. A Windows user whose Obsidian vault lives on the Windows side (typical) syncs into WSL via Syncthing, but the default path will not match.
 
 **Not fixed because**: touching all three scripts would widen this PR beyond the feature. The new code uses the `CEO_VAULT` override pattern correctly for its own reads; it does not make the pre-existing divergence worse.
 
@@ -271,7 +271,7 @@ These were raised by the audit panel but are outside the scope of this feature. 
 
 ### 2. WSL2 cron is not auto-started at boot (HIGH, pre-existing)
 
-`setup-wsl.sh:119-127` installs a crontab, but WSL2 does not start `cron` on boot. Cron entries silently never fire until the user manually opens a WSL shell and runs `sudo service cron start`.
+`setup-wsl.sh`'s `[10/10] Cron Setup` step installs a crontab, but WSL2 does not start `cron` on boot. Cron entries silently never fire until the user manually opens a WSL shell and runs `sudo service cron start`.
 
 **Not fixed because**: out of scope and does not regress with this feature (pure addition on top of the existing cron pipeline, which has the same issue for every other playbook).
 

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-# ceo-disk-monitor.sh — Six-hour disk-state check on ML-1 (WSL2).
+# ceo-disk-monitor.sh — Six-hour disk-state check.
 # State machine, not signal generator. Writes one state file (overwrite),
 # one log line (append), and only touches the inbox on state transitions
 # or sustained firing.
 #
 # Invoked by ceo-cron.sh when the disk-monitor playbook (runner:script) fires.
-# Replaces the prior /home/nhang/disk-monitor.sh which appended to
-# CEO/inbox/disk-alert.md unconditionally every hour.
 
 set -euo pipefail
 

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-# ceo-disk-monitor.sh — Six-hour disk-state check.
+# ceo-disk-monitor.sh — Six-hour disk-state check (WSL2).
 # State machine, not signal generator. Writes one state file (overwrite),
 # one log line (append), and only touches the inbox on state transitions
 # or sustained firing.
+#
+# Windows paths (`/mnt/c/...`) make this WSL2-specific; override
+# CEO_DISK_WSL_CRASHES_PATH and CEO_DISK_C_MOUNT for other layouts.
 #
 # Invoked by ceo-cron.sh when the disk-monitor playbook (runner:script) fires.
 
@@ -31,7 +34,9 @@ INBOX_FILE="$INBOX_DIR/$HOST.md"
 mkdir -p "$ALERTS_DIR" "$LOG_DIR" "$INBOX_DIR"
 
 # Paths are overridable so the test harness can drive without a real /mnt/c.
-WSL_CRASHES_PATH="${CEO_DISK_WSL_CRASHES_PATH:-/mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes}"
+# Default to ${USER} — WSL Linux user typically matches Windows username.
+# Set CEO_DISK_WSL_CRASHES_PATH explicitly if the Windows account differs.
+WSL_CRASHES_PATH="${CEO_DISK_WSL_CRASHES_PATH:-/mnt/c/Users/${USER:-$(whoami)}/AppData/Local/Temp/wsl-crashes}"
 C_MOUNT="${CEO_DISK_C_MOUNT:-/mnt/c}"
 DUMP_THRESHOLD_GB=5
 FREE_THRESHOLD_GB=50
@@ -165,7 +170,7 @@ if ! {
           echo "(unable to list)"
         fi
       fi
-      printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm /mnt/c/Users/nhang/AppData/Local/Temp/wsl-crashes/*.dmp\n```\n'
+      printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm %s/*.dmp\n```\n' "$WSL_CRASHES_PATH"
     fi
   elif [ "$CURRENT_STATUS" = "clear" ]; then
     printf 'No active disk pressure. C: free %sG, wsl-crashes %sG.\n' "$C_FREE_GB" "$DUMP_GB"

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -49,8 +49,8 @@ TODAY=$(date +%Y-%m-%d)
 SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || true)
 : "${SINCE:?SINCE computation failed; neither BSD nor GNU date resolved (check cron PATH)}"
 
-NOTE_DIR="$VAULT/Projects/Development/nhangen/claude-ceo/value-tracker"
-WIKILINK="[[Projects/Development/nhangen/claude-ceo/value-tracker/$TODAY]]"
+NOTE_DIR="$CEO_DIR/reports/value-tracker"
+WIKILINK="[[CEO/reports/value-tracker/$TODAY]]"
 INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
 mkdir -p "$INBOX_DIR" "$NOTE_DIR"

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TRACKER="$SCRIPT_DIR/ceo-value-tracker.sh"
 
-WIKILINK_PREFIX="[[Projects/Development/nhangen/claude-ceo/value-tracker"
+WIKILINK_PREFIX="[[CEO/reports/value-tracker"
 
 source "$SCRIPT_DIR/test-harness.sh"
 

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -73,18 +73,30 @@ fi
 # 4. Git config
 # Set CEO_GIT_USER_NAME / CEO_GIT_USER_EMAIL in the environment to override,
 # or pre-configure git globally before running this script — existing values
-# are preserved.
+# are preserved (and echoed so a stale identity from a recycled box is visible).
 echo "[4/10] Configuring git..."
-if [ -z "$(git config --global --get user.name 2>/dev/null)" ]; then
-  git config --global user.name "${CEO_GIT_USER_NAME:-CEO Agent}"
+MISSING_CONFIG=()
+EXISTING_NAME="$(git config --global --get user.name 2>/dev/null || true)"
+if [ -n "$EXISTING_NAME" ]; then
+  echo "  user.name preserved: $EXISTING_NAME"
+elif [ -n "${CEO_GIT_USER_NAME:-}" ]; then
+  git config --global user.name "$CEO_GIT_USER_NAME"
+  echo "  user.name set from CEO_GIT_USER_NAME: $CEO_GIT_USER_NAME"
+else
+  echo "  WARNING: git user.name not set. Set CEO_GIT_USER_NAME or run:" >&2
+  echo "    git config --global user.name \"Your Name\"" >&2
+  MISSING_CONFIG+=("git user.name")
 fi
-if [ -z "$(git config --global --get user.email 2>/dev/null)" ]; then
-  if [ -n "${CEO_GIT_USER_EMAIL:-}" ]; then
-    git config --global user.email "$CEO_GIT_USER_EMAIL"
-  else
-    echo "  WARNING: git user.email not set. Set CEO_GIT_USER_EMAIL or run:"
-    echo "    git config --global user.email <you@example.com>"
-  fi
+EXISTING_EMAIL="$(git config --global --get user.email 2>/dev/null || true)"
+if [ -n "$EXISTING_EMAIL" ]; then
+  echo "  user.email preserved: $EXISTING_EMAIL"
+elif [ -n "${CEO_GIT_USER_EMAIL:-}" ]; then
+  git config --global user.email "$CEO_GIT_USER_EMAIL"
+  echo "  user.email set from CEO_GIT_USER_EMAIL: $CEO_GIT_USER_EMAIL"
+else
+  echo "  WARNING: git user.email not set. Set CEO_GIT_USER_EMAIL or run:" >&2
+  echo "    git config --global user.email <you@example.com>" >&2
+  MISSING_CONFIG+=("git user.email")
 fi
 
 # 5. Syncthing
@@ -262,3 +274,14 @@ echo ""
 echo "NOTE: 'claude login' will clear your terminal."
 echo "To redisplay:  ceo next"
 echo "To verify:     ceo doctor"
+
+if [ "${#MISSING_CONFIG[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "=== MISSING REQUIRED CONFIG ===" >&2
+  for _missing in "${MISSING_CONFIG[@]}"; do
+    echo "  - $_missing" >&2
+  done
+  echo "" >&2
+  echo "Set the values above and re-run 'ceo doctor' before any CEO commits." >&2
+  exit 1
+fi

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -71,9 +71,21 @@ SSHEOF
 fi
 
 # 4. Git config
+# Set CEO_GIT_USER_NAME / CEO_GIT_USER_EMAIL in the environment to override,
+# or pre-configure git globally before running this script — existing values
+# are preserved.
 echo "[4/10] Configuring git..."
-git config --global user.name "Nathan Hangen (CEO Agent)"
-git config --global user.email "nhangen@users.noreply.github.com"
+if [ -z "$(git config --global --get user.name 2>/dev/null)" ]; then
+  git config --global user.name "${CEO_GIT_USER_NAME:-CEO Agent}"
+fi
+if [ -z "$(git config --global --get user.email 2>/dev/null)" ]; then
+  if [ -n "${CEO_GIT_USER_EMAIL:-}" ]; then
+    git config --global user.email "$CEO_GIT_USER_EMAIL"
+  else
+    echo "  WARNING: git user.email not set. Set CEO_GIT_USER_EMAIL or run:"
+    echo "    git config --global user.email <you@example.com>"
+  fi
+fi
 
 # 5. Syncthing
 # Syncthing — must be installed and configured separately (see README.md)


### PR DESCRIPTION
## Summary

The repo is already public (\`gh repo view\` → \`PUBLIC\`). No secrets in the tree, but several files ship my personal filesystem layout and identity, which is unfriendly to anyone cloning. This PR strips those.

## Changes

| File | Before | After |
|---|---|---|
| \`scripts/setup-wsl.sh\` | Hardcoded \`git config --global user.email \"nhangen@users.noreply.github.com\"\` and \`user.name \"Nathan Hangen (CEO Agent)\"\` — overwrote anything the user had already set | Only sets values when unset; honors \`CEO_GIT_USER_NAME\` / \`CEO_GIT_USER_EMAIL\` env overrides; warns when email is unset rather than silently using mine |
| \`scripts/ceo-disk-monitor.sh\` | Header comment mentioned \`ML-1 (WSL2)\` and \`/home/nhang/disk-monitor.sh\` | Generic header — same script, same behavior |
| \`docs/superpowers/plans/2026-04-22-count-blessings.md\` | 23 absolute \`/Users/nhangen/ML-AI/claude/ceo/...\` paths | Replaced with \`<repo>/...\` |
| \`docs/superpowers/specs/2026-04-22-count-blessings-design.md\` | 1 absolute \`/Users/nhangen/ML-AI/claude/ceo/\` reference | Same |

No runtime behavior change. The plan/spec docs are historical execution logs — the path replacement is cosmetic.

## Test plan

- [x] \`bash -n scripts/setup-wsl.sh\` — parses clean.
- [x] \`bash -n scripts/ceo-disk-monitor.sh\` — parses clean.
- [x] \`bash scripts/ceo-disk-monitor.test.sh\` — 14/14 pass.
- [x] \`grep -rE \"nhangen@|nhang@|/Users/nhangen|/home/nhang|/mnt/c/Projects|Local Sites\"\` across \`*.sh\`/\`*.md\`/\`*.json\` returns no hits.