### PR TITLE
Gate `/mnt/*` discovery candidates on WSL

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -75,8 +75,8 @@ ceo_load_config() {
     fi
   fi
 
-  # Step 3: Legacy discovery loop — kept as fallback until 2026-05-26.
-  # TODO: Remove this block after 2026-05-26 once all machines have ~/.ceo/config.
+  # Step 3: Legacy discovery loop — kept as fallback while older hosts catch up to ~/.ceo/config.
+  # TODO: Re-evaluate removal once every machine has ~/.ceo/config; original 2026-05-26 target slipped.
   local _user="${USER:-$(whoami)}"
   local _candidates=()
   if [ "$(ceo_detect_os)" = "wsl" ]; then

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -78,13 +78,19 @@ ceo_load_config() {
   # Step 3: Legacy discovery loop — kept as fallback until 2026-05-26.
   # TODO: Remove this block after 2026-05-26 once all machines have ~/.ceo/config.
   local _user="${USER:-$(whoami)}"
-  local _candidate
-  for _candidate in \
-    "/mnt/z/Users/$_user/Documents/Obsidian" \
-    "/mnt/c/Users/$_user/Documents/Obsidian" \
+  local _candidates=()
+  if [ "$(ceo_detect_os)" = "wsl" ]; then
+    _candidates+=( \
+      "/mnt/z/Users/$_user/Documents/Obsidian" \
+      "/mnt/c/Users/$_user/Documents/Obsidian" \
+    )
+  fi
+  _candidates+=( \
     "$HOME/Documents/Obsidian" \
-    "$HOME/Obsidian"
-  do
+    "$HOME/Obsidian" \
+  )
+  local _candidate
+  for _candidate in "${_candidates[@]}"; do
     if [ -d "$_candidate/CEO" ]; then
       export CEO_VAULT="$_candidate"
       return 0

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -915,4 +915,37 @@ test_status_valid_rejects_empty() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_discovery_skips_mnt_candidates_on_macos() {
+  local trace rc=0
+  trace=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_detect_os() { echo macos; }
+    set -x
+    ceo_load_config || true
+  " 2>&1) || rc=$?
+  if echo "$trace" | grep -qE '/mnt/[zc]/'; then
+    printf '  FAIL [%s] discovery probed /mnt/ candidates on macos\n    trace: %q\n' \
+      "$CURRENT_TEST" "$(echo "$trace" | grep -E '/mnt/[zc]/' | head -2)"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_discovery_probes_mnt_candidates_on_wsl() {
+  local trace
+  trace=$(env -i HOME="$TEST_HOME" PATH="$PATH" bash -c "
+    set -uo pipefail
+    source '$LIB'
+    ceo_detect_os() { echo wsl; }
+    set -x
+    ceo_load_config || true
+  " 2>&1)
+  if ! echo "$trace" | grep -qE '/mnt/[zc]/.*Documents/Obsidian'; then
+    printf '  FAIL [%s] wsl discovery did not probe /mnt/ candidates\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -929,6 +929,11 @@ test_discovery_skips_mnt_candidates_on_macos() {
       "$CURRENT_TEST" "$(echo "$trace" | grep -E '/mnt/[zc]/' | head -2)"
     FAILS=$((FAILS + 1))
   fi
+  if ! echo "$trace" | grep -qF "$TEST_HOME/Documents/Obsidian"; then
+    printf '  FAIL [%s] discovery did not probe HOME candidate (loop may have been short-circuited)\n' \
+      "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #94

## Description (Issue Fixed & New Behavior)

The legacy vault discovery loop in `ceo_load_config` probed `/mnt/z` and `/mnt/c` unconditionally. Those candidates are now behind an `if ceo_detect_os = wsl` gate, so Mac/Linux runs don't waste stat calls on paths that can never exist there, and so future setup helpers can present a candidate list matching the host platform.

WSL behavior is unchanged — the same four candidates probe in the same order. Sub-ticket of #1.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-config.test.sh` — expect 64 tests, no FAIL lines.
3. Revert the `if` block in `scripts/ceo-config.sh:82-92` (restore the original 4-candidate array) and re-run step 2 — `test_discovery_skips_mnt_candidates_on_macos` must print a FAIL line naming the offending /mnt/ trace.
4. On WSL, run `ceo` against an existing vault under `/mnt/z` or `/mnt/c` and confirm `CEO_VAULT` still resolves.

## Additional Notes

Tests use a `set -x` trace + `grep -E '/mnt/[zc]/'` to assert which candidates were probed for each platform. Same pre-existing harness behavior as #99: `assert_contains`-style failures don't propagate to the final summary count, but FAIL lines print loudly when revert-gated.

Independent of #99 (different files); ships in either order.