### PR TITLE
Add draft/disabled playbook status + scan --dry-run + schema docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ ceo test             Smoke test: trigger morning-brief, check log
 ceo cron <name>      Manually run a cron trigger
 ceo chat [name]      Interactive playbook (no cron); empty = triage conversation; defaults to --effort medium
 ceo playbook scan|list|info     Self-registering playbook management
+ceo playbook scan --dry-run     Preview what scan would install, no writes
 ceo schedule [name]  List effective schedules; with name, reschedule one
 ceo preflight        Preview what cron would run vs skip
 ```
@@ -314,6 +315,7 @@ count-blessings show         Show today's three picks
 - **WSL2 cron does not auto-start at boot.** Add `[boot] command = service cron start` to `/etc/wsl.conf`, or set up a Windows Task Scheduler job that runs `wsl.exe -u <user> -- /etc/init.d/cron start` at logon.
 - **Portable timeout.** `ceo-cron.sh` uses `timeout` (Linux) or `gtimeout` (macOS via `brew install coreutils`). If neither is installed, the wrapper degrades to no wall-clock cap (`--max-turns` and API timeout still apply) and a `WARN` is logged.
 - **Schedule collisions are refused, not coerced.** Two cron-trigger playbooks on the same minute would race the global `/tmp/ceo-cron.lock`; `ceo playbook scan` refuses to install the crontab until you resolve via `ceo schedule <playbook>` or by editing `schedules.json`.
+- **Playbook frontmatter schema.** See [`docs/playbooks/SCHEMA.md`](docs/playbooks/SCHEMA.md) for the full field reference. `status:` is now an enum (`active` / `draft` / `disabled`) — drafts are runnable on-demand but never cron-installed, disabled tears down previously-installed cron lines. Unknown status values are rejected at parse time.
 
 ## License
 

--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -1,0 +1,71 @@
+# Playbook Frontmatter Schema
+
+Every playbook is a markdown file in `$CEO_VAULT/CEO/playbooks/` (or `docs/playbooks/` in this repo for the default seed) with a YAML frontmatter block. `ceo playbook scan` reads each file, validates the frontmatter, and writes a normalized entry into `$CEO_VAULT/CEO/registry.json`.
+
+Unknown values for enum fields are **rejected at parse time** with a `SKIP` diagnostic per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md). The dispatcher never silently coerces a typo to a default.
+
+## Fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `name` | yes | string | Unique playbook ID. Used as `ceo-cron.sh <name>` and as the cron-runs.log key. No newlines, no whitespace-only. Vault entries shadow same-named repo entries. |
+| `description` | recommended | string | Free text. Surfaced by `ceo playbook info` and used by `ceo doctor` reporting. |
+| `trigger` | yes | enum: `cron`, `manual` | Only `cron` entries get installed by `ceo playbook scan`. `manual` is runnable via `ceo-cron.sh <name>` on demand but never installed. |
+| `schedule` | required when `trigger: cron` and `status: active` | 5-field cron expression | Validated with [`_validate_cron_expr`](../../scripts/ceo). User-level overrides live in `$CEO_VAULT/CEO/schedules.json` and win at scan time. |
+| `model` | depends on `runner` | string | Claude model (e.g. `haiku`, `sonnet`) for `runner: claude`; Ollama tag for `runner: ollama` / `runner: ollama-think`. Ignored for `runner: script` / `runner: skill`. |
+| `preflight` | recommended | function name | Bash function defined in `scripts/ceo-cron.sh` that gates whether the playbook runs (e.g. `has_unchecked_inbox`, `has_pending_items`, `none`). Missing/unknown preflight short-circuits to skip. |
+| `tier` | yes | enum: `read`, `low-stakes-write`, `high-stakes` | Controls notification posture and approval gating. `read` posts the full report to Discord; writes go to an approvals queue. |
+| `status` | recommended | enum: `active`, `draft`, `disabled` | See [Status semantics](#status-semantics) below. Empty/missing is treated as "not active" for back-compat but is **discouraged** — be explicit. |
+| `runner` | no | enum: `claude`, `script`, `ollama`, `ollama-think`, `skill` | Dispatch shape. Default is `claude`. `script` runs `script:` directly without an LLM call. |
+| `script` | required when `runner: script` | string | Relative path under `scripts/` (e.g. `ceo-value-tracker.sh`). The dispatcher resolves to `$INSTALL_DIR/scripts/<script>`. |
+| `skill` | required when `runner: skill` | string | Skill name passed to the Claude Code skill invoker. |
+| `bin` | no | string | If set, `ceo playbook scan` installs a `~/.local/bin/<bin-without-.sh>` symlink pointing at `scripts/<bin>`. Only created for `status: active`. |
+| `inputs` | no | JSON array | Pre-gather keys the dispatcher injects into the prompt context. Empty array = no pre-gathered context. Absent = all keys (back-compat default). Unknown keys warn-and-skip at dispatch. Valid keys: `pr_data`, `pending_count`, `today_log`, `yesterday_log`, `daily_note`, `briefings_training`, `active_domains`, `pending_ask`, `scan_data`, `blessings`. |
+| `requires` | no | JSON array of env-var names | Credentials the playbook needs (e.g. `["HUBSPOT_REFRESH_TOKEN"]`). `ceo creds check <name>` reports missing values. Non-array entries are warned and dropped. |
+| `artifact` | recommended for `runner: script` | string template | Expected output path relative to the vault. Must start with `CEO/`. Supports `{TODAY}` (YYYY-MM-DD) and `{HOST}` (short hostname). Unknown tokens reject at parse. `ceo doctor` cross-checks declared artifact vs disk for every active script that logged "completed" today. |
+| `out_pattern` | no | string | Legacy reporting pattern (output filename hint). Kept for back-compat with older playbooks. New playbooks should use `artifact`. |
+
+## Status semantics
+
+| status | `ceo-cron.sh <name>` (on-demand) | `ceo playbook scan` installs cron line? | `ceo playbook list` shows? | `ceo doctor` surfaces? |
+|---|---|---|---|---|
+| `active` | yes | yes | yes | inferred from health checks |
+| `draft` | yes | **no** | yes (with `status: draft`) | yes, in the **Drafts** section, with a hint to flip to `active` |
+| `disabled` | yes | **no**; rescan removes any previously-installed line | yes (with `status: disabled`) | no special surface |
+| missing / empty | yes | no (treated as inactive) | yes (`status: -`) | no special surface |
+| anything else | **rejected at parse** with `SKIP <basename> (unknown status: ...)` — entry is dropped from the registry, no fallback to a default | — | — | — |
+
+### Use draft for WIP playbooks
+
+`draft` exists for "exists, runnable on demand, not ready for cron." Author iteratively via `bash scripts/ceo-cron.sh <name>` until happy with the behavior, then flip frontmatter to `status: active` and re-run `ceo playbook scan` to install.
+
+### Use disabled to durably tear down
+
+`disabled` is "I previously had this installed and want it removed everywhere." Flipping `active → disabled` and running `ceo playbook scan` removes the cron line on the next scan. Unlike a draft, `disabled` is the explicit "stop running" signal, distinct from "still working on it."
+
+## Validation
+
+`ceo playbook scan` validates frontmatter in order:
+1. `name` present and well-formed.
+2. Duplicate `name` (vault vs repo or within either tree) → shadow / skip.
+3. `runner` (if set) is in `CEO_VALID_RUNNERS`.
+4. `status` (if set) is in `CEO_VALID_STATUSES`.
+5. `artifact` (if set) starts with `CEO/` and contains only `{TODAY}` / `{HOST}` tokens.
+6. `requires`, `inputs` shapes are valid JSON arrays.
+7. For `runner: ollama` / `ollama-think`, the model must be locally available (unless `CEO_OLLAMA_SKIP_PROBE=1`).
+
+Any failure: the playbook is skipped with a diagnostic line. The dispatcher will not run a skipped playbook; the registry will not list it.
+
+## Preview a scan
+
+```bash
+ceo playbook scan --dry-run
+```
+
+Walks the same parse path and prints the cron block that would be installed, without touching the crontab or rewriting the registry. Useful when iterating on a draft, or when verifying what a sibling machine would do after a `git pull`.
+
+## Related
+
+- [`ceo-automated-writers-are-playbooks`](../../../.claude/rules/ceo-automated-writers-are-playbooks.md) — registered playbooks are the only sanctioned writers under `$CEO_VAULT/CEO/`.
+- [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md) — the parse-time rejection discipline this schema enforces.
+- nhangen/claude-ceo#90 — the issue that introduced `draft` / `disabled` and the `--dry-run` flag.

--- a/docs/playbooks/auto-review.md
+++ b/docs/playbooks/auto-review.md
@@ -6,7 +6,7 @@ schedule: "17 9,13 * * 1-5"
 model: sonnet
 preflight: has_auto_review_prs
 tier: read
-status: active
+status: draft
 ---
 
 # Auto PR Review

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -356,6 +356,20 @@ cmd_doctor() {
     fi
   fi
 
+  # Drafts surfaced as info — not failures. Promotes via `status: active` flip.
+  if [ -f "$registry_file" ] && command -v jq &>/dev/null; then
+    local drafts
+    drafts=$(jq -r '.playbooks[] | select(.status == "draft") | .name' "$registry_file" 2>/dev/null)
+    if [ -n "$drafts" ]; then
+      echo ""
+      echo "  Drafts (not installed in cron; runnable on-demand):"
+      while IFS= read -r d; do
+        [ -z "$d" ] && continue
+        echo "    - $d  (flip frontmatter to 'status: active' then re-run 'ceo playbook scan' to install)"
+      done <<< "$drafts"
+    fi
+  fi
+
   echo ""
   echo "Result: $ok ok, $warn warnings, $fail failures"
   [ "$fail" -gt 0 ] && return 1
@@ -482,17 +496,18 @@ cmd_playbook() {
   local subcmd="${1:-help}"
   shift 2>/dev/null || true
   case "$subcmd" in
-    scan) cmd_playbook_scan ;;
+    scan) cmd_playbook_scan "$@" ;;
     list) cmd_playbook_list ;;
     info) cmd_playbook_info "$@" ;;
     diff) cmd_playbook_diff "$@" ;;
     help|--help|-h)
       echo "Usage: ceo playbook <scan|list|info|diff>"
       echo ""
-      echo "  scan          Discover playbooks, update registry + crontab"
-      echo "  list          Show all registered playbooks"
-      echo "  info <name>   Show details for one playbook"
-      echo "  diff [--quiet] Detect drift between vault and repo playbooks"
+      echo "  scan [--dry-run]   Discover playbooks, update registry + crontab"
+      echo "                     (--dry-run prints would-be cron block, no writes)"
+      echo "  list               Show all registered playbooks"
+      echo "  info <name>        Show details for one playbook"
+      echo "  diff [--quiet]     Detect drift between vault and repo playbooks"
       ;;
     *)
       echo "Unknown playbook command: $subcmd"
@@ -573,6 +588,14 @@ cmd_playbook_scan() {
     echo "Install: brew install yq (macOS) or snap install yq (Linux)"
     exit 1
   fi
+
+  local dry_run=0
+  for arg in "$@"; do
+    case "$arg" in
+      --dry-run) dry_run=1 ;;
+      *) echo "  WARN  unknown scan argument: '$arg' (supported: --dry-run)" >&2 ;;
+    esac
+  done
 
   ceo_validate_vault || exit 1
   ceo_assert_primary_host || exit 1
@@ -676,6 +699,11 @@ cmd_playbook_scan() {
     preflight=$(yq --front-matter=extract '.preflight // ""' "$f" 2>/dev/null || echo "")
     tier=$(yq --front-matter=extract '.tier // ""' "$f" 2>/dev/null || echo "")
     status=$(yq --front-matter=extract '.status // ""' "$f" 2>/dev/null || echo "")
+    if [ -n "$status" ] && ! ceo_status_valid "$status"; then
+      echo "  SKIP  $basename (unknown status: '$status', expected: ${CEO_VALID_STATUSES[*]})"
+      skipped=$((skipped + 1))
+      continue
+    fi
     bin=$(yq --front-matter=extract '.bin // ""' "$f" 2>/dev/null || echo "")
     runner=$(yq --front-matter=extract '.runner // ""' "$f" 2>/dev/null || echo "")
     script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
@@ -857,6 +885,15 @@ cmd_playbook_scan() {
   # Apply schedule overrides — registry should reflect effective schedules.
   new_registry=$(_playbook_apply_schedule_overrides "$new_registry")
 
+  if [ "$dry_run" -eq 1 ]; then
+    echo ""
+    echo "=== DRY-RUN: would-be crontab block (no changes applied) ==="
+    _playbook_print_cron_block "$new_registry"
+    echo ""
+    echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed) — NOT written"
+    return 0
+  fi
+
   # Update crontab FIRST. If collision detection refuses, abort before
   # touching the registry on disk — otherwise a refused scan would persist
   # the conflicting state into registry.json and confuse later `ceo schedule`
@@ -992,6 +1029,29 @@ _playbook_apply_schedule_overrides() {
   done <<< "$override_keys"
 
   echo "$registry"
+}
+
+# _playbook_print_cron_block <registry-json>
+#   Prints the CEO Agent crontab block that would be installed for <registry>
+#   to stdout, without touching the user's crontab. Skips collision detection
+#   (dry-run only — collisions are caught by _playbook_update_crontab on the
+#   real install path).
+_playbook_print_cron_block() {
+  local registry="$1"
+  local marker_start="# CEO Agent START"
+  local marker_end="# CEO Agent END"
+  echo "$marker_start"
+  while IFS= read -r row; do
+    local p_name p_trigger p_schedule p_status
+    p_name=$(echo "$row" | jq -r '.name')
+    p_trigger=$(echo "$row" | jq -r '.trigger')
+    p_schedule=$(echo "$row" | jq -r '.schedule')
+    p_status=$(echo "$row" | jq -r '.status')
+    if [ "$p_trigger" = "cron" ] && [ "$p_status" = "active" ] && [ -n "$p_schedule" ]; then
+      echo "$p_schedule $CEO_CRON $p_name  # ceo:$p_name"
+    fi
+  done < <(echo "$registry" | jq -c '.playbooks[]')
+  echo "$marker_end"
 }
 
 _playbook_update_crontab() {

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -357,7 +357,16 @@ cmd_doctor() {
   fi
 
   # Drafts surfaced as info — not failures. Promotes via `status: active` flip.
-  if [ -f "$registry_file" ] && command -v jq &>/dev/null; then
+  # Per ~/.claude/rules/safety-invariant-scope.md, surface missing preconditions
+  # explicitly rather than silently hiding the check — drafts are exactly the
+  # incident shape this PR exists to prevent.
+  if [ ! -f "$registry_file" ]; then
+    echo "  ⚠ Drafts check skipped: registry.json not found (run: ceo playbook scan)"
+    warn=$((warn + 1))
+  elif ! command -v jq &>/dev/null; then
+    echo "  ⚠ Drafts check skipped: jq not on PATH"
+    warn=$((warn + 1))
+  else
     local drafts
     drafts=$(jq -r '.playbooks[] | select(.status == "draft") | .name' "$registry_file" 2>/dev/null)
     if [ -n "$drafts" ]; then
@@ -593,7 +602,13 @@ cmd_playbook_scan() {
   for arg in "$@"; do
     case "$arg" in
       --dry-run) dry_run=1 ;;
-      *) echo "  WARN  unknown scan argument: '$arg' (supported: --dry-run)" >&2 ;;
+      *)
+        # Reject unknown args rather than fall through to a real scan —
+        # `--dryrun` typo must not silently run the destructive path. Per
+        # ~/.claude/rules/enum-config-typo-fallback.md.
+        echo "ERROR: unknown scan argument: '$arg' (supported: --dry-run)" >&2
+        return 1
+        ;;
     esac
   done
 
@@ -639,6 +654,10 @@ cmd_playbook_scan() {
     '{schema_version: $v, generated: $ts, playbooks: []}')
   local found=0
   local skipped=0
+  # Tracked separately from `skipped` so a typo'd enum can propagate to
+  # cmd_playbook_scan's exit code per ~/.claude/rules/enum-config-typo-fallback.md
+  # ("failed dispatch counts toward failure observability").
+  local invalid_status=0
 
   local seen_names_vault=""
   local seen_names_repo=""
@@ -700,8 +719,9 @@ cmd_playbook_scan() {
     tier=$(yq --front-matter=extract '.tier // ""' "$f" 2>/dev/null || echo "")
     status=$(yq --front-matter=extract '.status // ""' "$f" 2>/dev/null || echo "")
     if [ -n "$status" ] && ! ceo_status_valid "$status"; then
-      echo "  SKIP  $basename (unknown status: '$status', expected: ${CEO_VALID_STATUSES[*]})"
+      echo "  SKIP  $basename (unknown status: '$status', expected: ${CEO_VALID_STATUSES[*]})" >&2
       skipped=$((skipped + 1))
+      invalid_status=$((invalid_status + 1))
       continue
     fi
     bin=$(yq --front-matter=extract '.bin // ""' "$f" 2>/dev/null || echo "")
@@ -891,6 +911,10 @@ cmd_playbook_scan() {
     _playbook_print_cron_block "$new_registry"
     echo ""
     echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed) — NOT written"
+    if [ "$invalid_status" -gt 0 ]; then
+      echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+      return 1
+    fi
     return 0
   fi
 
@@ -912,6 +936,11 @@ cmd_playbook_scan() {
   echo "Wrote: $registry_file"
 
   _playbook_sync_bins "$new_registry"
+
+  if [ "$invalid_status" -gt 0 ]; then
+    echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+    return 1
+  fi
 }
 
 _playbook_sync_bins() {
@@ -1079,25 +1108,11 @@ _playbook_update_crontab() {
     return 1
   fi
 
-  local cron_block="$marker_start"
-  local cron_count=0
-
-  while IFS= read -r row; do
-    local p_name p_trigger p_schedule p_status
-    p_name=$(echo "$row" | jq -r '.name')
-    p_trigger=$(echo "$row" | jq -r '.trigger')
-    p_schedule=$(echo "$row" | jq -r '.schedule')
-    p_status=$(echo "$row" | jq -r '.status')
-
-    if [ "$p_trigger" = "cron" ] && [ "$p_status" = "active" ] && [ -n "$p_schedule" ]; then
-      cron_block="$cron_block
-$p_schedule $CEO_CRON $p_name  # ceo:$p_name"
-      cron_count=$((cron_count + 1))
-    fi
-  done < <(echo "$registry" | jq -c '.playbooks[]')
-
-  cron_block="$cron_block
-$marker_end"
+  # Share the emission body with _playbook_print_cron_block so dry-run and
+  # real install can't drift on the active+cron+scheduled filter.
+  local cron_block cron_count
+  cron_block=$(_playbook_print_cron_block "$registry")
+  cron_count=$(printf '%s\n' "$cron_block" | grep -c '# ceo:' || true)
 
   local existing
   existing=$(crontab -l 2>/dev/null || true)

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -315,6 +315,21 @@ ceo_pin_home_or_warn() {
 CEO_REGISTRY_SCHEMA_VERSION=3
 # shellcheck disable=SC2034
 CEO_VALID_RUNNERS=(claude script ollama ollama-think skill)
+# shellcheck disable=SC2034
+CEO_VALID_STATUSES=(active draft disabled)
+
+# ceo_status_valid <value>
+#   Returns 0 if <value> is one of the supported statuses, 1 otherwise.
+#   Empty string is treated as "not active" by the dispatcher but is NOT
+#   accepted here — callers decide whether to allow missing/empty separately
+#   from typos.
+ceo_status_valid() {
+  local v="${1:-}"
+  for s in "${CEO_VALID_STATUSES[@]}"; do
+    [ "$v" = "$s" ] && return 0
+  done
+  return 1
+}
 
 # ceo_registry_version <registry_file>
 #   Prints the integer schema_version, or nothing if missing/malformed.

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -890,4 +890,29 @@ test_artifact_expand_rejects_empty_template() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_status_valid_accepts_canonical_values() {
+  for s in active draft disabled; do
+    local rc=0
+    bash -c "source '$LIB'; ceo_status_valid '$s'" || rc=$?
+    assert_eq "$rc" "0" "ceo_status_valid must accept canonical status: $s"
+  done
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_valid_rejects_typos_and_case_variants() {
+  for s in scrpt Active ACTIVE 'active ' ' active' disable enabled drft; do
+    local rc=0
+    bash -c "source '$LIB'; ceo_status_valid '$s'" || rc=$?
+    assert_eq "$rc" "1" "ceo_status_valid must reject non-canonical status: '$s'"
+  done
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_valid_rejects_empty() {
+  local rc=0
+  bash -c "source '$LIB'; ceo_status_valid ''" || rc=$?
+  assert_eq "$rc" "1" "ceo_status_valid must reject empty string"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-playbook-status.test.sh
+++ b/scripts/ceo-playbook-status.test.sh
@@ -101,6 +101,9 @@ test_status_disabled_removes_previously_installed_line() {
   local crontab_after
   crontab_after=$(cat "$HOME/.fake-crontab")
   assert_not_contains "$crontab_after" "ceo:p-toggle" "disabled rescan must drop the previously-installed line"
+  local registry_status
+  registry_status=$(jq -r '.playbooks[] | select(.name=="p-toggle") | .status' "$CEO_DIR/registry.json" 2>/dev/null)
+  assert_eq "$registry_status" "disabled" "registry must reflect the new disabled status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -108,6 +111,7 @@ test_status_invalid_rejects_at_parse() {
   _write_playbook "p-typo" "scrpt"
   local output
   output=$(bash "$CEO_CLI" playbook scan 2>&1 || true)
+  assert_contains "$output" "SKIP" "parse must emit the SKIP diagnostic"
   assert_contains "$output" "p-typo" "scan must mention the offending playbook"
   assert_contains "$output" "scrpt" "scan must echo the rejected value"
   local registry_has
@@ -116,8 +120,30 @@ test_status_invalid_rejects_at_parse() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_status_invalid_exits_nonzero() {
+  _write_playbook "p-typo-rc" "scrpt"
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "unknown-status SKIP must propagate non-zero exit per enum-config-typo-fallback"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_scan_rejects_unknown_argument() {
+  _write_playbook "p-arg" "active"
+  : > "$HOME/.fake-crontab"
+  local rc=0 output
+  output=$(bash "$CEO_CLI" playbook scan --dryrun 2>&1) || rc=$?
+  assert_eq "$rc" "1" "unknown scan argument must exit non-zero (not silently run a real scan)"
+  assert_contains "$output" "ERROR" "unknown scan argument must emit an ERROR line"
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_eq "$crontab" "" "unknown scan argument must NOT touch the crontab"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_status_missing_defaults_to_inactive() {
-  # status: "" / absent — current behavior is "not active". Preserve that.
+  # status: "" / absent — current behavior is "not active" but still parses
+  # cleanly and lands in the registry (back-compat).
   cat > "$CEO_DIR/playbooks/p-empty.md" << 'PB'
 ---
 name: p-empty
@@ -133,6 +159,9 @@ PB
   local crontab
   crontab=$(cat "$HOME/.fake-crontab")
   assert_not_contains "$crontab" "ceo:p-empty" "missing status must not install cron line"
+  local registry_has
+  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-empty")] | length' "$CEO_DIR/registry.json" 2>/dev/null)
+  assert_eq "$registry_has" "1" "missing-status playbook must still land in registry (back-compat)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -165,6 +194,29 @@ test_dry_run_prints_would_install_block() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_dry_run_output_matches_installed_block() {
+  # Locks in the invariant that the dry-run preview emits the SAME cron
+  # block the real install would write — protects against drift between
+  # _playbook_print_cron_block and _playbook_update_crontab.
+  _write_playbook "p-parity-a" "active"
+  _write_playbook "p-parity-b" "draft"
+  _write_playbook "p-parity-c" "active"
+  # Use unique schedules so collision detection on the real path passes.
+  sed -i.bak 's|0 9 \* \* \*|0 11 * * *|' "$CEO_DIR/playbooks/p-parity-c.md"
+  rm -f "$CEO_DIR/playbooks/p-parity-c.md.bak"
+
+  local dry_out
+  dry_out=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1 \
+    | awk '/CEO Agent START/,/CEO Agent END/')
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local installed
+  installed=$(awk '/CEO Agent START/,/CEO Agent END/' "$HOME/.fake-crontab")
+
+  assert_eq "$dry_out" "$installed" "dry-run cron block must byte-equal the installed cron block"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_dry_run_omits_draft_and_disabled() {
   _write_playbook "p-dry-a" "active"
   _write_playbook "p-dry-d" "draft"
@@ -178,31 +230,36 @@ test_dry_run_omits_draft_and_disabled() {
 }
 
 test_playbook_list_shows_draft_tag() {
-  _write_playbook "p-list-draft" "draft"
+  # Use a fixture name that does NOT contain the status word so the
+  # assert_contains check can't trivially match on the playbook name.
+  _write_playbook "p-wip" "draft"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local output
   output=$(bash "$CEO_CLI" playbook list 2>&1)
-  assert_contains "$output" "p-list-draft" "list must include draft playbooks"
+  assert_contains "$output" "p-wip" "list must include draft playbooks"
   assert_contains "$output" "draft" "list must surface the draft status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_playbook_list_shows_disabled_tag() {
-  _write_playbook "p-list-disabled" "disabled"
+  _write_playbook "p-off" "disabled"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local output
   output=$(bash "$CEO_CLI" playbook list 2>&1)
-  assert_contains "$output" "p-list-disabled" "list must include disabled playbooks"
+  assert_contains "$output" "p-off" "list must include disabled playbooks"
   assert_contains "$output" "disabled" "list must surface the disabled status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_doctor_surfaces_drafts() {
-  _write_playbook "p-doctor-draft" "draft"
+  _write_playbook "p-doctor-wip" "draft"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local output
   output=$(bash "$CEO_CLI" doctor 2>&1 || true)
-  assert_contains "$output" "p-doctor-draft" "doctor must surface draft playbooks"
+  # Anchor on the section header literal so a regression that deletes the
+  # Drafts block but leaves the standard playbook enumeration intact fails.
+  assert_contains "$output" "Drafts (not installed in cron" "doctor must emit the Drafts section header"
+  assert_contains "$output" "p-doctor-wip" "doctor must list the draft playbook by name"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-playbook-status.test.sh
+++ b/scripts/ceo-playbook-status.test.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Self-contained test harness for the playbook status enum (active/draft/disabled).
+# Covers nhangen/claude-ceo#90.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$TEST_HOME/empty-repo-playbooks"
+  export CEO_REPO_PLAYBOOK_DIR="$TEST_HOME/empty-repo-playbooks"
+  : > "$CEO_DIR/AGENTS.md"
+  : > "$CEO_DIR/IDENTITY.md"
+  : > "$CEO_DIR/TRAINING.md"
+  : > "$CEO_DIR/inbox.md"
+
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/crontab" << 'STUB'
+#!/bin/bash
+if [ "${1:-}" = "-l" ]; then
+  cat "$HOME/.fake-crontab" 2>/dev/null || true
+  exit 0
+fi
+cat > "$HOME/.fake-crontab"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/crontab"
+  : > "$HOME/.fake-crontab"
+
+  export PATH="$TEST_HOME/.bun/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_VAULT CEO_DIR CEO_REPO_PLAYBOOK_DIR TEST_HOME HOME_BACKUP PATH_BACKUP
+}
+
+_write_playbook() {
+  local name="$1" status="$2"
+  cat > "$CEO_DIR/playbooks/$name.md" << PB
+---
+name: $name
+description: status-enum fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: $status
+---
+# noop
+PB
+}
+
+test_status_active_installs_cron_line() {
+  _write_playbook "p-active" "active"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_contains "$crontab" "ceo:p-active" "active playbook must appear in installed crontab"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_draft_does_not_install_cron_line() {
+  _write_playbook "p-draft" "draft"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_not_contains "$crontab" "ceo:p-draft" "draft playbook must NOT appear in crontab"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_disabled_does_not_install_cron_line() {
+  _write_playbook "p-disabled" "disabled"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_not_contains "$crontab" "ceo:p-disabled" "disabled playbook must NOT appear in crontab"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_disabled_removes_previously_installed_line() {
+  _write_playbook "p-toggle" "active"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab_before
+  crontab_before=$(cat "$HOME/.fake-crontab")
+  assert_contains "$crontab_before" "ceo:p-toggle" "precondition: active install must have placed a line"
+
+  _write_playbook "p-toggle" "disabled"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab_after
+  crontab_after=$(cat "$HOME/.fake-crontab")
+  assert_not_contains "$crontab_after" "ceo:p-toggle" "disabled rescan must drop the previously-installed line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_invalid_rejects_at_parse() {
+  _write_playbook "p-typo" "scrpt"
+  local output
+  output=$(bash "$CEO_CLI" playbook scan 2>&1 || true)
+  assert_contains "$output" "p-typo" "scan must mention the offending playbook"
+  assert_contains "$output" "scrpt" "scan must echo the rejected value"
+  local registry_has
+  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-typo")] | length' "$CEO_DIR/registry.json" 2>/dev/null)
+  assert_eq "$registry_has" "0" "rejected playbook must not land in the registry"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_status_missing_defaults_to_inactive() {
+  # status: "" / absent — current behavior is "not active". Preserve that.
+  cat > "$CEO_DIR/playbooks/p-empty.md" << 'PB'
+---
+name: p-empty
+description: no status field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_not_contains "$crontab" "ceo:p-empty" "missing status must not install cron line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_dry_run_does_not_modify_crontab() {
+  : > "$HOME/.fake-crontab"
+  _write_playbook "p-dry" "active"
+  bash "$CEO_CLI" playbook scan --dry-run >/dev/null 2>&1
+  local crontab
+  crontab=$(cat "$HOME/.fake-crontab")
+  assert_eq "$crontab" "" "scan --dry-run must not write to the crontab"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_dry_run_does_not_write_registry() {
+  _write_playbook "p-dry-reg" "active"
+  [ -f "$CEO_DIR/registry.json" ] && rm -f "$CEO_DIR/registry.json"
+  bash "$CEO_CLI" playbook scan --dry-run >/dev/null 2>&1
+  local exists="missing"
+  [ -f "$CEO_DIR/registry.json" ] && exists="present"
+  assert_eq "$exists" "missing" "scan --dry-run must not create registry.json"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_dry_run_prints_would_install_block() {
+  _write_playbook "p-dry-print" "active"
+  local output
+  output=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1)
+  assert_contains "$output" "DRY-RUN" "dry-run output must declare itself"
+  assert_contains "$output" "ceo:p-dry-print" "dry-run output must show the would-be cron line"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_dry_run_omits_draft_and_disabled() {
+  _write_playbook "p-dry-a" "active"
+  _write_playbook "p-dry-d" "draft"
+  _write_playbook "p-dry-x" "disabled"
+  local output
+  output=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1)
+  assert_contains "$output" "ceo:p-dry-a" "dry-run must include active playbooks"
+  assert_not_contains "$output" "ceo:p-dry-d" "dry-run must omit draft playbooks from the cron block"
+  assert_not_contains "$output" "ceo:p-dry-x" "dry-run must omit disabled playbooks from the cron block"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_playbook_list_shows_draft_tag() {
+  _write_playbook "p-list-draft" "draft"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local output
+  output=$(bash "$CEO_CLI" playbook list 2>&1)
+  assert_contains "$output" "p-list-draft" "list must include draft playbooks"
+  assert_contains "$output" "draft" "list must surface the draft status"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_playbook_list_shows_disabled_tag() {
+  _write_playbook "p-list-disabled" "disabled"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local output
+  output=$(bash "$CEO_CLI" playbook list 2>&1)
+  assert_contains "$output" "p-list-disabled" "list must include disabled playbooks"
+  assert_contains "$output" "disabled" "list must surface the disabled status"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_surfaces_drafts() {
+  _write_playbook "p-doctor-draft" "draft"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local output
+  output=$(bash "$CEO_CLI" doctor 2>&1 || true)
+  assert_contains "$output" "p-doctor-draft" "doctor must surface draft playbooks"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests


### PR DESCRIPTION
Closes #90.

## Summary

Replaces the implicit binary `status: active` / anything-else with an explicit enum validated at parse time, adds a no-write preview mode for scan, and documents the playbook frontmatter schema.

### Status taxonomy

| status | runnable on-demand | scan installs cron line? | list/doctor visible |
|---|---|---|---|
| `active` | yes | yes | yes |
| `draft` | yes | **no** | yes (doctor "Drafts" section + hint to flip) |
| `disabled` | yes | **no**, and removes any previously-installed line | yes |
| anything else | — | rejected at parse with `SKIP`, no fallback | — |

`status:` validation uses `ceo_status_valid` against `CEO_VALID_STATUSES=(active draft disabled)` per [`enum-config-typo-fallback`](https://github.com/nhangen/claude-ceo/blob/main/.claude/rules/enum-config-typo-fallback.md). Empty/missing remains "not active" for back-compat (same as before).

### `ceo playbook scan --dry-run`

Walks the same parse path, prints the would-be `# CEO Agent START`…`END` block, exits 0 without writing crontab or `registry.json`. Useful for previewing what a sibling machine would do after a `git pull`, or while iterating on a draft.

