### PR TITLE
feat(safer-merge): refuse `gh pr merge --admin` on red head-SHA checks

### DIFF
--- a/scripts/ceo-safer-merge.sh
+++ b/scripts/ceo-safer-merge.sh
@@ -23,6 +23,11 @@ LOG_FILE="$LOG_DIR/ceo-admin-merges.log"
 
 GH_BIN="${GH_BIN:-gh}"
 
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: ceo-safer-merge: jq is required but not on PATH" >&2
+  exit 5
+}
+
 usage() {
   cat >&2 <<EOF
 Usage: ceo-safer-merge.sh <pr> [--admin-reason "<text>"] [gh pr merge flags]
@@ -39,6 +44,24 @@ admin_reason=""
 pr_ref=""
 gh_args=()
 
+# Help is allowed without a PR ref.
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+# `pr_ref` MUST be the first positional. Parsing `--repo OWNER/NAME 87 ...`
+# instead of `87 --repo OWNER/NAME ...` previously captured the `OWNER/NAME`
+# slug as the PR ref (no awareness of value-taking options); making the PR
+# ref a required leading positional is the smallest fix.
+if [ $# -eq 0 ] || [[ "${1:-}" == -* ]]; then
+  echo "ERROR: ceo-safer-merge: first argument must be the PR ref (number, URL, or branch)" >&2
+  usage
+  exit 2
+fi
+pr_ref="$1"
+shift
+gh_args+=("$pr_ref")
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --admin)
@@ -48,6 +71,10 @@ while [ $# -gt 0 ]; do
       ;;
     --admin-reason)
       admin_reason="${2:-}"
+      if [[ "$admin_reason" == --* ]]; then
+        echo "ERROR: ceo-safer-merge: --admin-reason requires a value (got '$admin_reason')" >&2
+        exit 3
+      fi
       shift 2
       ;;
     --admin-reason=*)
@@ -59,18 +86,14 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     *)
-      if [ -z "$pr_ref" ] && [[ "$1" != -* ]]; then
-        pr_ref="$1"
-      fi
       gh_args+=("$1")
       shift
       ;;
   esac
 done
 
-if [ -z "$pr_ref" ]; then
-  echo "ERROR: ceo-safer-merge: no PR specified" >&2
-  usage
+if [ -n "$admin_reason" ] && [ "$admin" -eq 0 ]; then
+  echo "ERROR: ceo-safer-merge: --admin-reason requires --admin" >&2
   exit 2
 fi
 
@@ -81,8 +104,15 @@ fi
 log_admin_merge() {
   local reason="$1"
   mkdir -p "$LOG_DIR"
-  local sha
-  sha=$("$GH_BIN" pr view "$pr_ref" --json headRefOid -q .headRefOid 2>/dev/null || echo "unknown")
+  local sha sha_err
+  if ! sha=$("$GH_BIN" pr view "$pr_ref" --json headRefOid -q .headRefOid 2>&1); then
+    sha_err="$sha"
+    echo "ERROR: ceo-safer-merge: could not resolve head SHA for PR $pr_ref; refusing override (audit log would be incomplete)" >&2
+    echo "$sha_err" >&2
+    exit 5
+  fi
+  # Sanitize: tab/newline in the reason would break the TSV log format.
+  reason=$(printf '%s' "$reason" | tr '\t\n' '  ')
   printf '%s\tPR=%s\tSHA=%s\tREASON=%s\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pr_ref" "$sha" "$reason" >> "$LOG_FILE"
 }
@@ -103,17 +133,43 @@ if [ -n "$admin_reason" ]; then
   exec "$GH_BIN" pr merge "${gh_args[@]}"
 fi
 
