### PR TITLE
Add brew/apt/dnf package install drivers + --dry-run flag

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1470,9 +1470,9 @@ cmd_setup() {
   local _os
   _os="$(ceo_detect_os)"
   case "$_os" in
-    wsl)     bash "$SCRIPT_DIR/setup-wsl.sh" ;;
-    macos)   bash "$SCRIPT_DIR/setup-mac.sh" ;;
-    linux)   bash "$SCRIPT_DIR/setup-linux.sh" ;;
+    wsl)     bash "$SCRIPT_DIR/setup-wsl.sh" "$@" ;;
+    macos)   bash "$SCRIPT_DIR/setup-mac.sh" "$@" ;;
+    linux)   bash "$SCRIPT_DIR/setup-linux.sh" "$@" ;;
     unknown|*)
       echo "ceo setup: unsupported or undetected platform ('$_os')." >&2
       echo "  Supported: wsl, macos, linux." >&2

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -12,6 +12,17 @@ declare -p MISSING_CONFIG &>/dev/null || {
   exit 1
 }
 
+# Echo the command (with a [dry-run] prefix) when CEO_SETUP_DRY_RUN=1; otherwise execute it.
+# Callers pass `argv...` with no shell quoting tricks — this is for package-install drivers,
+# not arbitrary shell pipelines.
+ceo_setup_print_or_run() {
+  if [ "${CEO_SETUP_DRY_RUN:-0}" = "1" ]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
 ceo_setup_ssh_key() {
   local host_label="$1"
   local ssh_key="$HOME/.ssh/github_ceo"

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -25,6 +25,7 @@ ceo_setup_print_or_run() {
 
 ceo_setup_ssh_key() {
   local host_label="$1"
+  [ -n "$host_label" ] || host_label="host"
   local ssh_key="$HOME/.ssh/github_ceo"
   if [ -f "$ssh_key" ]; then
     echo "[3/10] SSH key already exists at $ssh_key"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # setup-linux.sh — Provision a Linux box (non-WSL) as the CEO agent's execution environment.
 # Run this once, interactively, on the Linux machine.
+#
+# Flags:
+#   --dry-run   Print package-install commands instead of executing them.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -14,25 +17,42 @@ source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
 
+CEO_SETUP_DRY_RUN=0
+for _arg in "$@"; do
+  case "$_arg" in
+    --dry-run) CEO_SETUP_DRY_RUN=1 ;;
+    *) echo "setup-linux.sh: unknown argument '$_arg'" >&2; exit 2 ;;
+  esac
+done
+export CEO_SETUP_DRY_RUN
+
 echo "=== CEO Agent — Linux Setup ==="
 echo ""
 
-# 1. System packages — manual install at this stage (#96 will add apt/dnf driver)
-echo "[1/10] Required CLIs (install manually for now):"
-echo "  Debian/Ubuntu:  sudo apt install git gh jq"
-echo "  Fedora/RHEL:    sudo dnf install git gh jq"
-echo "  yq:             see https://github.com/mikefarah/yq/releases"
-echo ""
+# 1. System packages — detect apt-get vs dnf
+if command -v apt-get &>/dev/null; then
+  _pkg_mgr="apt-get"
+  _pkg_install=(sudo apt-get install -y)
+elif command -v dnf &>/dev/null; then
+  _pkg_mgr="dnf"
+  _pkg_install=(sudo dnf install -y)
+else
+  echo "[1/10] ERROR: no supported package manager (apt-get or dnf) found." >&2
+  echo "  Install git, gh, jq, and yq manually, then re-run 'ceo setup'." >&2
+  exit 1
+fi
+echo "[1/10] Installing required CLIs via $_pkg_mgr..."
+ceo_setup_print_or_run "${_pkg_install[@]}" git gh jq yq
+
 _missing_tools=()
 for _tool in git gh jq; do
   command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
 done
-if [ "${#_missing_tools[@]}" -gt 0 ]; then
-  echo "  Missing: ${_missing_tools[*]}"
-  echo "  Install the above and re-run 'ceo setup'."
+if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
+  echo "  Missing after install: ${_missing_tools[*]}" >&2
+  echo "  Check $_pkg_mgr output above. On Ubuntu, 'gh' may require https://cli.github.com/." >&2
   exit 1
 fi
-echo "  All required CLIs present."
 
 # 2. gh authentication
 if gh auth status &>/dev/null; then
@@ -42,15 +62,15 @@ else
   gh auth login
 fi
 
-ceo_setup_ssh_key "linux"
+ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo linux)"
 ceo_setup_git_config
 ceo_setup_check_syncthing
-ceo_setup_check_yq "sudo apt install yq  (or download from https://github.com/mikefarah/yq/releases)"
+ceo_setup_check_yq "sudo $_pkg_mgr install yq"
 ceo_setup_repos_dir
 ceo_setup_check_claude
 ceo_setup_vault
 ceo_setup_pr_sources
 ceo_setup_cron
 ceo_setup_path_symlink
-ceo_setup_write_next_steps "sudo apt install yq  (or download from https://github.com/mikefarah/yq/releases)"
+ceo_setup_write_next_steps "sudo $_pkg_mgr install yq"
 ceo_setup_exit_if_missing

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -30,19 +30,25 @@ echo "=== CEO Agent — Linux Setup ==="
 echo ""
 
 # 1. System packages — detect apt-get vs dnf
+# apt's `yq` is kislyuk/yq (python wrapper), not mikefarah/yq the codebase needs;
+# Fedora's dnf ships mikefarah/yq, so it's safe there.
 if command -v apt-get &>/dev/null; then
   _pkg_mgr="apt-get"
   _pkg_install=(sudo apt-get install -y)
+  _pkg_argv=(git gh jq)
+  _yq_hint="snap install yq  (or download from https://github.com/mikefarah/yq/releases)"
 elif command -v dnf &>/dev/null; then
   _pkg_mgr="dnf"
   _pkg_install=(sudo dnf install -y)
+  _pkg_argv=(git gh jq yq)
+  _yq_hint="sudo dnf install yq"
 else
   echo "[1/10] ERROR: no supported package manager (apt-get or dnf) found." >&2
   echo "  Install git, gh, jq, and yq manually, then re-run 'ceo setup'." >&2
   exit 1
 fi
 echo "[1/10] Installing required CLIs via $_pkg_mgr..."
-ceo_setup_print_or_run "${_pkg_install[@]}" git gh jq yq
+ceo_setup_print_or_run "${_pkg_install[@]}" "${_pkg_argv[@]}"
 
 _missing_tools=()
 for _tool in git gh jq; do
@@ -65,12 +71,12 @@ fi
 ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo linux)"
 ceo_setup_git_config
 ceo_setup_check_syncthing
