### PR TITLE
Split `cmd_setup` dispatch and extract `setup-common.sh`

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1465,9 +1465,21 @@ cmd_creds() {
 cmd_setup() {
   if [ "${1:-}" = "discord" ]; then
     bash "$SCRIPT_DIR/ceo-setup-discord.sh"
-  else
-    bash "$SCRIPT_DIR/setup-wsl.sh"
+    return
   fi
+  local _os
+  _os="$(ceo_detect_os)"
+  case "$_os" in
+    wsl)     bash "$SCRIPT_DIR/setup-wsl.sh" ;;
+    macos)   bash "$SCRIPT_DIR/setup-mac.sh" ;;
+    linux)   bash "$SCRIPT_DIR/setup-linux.sh" ;;
+    unknown|*)
+      echo "ceo setup: unsupported or undetected platform ('$_os')." >&2
+      echo "  Supported: wsl, macos, linux." >&2
+      echo "  Re-run on a supported host, or hand-write ~/.ceo/config (see docs)." >&2
+      exit 1
+      ;;
+  esac
 }
 
 cmd_pr_sources() {

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -7,6 +7,11 @@
 #   - SCRIPT_DIR resolved (the dirname of the calling installer)
 #   - MISSING_CONFIG array declared (callers populate this; final exit check reads it)
 
+declare -p MISSING_CONFIG &>/dev/null || {
+  echo "setup-common.sh: caller must declare MISSING_CONFIG=() before sourcing." >&2
+  exit 1
+}
+
 ceo_setup_ssh_key() {
   local host_label="$1"
   local ssh_key="$HOME/.ssh/github_ceo"

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -106,6 +106,9 @@ ceo_setup_repos_dir() {
   done
   if [ "$INSTALL_DIR" = "/" ]; then
     INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
+    echo "  WARNING: could not locate .claude-plugin/ above $SCRIPT_DIR — falling back to $INSTALL_DIR" >&2
+    echo "  'ceo doctor' may not find plugin assets if this is wrong." >&2
+    MISSING_CONFIG+=("plugin INSTALL_DIR")
   fi
   REPOS_DIR="$(dirname "$INSTALL_DIR")/repos"
   echo "[7/10] Creating repo directory at $REPOS_DIR..."

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# setup-common.sh — Shared steps for ceo setup across WSL/Mac/Linux installers.
+# Sourced, not executed. Functions preserve the WSL-baseline output strings
+# verbatim so `diff` against captured baselines shows only date drift.
+#
+# Required from caller (sourced before any function is called):
+#   - SCRIPT_DIR resolved (the dirname of the calling installer)
+#   - MISSING_CONFIG array declared (callers populate this; final exit check reads it)
+
+ceo_setup_ssh_key() {
+  local host_label="$1"
+  local ssh_key="$HOME/.ssh/github_ceo"
+  if [ -f "$ssh_key" ]; then
+    echo "[3/10] SSH key already exists at $ssh_key"
+  else
+    echo "[3/10] Generating SSH key..."
+    mkdir -p "$HOME/.ssh"
+    ssh-keygen -t ed25519 -f "$ssh_key" -N "" -C "ceo-agent@$host_label"
+
+    echo ""
+    echo "  Add this public key to GitHub → Settings → SSH Keys:"
+    echo ""
+    cat "${ssh_key}.pub"
+    echo ""
+    read -p "  Press Enter after adding the key to GitHub..."
+  fi
+
+  if grep -q "github_ceo" "$HOME/.ssh/config" 2>/dev/null; then
+    echo "  SSH config already references github_ceo"
+  elif grep -q "^Host github.com" "$HOME/.ssh/config" 2>/dev/null; then
+    sed -i.bak '/^Host github.com/a\
+  IdentityFile ~/.ssh/github_ceo' "$HOME/.ssh/config"
+    rm -f "$HOME/.ssh/config.bak"
+    echo "  Added github_ceo key to existing Host github.com block"
+  else
+    cat >> "$HOME/.ssh/config" << 'SSHEOF'
+
+Host github.com
+  IdentityFile ~/.ssh/github_ceo
+  IdentityFile ~/.ssh/id_ed25519
+SSHEOF
+    chmod 600 "$HOME/.ssh/config"
+    echo "  SSH config updated"
+  fi
+}
+
+ceo_setup_git_config() {
+  echo "[4/10] Configuring git..."
+  local existing_name existing_email
+  existing_name="$(git config --global --get user.name 2>/dev/null || true)"
+  if [ -n "$existing_name" ]; then
+    echo "  user.name preserved: $existing_name"
+  elif [ -n "${CEO_GIT_USER_NAME:-}" ]; then
+    git config --global user.name "$CEO_GIT_USER_NAME"
+    echo "  user.name set from CEO_GIT_USER_NAME: $CEO_GIT_USER_NAME"
+  else
+    echo "  WARNING: git user.name not set. Set CEO_GIT_USER_NAME or run:" >&2
+    echo "    git config --global user.name \"Your Name\"" >&2
+    MISSING_CONFIG+=("git user.name")
+  fi
+  existing_email="$(git config --global --get user.email 2>/dev/null || true)"
+  if [ -n "$existing_email" ]; then
+    echo "  user.email preserved: $existing_email"
+  elif [ -n "${CEO_GIT_USER_EMAIL:-}" ]; then
+    git config --global user.email "$CEO_GIT_USER_EMAIL"
+    echo "  user.email set from CEO_GIT_USER_EMAIL: $CEO_GIT_USER_EMAIL"
+  else
+    echo "  WARNING: git user.email not set. Set CEO_GIT_USER_EMAIL or run:" >&2
+    echo "    git config --global user.email <you@example.com>" >&2
+    MISSING_CONFIG+=("git user.email")
+  fi
+}
+
+ceo_setup_check_syncthing() {
+  if command -v syncthing &>/dev/null; then
+    echo "[5/10] Syncthing found"
+  else
+    echo "[5/10] WARNING: Syncthing not found."
+    echo "  Install Syncthing on all machines before proceeding."
+    echo "  See README.md and syncthing/README.md for setup instructions."
+  fi
+}
+
+ceo_setup_check_yq() {
+  local install_hint="${1:-sudo snap install yq  (or: brew install yq on Mac)}"
+  if command -v yq &>/dev/null; then
+    echo "[6/10] yq found ($(yq --version 2>/dev/null || echo 'unknown'))"
+  else
+    echo "[6/10] WARNING: yq not found."
+    echo "  Install: $install_hint"
+  fi
+}
+
+# Resolves INSTALL_DIR (the plugin clone root) by walking up from $SCRIPT_DIR
+# to find .claude-plugin/. Exports INSTALL_DIR and REPOS_DIR for later steps.
+ceo_setup_repos_dir() {
+  INSTALL_DIR="$SCRIPT_DIR"
+  while [ "$INSTALL_DIR" != "/" ]; do
+    [ -d "$INSTALL_DIR/.claude-plugin" ] && break
+    INSTALL_DIR="$(dirname "$INSTALL_DIR")"
+  done
+  if [ "$INSTALL_DIR" = "/" ]; then
+    INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
+  fi
+  REPOS_DIR="$(dirname "$INSTALL_DIR")/repos"
+  echo "[7/10] Creating repo directory at $REPOS_DIR..."
+  mkdir -p "$REPOS_DIR"
+  export INSTALL_DIR REPOS_DIR
+}
+
+ceo_setup_check_claude() {
+  if command -v claude &>/dev/null; then
+    echo "[8/10] Claude Code already installed ($(claude --version 2>/dev/null || echo 'unknown version'))"
+  else
+    echo "[8/10] Claude Code not found."
+    echo "  Install it manually: https://claude.ai/download"
+    echo "  After installing, run: claude login"
+  fi
+}
+
+# Vault detection + write ~/.ceo/config. Exports VAULT and CEO_OS for later
+# steps (next-steps banner). Candidate list mirrors ceo_load_config's
+# Step 3 — gated so /mnt/* only suggested on WSL.
+ceo_setup_vault() {
+  echo ""
+  echo "[9/10] Vault configuration"
+  CEO_OS="$(ceo_detect_os)"
+
+  local _detected_vault=""
+  local _user="${USER:-$(whoami)}"
+  local _candidates=()
+  if [ "$CEO_OS" = "wsl" ]; then
+    _candidates+=( \
+      "/mnt/z/Users/$_user/Documents/Obsidian" \
+      "/mnt/c/Users/$_user/Documents/Obsidian" \
+    )
+  fi
+  _candidates+=( \
+    "$HOME/Documents/Obsidian" \
+    "$HOME/Obsidian" \
+  )
+  local _c
+  for _c in "${_candidates[@]}"; do
+    if [ -d "$_c/CEO" ]; then
+      _detected_vault="$_c"
+      break
+    fi
+  done
+
+  local _example_path
+  if [ "$CEO_OS" = "wsl" ]; then
+    _example_path="/mnt/z/Users/$_user/Documents/Obsidian"
+  else
+    _example_path="$HOME/Documents/Obsidian"
+  fi
+
+  if [ -n "$_detected_vault" ]; then
+    echo "  Detected vault: $_detected_vault"
+    local _input_vault
+    read -rp "  Vault path [press Enter to accept, or type a different path]: " _input_vault
+    VAULT="${_input_vault:-$_detected_vault}"
+  else
+    echo "  No vault auto-detected. Enter the full path to your Obsidian vault."
+    read -rp "  Vault path (e.g. $_example_path): " VAULT
+  fi
+
+  if [ -f "$VAULT/CEO/inbox.md" ]; then
+    echo "  Vault OK — CEO/inbox.md found at $VAULT/CEO/"
+  else
+    echo "  WARNING: CEO/inbox.md not found at $VAULT/CEO/"
+    echo "  Make sure Syncthing is running and the vault has fully synced."
+    echo "  You can re-run 'ceo setup' after syncing to update the config."
+  fi
+
+  mkdir -p "$HOME/.ceo"
+  cat > "$HOME/.ceo/config" << CEOCONF
+# CEO agent configuration — written by ceo setup on $(date)
+# Edit this file to change the vault path or OS hint.
+CEO_VAULT="$VAULT"
+CEO_OS="$CEO_OS"
+CEOCONF
+  echo "  Config written: $HOME/.ceo/config"
+
+  export VAULT CEO_OS
+}
+
+ceo_setup_pr_sources() {
+  echo ""
+  echo "[9b] PR sources configuration"
+  echo "  Selects which gh/glab accounts the morning brief queries for PR counts."
+  ceo_pr_sources_setup || echo "  (skipped — re-run later with: ceo pr-sources)"
+}
+
+ceo_setup_cron() {
+  local ceo_cli="$SCRIPT_DIR/ceo"
+  if [ -f "$ceo_cli" ] && command -v yq &>/dev/null; then
+    echo ""
+    echo "[10/10] Cron Setup"
+    local install_cron
+    read -p "  Scan playbooks and install cron entries? (y/n) " install_cron
+    if [ "$install_cron" = "y" ]; then
+      bash "$ceo_cli" playbook scan
+    else
+      echo "  Skipped. Run 'ceo playbook scan' later to install cron entries."
+    fi
+  else
+    echo ""
+    echo "[10/10] Skipping cron setup (ceo CLI or yq not available)."
+    echo "  Run 'ceo playbook scan' after installing yq."
+  fi
+}
+
+ceo_setup_path_symlink() {
+  local ceo_cli="$SCRIPT_DIR/ceo"
+  if [ ! -f "$ceo_cli" ]; then
+    return 0
+  fi
+  if command -v ceo &>/dev/null && [ "$(command -v ceo)" = "$ceo_cli" ]; then
+    echo ""
+    echo "[11] ceo CLI already on PATH"
+  elif command -v ceo &>/dev/null; then
+    echo ""
+    echo "[11] WARNING: 'ceo' already exists on PATH at $(command -v ceo)"
+    echo "  Skipping — add an alias manually if needed:"
+    echo "  echo 'alias ceo=\"$ceo_cli\"' >> ~/.bashrc"
+  else
+    echo ""
+    echo "[11] Add 'ceo' command to PATH?"
+    echo "  This creates a symlink in ~/.local/bin/ so you can run 'ceo' from anywhere."
+    local add_path
+    read -p "  Add to PATH? (y/n) " add_path
+    if [ "$add_path" = "y" ]; then
+      mkdir -p "$HOME/.local/bin"
+      ln -sf "$ceo_cli" "$HOME/.local/bin/ceo"
+      echo "  Symlinked: ~/.local/bin/ceo → $ceo_cli"
+      if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+        echo "  NOTE: ~/.local/bin is not in your PATH yet."
+        echo "  Add this to your ~/.bashrc or ~/.zshrc:"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
+    fi
+  fi
+}
+
+ceo_setup_write_next_steps() {
+  local next_steps="$INSTALL_DIR/next-steps.txt"
+  local yq_hint="${1:-sudo snap install yq  (or: brew install yq)}"
+  {
+    echo "=== CEO Agent — Next Steps ==="
+    echo ""
+    echo "Setup finished $(date). Pick up here after claude login."
+    echo ""
+    echo "  1. Verify Syncthing is syncing the vault"
+    echo "  2. Install yq if missing:  $yq_hint"
+    echo "  3. Run: claude login  (if not already authenticated)"
+    echo "  4. Run: claude plugin add nhangen/claude-ceo"
+    echo "  5. Run: ceo doctor  (verify everything is configured)"
+    echo "  6. Run: ceo pr-sources  (pick which gh/glab accounts to query, if you skipped it)"
+    echo "  7. Run: ceo playbook scan  (register playbooks + install cron)"
+    echo "  8. Test interactive:  cd $VAULT && claude"
+    echo "     Then type:  /ceo"
+    echo "  9. Test cron:  ceo test"
+    echo ""
+    echo "Redisplay:  ceo next"
+  } > "$next_steps"
+
+  echo ""
+  echo "=== Setup Complete ==="
+  echo ""
+  cat "$next_steps"
+  echo ""
+  echo "NOTE: 'claude login' will clear your terminal."
+  echo "To redisplay:  ceo next"
+  echo "To verify:     ceo doctor"
+}
+
+ceo_setup_exit_if_missing() {
+  if [ "${#MISSING_CONFIG[@]}" -gt 0 ]; then
+    echo "" >&2
+    echo "=== MISSING REQUIRED CONFIG ===" >&2
+    local _missing
+    for _missing in "${MISSING_CONFIG[@]}"; do
+      echo "  - $_missing" >&2
+    done
+    echo "" >&2
+    echo "Set the values above and re-run 'ceo doctor' before any CEO commits." >&2
+    exit 1
+  fi
+}

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-linux.sh — Provision a Linux box (non-WSL) as the CEO agent's execution environment.
+# Run this once, interactively, on the Linux machine.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+# shellcheck source=setup-common.sh
+source "$SCRIPT_DIR/setup-common.sh"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
+
+echo "=== CEO Agent — Linux Setup ==="
+echo ""
+
+# 1. System packages — manual install at this stage (#96 will add apt/dnf driver)
+echo "[1/10] Required CLIs (install manually for now):"
+echo "  Debian/Ubuntu:  sudo apt install git gh jq"
+echo "  Fedora/RHEL:    sudo dnf install git gh jq"
+echo "  yq:             see https://github.com/mikefarah/yq/releases"
+echo ""
+_missing_tools=()
+for _tool in git gh jq; do
+  command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
+done
+if [ "${#_missing_tools[@]}" -gt 0 ]; then
+  echo "  Missing: ${_missing_tools[*]}"
+  echo "  Install the above and re-run 'ceo setup'."
+  exit 1
+fi
+echo "  All required CLIs present."
+
+# 2. gh authentication
+if gh auth status &>/dev/null; then
+  echo "[2/10] gh already authenticated"
+else
+  echo "[2/10] Authenticating gh CLI..."
+  gh auth login
+fi
+
+ceo_setup_ssh_key "linux"
+ceo_setup_git_config
+ceo_setup_check_syncthing
+ceo_setup_check_yq "sudo apt install yq  (or download from https://github.com/mikefarah/yq/releases)"
+ceo_setup_repos_dir
+ceo_setup_check_claude
+ceo_setup_vault
+ceo_setup_pr_sources
+ceo_setup_cron
+ceo_setup_path_symlink
+ceo_setup_write_next_steps "sudo apt install yq  (or download from https://github.com/mikefarah/yq/releases)"
+ceo_setup_exit_if_missing

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-mac.sh — Provision a Mac as the CEO agent's execution environment.
+# Run this once, interactively, on the Mac.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+# shellcheck source=setup-common.sh
+source "$SCRIPT_DIR/setup-common.sh"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
+
+echo "=== CEO Agent — Mac Setup ==="
+echo ""
+
+# 1. System packages — manual install at this stage (#96 will add brew driver)
+echo "[1/10] Required CLIs (install manually for now):"
+echo "  brew install git gh jq yq"
+echo ""
+_missing_tools=()
+for _tool in git gh jq; do
+  command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
+done
+if [ "${#_missing_tools[@]}" -gt 0 ]; then
+  echo "  Missing: ${_missing_tools[*]}"
+  echo "  Install the above with brew and re-run 'ceo setup'."
+  exit 1
+fi
+echo "  All required CLIs present."
+
+# 2. gh authentication
+if gh auth status &>/dev/null; then
+  echo "[2/10] gh already authenticated"
+else
+  echo "[2/10] Authenticating gh CLI..."
+  gh auth login
+fi
+
+ceo_setup_ssh_key "mac"
+ceo_setup_git_config
+ceo_setup_check_syncthing
+ceo_setup_check_yq "brew install yq"
+ceo_setup_repos_dir
+ceo_setup_check_claude
+ceo_setup_vault
+ceo_setup_pr_sources
+ceo_setup_cron
+ceo_setup_path_symlink
+ceo_setup_write_next_steps "brew install yq"
+ceo_setup_exit_if_missing

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 # setup-wsl.sh — Provision a WSL box as the CEO agent's execution environment.
 # Run this once, interactively, on the WSL machine.
 
-# Source config library for ceo_detect_os
-SCRIPT_DIR_EARLY="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=ceo-config.sh
-source "$SCRIPT_DIR_EARLY/ceo-config.sh"
+source "$SCRIPT_DIR/ceo-config.sh"
+# shellcheck source=setup-common.sh
+source "$SCRIPT_DIR/setup-common.sh"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
 
 echo "=== CEO Agent — WSL Setup ==="
 echo ""
@@ -27,7 +31,6 @@ else
   sudo apt update -qq && sudo apt install -y -qq gh
 fi
 
-# Authenticate gh
 if gh auth status &>/dev/null; then
   echo "  gh already authenticated"
 else
@@ -35,253 +38,15 @@ else
   gh auth login
 fi
 
-# 3. SSH key for GitHub
-SSH_KEY="$HOME/.ssh/github_ceo"
-if [ -f "$SSH_KEY" ]; then
-  echo "[3/10] SSH key already exists at $SSH_KEY"
-else
-  echo "[3/10] Generating SSH key..."
-  mkdir -p "$HOME/.ssh"
-  ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -C "ceo-agent@wsl"
-
-  echo ""
-  echo "  Add this public key to GitHub → Settings → SSH Keys:"
-  echo ""
-  cat "${SSH_KEY}.pub"
-  echo ""
-  read -p "  Press Enter after adding the key to GitHub..."
-fi
-
-# Configure SSH to use this key
-if grep -q "github_ceo" "$HOME/.ssh/config" 2>/dev/null; then
-  echo "  SSH config already references github_ceo"
-elif grep -q "^Host github.com" "$HOME/.ssh/config" 2>/dev/null; then
-  # Existing Host block — inject the CEO key as an additional IdentityFile
-  sed -i '/^Host github.com/a\  IdentityFile ~/.ssh/github_ceo' "$HOME/.ssh/config"
-  echo "  Added github_ceo key to existing Host github.com block"
-else
-  cat >> "$HOME/.ssh/config" << 'SSHEOF'
-
-Host github.com
-  IdentityFile ~/.ssh/github_ceo
-  IdentityFile ~/.ssh/id_ed25519
-SSHEOF
-  chmod 600 "$HOME/.ssh/config"
-  echo "  SSH config updated"
-fi
-
-# 4. Git config
-# Set CEO_GIT_USER_NAME / CEO_GIT_USER_EMAIL in the environment to override,
-# or pre-configure git globally before running this script — existing values
-# are preserved (and echoed so a stale identity from a recycled box is visible).
-echo "[4/10] Configuring git..."
-MISSING_CONFIG=()
-EXISTING_NAME="$(git config --global --get user.name 2>/dev/null || true)"
-if [ -n "$EXISTING_NAME" ]; then
-  echo "  user.name preserved: $EXISTING_NAME"
-elif [ -n "${CEO_GIT_USER_NAME:-}" ]; then
-  git config --global user.name "$CEO_GIT_USER_NAME"
-  echo "  user.name set from CEO_GIT_USER_NAME: $CEO_GIT_USER_NAME"
-else
-  echo "  WARNING: git user.name not set. Set CEO_GIT_USER_NAME or run:" >&2
-  echo "    git config --global user.name \"Your Name\"" >&2
-  MISSING_CONFIG+=("git user.name")
-fi
-EXISTING_EMAIL="$(git config --global --get user.email 2>/dev/null || true)"
-if [ -n "$EXISTING_EMAIL" ]; then
-  echo "  user.email preserved: $EXISTING_EMAIL"
-elif [ -n "${CEO_GIT_USER_EMAIL:-}" ]; then
-  git config --global user.email "$CEO_GIT_USER_EMAIL"
-  echo "  user.email set from CEO_GIT_USER_EMAIL: $CEO_GIT_USER_EMAIL"
-else
-  echo "  WARNING: git user.email not set. Set CEO_GIT_USER_EMAIL or run:" >&2
-  echo "    git config --global user.email <you@example.com>" >&2
-  MISSING_CONFIG+=("git user.email")
-fi
-
-# 5. Syncthing
-# Syncthing — must be installed and configured separately (see README.md)
-if command -v syncthing &>/dev/null; then
-  echo "[5/10] Syncthing found"
-else
-  echo "[5/10] WARNING: Syncthing not found."
-  echo "  Install Syncthing on all machines before proceeding."
-  echo "  See README.md and syncthing/README.md for setup instructions."
-fi
-
-# 6. yq (YAML parser for playbook frontmatter)
-if command -v yq &>/dev/null; then
-  echo "[6/10] yq found ($(yq --version 2>/dev/null || echo 'unknown'))"
-else
-  echo "[6/10] WARNING: yq not found."
-  echo "  Install: sudo snap install yq  (or: brew install yq on Mac)"
-fi
-
-# Derive install root from script location (works regardless of clone path)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# Find repo root by walking up from scripts/ to find .claude-plugin/
-INSTALL_DIR="$SCRIPT_DIR"
-while [ "$INSTALL_DIR" != "/" ]; do
-  [ -d "$INSTALL_DIR/.claude-plugin" ] && break
-  INSTALL_DIR="$(dirname "$INSTALL_DIR")"
-done
-if [ "$INSTALL_DIR" = "/" ]; then
-  INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
-fi
-
-# 7. Repo directory (sibling of the plugin clone)
-REPOS_DIR="$(dirname "$INSTALL_DIR")/repos"
-echo "[7/10] Creating repo directory at $REPOS_DIR..."
-mkdir -p "$REPOS_DIR"
-
-# 8. Claude Code
-if command -v claude &>/dev/null; then
-  echo "[8/10] Claude Code already installed ($(claude --version 2>/dev/null || echo 'unknown version'))"
-else
-  echo "[8/10] Claude Code not found."
-  echo "  Install it manually: https://claude.ai/download"
-  echo "  After installing, run: claude login"
-fi
-
-# 9. Vault directory — ask user, validate, write ~/.ceo/config
-echo ""
-echo "[9/10] Vault configuration"
-CEO_OS="$(ceo_detect_os)"
-
-# Suggest detected location, let user override
-_detected_vault=""
-_user="${USER:-$(whoami)}"
-for _c in \
-  "/mnt/z/Users/$_user/Documents/Obsidian" \
-  "/mnt/c/Users/$_user/Documents/Obsidian" \
-  "$HOME/Documents/Obsidian" \
-  "$HOME/Obsidian"
-do
-  if [ -d "$_c/CEO" ]; then
-    _detected_vault="$_c"
-    break
-  fi
-done
-
-if [ -n "$_detected_vault" ]; then
-  echo "  Detected vault: $_detected_vault"
-  read -rp "  Vault path [press Enter to accept, or type a different path]: " _input_vault
-  VAULT="${_input_vault:-$_detected_vault}"
-else
-  echo "  No vault auto-detected. Enter the full path to your Obsidian vault."
-  read -rp "  Vault path (e.g. /mnt/z/Users/$_user/Documents/Obsidian): " VAULT
-fi
-
-# Validate
-if [ -f "$VAULT/CEO/inbox.md" ]; then
-  echo "  Vault OK — CEO/inbox.md found at $VAULT/CEO/"
-else
-  echo "  WARNING: CEO/inbox.md not found at $VAULT/CEO/"
-  echo "  Make sure Syncthing is running and the vault has fully synced."
-  echo "  You can re-run 'ceo setup' after syncing to update the config."
-fi
-
-# Write ~/.ceo/config
-mkdir -p "$HOME/.ceo"
-cat > "$HOME/.ceo/config" << CEOCONF
-# CEO agent configuration — written by ceo setup on $(date)
-# Edit this file to change the vault path or OS hint.
-CEO_VAULT="$VAULT"
-CEO_OS="$CEO_OS"
-CEOCONF
-echo "  Config written: $HOME/.ceo/config"
-
-# 9b. PR sources (GitHub accounts + GitLab usernames)
-echo ""
-echo "[9b] PR sources configuration"
-echo "  Selects which gh/glab accounts the morning brief queries for PR counts."
-ceo_pr_sources_setup || echo "  (skipped — re-run later with: ceo pr-sources)"
-
-# 10. Install cron via playbook scan
-CEO_CLI="$SCRIPT_DIR/ceo"
-if [ -f "$CEO_CLI" ] && command -v yq &>/dev/null; then
-  echo ""
-  echo "[10/10] Cron Setup"
-  read -p "  Scan playbooks and install cron entries? (y/n) " INSTALL_CRON
-  if [ "$INSTALL_CRON" = "y" ]; then
-    bash "$CEO_CLI" playbook scan
-  else
-    echo "  Skipped. Run 'ceo playbook scan' later to install cron entries."
-  fi
-else
-  echo ""
-  echo "[10/10] Skipping cron setup (ceo CLI or yq not available)."
-  echo "  Run 'ceo playbook scan' after installing yq."
-fi
-
-# 11. Add ceo CLI to PATH
-CEO_CLI="$SCRIPT_DIR/ceo"
-if [ -f "$CEO_CLI" ]; then
-  # Check if already on PATH
-  if command -v ceo &>/dev/null && [ "$(command -v ceo)" = "$CEO_CLI" ]; then
-    echo ""
-    echo "[11] ceo CLI already on PATH"
-  elif command -v ceo &>/dev/null; then
-    echo ""
-    echo "[11] WARNING: 'ceo' already exists on PATH at $(command -v ceo)"
-    echo "  Skipping — add an alias manually if needed:"
-    echo "  echo 'alias ceo=\"$CEO_CLI\"' >> ~/.bashrc"
-  else
-    echo ""
-    echo "[11] Add 'ceo' command to PATH?"
-    echo "  This creates a symlink in ~/.local/bin/ so you can run 'ceo' from anywhere."
-    read -p "  Add to PATH? (y/n) " ADD_PATH
-    if [ "$ADD_PATH" = "y" ]; then
-      mkdir -p "$HOME/.local/bin"
-      ln -sf "$CEO_CLI" "$HOME/.local/bin/ceo"
-      echo "  Symlinked: ~/.local/bin/ceo → $CEO_CLI"
-      if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-        echo "  NOTE: ~/.local/bin is not in your PATH yet."
-        echo "  Add this to your ~/.bashrc or ~/.zshrc:"
-        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
-      fi
-    fi
-  fi
-fi
-
-# Write next steps to a file (claude login clears terminal history)
-NEXT_STEPS="$INSTALL_DIR/next-steps.txt"
-{
-  echo "=== CEO Agent — Next Steps ==="
-  echo ""
-  echo "Setup finished $(date). Pick up here after claude login."
-  echo ""
-  echo "  1. Verify Syncthing is syncing the vault"
-  echo "  2. Install yq if missing:  sudo snap install yq  (or: brew install yq)"
-  echo "  3. Run: claude login  (if not already authenticated)"
-  echo "  4. Run: claude plugin add nhangen/claude-ceo"
-  echo "  5. Run: ceo doctor  (verify everything is configured)"
-  echo "  6. Run: ceo pr-sources  (pick which gh/glab accounts to query, if you skipped it)"
-  echo "  7. Run: ceo playbook scan  (register playbooks + install cron)"
-  echo "  8. Test interactive:  cd $VAULT && claude"
-  echo "     Then type:  /ceo"
-  echo "  9. Test cron:  ceo test"
-  echo ""
-  echo "Redisplay:  ceo next"
-} > "$NEXT_STEPS"
-
-echo ""
-echo "=== Setup Complete ==="
-echo ""
-cat "$NEXT_STEPS"
-echo ""
-echo "NOTE: 'claude login' will clear your terminal."
-echo "To redisplay:  ceo next"
-echo "To verify:     ceo doctor"
-
-if [ "${#MISSING_CONFIG[@]}" -gt 0 ]; then
-  echo "" >&2
-  echo "=== MISSING REQUIRED CONFIG ===" >&2
-  for _missing in "${MISSING_CONFIG[@]}"; do
-    echo "  - $_missing" >&2
-  done
-  echo "" >&2
-  echo "Set the values above and re-run 'ceo doctor' before any CEO commits." >&2
-  exit 1
-fi
+ceo_setup_ssh_key "wsl"
+ceo_setup_git_config
+ceo_setup_check_syncthing
+ceo_setup_check_yq "sudo snap install yq  (or: brew install yq on Mac)"
+ceo_setup_repos_dir
+ceo_setup_check_claude
+ceo_setup_vault
+ceo_setup_pr_sources
+ceo_setup_cron
+ceo_setup_path_symlink
+ceo_setup_write_next_steps "sudo snap install yq  (or: brew install yq)"
+ceo_setup_exit_if_missing


### PR DESCRIPTION
Closes #95

## Description (Issue Fixed & New Behavior)

`cmd_setup` now dispatches by `ceo_detect_os()` to one of `setup-wsl.sh`, `setup-mac.sh`, or `setup-linux.sh`; `unknown` exits 1 with guidance. Shared post-package-install steps live in a new `scripts/setup-common.sh` sourced by all three installers:

- `ceo_setup_ssh_key <host_label>` — SSH key gen + ssh config
- `ceo_setup_git_config` — git config check, populates `MISSING_CONFIG` array
- `ceo_setup_check_syncthing` / `ceo_setup_check_yq` — presence checks (yq install hint per-platform)
- `ceo_setup_repos_dir` — resolve plugin clone root, create `../repos`
- `ceo_setup_check_claude`
- `ceo_setup_vault` — vault detection + write `~/.ceo/config` (candidates gate on `ceo_detect_os = wsl` mirroring #94)
- `ceo_setup_pr_sources` / `ceo_setup_cron` / `ceo_setup_path_symlink`
- `ceo_setup_write_next_steps <yq_hint>`
- `ceo_setup_exit_if_missing` — final exit-1 gate on `MISSING_CONFIG`

Each installer keeps only its platform-specific `[1]`/`[2]` (package install + gh auth) and platform-specific install-hint strings. WSL stdout is preserved byte-for-byte — every `echo`/`read`/`cat` string from the original `setup-wsl.sh` is reproduced verbatim in `setup-common.sh`, with variable renames (UPPER → lower for locals inside functions) that expand identically at runtime.

`setup-mac.sh` and `setup-linux.sh` print a manual-install list at `[1/10]` and exit 1 if required CLIs (git/gh/jq) are missing — the actual brew/apt/dnf drivers will land in #96. ssh-keygen host comment is `"wsl"`/`"mac"`/`"linux"` per installer for now; #96 will switch all three to `ceo-agent@$(hostname)`.

Sub-ticket of #1.

## Testing Procedure

1. Check out this branch.
2. Run `for t in scripts/*.test.sh; do bash "$t"; done` — expect 14 files green.
3. Run `shellcheck --severity=warning scripts/setup-*.sh scripts/ceo` — expect no output.
4. On Mac: `bash scripts/ceo setup` → prints `=== CEO Agent — Mac Setup ===` banner and `[1/10] Required CLIs (install manually for now): ...`. With git/gh/jq installed and `gh auth status` green, proceeds to `[3/10] Generating SSH key...`. Abort there for non-real-installs.
5. On WSL: capture a baseline `bash scripts/setup-wsl.sh > /tmp/wsl-new.log 2>&1` (interactive — Enter through prompts) against `git show origin/main^^^:scripts/setup-wsl.sh` output. `diff` should show only date drift (next-steps banner uses `$(date)`).
6. Dispatch on `unknown` platform exits 1: temporarily `ceo_detect_os() { echo unknown; }` in a wrapper and call `cmd_setup` — exits with "ceo setup: unsupported or undetected platform ('unknown')".

## Additional Notes

`MISSING_CONFIG=()` declarations in each installer carry a `# shellcheck disable=SC2034` because `ceo_setup_git_config`/`ceo_setup_exit_if_missing` read it from the sourced library and shellcheck can't follow the source.

`sed -i.bak` (then `rm -f config.bak`) replaces `sed -i` in the SSH-config update path — portable across BSD/GNU sed, byte-identical stdout to the original (the .bak file is intermediate, no announcement).

Depends on #93 (platform line) and #94 (discovery gate) — both merged. Foundation for #96 (Mac/Linux install drivers), #97 (scheduler abstraction).