-# Gate on PR head-SHA check status. statusCheckRollup mixes CheckRun
-# (`.conclusion`) and StatusContext (`.state`) entries; SUCCESS / NEUTRAL /
-# SKIPPED / PENDING are non-blocking, anything else (FAILURE / CANCELLED /
-# TIMED_OUT / ACTION_REQUIRED / STARTUP_FAILURE / ERROR) blocks the merge.
-checks_json=$("$GH_BIN" pr view "$pr_ref" --json statusCheckRollup -q '.statusCheckRollup' 2>/dev/null || echo "[]")
+# Gate on PR head-SHA check status. Fail closed: any failure to fetch or
+# parse the rollup refuses the merge — silently coercing the lookup error
+# into "[]" was the very bypass channel this wrapper exists to prevent.
+# statusCheckRollup mixes CheckRun (`.conclusion`) and StatusContext
+# (`.state`) entries; SUCCESS / NEUTRAL / SKIPPED / PENDING are non-blocking,
+# anything else (FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED /
+# STARTUP_FAILURE / ERROR) blocks the merge.
+if ! checks_json=$("$GH_BIN" pr view "$pr_ref" --json statusCheckRollup -q '.statusCheckRollup' 2>&1); then
+  echo "ERROR: ceo-safer-merge: could not read check status for PR $pr_ref; refusing --admin merge" >&2
+  echo "$checks_json" >&2
+  exit 5
+fi
 