-ceo_setup_check_yq "sudo $_pkg_mgr install yq"
+ceo_setup_check_yq "$_yq_hint"
 ceo_setup_repos_dir
 ceo_setup_check_claude
 ceo_setup_vault
 ceo_setup_pr_sources
 ceo_setup_cron
 ceo_setup_path_symlink
-ceo_setup_write_next_steps "sudo $_pkg_mgr install yq"
+ceo_setup_write_next_steps "$_yq_hint"
 ceo_setup_exit_if_missing

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -5,13 +5,14 @@ set -euo pipefail
 # Run this once, interactively, on the Linux machine.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
+
 # shellcheck source=ceo-config.sh
 source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
-
-# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
-MISSING_CONFIG=()
 
 echo "=== CEO Agent — Linux Setup ==="
 echo ""

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # setup-mac.sh — Provision a Mac as the CEO agent's execution environment.
 # Run this once, interactively, on the Mac.
+#
+# Flags:
+#   --dry-run   Print package-install commands instead of executing them.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -14,23 +17,35 @@ source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
 
+CEO_SETUP_DRY_RUN=0
+for _arg in "$@"; do
+  case "$_arg" in
+    --dry-run) CEO_SETUP_DRY_RUN=1 ;;
+    *) echo "setup-mac.sh: unknown argument '$_arg'" >&2; exit 2 ;;
+  esac
+done
+export CEO_SETUP_DRY_RUN
+
 echo "=== CEO Agent — Mac Setup ==="
 echo ""
 
