### PR TITLE
Fix #88 #89: fail-closed value-tracker + doctor artifact cross-check

### DIFF
--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -8,6 +8,7 @@ tier: read
 status: active
 runner: script
 script: ceo-token-intake.sh
+artifact: CEO/reports/token/{TODAY}-{HOST}.md
 ---
 
 # Token Intake

--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -8,6 +8,7 @@ tier: read
 status: active
 runner: script
 script: ceo-value-tracker.sh
+artifact: CEO/reports/value-tracker/{TODAY}.md
 ---
 
 # Value Tracker

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -233,7 +233,13 @@ cmd_doctor() {
 
   # bin symlinks for playbooks
   local registry_file="$CEO_DIR/registry.json"
-  if [ -f "$registry_file" ] && command -v jq &>/dev/null; then
+  if [ ! -f "$registry_file" ]; then
+    echo "  ⚠ bin-symlink check skipped: registry.json not found (run: ceo playbook scan)"
+    warn=$((warn + 1))
+  elif ! command -v jq &>/dev/null; then
+    echo "  ⚠ bin-symlink check skipped: jq not on PATH"
+    warn=$((warn + 1))
+  else
     local registry_rc=0
     ceo_registry_validate "$registry_file" || registry_rc=$?
     if [ "$registry_rc" != "0" ]; then
@@ -292,16 +298,26 @@ cmd_doctor() {
   # completed, verify the artifact exists. This catches the #88 / #89 shape
   # where the dispatcher records 'completed' but the script produced no
   # visible side-effect.
-  if [ -f "$registry_file" ] && command -v jq &>/dev/null && [ -f "$CEO_DIR/log/cron-runs.log" ]; then
+  if [ ! -f "$registry_file" ]; then
+    echo "  ⚠ doctor artifact cross-check skipped: registry.json not found (run: ceo playbook scan)"
+    warn=$((warn + 1))
+  elif ! command -v jq &>/dev/null; then
+    echo "  ⚠ doctor artifact cross-check skipped: jq not on PATH"
+    warn=$((warn + 1))
+  elif [ ! -f "$CEO_DIR/log/cron-runs.log" ]; then
+    echo "  ⚠ doctor artifact cross-check skipped: cron-runs.log not found"
+    warn=$((warn + 1))
+  else
     # cron-runs.log lines look like: "Wed May 28 06:00:11 EDT 2026: <name> completed"
-    # (written by ceo-cron.sh:47 via $(date)). Day-of-month is %e-padded — single
-    # space on 2-digit days, leading-space on 1-digit days. Match on the stable
-    # "<weekday> <month> <day>" prefix plus the year; substring-match is fine
-    # because the log doesn't repeat the same calendar day across years.
+    # (written by ceo-cron.sh:47 via $(date)). Force LC_TIME=C when building the
+    # prefix so a localized writer/reader pair can't false-negative every match
+    # (jeu. mai 28 vs Thu May 28). Anchor the playbook-name match with a regex
+    # ending in ` completed$` per `~/.claude/rules/anchored-regex-for-identifier-allowlists.md`
+    # so `value-tracker` doesn't substring-match `value-tracker-v2 completed`.
     local _date_prefix _year _host _missing=0 _checked=0
-    _date_prefix=$(date '+%a %b %e')
+    _date_prefix=$(LC_TIME=C date '+%a %b %e')
     _year=$(date '+%Y')
-    _host="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo unknown)}"
+    _host="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo "")}"
     while IFS= read -r row; do
       local p_name p_artifact p_runner p_status
       p_name=$(echo "$row" | jq -r '.name')
@@ -311,11 +327,16 @@ cmd_doctor() {
       [ "$p_runner" = "script" ] || continue
       [ "$p_status" = "active" ] || continue
       [ -n "$p_artifact" ] || continue
-      grep -F -- "$_date_prefix" "$CEO_DIR/log/cron-runs.log" 2>/dev/null \
+      LC_TIME=C grep -F -- "$_date_prefix" "$CEO_DIR/log/cron-runs.log" 2>/dev/null \
         | grep -F -- "$_year" \
-        | grep -qF -- ": $p_name completed" \
-        || continue
+        | awk -v n="$p_name" '$0 ~ ": "n" completed$"' \
+        | grep -q . || continue
       _checked=$((_checked + 1))
+      if [ -z "$_host" ] && [[ "$p_artifact" == *"{HOST}"* ]]; then
+        echo "  ⚠ '$p_name' artifact template uses {HOST} but hostname -s returned empty — set CEO_HOSTNAME"
+        warn=$((warn + 1))
+        continue
+      fi
       local _rel _abs
       if ! _rel=$(ceo_artifact_expand "$p_artifact" "$_host"); then
         echo "  ✗ Playbook '$p_name' has malformed artifact template '$p_artifact' (unknown token)"
@@ -611,7 +632,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -683,7 +704,6 @@ cmd_playbook_scan() {
           artifact=""
           ;;
       esac
-      unset _artifact_residual
     fi
     requires=$(yq --front-matter=extract --output-format=json '.requires // null' "$f" 2>/dev/null || echo "null")
     case "$requires" in

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -287,6 +287,54 @@ cmd_doctor() {
     } > "$alert_file"
   fi
 
+  # Completed-but-no-output cross-check — for every active runner:script
+  # playbook with a declared `artifact:`, if today's cron-runs.log says it
+  # completed, verify the artifact exists. This catches the #88 / #89 shape
+  # where the dispatcher records 'completed' but the script produced no
+  # visible side-effect.
+  if [ -f "$registry_file" ] && command -v jq &>/dev/null && [ -f "$CEO_DIR/log/cron-runs.log" ]; then
+    # cron-runs.log lines look like: "Wed May 28 06:00:11 EDT 2026: <name> completed"
+    # (written by ceo-cron.sh:47 via $(date)). Day-of-month is %e-padded — single
+    # space on 2-digit days, leading-space on 1-digit days. Match on the stable
+    # "<weekday> <month> <day>" prefix plus the year; substring-match is fine
+    # because the log doesn't repeat the same calendar day across years.
+    local _date_prefix _year _host _missing=0 _checked=0
+    _date_prefix=$(date '+%a %b %e')
+    _year=$(date '+%Y')
+    _host="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo unknown)}"
+    while IFS= read -r row; do
+      local p_name p_artifact p_runner p_status
+      p_name=$(echo "$row" | jq -r '.name')
+      p_artifact=$(echo "$row" | jq -r '.artifact // ""')
+      p_runner=$(echo "$row" | jq -r '.runner // ""')
+      p_status=$(echo "$row" | jq -r '.status // ""')
+      [ "$p_runner" = "script" ] || continue
+      [ "$p_status" = "active" ] || continue
+      [ -n "$p_artifact" ] || continue
+      grep -F -- "$_date_prefix" "$CEO_DIR/log/cron-runs.log" 2>/dev/null \
+        | grep -F -- "$_year" \
+        | grep -qF -- ": $p_name completed" \
+        || continue
+      _checked=$((_checked + 1))
+      local _rel _abs
+      if ! _rel=$(ceo_artifact_expand "$p_artifact" "$_host"); then
+        echo "  ✗ Playbook '$p_name' has malformed artifact template '$p_artifact' (unknown token)"
+        fail=$((fail + 1))
+        continue
+      fi
+      _abs="$CEO_DIR/${_rel#CEO/}"
+      if [ ! -s "$_abs" ]; then
+        echo "  ✗ '$p_name' logged 'completed' today but artifact missing or empty: $_abs"
+        fail=$((fail + 1))
+        _missing=$((_missing + 1))
+      fi
+    done < <(jq -c '.playbooks[]' "$registry_file" 2>/dev/null)
+    if [ "$_checked" -gt 0 ] && [ "$_missing" -eq 0 ]; then
+      echo "  ✓ Playbook artifacts present for today's completed runs ($_checked checked)"
+      ok=$((ok + 1))
+    fi
+  fi
+
   echo ""
   echo "Result: $ok ok, $warn warnings, $fail failures"
   [ "$fail" -gt 0 ] && return 1
@@ -563,7 +611,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact
     name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -612,6 +660,31 @@ cmd_playbook_scan() {
     script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
     skill=$(yq --front-matter=extract '.skill // ""' "$f" 2>/dev/null || echo "")
     out_pattern=$(yq --front-matter=extract '.out_pattern // ""' "$f" 2>/dev/null || echo "")
+    artifact=$(yq --front-matter=extract '.artifact // ""' "$f" 2>/dev/null || echo "")
+    # Validate at parse time per enum-config-typo-fallback: an artifact
+    # template must be vault-relative ("CEO/...") and reference only the
+    # supported tokens {TODAY} and {HOST}. Reject anything else with a warn,
+    # treating it as absent — better to skip the doctor cross-check than emit
+    # a broken path on every check.
+    if [ -n "$artifact" ]; then
+      case "$artifact" in
+        CEO/*) ;;
+        *)
+          echo "  WARN  $basename: 'artifact' must be vault-relative (start with 'CEO/'); got: $artifact — dropping" >&2
+          artifact=""
+          ;;
+      esac
+    fi
+    if [ -n "$artifact" ]; then
+      _artifact_residual=$(printf '%s' "$artifact" | sed -e 's/{TODAY}//g' -e 's/{HOST}//g')
+      case "$_artifact_residual" in
+        *\{*\}*)
+          echo "  WARN  $basename: 'artifact' contains unknown token(s) (supported: {TODAY}, {HOST}); got: $artifact — dropping" >&2
+          artifact=""
+          ;;
+      esac
+      unset _artifact_residual
+    fi
     requires=$(yq --front-matter=extract --output-format=json '.requires // null' "$f" 2>/dev/null || echo "null")
     case "$requires" in
       "null"|"") requires="null" ;;
@@ -718,10 +791,11 @@ cmd_playbook_scan() {
       --arg script "$script" \
       --arg skill "$skill" \
       --arg out_pattern "$out_pattern" \
+      --arg artifact "$artifact" \
       --argjson inputs "$inputs" \
       --argjson requires "$requires" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, inputs:$inputs, requires:$requires, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, inputs:$inputs, requires:$requires, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -307,10 +307,12 @@ ceo_pin_home_or_warn() {
 # the next `ceo playbook scan`.
 #
 # Version history:
+#   3 — adds optional artifact field (per-playbook expected-output path) so
+#       `ceo doctor` can flag completed-but-no-output runs (#88, #89)
 #   2 — adds runner, script fields (PR #4)
 #   1 — implicit (pre-runner-script registry; missing field treated as <2)
 # ---------------------------------------------------------------------------
-CEO_REGISTRY_SCHEMA_VERSION=2
+CEO_REGISTRY_SCHEMA_VERSION=3
 # shellcheck disable=SC2034
 CEO_VALID_RUNNERS=(claude script ollama ollama-think skill)
 
@@ -343,6 +345,36 @@ ceo_registry_validate() {
     return 2
   fi
   return 0
+}
+
+# ---------------------------------------------------------------------------
+# ceo_artifact_expand <template> [host]
+#   Expand a playbook artifact template into a vault-relative path. Templates
+#   may reference {TODAY} (YYYY-MM-DD) and {HOST} (short hostname). Optional
+#   second arg overrides the host (used by tests).
+#
+#   Prints the expanded path on stdout. Returns 0 on success, 1 if the
+#   template is empty or contains an unknown {...} token (per the
+#   enum-config-typo-fallback rule: reject unknown tokens, do not silently
+#   coerce them to the empty string).
+# ---------------------------------------------------------------------------
+ceo_artifact_expand() {
+  local template="${1:-}"
+  local host="${2:-${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo unknown)}}"
+  [ -z "$template" ] && return 1
+  local today
+  today=$(date +%Y-%m-%d)
+  local expanded="$template"
+  expanded="${expanded//\{TODAY\}/$today}"
+  expanded="${expanded//\{HOST\}/$host}"
+  # After expanding known tokens, any remaining {...} is a typo or an
+  # unsupported token — reject rather than emit a broken path.
+  case "$expanded" in
+    *\{*\}*)
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$expanded"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -115,7 +115,7 @@ test_ceo_help_works_on_fresh_host() {
 
 test_registry_validate_accepts_integer_current_schema() {
   local registry="$TEST_HOME/registry.json"
-  printf '{"schema_version":2,"playbooks":[]}\n' > "$registry"
+  printf '{"schema_version":3,"playbooks":[]}\n' > "$registry"
 
   local rc=0
   env -i PATH="$PATH" bash -c "
@@ -857,6 +857,36 @@ test_pr_sources_setup_writes_valid_json_when_no_sources() {
     jq empty "$TEST_HOME/.ceo/pr-sources.json" 2>/dev/null || rc=$?
   fi
   assert_eq "$rc" "0" "setup must either skip cleanly or write valid JSON"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_artifact_expand_substitutes_today_and_host() {
+  local today out
+  today=$(date +%Y-%m-%d)
+  out=$(bash -c "source '$LIB'; ceo_artifact_expand 'CEO/reports/token/{TODAY}-{HOST}.md' 'testhost'")
+  assert_eq "$out" "CEO/reports/token/${today}-testhost.md" "ceo_artifact_expand must substitute {TODAY} and {HOST}"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_artifact_expand_uses_env_host_default() {
+  local today out
+  today=$(date +%Y-%m-%d)
+  out=$(CEO_HOSTNAME=envhost bash -c "source '$LIB'; ceo_artifact_expand 'CEO/reports/x/{TODAY}-{HOST}.md'")
+  assert_eq "$out" "CEO/reports/x/${today}-envhost.md" "ceo_artifact_expand must fall back to \$CEO_HOSTNAME"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_artifact_expand_rejects_unknown_token() {
+  local rc=0 out
+  out=$(bash -c "source '$LIB'; ceo_artifact_expand 'CEO/reports/{BOGUS}/{TODAY}.md' 'testhost'") || rc=$?
+  assert_eq "$rc" "1" "ceo_artifact_expand must reject unknown tokens per enum-config-typo-fallback"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_artifact_expand_rejects_empty_template() {
+  local rc=0
+  bash -c "source '$LIB'; ceo_artifact_expand ''" >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "ceo_artifact_expand must return 1 on empty template"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1880,7 +1880,7 @@ status: active
 ---
 PB
   cat > "$CEO_DIR/registry.json" << JSON
-{"schema_version":2,"playbooks":[{"name":"pending-drip","file":"$CEO_DIR/playbooks/pending-drip.md","model":"haiku","preflight":"has_pending_items","trigger":"cron","tier":"read","status":"active"}]}
+{"schema_version":3,"playbooks":[{"name":"pending-drip","file":"$CEO_DIR/playbooks/pending-drip.md","model":"haiku","preflight":"has_pending_items","trigger":"cron","tier":"read","status":"active"}]}
 JSON
   printf -- '- [ ] pending approval sentinel\n' > "$CEO_DIR/approvals/pending.md"
   printf -- '- [ ] **file:** sentinel.md **question:** sentinel ask?\n' > "$CEO_VAULT/Pending.md"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1360,7 +1360,7 @@ PB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_playbook_scan_writes_schema_version_2() {
+test_playbook_scan_writes_schema_version_3() {
   cat > "$CEO_DIR/playbooks/example.md" << 'PB'
 ---
 name: example
@@ -1377,7 +1377,7 @@ PB
 
   local v
   v=$(jq -r '.schema_version // "missing"' "$CEO_DIR/registry.json")
-  assert_eq "$v" "2" "playbook scan must write schema_version=2 into registry.json"
+  assert_eq "$v" "3" "playbook scan must write schema_version=3 into registry.json"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Self-contained test harness for `ceo doctor`'s completed-but-no-output
+# cross-check (#88, #89). Stubs out the deps cmd_doctor probes (gh/claude/yq
+# presence, vault marker, ssh key, crontab, plugin) so the artifact check is
+# what determines pass/fail rather than the surrounding environment.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_BIN="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  PATH_BACKUP="$PATH"
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="testhost"
+  mkdir -p "$CEO_DIR/log" "$CEO_DIR/reports/value-tracker" "$CEO_DIR/reports/token"
+  : > "$CEO_DIR/AGENTS.md"
+
+  # Stub the binaries cmd_doctor probes so the surrounding checks don't
+  # dominate the result. They only need to satisfy `command -v` and any
+  # subcommand the doctor invokes; failures here are not what's under test.
+  mkdir -p "$TEST_HOME/stubs"
+  for tool in gh claude yq syncthing crontab jq; do
+    cat > "$TEST_HOME/stubs/$tool" << STUB
+#!/bin/bash
+case "\$1" in
+  auth) [ "\$2" = "status" ] && exit 0 ;;
+  --version) echo "stub $tool 0.0" ;;
+  -l) ;;
+  plugin) [ "\$2" = "list" ] && echo "ceo (stub)" && exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$TEST_HOME/stubs/$tool"
+  done
+
+  # jq is needed for real registry parsing — pass through to the system jq.
+  rm -f "$TEST_HOME/stubs/jq"
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+
+  # Minimal registry with one runner:script playbook + artifact template.
+  cat > "$CEO_DIR/registry.json" << EOF
+{
+  "schema_version": 3,
+  "generated": "2026-05-28T00:00:00Z",
+  "playbooks": [
+    {
+      "name": "value-tracker",
+      "runner": "script",
+      "status": "active",
+      "artifact": "CEO/reports/value-tracker/{TODAY}.md"
+    }
+  ]
+}
+EOF
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export PATH="$PATH_BACKUP"
+  export HOME="$HOME_BACKUP"
+  unset TEST_HOME PATH_BACKUP HOME_BACKUP CEO_VAULT CEO_DIR CEO_HOSTNAME
+}
+
+_log_completed_today() {
+  local name="$1"
+  printf '%s: %s completed\n' "$(date)" "$name" >> "$CEO_DIR/log/cron-runs.log"
+}
+
+test_doctor_flags_completed_but_missing_artifact() {
+  _log_completed_today value-tracker
+  # No artifact written.
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "value-tracker" "doctor output must name the offending playbook"
+  assert_contains "$output" "artifact missing or empty" "doctor must surface the missing-artifact reason"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero when an artifact is missing (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_passes_when_artifact_present() {
+  _log_completed_today value-tracker
+  local today
+  today=$(date +%Y-%m-%d)
+  printf '# stub note\n' > "$CEO_DIR/reports/value-tracker/$today.md"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "Playbook artifacts present" "doctor must report the artifact check passing"
+  if echo "$output" | grep -qF "artifact missing"; then
+    printf '  FAIL [%s] doctor must NOT flag when artifact is present\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_skips_when_playbook_not_completed_today() {
+  # No cron-runs.log entry for value-tracker today. The check should be a
+  # no-op — not a failure (the playbook hasn't run yet, that's not a bug).
+  : > "$CEO_DIR/log/cron-runs.log"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  if echo "$output" | grep -qF "artifact missing"; then
+    printf '  FAIL [%s] doctor must NOT flag a playbook that did not run today\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_skips_empty_artifact_field() {
+  # Playbook with no artifact declared must not be checked.
+  cat > "$CEO_DIR/registry.json" << EOF
+{
+  "schema_version": 3,
+  "generated": "2026-05-28T00:00:00Z",
+  "playbooks": [
+    {
+      "name": "no-artifact",
+      "runner": "script",
+      "status": "active",
+      "artifact": ""
+    }
+  ]
+}
+EOF
+  _log_completed_today no-artifact
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  if echo "$output" | grep -qF "artifact missing"; then
+    printf '  FAIL [%s] doctor must not check playbooks without an artifact template\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -115,6 +115,51 @@ test_doctor_skips_when_playbook_not_completed_today() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_doctor_flags_malformed_artifact_template() {
+  # Per panel H5: the `ceo_artifact_expand` failure branch in cmd_doctor (the
+  # "malformed artifact template ... unknown token" path) had no end-to-end
+  # coverage before this test. Seed a registry with a {BOGUS} token + a
+  # completed log line and assert doctor surfaces the error and returns
+  # non-zero.
+  cat > "$CEO_DIR/registry.json" << EOF
+{
+  "schema_version": 3,
+  "generated": "2026-05-28T00:00:00Z",
+  "playbooks": [
+    {
+      "name": "bogus-token",
+      "runner": "script",
+      "status": "active",
+      "artifact": "CEO/reports/bogus-token/{BOGUS}-{TODAY}.md"
+    }
+  ]
+}
+EOF
+  _log_completed_today bogus-token
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "malformed artifact template" "doctor must name the malformed-template failure"
+  assert_contains "$output" "bogus-token" "doctor must name the offending playbook"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on malformed artifact template\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_warns_when_cron_log_missing() {
+  # Per panel H3: the cross-check used to silently skip when its preconditions
+  # weren't met. The registry exists from setup() and jq is on PATH, but we
+  # leave cron-runs.log absent — the cross-check must emit a WARN naming the
+  # missing log file, not silently skip.
+  rm -f "$CEO_DIR/log/cron-runs.log"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "doctor artifact cross-check skipped" "doctor must surface skip-reason when log absent"
+  assert_contains "$output" "cron-runs.log not found" "skip message must name the missing log"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_doctor_skips_empty_artifact_field() {
   # Playbook with no artifact declared must not be checked.
   cat > "$CEO_DIR/registry.json" << EOF

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -65,10 +65,15 @@ bun "$ENTRY" \
 # Fail-closed: bun can exit 0 without writing the daily note (zero sessions
 # found, wrong write path, silent error). That's the shape behind #88 where
 # cron-runs.log showed 'completed' weekdays for weeks with no artifact on
-# disk. Assert the daily note exists and is non-empty before declaring
-# success — otherwise the dispatcher's _record_success is lying.
+# disk. Assert the daily note exists AND has a real markdown heading — a
+# bare newline / partial frontmatter / panic-traceback all pass `-s` but
+# aren't a real report.
 if [ ! -s "$NOTE_FILE" ]; then
   echo "ERROR: value-tracker exited 0 but did not write $NOTE_FILE" >&2
+  exit 1
+fi
+if ! grep -q '^# value-tracker' "$NOTE_FILE"; then
+  echo "ERROR: value-tracker wrote $NOTE_FILE but it has no '# value-tracker' h1 (truncated or panicked)" >&2
   exit 1
 fi
 

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -50,6 +50,7 @@ SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev
 : "${SINCE:?SINCE computation failed; neither BSD nor GNU date resolved (check cron PATH)}"
 
 NOTE_DIR="$CEO_DIR/reports/value-tracker"
+NOTE_FILE="$NOTE_DIR/$TODAY.md"
 WIKILINK="[[CEO/reports/value-tracker/$TODAY]]"
 INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
@@ -60,6 +61,16 @@ mkdir -p "$INBOX_DIR" "$NOTE_DIR"
 bun "$ENTRY" \
   --since "$SINCE" \
   --obsidian-vault "$VAULT"
+
+# Fail-closed: bun can exit 0 without writing the daily note (zero sessions
+# found, wrong write path, silent error). That's the shape behind #88 where
+# cron-runs.log showed 'completed' weekdays for weeks with no artifact on
+# disk. Assert the daily note exists and is non-empty before declaring
+# success — otherwise the dispatcher's _record_success is lying.
+if [ ! -s "$NOTE_FILE" ]; then
+  echo "ERROR: value-tracker exited 0 but did not write $NOTE_FILE" >&2
+  exit 1
+fi
 
 # Idempotent inbox append — skip if the line is already there.
 if [ ! -f "$INBOX_FILE" ] || ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -20,9 +20,25 @@ setup() {
   export CEO_HOSTNAME="testhost"
 
   mkdir -p "$TEST_HOME/.bun/bin"
+  # Default stub mirrors production bun: echo args AND write the daily note.
+  # The wrapper's post-bun fail-closed check (#88) treats a missing note as
+  # failure, so happy-path tests need the stub to produce one. Tests that want
+  # the "exit 0 with no note" path override this stub.
   cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
 #!/bin/bash
 echo "bun-stub: $*"
+vault=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --obsidian-vault) vault="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$vault" ]; then
+  note_dir="$vault/CEO/reports/value-tracker"
+  mkdir -p "$note_dir"
+  printf '# value-tracker stub %s\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+fi
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 
@@ -189,6 +205,64 @@ test_two_hosts_write_to_disjoint_files() {
   h2=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$CEO_DIR/inbox/otherhost.md" || true)
   assert_eq "$h1" "1" "host1 must have its own line"
   assert_eq "$h2" "1" "host2 must have its own line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_fails_when_bun_exits_zero_but_writes_no_note() {
+  # Replace the default stub with one that exits 0 without writing the note —
+  # this is the production failure mode behind #88 (silent no-op under cron).
+  # The wrapper must reject this case and exit non-zero so the cron dispatcher
+  # records 'failed' instead of 'completed'.
+  cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
+#!/bin/bash
+echo "bun-stub silent: $*"
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/bun"
+
+  local rc=0 stderr
+  stderr=$(bash "$TRACKER" 2>&1 >/dev/null) || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] wrapper must exit non-zero when bun produced no note (#88)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$stderr" "did not write" "stderr must name the missing-note failure (got: $stderr)"
+
+  local today inbox
+  today=$(date +%Y-%m-%d)
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  if [ -f "$inbox" ] && grep -qF "$WIKILINK_PREFIX/$today]]" "$inbox"; then
+    printf '  FAIL [%s] inbox must NOT have a line when no note was written\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_fails_when_bun_writes_empty_note() {
+  # An empty file shouldn't pass the fail-closed check either — a zero-byte
+  # note is indistinguishable from a missing note for the user.
+  cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
+#!/bin/bash
+vault=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --obsidian-vault) vault="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+note_dir="$vault/CEO/reports/value-tracker"
+mkdir -p "$note_dir"
+: > "$note_dir/$(date +%Y-%m-%d).md"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/bun"
+
+  local rc=0 stderr
+  stderr=$(bash "$TRACKER" 2>&1 >/dev/null) || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] wrapper must exit non-zero on empty note file\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$stderr" "did not write" "stderr must name the missing-note failure (got: $stderr)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -37,7 +37,7 @@ done
 if [ -n "$vault" ]; then
   note_dir="$vault/CEO/reports/value-tracker"
   mkdir -p "$note_dir"
-  printf '# value-tracker stub %s\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+  printf '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
 fi
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
@@ -263,6 +263,35 @@ STUB
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$stderr" "did not write" "stderr must name the missing-note failure (got: $stderr)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_fails_when_note_has_no_h1() {
+  # Bun wrote a non-empty file but it has no `## ` heading — partial frontmatter
+  # only, panic traceback, or any other not-a-real-report content. The content
+  # sentinel must catch this (per panel M7).
+  cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
+#!/bin/bash
+vault=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --obsidian-vault) vault="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+note_dir="$vault/CEO/reports/value-tracker"
+mkdir -p "$note_dir"
+printf -- '---\ndate: %s\n---\n\nno h1 here\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/bun"
+
+  local rc=0 stderr
+  stderr=$(bash "$TRACKER" 2>&1 >/dev/null) || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] wrapper must exit non-zero when note has no '"'"'# value-tracker'"'"' h1\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$stderr" "no '# value-tracker' h1" "stderr must name the sentinel failure (got: $stderr)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #88
Closes #89

## Description (Issue Fixed & New Behavior)

Both #88 (value-tracker silent no-op) and #89 (token-intake silent no-op on MacBook) share the same observability shape: the cron dispatcher records `<playbook> completed` in `cron-runs.log` while the wrapper produced no artifact on disk. Two changes close the gap:

1. **`scripts/ceo-value-tracker.sh` — fail-closed assertion.** After `bun` returns, assert the daily note exists at `$NOTE_DIR/$TODAY.md` and is non-empty. `bun` exiting 0 with no file written (zero sessions found, silent error, wrong write path) now exits the wrapper with a distinct error so the dispatcher records `failed`, not `completed`. Mirrors the posture token-intake's wrapper already had (PRs #25 / #37).

2. **Registry schema v3 + `ceo doctor` cross-check.** New optional `artifact:` frontmatter field per playbook with `{TODAY}` and `{HOST}` tokens, validated at parse time per `enum-config-typo-fallback` (rejects non-`CEO/` paths and unknown tokens). `ceo doctor` reads the registry and, for every active `runner:script` playbook with an `artifact:` declared, checks that whenever today's `cron-runs.log` says it completed, the artifact actually exists and is non-empty. Surfaces "completed but no output" as a hard failure regardless of which environment delta caused the silent failure.

Also annotates `token-intake` and `value-tracker` playbook frontmatter with their artifact paths as the first beneficiaries.

### Why a generic check instead of root-causing each cron-env delta

The token-intake wrapper already has fail-closed logic (lines 96–100), so #89's primary hypothesis ("`set -e` swallows partial failures, exit 0") doesn't fit the current code. The remaining failure modes (older binary on MacBook, `ceo_load_config` taking an unexpected path, etc.) are hard to diagnose remotely. The doctor cross-check catches every shape of "completed but no output" without needing to identify which one fired.

## Testing Procedure

1. Check out this branch: `git fetch && git switch nh/fix/cron-observability-gap`
2. Run the full test suite from the repo root:
   ```bash
   for t in scripts/*.test.sh; do echo "=== $t ==="; bash "$t" || break; done
   ```
   Confirm all 13 test files report `All tests passed.` (241 tests total).
3. Run shellcheck at CI severity:
   ```bash
   find scripts -maxdepth 1 -type f \( -name '*.sh' -o -name 'ceo' \) -print0 | xargs -0 shellcheck --severity=warning
   ```
   Confirm exit 0, no warnings.
4. Exercise the fail-closed path locally:
   ```bash
   bash scripts/ceo-value-tracker.test.sh
   ```
   Confirm `test_fails_when_bun_exits_zero_but_writes_no_note` and `test_fails_when_bun_writes_empty_note` pass.
5. Exercise the doctor cross-check:
   ```bash
   bash scripts/ceo-doctor.test.sh
   ```
   Confirm 4 tests pass (flags missing artifact, passes when present, skips not-run-today, skips empty-artifact-field).
6. Optional: run `ceo doctor` against a real vault on a machine that ran value-tracker today but where the report is missing — confirm the new `✗ '<name>' logged 'completed' today but artifact missing or empty: ...` line fires.

## Additional Notes / HelpScout Tickets

- Registry schema bumped 2 → 3. Peer hosts on older binaries will refuse to dispatch until they pull this change and re-run `ceo playbook scan`, per the existing schema-version contract in `ceo-config.sh`.
- Adds no new dependencies. `yq`, `jq`, `bun`, `shellcheck` already required.
- `artifact:` is optional — existing playbooks without it are unaffected by the doctor check.
- Token expansion (`{TODAY}`, `{HOST}`) is deliberately minimal; extending the set later is additive.