-failing=$(printf '%s' "$checks_json" | jq -r '
+if ! failing=$(printf '%s' "$checks_json" | jq -r '
   ( . // [] )[] |
   ( .conclusion // .state // "" ) as $c |
   select($c != "" and $c != "SUCCESS" and $c != "NEUTRAL" and $c != "SKIPPED" and $c != "PENDING") |
-  "  - \(.name // .context // "check"): \($c)"' 2>/dev/null || true)
+  "  - \(.name // .context // "check"): \($c)"'); then
+  echo "ERROR: ceo-safer-merge: failed to parse statusCheckRollup; refusing --admin merge" >&2
+  exit 5
+fi
+
+if ! rollup_count=$(printf '%s' "$checks_json" | jq -r '( . // [] ) | length'); then
+  echo "ERROR: ceo-safer-merge: failed to count statusCheckRollup; refusing --admin merge" >&2
+  exit 5
+fi
+if [ "$rollup_count" = "0" ]; then
+  cat >&2 <<EOF
+REFUSED: ceo-safer-merge blocked \`gh pr merge --admin\` on PR $pr_ref —
+no checks reported on the head SHA. The wrapper cannot distinguish "all
+green" from "no signal" (broken workflow file, missing CI registration).
+
+To proceed, re-run with --admin-reason "<at least 10 chars>" or set
+CEO_ALLOW_RED_ADMIN_MERGE=1 if you've verified the absence is intentional.
+EOF
+  exit 4
+fi
 
 if [ -n "$failing" ]; then
   cat >&2 <<EOF

--- a/scripts/ceo-safer-merge.sh
+++ b/scripts/ceo-safer-merge.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# ceo-safer-merge.sh — wrap `gh pr merge` so `--admin` refuses to land a PR
+# whose head-commit checks are red.
+#
+# Background: PR #76 was merged with `gh pr merge --admin --merge` while the
+# Tests workflow reported 9 failures. `--admin` is meant as an emergency
+# escape hatch, not a way for agents to silently steamroll real failures.
+#
+# When --admin is present this wrapper requires one of:
+#   1. PR head-SHA status checks all SUCCESS / NEUTRAL / SKIPPED / PENDING.
+#   2. --admin-reason "<text>" with a non-trivial (>=10 char) reason,
+#      logged to ~/.local/state/ceo-admin-merges.log.
+#   3. CEO_ALLOW_RED_ADMIN_MERGE=1 in the environment.
+#
+# Without --admin the wrapper is a transparent passthrough to `gh pr merge`.
+
+set -euo pipefail
+
+: "${HOME:?HOME must be set before ceo-safer-merge.sh}"
+
+LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}"
+LOG_FILE="$LOG_DIR/ceo-admin-merges.log"
+
+GH_BIN="${GH_BIN:-gh}"
+
+usage() {
+  cat >&2 <<EOF
+Usage: ceo-safer-merge.sh <pr> [--admin-reason "<text>"] [gh pr merge flags]
+
+Wrapper for \`gh pr merge\`. With --admin, requires one of:
+  - head-SHA checks all SUCCESS / NEUTRAL / SKIPPED / PENDING, or
+  - --admin-reason "<text>" (>=10 chars; logged to $LOG_FILE), or
+  - CEO_ALLOW_RED_ADMIN_MERGE=1.
+EOF
+}
+
+admin=0
+admin_reason=""
+pr_ref=""
+gh_args=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --admin)
+      admin=1
+      gh_args+=("$1")
+      shift
+      ;;
+    --admin-reason)
+      admin_reason="${2:-}"
+      shift 2
+      ;;
+    --admin-reason=*)
+      admin_reason="${1#--admin-reason=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [ -z "$pr_ref" ] && [[ "$1" != -* ]]; then
+        pr_ref="$1"
+      fi
+      gh_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$pr_ref" ]; then
+  echo "ERROR: ceo-safer-merge: no PR specified" >&2
+  usage
+  exit 2
+fi
+
+if [ "$admin" -eq 0 ]; then
+  exec "$GH_BIN" pr merge "${gh_args[@]}"
+fi
+
+log_admin_merge() {
+  local reason="$1"
+  mkdir -p "$LOG_DIR"
+  local sha
+  sha=$("$GH_BIN" pr view "$pr_ref" --json headRefOid -q .headRefOid 2>/dev/null || echo "unknown")
+  printf '%s\tPR=%s\tSHA=%s\tREASON=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pr_ref" "$sha" "$reason" >> "$LOG_FILE"
+}
+
+if [ "${CEO_ALLOW_RED_ADMIN_MERGE:-0}" = "1" ]; then
+  log_admin_merge "env:CEO_ALLOW_RED_ADMIN_MERGE"
+  exec "$GH_BIN" pr merge "${gh_args[@]}"
+fi
+
+if [ -n "$admin_reason" ]; then
+  trimmed="${admin_reason#"${admin_reason%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  if [ "${#trimmed}" -lt 10 ]; then
+    echo "ERROR: ceo-safer-merge: --admin-reason must be at least 10 non-whitespace characters" >&2
+    exit 3
+  fi
+  log_admin_merge "$trimmed"
+  exec "$GH_BIN" pr merge "${gh_args[@]}"
+fi
+
+# Gate on PR head-SHA check status. statusCheckRollup mixes CheckRun
+# (`.conclusion`) and StatusContext (`.state`) entries; SUCCESS / NEUTRAL /
+# SKIPPED / PENDING are non-blocking, anything else (FAILURE / CANCELLED /
+# TIMED_OUT / ACTION_REQUIRED / STARTUP_FAILURE / ERROR) blocks the merge.
+checks_json=$("$GH_BIN" pr view "$pr_ref" --json statusCheckRollup -q '.statusCheckRollup' 2>/dev/null || echo "[]")
+
+failing=$(printf '%s' "$checks_json" | jq -r '
+  ( . // [] )[] |
+  ( .conclusion // .state // "" ) as $c |
+  select($c != "" and $c != "SUCCESS" and $c != "NEUTRAL" and $c != "SKIPPED" and $c != "PENDING") |
+  "  - \(.name // .context // "check"): \($c)"' 2>/dev/null || true)
+
+if [ -n "$failing" ]; then
+  cat >&2 <<EOF
+REFUSED: ceo-safer-merge blocked \`gh pr merge --admin\` on PR $pr_ref —
+head-SHA checks are failing:
+$failing
+
+To proceed, either fix the failing checks, re-run with
+  --admin-reason "<at least 10 chars explaining why>"
+or set CEO_ALLOW_RED_ADMIN_MERGE=1.
+EOF
+  exit 4
+fi
+
+exec "$GH_BIN" pr merge "${gh_args[@]}"

--- a/scripts/ceo-safer-merge.test.sh
+++ b/scripts/ceo-safer-merge.test.sh
@@ -21,8 +21,11 @@ setup() {
   GH_LOG="$TEST_HOME/gh-calls.log"
   CHECKS_JSON="$TEST_HOME/checks.json"
   HEAD_SHA="$TEST_HOME/head-sha.txt"
-  echo '[]' > "$CHECKS_JSON"
+  GH_EXIT="$TEST_HOME/gh-exit.txt"
+  echo '[{"__typename":"CheckRun","name":"Tests","conclusion":"SUCCESS"}]' > "$CHECKS_JSON"
   echo 'deadbeef' > "$HEAD_SHA"
+  echo '0' > "$GH_EXIT"
+  : > "$GH_LOG"
 
   cat > "$STUB_DIR/gh" <<EOF
 #!/bin/bash
@@ -35,7 +38,9 @@ case "\$1 \$2" in
     esac
     ;;
   "pr merge")
-    echo "merged" ;;
+    echo "merged"
+    exit "\$(cat "$GH_EXIT")"
+    ;;
 esac
 exit 0
 EOF
@@ -59,10 +64,26 @@ test_no_admin_passes_through_to_gh_pr_merge() {
   assert_contains "$call" "pr merge 42 --merge" "args forwarded verbatim"
 }
 
+test_passthrough_propagates_gh_exit_code() {
+  echo '7' > "$GH_EXIT"
+  "$SAFER_MERGE" 42 --merge >/dev/null 2>&1
+  assert_eq "$?" "7" "non-zero gh exit propagated"
+}
+
 test_missing_pr_ref_errors() {
   out=$("$SAFER_MERGE" --merge 2>&1); rc=$?
   assert_eq "$rc" "2" "exit 2 when no PR ref"
-  assert_contains "$out" "no PR specified" "error message"
+  assert_contains "$out" "first argument must be the PR ref" "error message"
+}
+
+test_pr_ref_must_be_first_positional() {
+  # Pre-fix behavior: `--repo OWNER/NAME 87` captured OWNER/NAME as pr_ref
+  # and silently green-lit the merge when the downstream gh lookup failed.
+  out=$("$SAFER_MERGE" --repo nhangen/claude-ceo 87 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "2" "leading --repo rejected"
+  assert_contains "$out" "first argument must be the PR ref" "error names the constraint"
+  call=$(cat "$GH_LOG")
+  assert_no_match "$call" "pr merge" "no merge attempted"
 }
 
 # --- Admin path: red checks ------------------------------------------------
@@ -80,6 +101,37 @@ JSON
   assert_contains "$out" "Tests: FAILURE" "names the failing check"
   call=$(cat "$GH_LOG")
   assert_no_match "$call" "pr merge 76" "gh pr merge was NOT called"
+}
+
+test_admin_refuses_on_each_blocking_conclusion() {
+  for conclusion in CANCELLED TIMED_OUT ACTION_REQUIRED STARTUP_FAILURE ERROR; do
+    cat > "$CHECKS_JSON" <<JSON
+[{"__typename":"CheckRun","name":"Probe","conclusion":"$conclusion"}]
+JSON
+    : > "$GH_LOG"
+    "$SAFER_MERGE" 76 --admin --merge >/dev/null 2>&1
+    assert_eq "$?" "4" "exit 4 on conclusion=$conclusion"
+    assert_no_match "$(cat "$GH_LOG")" "pr merge 76" "no merge attempted for $conclusion"
+  done
+}
+
+test_admin_refuses_on_status_context_failure_state() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"StatusContext","context":"ci/legacy","state":"FAILURE"}]
+JSON
+  "$SAFER_MERGE" 76 --admin --merge >/dev/null 2>&1
+  assert_eq "$?" "4" "StatusContext .state=FAILURE blocks"
+}
+
+test_admin_refuses_on_mixed_pending_and_failure() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[
+  {"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"},
+  {"__typename":"CheckRun","name":"Lint","status":"IN_PROGRESS","conclusion":""}
+]
+JSON
+  "$SAFER_MERGE" 76 --admin --merge >/dev/null 2>&1
+  assert_eq "$?" "4" "pending alongside failure still blocks"
 }
 
 test_admin_allows_when_all_checks_passing() {
@@ -116,6 +168,45 @@ JSON
   assert_eq "$?" "0" "neutral/skipped do not block"
 }
 
+# --- Admin path: silent-failure modes the gate must close ------------------
+
+test_admin_refuses_when_gh_pr_view_fails() {
+  # Override gh stub to fail on `pr view` so the wrapper cannot read checks.
+  cat > "$STUB_DIR/gh" <<EOF
+#!/bin/bash
+echo "\$@" >> "$GH_LOG"
+if [ "\$1 \$2" = "pr view" ]; then
+  echo "boom: auth expired" >&2
+  exit 1
+fi
+echo "merged"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/gh"
+  out=$("$SAFER_MERGE" 76 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "5" "exit 5 when gh pr view fails"
+  assert_contains "$out" "could not read check status" "explains the refusal"
+  assert_no_match "$(cat "$GH_LOG")" "pr merge 76" "no merge attempted"
+}
+
+test_admin_refuses_when_rollup_is_empty() {
+  echo '[]' > "$CHECKS_JSON"
+  out=$("$SAFER_MERGE" 76 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "4" "exit 4 when rollup empty"
+  assert_contains "$out" "no checks reported" "explains the refusal"
+  assert_no_match "$(cat "$GH_LOG")" "pr merge 76" "no merge attempted"
+}
+
+test_admin_refuses_when_jq_missing() {
+  # Wrap the safer-merge invocation in a PATH that lacks jq.
+  PATH_NO_JQ=$(printf '%s\n' "$PATH" | tr ':' '\n' | while read -r p; do
+    [ -x "$p/jq" ] || printf '%s:' "$p"
+  done)
+  out=$(PATH="$PATH_NO_JQ" "$SAFER_MERGE" 76 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "5" "exit 5 when jq missing"
+  assert_contains "$out" "jq is required" "explains the refusal"
+}
+
 # --- Admin path: --admin-reason override -----------------------------------
 
 test_admin_reason_unblocks_red_merge_and_is_logged() {
@@ -143,9 +234,8 @@ JSON
   assert_eq "$rc" "3" "exit 3 on trivial reason"
   assert_contains "$out" "at least 10" "error explains threshold"
   log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
-  if [ -f "$log_file" ]; then
-    assert_eq "found" "absent" "log must not be written for rejected reason"
-  fi
+  [ ! -f "$log_file" ] || assert_eq "exists" "absent" "log must not be written for rejected reason"
+  assert_eq "1" "1" "anchor assertion"
 }
 
 test_admin_reason_whitespace_only_is_rejected() {
@@ -156,12 +246,28 @@ JSON
   assert_eq "$?" "3" "whitespace-only reason rejected"
 }
 
-test_admin_reason_equals_form_accepted() {
+test_admin_reason_equals_form_accepted_and_logged() {
   cat > "$CHECKS_JSON" <<'JSON'
 [{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
 JSON
   "$SAFER_MERGE" 76 --admin --merge --admin-reason="branch protection irrelevant on personal repo" >/dev/null 2>&1
   assert_eq "$?" "0" "--admin-reason=<text> form accepted"
+  log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
+  assert_file_exists "$log_file" "log written"
+  assert_contains "$(cat "$log_file")" "branch protection irrelevant on personal repo" "reason logged"
+  assert_no_match "$(cat "$GH_LOG")" "admin-reason" "= form stripped before gh"
+}
+
+test_admin_reason_swallowing_next_flag_is_rejected() {
+  out=$("$SAFER_MERGE" 76 --admin --admin-reason --merge 2>&1); rc=$?
+  assert_eq "$rc" "3" "rejects --admin-reason whose value starts with --"
+  assert_contains "$out" "requires a value" "explains the rejection"
+}
+
+test_admin_reason_without_admin_is_rejected() {
+  out=$("$SAFER_MERGE" 76 --merge --admin-reason "this should require --admin" 2>&1); rc=$?
+  assert_eq "$rc" "2" "rejects --admin-reason without --admin"
+  assert_contains "$out" "requires --admin" "explains the rejection"
 }
 
 # --- Admin path: env override ----------------------------------------------
@@ -176,6 +282,31 @@ JSON
   log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
   assert_file_exists "$log_file" "env override is logged"
   assert_contains "$(cat "$log_file")" "env:CEO_ALLOW_RED_ADMIN_MERGE" "env reason recorded"
+  assert_contains "$(cat "$GH_LOG")" "pr merge 76 --admin --merge" "merge forwarded"
+  unset CEO_ALLOW_RED_ADMIN_MERGE
+}
+
+test_override_refuses_when_head_sha_fetch_fails() {
+  cat > "$STUB_DIR/gh" <<EOF
+#!/bin/bash
+echo "\$@" >> "$GH_LOG"
+if [ "\$1 \$2" = "pr view" ] && [[ "\$*" == *headRefOid* ]]; then
+  echo "boom: rate limited" >&2
+  exit 1
+fi
+if [ "\$1 \$2" = "pr view" ] && [[ "\$*" == *statusCheckRollup* ]]; then
+  cat "$CHECKS_JSON"
+  exit 0
+fi
+echo "merged"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/gh"
+  export CEO_ALLOW_RED_ADMIN_MERGE=1
+  out=$("$SAFER_MERGE" 76 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "5" "exit 5 when audit-trail SHA fetch fails"
+  assert_contains "$out" "could not resolve head SHA" "explains refusal"
+  assert_no_match "$(cat "$GH_LOG")" "pr merge 76" "no merge attempted"
   unset CEO_ALLOW_RED_ADMIN_MERGE
 }
 

--- a/scripts/ceo-safer-merge.test.sh
+++ b/scripts/ceo-safer-merge.test.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Self-contained test harness for ceo-safer-merge.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SAFER_MERGE="$SCRIPT_DIR/ceo-safer-merge.sh"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export XDG_STATE_HOME="$TEST_HOME/.local/state"
+  unset CEO_ALLOW_RED_ADMIN_MERGE
+
+  STUB_DIR="$TEST_HOME/stubs"
+  mkdir -p "$STUB_DIR"
+  GH_LOG="$TEST_HOME/gh-calls.log"
+  CHECKS_JSON="$TEST_HOME/checks.json"
+  HEAD_SHA="$TEST_HOME/head-sha.txt"
+  echo '[]' > "$CHECKS_JSON"
+  echo 'deadbeef' > "$HEAD_SHA"
+
+  cat > "$STUB_DIR/gh" <<EOF
+#!/bin/bash
+echo "\$@" >> "$GH_LOG"
+case "\$1 \$2" in
+  "pr view")
+    case "\$*" in
+      *statusCheckRollup*) cat "$CHECKS_JSON" ;;
+      *headRefOid*)        cat "$HEAD_SHA" ;;
+    esac
+    ;;
+  "pr merge")
+    echo "merged" ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_DIR/gh"
+  export PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  rm -rf "$TEST_HOME"
+}
+
+# --- Non-admin path: pure passthrough --------------------------------------
+
+test_no_admin_passes_through_to_gh_pr_merge() {
+  out=$("$SAFER_MERGE" 42 --merge 2>&1)
+  assert_eq "$?" "0" "passthrough exits 0"
+  assert_contains "$out" "merged" "stub gh ran"
+  call=$(cat "$GH_LOG")
+  assert_contains "$call" "pr merge 42 --merge" "args forwarded verbatim"
+}
+
+test_missing_pr_ref_errors() {
+  out=$("$SAFER_MERGE" --merge 2>&1); rc=$?
+  assert_eq "$rc" "2" "exit 2 when no PR ref"
+  assert_contains "$out" "no PR specified" "error message"
+}
+
+# --- Admin path: red checks ------------------------------------------------
+
+test_admin_refuses_when_checks_failing() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[
+  {"__typename":"CheckRun","name":"Tests","status":"COMPLETED","conclusion":"FAILURE"},
+  {"__typename":"CheckRun","name":"Lint","status":"COMPLETED","conclusion":"SUCCESS"}
+]
+JSON
+  out=$("$SAFER_MERGE" 76 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "4" "exit 4 on red admin merge"
+  assert_contains "$out" "REFUSED" "refused header"
+  assert_contains "$out" "Tests: FAILURE" "names the failing check"
+  call=$(cat "$GH_LOG")
+  assert_no_match "$call" "pr merge 76" "gh pr merge was NOT called"
+}
+
+test_admin_allows_when_all_checks_passing() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[
+  {"__typename":"CheckRun","name":"Tests","status":"COMPLETED","conclusion":"SUCCESS"},
+  {"__typename":"StatusContext","context":"ci/lint","state":"SUCCESS"}
+]
+JSON
+  out=$("$SAFER_MERGE" 77 --admin --merge 2>&1); rc=$?
+  assert_eq "$rc" "0" "exit 0 on green admin merge"
+  call=$(cat "$GH_LOG")
+  assert_contains "$call" "pr merge 77 --admin --merge" "merge forwarded"
+}
+
+test_admin_allows_when_checks_pending() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[
+  {"__typename":"CheckRun","name":"Tests","status":"IN_PROGRESS","conclusion":""}
+]
+JSON
+  "$SAFER_MERGE" 78 --admin --merge >/dev/null 2>&1
+  assert_eq "$?" "0" "pending checks do not block"
+}
+
+test_admin_allows_when_only_neutral_or_skipped() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[
+  {"__typename":"CheckRun","name":"Optional","conclusion":"NEUTRAL"},
+  {"__typename":"CheckRun","name":"Skipped","conclusion":"SKIPPED"}
+]
+JSON
+  "$SAFER_MERGE" 79 --admin --merge >/dev/null 2>&1
+  assert_eq "$?" "0" "neutral/skipped do not block"
+}
+
+# --- Admin path: --admin-reason override -----------------------------------
+
+test_admin_reason_unblocks_red_merge_and_is_logged() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
+JSON
+  out=$("$SAFER_MERGE" 76 --admin --merge --admin-reason "stuck check on cancelled runner" 2>&1); rc=$?
+  assert_eq "$rc" "0" "exit 0 with valid reason"
+  log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
+  assert_file_exists "$log_file" "log written"
+  log_line=$(cat "$log_file")
+  assert_contains "$log_line" "PR=76" "PR logged"
+  assert_contains "$log_line" "SHA=deadbeef" "SHA logged"
+  assert_contains "$log_line" "stuck check on cancelled runner" "reason logged"
+  call=$(cat "$GH_LOG")
+  assert_contains "$call" "pr merge 76 --admin --merge" "merge forwarded"
+  assert_no_match "$call" "admin-reason" "admin-reason stripped before gh"
+}
+
+test_admin_reason_too_short_is_rejected() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
+JSON
+  out=$("$SAFER_MERGE" 76 --admin --merge --admin-reason "fix it" 2>&1); rc=$?
+  assert_eq "$rc" "3" "exit 3 on trivial reason"
+  assert_contains "$out" "at least 10" "error explains threshold"
+  log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
+  if [ -f "$log_file" ]; then
+    assert_eq "found" "absent" "log must not be written for rejected reason"
+  fi
+}
+
+test_admin_reason_whitespace_only_is_rejected() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
+JSON
+  "$SAFER_MERGE" 76 --admin --merge --admin-reason "          " >/dev/null 2>&1
+  assert_eq "$?" "3" "whitespace-only reason rejected"
+}
+
+test_admin_reason_equals_form_accepted() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
+JSON
+  "$SAFER_MERGE" 76 --admin --merge --admin-reason="branch protection irrelevant on personal repo" >/dev/null 2>&1
+  assert_eq "$?" "0" "--admin-reason=<text> form accepted"
+}
+
+# --- Admin path: env override ----------------------------------------------
+
+test_env_override_unblocks_red_merge_and_is_logged() {
+  cat > "$CHECKS_JSON" <<'JSON'
+[{"__typename":"CheckRun","name":"Tests","conclusion":"FAILURE"}]
+JSON
+  export CEO_ALLOW_RED_ADMIN_MERGE=1
+  "$SAFER_MERGE" 76 --admin --merge >/dev/null 2>&1
+  assert_eq "$?" "0" "env override allows merge"
+  log_file="$TEST_HOME/.local/state/ceo-admin-merges.log"
+  assert_file_exists "$log_file" "env override is logged"
+  assert_contains "$(cat "$log_file")" "env:CEO_ALLOW_RED_ADMIN_MERGE" "env reason recorded"
+  unset CEO_ALLOW_RED_ADMIN_MERGE
+}
+
+run_tests


### PR DESCRIPTION
Closes #80

## Description (Issue Fixed & New Behavior)

Adds `scripts/ceo-safer-merge.sh`, a wrapper around `gh pr merge` that prevents agents (and humans) from silently landing red PRs via `--admin`.

When invoked **without** `--admin`, the wrapper is a transparent passthrough — it forwards all args to `gh pr merge` and exits with whatever `gh` returns.

When invoked **with** `--admin`, the wrapper requires one of:

1. **Head-SHA checks are non-blocking** — every entry in the PR's `statusCheckRollup` resolves to `SUCCESS`, `NEUTRAL`, `SKIPPED`, or `PENDING`. Anything else (`FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `ERROR`) blocks the merge.
2. **`--admin-reason "<text>"`** — explicit reason of at least 10 non-whitespace chars. Stripped from the args before forwarding to `gh`. Appended to `~/.local/state/ceo-admin-merges.log` (`XDG_STATE_HOME` honored) with timestamp, PR ref, head SHA, and reason — so the override pattern is auditable.
3. **`CEO_ALLOW_RED_ADMIN_MERGE=1`** — env override for "I really, truly know." Also logged with `REASON=env:CEO_ALLOW_RED_ADMIN_MERGE`.

Motivated by PR #76, which was merged via `gh pr merge --admin --merge` while its `Tests` workflow reported 9 failures. The dispatcher's `runner: skill` branch was structurally broken on `main` until PR #77/#78 patched it. `--admin` is a legitimate escape hatch; this wrapper is the client-side discipline that keeps it from steamrolling real failures.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-safer-merge.test.sh` — expect `All tests passed. (11 tests)`. Coverage:
   - non-admin passthrough forwards args verbatim
   - missing PR ref → exit 2
   - red checks under `--admin` → exit 4, names the failing check, does **not** call `gh pr merge`
   - all-green checks → exit 0, forwards `pr merge <pr> --admin --merge`
   - pending-only and neutral/skipped-only checks → not blocking
   - `--admin-reason "<≥10 chars>"` unblocks red merge, writes the log line (PR + SHA + reason), and strips `--admin-reason` before forwarding to `gh`
   - `--admin-reason "fix it"` → exit 3 (too short)
   - whitespace-only reason → exit 3
   - `--admin-reason=<text>` form → accepted
   - `CEO_ALLOW_RED_ADMIN_MERGE=1` unblocks red merge and records `env:CEO_ALLOW_RED_ADMIN_MERGE` in the log
3. Run `shellcheck scripts/ceo-safer-merge.sh` — expect clean (info-level SC1091 about dynamically-sourced `test-harness.sh` is the same noise other test files emit and only appears for the `.test.sh`).

## Additional Notes / HelpScout Tickets

- Non-goal: this is **not** a replacement for branch protection. Branch protection is the server-side enforcement; this wrapper is the client-side discipline that catches the agents allowed to drive `gh` directly.
- Could later be promoted to a `gh alias set safer-merge ...` for cross-repo coverage; this PR keeps it as a script under `scripts/` so the test harness can exercise it the same way the rest of the CEO scripts do.