-# 1. System packages — manual install at this stage (#96 will add brew driver)
-echo "[1/10] Required CLIs (install manually for now):"
-echo "  brew install git gh jq yq"
-echo ""
+# 1. System packages via Homebrew
+if ! command -v brew &>/dev/null; then
+  echo "[1/10] ERROR: brew not found. Install Homebrew from https://brew.sh and re-run." >&2
+  exit 1
+fi
+echo "[1/10] Installing required CLIs via brew..."
+ceo_setup_print_or_run brew install git gh jq yq
+
 _missing_tools=()
 for _tool in git gh jq; do
   command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
 done
-if [ "${#_missing_tools[@]}" -gt 0 ]; then
-  echo "  Missing: ${_missing_tools[*]}"
-  echo "  Install the above with brew and re-run 'ceo setup'."
+if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
+  echo "  Missing after install: ${_missing_tools[*]}" >&2
+  echo "  Check brew output above for errors." >&2
   exit 1
 fi
-echo "  All required CLIs present."
 
 # 2. gh authentication
 if gh auth status &>/dev/null; then
@@ -40,7 +55,7 @@ else
   gh auth login
 fi
 
-ceo_setup_ssh_key "mac"
+ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo mac)"
 ceo_setup_git_config
 ceo_setup_check_syncthing
 ceo_setup_check_yq "brew install yq"

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -5,13 +5,14 @@ set -euo pipefail
 # Run this once, interactively, on the Mac.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
+
 # shellcheck source=ceo-config.sh
 source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
-
-# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
-MISSING_CONFIG=()
 
 echo "=== CEO Agent — Mac Setup ==="
 echo ""

--- a/scripts/setup-scripts.test.sh
+++ b/scripts/setup-scripts.test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Tests for setup-mac.sh that lock in the package-driver / --dry-run contract
+# (#96) and the MISSING_CONFIG ordering hotfix (#101 regression bundled into
+# PR #104). Reverting setup-mac.sh:13 or setup-common.sh:27-28 must fail at
+# least one test here.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  mkdir -p "$TEST_HOME/stubs"
+
+  for tool in brew gh git sudo curl dd tee dpkg snap apt-get apt; do
+    cat > "$TEST_HOME/stubs/$tool" << 'STUB'
+#!/bin/bash
+exit 0
+STUB
+    chmod +x "$TEST_HOME/stubs/$tool"
+  done
+
+  cat > "$TEST_HOME/stubs/hostname" << 'STUB'
+#!/bin/bash
+echo "testhost"
+STUB
+  chmod +x "$TEST_HOME/stubs/hostname"
+
+  cat > "$TEST_HOME/stubs/ssh-keygen" << STUB
+#!/bin/bash
+echo "\$@" > "$TEST_HOME/ssh-keygen-args.log"
+_key_path=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in -f) shift; _key_path="\$1" ;; esac
+  shift
+done
+if [ -n "\$_key_path" ]; then
+  echo "stub-priv" > "\$_key_path"
+  echo "ssh-ed25519 stub-pub stub-comment" > "\${_key_path}.pub"
+fi
+STUB
+  chmod +x "$TEST_HOME/stubs/ssh-keygen"
+
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+}
+
+teardown() {
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  rm -rf "$TEST_HOME"
+}
+
+test_setup_mac_source_time_guard_does_not_trip() {
+  local out
+  out=$(bash "$SCRIPT_DIR/setup-mac.sh" --dry-run </dev/null 2>&1 || true)
+  assert_contains "$out" "CEO Agent" "setup-mac.sh must reach its header echo (hotfix: MISSING_CONFIG declared before source)"
+  assert_not_contains "$out" "caller must declare MISSING_CONFIG" "setup-common.sh guard must not trip"
+}
+
+test_setup_mac_dry_run_prints_brew_install_line() {
+  local out
+  out=$(bash "$SCRIPT_DIR/setup-mac.sh" --dry-run </dev/null 2>&1 || true)
+  assert_contains "$out" "[dry-run] brew install git gh jq yq"
+}
+
+test_setup_mac_rejects_unknown_arg_with_exit_2() {
+  local rc=0
+  bash "$SCRIPT_DIR/setup-mac.sh" --bogus </dev/null >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "unknown arg must exit 2"
+}
+
+test_empty_hostname_falls_back_to_host_in_ssh_comment() {
+  cat > "$TEST_HOME/stubs/hostname" << 'STUB'
+#!/bin/bash
+exit 0
+STUB
+  bash "$SCRIPT_DIR/setup-mac.sh" --dry-run </dev/null >/dev/null 2>&1 || true
+  local args
+  args=$(cat "$TEST_HOME/ssh-keygen-args.log" 2>/dev/null || echo "")
+  assert_contains "$args" "ceo-agent@host" "empty hostname must fall back to 'host', not produce naked 'ceo-agent@'"
+}
+
+run_tests

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -37,16 +37,20 @@ ceo_setup_print_or_run sudo apt install -y -qq git curl jq
 # 2. GitHub CLI
 if command -v gh &>/dev/null; then
   echo "[2/10] gh CLI already installed ($(gh --version | head -1))"
