### PR TITLE
Report detected platform in `ceo doctor`

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -107,6 +107,17 @@ cmd_doctor() {
   echo "=== CEO Doctor ==="
   echo ""
 
+  # platform
+  local _platform
+  _platform="$(ceo_detect_os)"
+  if [ "$_platform" = "unknown" ]; then
+    echo "  ! Platform: unknown — setup helpers may not work"
+    warn=$((warn + 1))
+  else
+    echo "  ✓ Platform: $_platform"
+    ok=$((ok + 1))
+  fi
+
   # config file
   local _cfg_path
   _cfg_path="$(ceo_config_path)"

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -186,4 +186,15 @@ EOF
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_doctor_reports_platform() {
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "Platform:" "doctor must report the detected platform"
+  if ! echo "$output" | grep -qE "Platform: (wsl|linux|macos|unknown)"; then
+    printf '  FAIL [%s] doctor platform line must name wsl/linux/macos/unknown\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests


### PR DESCRIPTION
Closes #93

## Description (Issue Fixed & New Behavior)

`cmd_doctor` now prints `Platform: <wsl|linux|macos|unknown>` near the top of its output, sourced from the existing `ceo_detect_os()` helper in `ceo-config.sh`. Unknown platforms render as a warning (`!`), not a pass (`✓`), so bug reports and setup-time misconfigurations surface the OS unambiguously.

First of six sub-tickets breaking down #1 (multi-platform support). The detection seam already existed; later sub-tickets (#95, #97) will branch on it.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-doctor.test.sh` — expect 7 tests, FAIL lines absent.
3. Run `bash scripts/ceo doctor` and confirm a `Platform: <value>` line appears between the `=== CEO Doctor ===` header and the config-file check, naming one of `wsl`/`linux`/`macos`/`unknown`.
4. Revert the platform block in `scripts/ceo` (lines 110–119) and re-run step 2 — `test_doctor_reports_platform` must print two FAIL lines.

## Additional Notes

Pre-existing harness behavior noticed while revert-gating: `assert_contains` increments `FAILS` inside a subshell, so the final summary line still reports "All tests passed" even when assertion FAIL lines have printed. The FAIL output itself is loud and visible — CI's per-test `bash "$t"` invocation also doesn't see the count, so the practical signal is whether FAIL lines appear. Not addressed here; out of scope for #93.