### `auto-review.md` → draft

The incident that motivated this issue: `auto-review.md` was authored as a WIP, flipped to `active` for a one-off test, never reverted. PR #62 backfilled it to the repo and every subsequent `ceo playbook scan` installed it on every machine. Flipped to `draft` here as the first beneficiary of the taxonomy.

### `docs/playbooks/SCHEMA.md`

Full frontmatter field reference, linked from README "Known Limitations." Was previously undocumented — new authors had to grep `scripts/ceo`.

## Design notes

- AC #3 says `disabled` removes a previously-installed line; `draft` "leaves existing lines alone." In the current cron-block rewrite model both are functionally excluded from install — the managed block is rewritten every scan, so the result is the same crontab state. The distinction lands in the **intent semantics** (draft = WIP, disabled = teardown) and in the LIST/DOCTOR display. The test suite captures the observable difference: `test_status_disabled_removes_previously_installed_line` flips active→disabled and verifies the line is gone.
- Dry-run shares a new `_playbook_print_cron_block` helper with `_playbook_update_crontab`. Collision detection is skipped in dry-run (it's only meaningful on the real install path).

## Test plan

- [ ] `bash scripts/ceo-playbook-status.test.sh` — all 13 tests pass
- [ ] `bash scripts/ceo-config.test.sh` — pre-existing 59 tests still pass (status validator added)
- [ ] Full suite: `for t in scripts/*.test.sh; do bash "$t"; done` — 270 tests, all pass
- [ ] `shellcheck scripts/ceo scripts/ceo-config.sh scripts/ceo-playbook-status.test.sh` — clean (only pre-existing warnings)
- [ ] Manual: `ceo playbook scan --dry-run` prints would-be block without touching crontab
- [ ] Manual: add a fixture with `status: scrpt` → `ceo playbook scan` emits `SKIP <name> (unknown status: 'scrpt', expected: active draft disabled)` and the entry is absent from `registry.json`
- [ ] Manual: `ceo doctor` with a draft playbook present shows the "Drafts" section

## Non-goals

- Per-host install filtering (`hosts: [<allowlist>]`) — separate concern worth filing.
- Migration of existing playbooks — default stays `active`.