-elif [ "$CEO_SETUP_DRY_RUN" = "1" ]; then
-  echo "[2/10] Installing GitHub CLI..."
-  echo "  [dry-run] curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg"
-  echo "  [dry-run] add cli.github.com apt source to /etc/apt/sources.list.d/github-cli.list"
-  echo "  [dry-run] sudo apt update -qq && sudo apt install -y -qq gh"
 else
   echo "[2/10] Installing GitHub CLI..."
-  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-  sudo apt update -qq && sudo apt install -y -qq gh
+  _gh_keyring='curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg'
+  _gh_apt_src='echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null'
+  _gh_install='sudo apt update -qq && sudo apt install -y -qq gh'
+  if [ "$CEO_SETUP_DRY_RUN" = "1" ]; then
+    echo "  [dry-run] $_gh_keyring"
+    echo "  [dry-run] $_gh_apt_src"
+    echo "  [dry-run] $_gh_install"
+  else
+    bash -eo pipefail -c "$_gh_keyring"
+    bash -eo pipefail -c "$_gh_apt_src"
+    bash -eo pipefail -c "$_gh_install"
+  fi
 fi
 
 if gh auth status &>/dev/null; then

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -5,13 +5,14 @@ set -euo pipefail
 # Run this once, interactively, on the WSL machine.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
+MISSING_CONFIG=()
+
 # shellcheck source=ceo-config.sh
 source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
-
-# shellcheck disable=SC2034  # populated by setup-common.sh's ceo_setup_git_config / read by ceo_setup_exit_if_missing
-MISSING_CONFIG=()
 
 echo "=== CEO Agent — WSL Setup ==="
 echo ""

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # setup-wsl.sh — Provision a WSL box as the CEO agent's execution environment.
 # Run this once, interactively, on the WSL machine.
+#
+# Flags:
+#   --dry-run   Print package-install commands instead of executing them.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -14,17 +17,31 @@ source "$SCRIPT_DIR/ceo-config.sh"
 # shellcheck source=setup-common.sh
 source "$SCRIPT_DIR/setup-common.sh"
 
+CEO_SETUP_DRY_RUN=0
+for _arg in "$@"; do
+  case "$_arg" in
+    --dry-run) CEO_SETUP_DRY_RUN=1 ;;
+    *) echo "setup-wsl.sh: unknown argument '$_arg'" >&2; exit 2 ;;
+  esac
+done
+export CEO_SETUP_DRY_RUN
+
 echo "=== CEO Agent — WSL Setup ==="
 echo ""
 
 # 1. System packages
 echo "[1/10] Installing system packages..."
-sudo apt update -qq
-sudo apt install -y -qq git curl jq
+ceo_setup_print_or_run sudo apt update -qq
+ceo_setup_print_or_run sudo apt install -y -qq git curl jq
 
 # 2. GitHub CLI
 if command -v gh &>/dev/null; then
   echo "[2/10] gh CLI already installed ($(gh --version | head -1))"
+elif [ "$CEO_SETUP_DRY_RUN" = "1" ]; then
+  echo "[2/10] Installing GitHub CLI..."
+  echo "  [dry-run] curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg"
+  echo "  [dry-run] add cli.github.com apt source to /etc/apt/sources.list.d/github-cli.list"
+  echo "  [dry-run] sudo apt update -qq && sudo apt install -y -qq gh"
 else
   echo "[2/10] Installing GitHub CLI..."
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -39,7 +56,7 @@ else
   gh auth login
 fi
 
-ceo_setup_ssh_key "wsl"
+ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo wsl)"
 ceo_setup_git_config
 ceo_setup_check_syncthing
 ceo_setup_check_yq "sudo snap install yq  (or: brew install yq on Mac)"


### PR DESCRIPTION
Closes #96

## Description (Issue Fixed & New Behavior)

Replaces the manual-install hint lists in `setup-mac.sh` / `setup-linux.sh` (split out in #101) with actual package install drivers, adds a `--dry-run` flag that prints the install command instead of executing it, and changes the SSH key comment from the hardcoded `ceo-agent@wsl` to `ceo-agent@<hostname>`.

**Mac (`setup-mac.sh`)**
- Probes for `brew`; if missing, prints the Homebrew install URL and exits 1.
- Runs `brew install git gh jq yq` via the new `ceo_setup_print_or_run` helper.
- Post-install presence check for `git gh jq` (skipped under `--dry-run`).

**Linux (`setup-linux.sh`)**
- Detects `apt-get` (Debian/Ubuntu) vs `dnf` (Fedora); errors out cleanly if neither is found.
- `sudo apt-get install -y git gh jq yq` or `sudo dnf install -y git gh jq yq`.
- Post-install presence check, skipped under `--dry-run`.

**WSL (`setup-wsl.sh`)**
- Existing `apt update` / `apt install` lines + the multi-step gh-CLI keyring install all routed through `ceo_setup_print_or_run`, so `--dry-run` prints them instead of executing.

**Common (`setup-common.sh`)**
- New `ceo_setup_print_or_run` helper: echoes `[dry-run] <cmd>` when `CEO_SETUP_DRY_RUN=1`, otherwise executes.
- `ceo_setup_ssh_key` accepts a host-suffix argument; all three drivers pass `\"\$(hostname -s 2>/dev/null || echo <platform>)\"` so the key comment reflects the actual host.

**Dispatch (`scripts/ceo`)**
- `cmd_setup` forwards `\"\$@\"` to the per-platform installer so `--dry-run` reaches the driver.

**Hotfix included**
- The first commit (`Move MISSING_CONFIG declaration above setup-common.sh source`) fixes a regression introduced in #101: the runtime guard at the top of `setup-common.sh` was tripping immediately on every \`ceo setup\` invocation because all three installers declared \`MISSING_CONFIG=()\` *after* sourcing the library. Bundled here because the same three files were already being modified.

## Testing Procedure

1. Check out this branch.
2. Run \`shellcheck scripts/ceo scripts/setup-{common,wsl,mac,linux}.sh\` — only pre-existing info-level findings (SC1091 source-following, SC2162 read -r) should appear; no errors or warnings.
3. Run \`bash scripts/ceo setup --dry-run\` on this Mac. Expect:
   - \`=== CEO Agent — Mac Setup ===\` header
   - \`[1/10] Installing required CLIs via brew...\`
   - \`  [dry-run] brew install git gh jq yq\`
   - Subsequent steps continue as normal (gh auth, ssh key, git config, etc.). \`--dry-run\` only gates the package-install command per AC, not the interactive setup flow.
4. Confirm the MISSING_CONFIG regression is fixed: without the hotfix commit, \`bash scripts/ceo setup --dry-run\` exits 1 with \"setup-common.sh: caller must declare MISSING_CONFIG=() before sourcing.\" With the hotfix, it proceeds normally.

## Additional Notes / HelpScout Tickets

- Sub-ticket of #1.
- Depends on #95 (installer split, merged as #101).
- Next sub-tickets: #97 (scheduler abstraction), #98 (launchd backend).
- Follow-up issues filed during #101: #102 (interactivity hardening), #103 (ceo-setup.test.sh harness).