### PR TITLE
Add ceo-scheduler.sh with crontab + noop-launchd backends

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -11,6 +11,10 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 ceo_load_config || true
 
+# Scheduler abstraction (crontab on linux/wsl; noop-launchd on macOS)
+# shellcheck source=ceo-scheduler.sh
+source "$SCRIPT_DIR/ceo-scheduler.sh"
+
 # Find repo root by walking up from scripts/ to find .claude-plugin/
 INSTALL_DIR="$SCRIPT_DIR"
 while [ "$INSTALL_DIR" != "/" ]; do
@@ -204,9 +208,11 @@ cmd_doctor() {
   fi
 
   # cron
-  if crontab -l 2>/dev/null | grep -q "ceo-cron.sh"; then
+  local _sched_state
+  _sched_state="$(ceo_scheduler_list 2>/dev/null || true)"
+  if printf '%s\n' "$_sched_state" | grep -q "ceo-cron.sh"; then
     local count
-    count=$(crontab -l 2>/dev/null | grep -c "ceo-cron.sh")
+    count=$(printf '%s\n' "$_sched_state" | grep -c "ceo-cron.sh")
     echo "  ✓ Cron entries installed ($count triggers)"
     ok=$((ok + 1))
   else
@@ -216,7 +222,7 @@ cmd_doctor() {
 
   # duplicate cron triggers
   local dup_count
-  dup_count=$(crontab -l 2>/dev/null | grep "ceo-cron\.sh" | sed 's/.*ceo-cron\.sh //' | sort | uniq -d | wc -l | xargs || true)
+  dup_count=$(printf '%s\n' "$_sched_state" | grep "ceo-cron\.sh" | sed 's/.*ceo-cron\.sh //' | sort | uniq -d | wc -l | xargs || true)
   if [ "${dup_count:-0}" -gt 0 ]; then
     echo "  ✗ Duplicate cron triggers detected — run: ceo playbook scan"
     fail=$((fail + 1))
@@ -934,7 +940,7 @@ cmd_playbook_scan() {
   # the conflicting state into registry.json and confuse later `ceo schedule`
   # listings.
   if ! _playbook_update_crontab "$new_registry"; then
-    echo "Aborted: registry not updated. Resolve collisions and re-run." >&2
+    echo "Aborted: registry not updated. See error above and re-run." >&2
     return 1
   fi
 
@@ -1126,20 +1132,16 @@ _playbook_update_crontab() {
   cron_count=$(printf '%s\n' "$cron_block" | grep -c '# ceo:' || true)
 
   local existing
-  existing=$(crontab -l 2>/dev/null || true)
+  existing=$(ceo_scheduler_list 2>/dev/null || true)
 
   local new_crontab
   new_crontab=$(echo "$existing" | sed "/$marker_start/,/$marker_end/d")
   new_crontab=$(echo "$new_crontab" | grep -v "ceo-cron\.sh" || true)
   new_crontab=$(echo "$new_crontab" | grep -v "^# CEO Agent$" || true)
 
-  # crontab(1) can fail for non-collision reasons too: locked spool, quota,
-  # read-only filesystem, missing crontab binary. Capture its rc explicitly
-  # — without this, a refused install would still echo "installed" while
-  # the caller wrote the new registry, leaving registry-on-disk diverged
-  # from the running cron. The reorder in cmd_playbook_scan only protects
-  # against the collision case; this catches the rest.
-  local crontab_bin="${CEO_CRONTAB_BIN:-crontab}"
+  # Scheduler can fail for non-collision reasons (locked spool, quota, RO fs,
+  # missing crontab binary, unimplemented backend on Mac). The scheduler
+  # abstraction emits its own ERROR line to stderr; we propagate the rc.
   local crontab_payload
   if [ -n "$new_crontab" ]; then
     crontab_payload=$(printf '%s\n%s\n' "$new_crontab" "$cron_block")
@@ -1147,11 +1149,7 @@ _playbook_update_crontab() {
     crontab_payload="$cron_block"
   fi
 
-  local crontab_err
-  crontab_err=$(echo "$crontab_payload" | "$crontab_bin" - 2>&1)
-  local crontab_rc=$?
-  if [ "$crontab_rc" -ne 0 ]; then
-    echo "ERROR: crontab install failed (rc=$crontab_rc): $crontab_err" >&2
+  if ! ceo_scheduler_install "$crontab_payload"; then
     return 1
   fi
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -938,10 +938,14 @@ cmd_playbook_scan() {
   # Update crontab FIRST. If collision detection refuses, abort before
   # touching the registry on disk — otherwise a refused scan would persist
   # the conflicting state into registry.json and confuse later `ceo schedule`
-  # listings.
-  if ! _playbook_update_crontab "$new_registry"; then
+  # listings. Propagate the scheduler's rc (rc=2 from noop-launchd, rc=1 for
+  # other errors) so callers / cron / CI can distinguish "not implemented"
+  # from "transient failure."
+  local _scan_install_rc=0
+  _playbook_update_crontab "$new_registry" || _scan_install_rc=$?
+  if [ "$_scan_install_rc" -ne 0 ]; then
     echo "Aborted: registry not updated. See error above and re-run." >&2
-    return 1
+    return "$_scan_install_rc"
   fi
 
   local registry_tmp="$registry_file.tmp"
@@ -1149,8 +1153,10 @@ _playbook_update_crontab() {
     crontab_payload="$cron_block"
   fi
 
-  if ! ceo_scheduler_install "$crontab_payload"; then
-    return 1
+  local _install_rc=0
+  ceo_scheduler_install "$crontab_payload" || _install_rc=$?
+  if [ "$_install_rc" -ne 0 ]; then
+    return "$_install_rc"
   fi
 
   echo "Crontab: $cron_count entries installed"

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# ceo-scheduler.sh — Scheduler abstraction for ceo playbook scan + ceo doctor.
+# Sourced, not executed. Caller must have already sourced ceo-config.sh
+# (provides ceo_detect_os).
+#
+# Public API:
+#   ceo_scheduler_backend       — prints the resolved backend name to stdout
+#   ceo_scheduler_list          — prints the current scheduler state to stdout
+#                                  (crontab content on the crontab backend; empty on noop)
+#   ceo_scheduler_install <payload>
+#                                — replaces the user's schedule with <payload>;
+#                                  rc=0 on success, rc=1 on backend error,
+#                                  rc=2 on noop-launchd (not yet implemented).
+#
+# Backend selection priority:
+#   1. CEO_SCHEDULER env (explicit override for tests/dev)
+#   2. CEO_CRONTAB_BIN env set ⇒ crontab backend (legacy override)
+#   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ noop-launchd
+
+ceo_scheduler_backend() {
+  if [ -n "${CEO_SCHEDULER:-}" ]; then
+    echo "$CEO_SCHEDULER"
+    return 0
+  fi
+  if [ -n "${CEO_CRONTAB_BIN:-}" ]; then
+    echo "crontab"
+    return 0
+  fi
+  case "$(ceo_detect_os)" in
+    wsl|linux)
+      echo "crontab"
+      ;;
+    macos)
+      # A `crontab` resolving under $HOME is a test stub (per test-harness
+      # conventions: stubs live under $TEST_HOME/.bun/bin). Real macOS
+      # crontab is at /usr/bin/crontab, outside $HOME. The sniffer lets
+      # ceo-cron.test.sh / ceo-schedule.test.sh exercise the crontab
+      # backend on Mac dev hosts without modification.
+      local _ct
+      _ct="$(command -v crontab 2>/dev/null || true)"
+      if [ -n "$_ct" ] && [ -n "${HOME:-}" ] && [ "${_ct#"$HOME"}" != "$_ct" ]; then
+        echo "crontab"
+      else
+        echo "noop-launchd"
+      fi
+      ;;
+    *)
+      echo "noop-launchd"
+      ;;
+  esac
+}
+
+ceo_scheduler_list() {
+  case "$(ceo_scheduler_backend)" in
+    crontab)
+      "${CEO_CRONTAB_BIN:-crontab}" -l 2>/dev/null
+      ;;
+    noop-launchd)
+      : # empty schedule
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ceo_scheduler_install() {
+  local payload="$1"
+  case "$(ceo_scheduler_backend)" in
+    crontab)
+      local crontab_bin="${CEO_CRONTAB_BIN:-crontab}"
+      local err
+      err=$(printf '%s' "$payload" | "$crontab_bin" - 2>&1)
+      local rc=$?
+      if [ "$rc" -ne 0 ]; then
+        echo "ERROR: crontab install failed (rc=$rc): $err" >&2
+        return 1
+      fi
+      return 0
+      ;;
+    noop-launchd)
+      echo "ERROR: launchd backend not yet implemented; install scheduled triggers manually" >&2
+      return 2
+      ;;
+    *)
+      echo "ERROR: unknown scheduler backend '$(ceo_scheduler_backend)'" >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -4,7 +4,9 @@
 # (provides ceo_detect_os).
 #
 # Public API:
-#   ceo_scheduler_backend       — prints the resolved backend name to stdout
+#   ceo_scheduler_backend       — prints the resolved backend name to stdout;
+#                                  returns 1 (with stderr message) on an
+#                                  unknown CEO_SCHEDULER value
 #   ceo_scheduler_list          — prints the current scheduler state to stdout
 #                                  (crontab content on the crontab backend; empty on noop)
 #   ceo_scheduler_install <payload>
@@ -13,14 +15,26 @@
 #                                  rc=2 on noop-launchd (not yet implemented).
 #
 # Backend selection priority:
-#   1. CEO_SCHEDULER env (explicit override for tests/dev)
+#   1. CEO_SCHEDULER env (explicit override for tests/dev); must be one of
+#      the known names — unknown values fail loud rather than fall through
+#      (per enum-config-typo-fallback)
 #   2. CEO_CRONTAB_BIN env set ⇒ crontab backend (legacy override)
 #   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ noop-launchd
 
+_CEO_SCHEDULER_KNOWN="crontab noop-launchd"
+
 ceo_scheduler_backend() {
   if [ -n "${CEO_SCHEDULER:-}" ]; then
-    echo "$CEO_SCHEDULER"
-    return 0
+    case " $_CEO_SCHEDULER_KNOWN " in
+      *" $CEO_SCHEDULER "*)
+        echo "$CEO_SCHEDULER"
+        return 0
+        ;;
+      *)
+        echo "ERROR: unknown CEO_SCHEDULER='$CEO_SCHEDULER'; valid: $_CEO_SCHEDULER_KNOWN" >&2
+        return 1
+        ;;
+    esac
   fi
   if [ -n "${CEO_CRONTAB_BIN:-}" ]; then
     echo "crontab"
@@ -31,14 +45,16 @@ ceo_scheduler_backend() {
       echo "crontab"
       ;;
     macos)
-      # A `crontab` resolving under $HOME is a test stub (per test-harness
-      # conventions: stubs live under $TEST_HOME/.bun/bin). Real macOS
-      # crontab is at /usr/bin/crontab, outside $HOME. The sniffer lets
-      # ceo-cron.test.sh / ceo-schedule.test.sh exercise the crontab
-      # backend on Mac dev hosts without modification.
+      : "${HOME:?HOME must be set to resolve scheduler backend on macOS}"
+      # A `crontab` resolving under $HOME/.bun/bin/ is a test stub (per
+      # test-harness conventions). Real macOS crontab is /usr/bin/crontab,
+      # outside $HOME. The narrow path check (not just any-$HOME-prefix)
+      # avoids matching unrelated $HOME/bin or asdf/Volta shims a user
+      # might legitimately have. Lets ceo-cron.test.sh / ceo-schedule.test.sh
+      # exercise the crontab backend on Mac dev hosts without modification.
       local _ct
       _ct="$(command -v crontab 2>/dev/null || true)"
-      if [ -n "$_ct" ] && [ -n "${HOME:-}" ] && [ "${_ct#"$HOME"}" != "$_ct" ]; then
+      if [ -n "$_ct" ] && [ "${_ct#"$HOME/.bun/bin/"}" != "$_ct" ]; then
         echo "crontab"
       else
         echo "noop-launchd"
@@ -51,7 +67,10 @@ ceo_scheduler_backend() {
 }
 
 ceo_scheduler_list() {
-  case "$(ceo_scheduler_backend)" in
+  local _backend _rc=0
+  _backend="$(ceo_scheduler_backend)" || _rc=$?
+  [ "$_rc" -eq 0 ] || return "$_rc"
+  case "$_backend" in
     crontab)
       "${CEO_CRONTAB_BIN:-crontab}" -l 2>/dev/null
       ;;
@@ -59,6 +78,7 @@ ceo_scheduler_list() {
       : # empty schedule
       ;;
     *)
+      echo "ERROR: unknown scheduler backend '$_backend'" >&2
       return 1
       ;;
   esac
@@ -66,7 +86,10 @@ ceo_scheduler_list() {
 
 ceo_scheduler_install() {
   local payload="$1"
-  case "$(ceo_scheduler_backend)" in
+  local _backend _rc=0
+  _backend="$(ceo_scheduler_backend)" || _rc=$?
+  [ "$_rc" -eq 0 ] || return "$_rc"
+  case "$_backend" in
     crontab)
       local crontab_bin="${CEO_CRONTAB_BIN:-crontab}"
       local err
@@ -83,7 +106,7 @@ ceo_scheduler_install() {
       return 2
       ;;
     *)
-      echo "ERROR: unknown scheduler backend '$(ceo_scheduler_backend)'" >&2
+      echo "ERROR: unknown scheduler backend '$_backend'" >&2
       return 1
       ;;
   esac

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Tests for the scheduler abstraction (#97).
+#
+# Covers:
+#   - Backend selection priority (CEO_SCHEDULER > CEO_CRONTAB_BIN > ceo_detect_os)
+#   - noop-launchd: list returns empty; install returns rc=2 with not-implemented message
+#   - crontab: list reads via CEO_CRONTAB_BIN; install routes payload to CEO_CRONTAB_BIN
+#   - Integration: `ceo playbook scan` on macOS (CEO_SCHEDULER=noop-launchd) exits
+#     non-zero and does NOT corrupt the registry on disk.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log"
+  : > "$CEO_DIR/AGENTS.md"
+  : > "$CEO_DIR/inbox.md"
+
+  unset CEO_SCHEDULER CEO_CRONTAB_BIN
+  # shellcheck source=ceo-config.sh
+  source "$SCRIPT_DIR/ceo-config.sh"
+  # shellcheck source=ceo-scheduler.sh
+  source "$SCRIPT_DIR/ceo-scheduler.sh"
+}
+
+teardown() {
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR
+  rm -rf "$TEST_HOME"
+}
+
+test_ceo_scheduler_env_overrides_os_detection() {
+  export CEO_SCHEDULER=noop-launchd
+  assert_eq "$(ceo_scheduler_backend)" "noop-launchd" "explicit CEO_SCHEDULER must win"
+  export CEO_SCHEDULER=crontab
+  assert_eq "$(ceo_scheduler_backend)" "crontab" "explicit CEO_SCHEDULER must win"
+}
+
+test_ceo_crontab_bin_implies_crontab_backend() {
+  export CEO_CRONTAB_BIN="$TEST_HOME/fake-crontab"
+  assert_eq "$(ceo_scheduler_backend)" "crontab" "CEO_CRONTAB_BIN set forces crontab backend"
+}
+
+test_noop_launchd_install_returns_rc_2_with_message() {
+  export CEO_SCHEDULER=noop-launchd
+  local out rc=0
+  out=$(ceo_scheduler_install "any-payload" 2>&1) || rc=$?
+  assert_eq "$rc" "2" "noop-launchd install must return rc=2"
+  assert_contains "$out" "launchd backend not yet implemented" "must surface not-implemented message"
+}
+
+test_noop_launchd_list_is_empty() {
+  export CEO_SCHEDULER=noop-launchd
+  local out
+  out=$(ceo_scheduler_list 2>&1)
+  assert_eq "$out" "" "noop-launchd list must produce empty output"
+}
+
+test_crontab_backend_install_routes_payload_to_ceo_crontab_bin() {
+  local capture="$TEST_HOME/crontab-capture.out"
+  cat > "$TEST_HOME/fake-crontab" <<STUB
+#!/bin/bash
+cat > "$capture"
+STUB
+  chmod +x "$TEST_HOME/fake-crontab"
+  export CEO_CRONTAB_BIN="$TEST_HOME/fake-crontab"
+  ceo_scheduler_install "marker-line-PAYLOAD" >/dev/null 2>&1
+  local got
+  got=$(cat "$capture" 2>/dev/null || echo "")
+  assert_contains "$got" "marker-line-PAYLOAD" "payload must reach the crontab binary"
+}
+
+test_crontab_install_failure_surfaces_as_rc_1() {
+  cat > "$TEST_HOME/failing-crontab" <<'STUB'
+#!/bin/bash
+echo "crontab: install failed (simulated)" >&2
+exit 7
+STUB
+  chmod +x "$TEST_HOME/failing-crontab"
+  export CEO_CRONTAB_BIN="$TEST_HOME/failing-crontab"
+  local out rc=0
+  out=$(ceo_scheduler_install "x" 2>&1) || rc=$?
+  assert_eq "$rc" "1" "crontab failure must propagate as rc=1"
+  assert_contains "$out" "crontab install failed" "error message must surface"
+}
+
+test_playbook_scan_on_noop_backend_does_not_corrupt_registry() {
+  # Seed a minimal registry that ceo playbook scan would normally overwrite.
+  cat > "$CEO_DIR/registry.json" <<'EOF'
+{
+  "schema_version": 3,
+  "generated": "1970-01-01T00:00:00Z",
+  "playbooks": [
+    {"name": "test-playbook", "trigger": "cron", "schedule": "0 9 * * *", "status": "active", "runner": "script"}
+  ]
+}
+EOF
+  local registry_before
+  registry_before=$(cat "$CEO_DIR/registry.json")
+
+  mkdir -p "$CEO_DIR/playbooks/test-playbook"
+  cat > "$CEO_DIR/playbooks/test-playbook/playbook.md" <<'EOF'
+---
+name: test-playbook
+trigger: cron
+schedule: "0 9 * * *"
+status: active
+runner: script
+script: noop.sh
+---
+EOF
+
+  export CEO_SCHEDULER=noop-launchd
+  local out rc=0
+  out=$(bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+
+  assert_eq "$([ "$rc" != "0" ] && echo nonzero || echo zero)" "nonzero" "playbook scan must exit non-zero on noop backend"
+  assert_contains "$out" "launchd backend not yet implemented" "must surface scheduler error to user"
+
+  local registry_after
+  registry_after=$(cat "$CEO_DIR/registry.json")
+  assert_eq "$registry_after" "$registry_before" "registry on disk must be unchanged after aborted scan"
+}
+
+run_tests

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -60,12 +60,88 @@ test_noop_launchd_install_returns_rc_2_with_message() {
   assert_contains "$out" "launchd backend not yet implemented" "must surface not-implemented message"
 }
 
-test_noop_launchd_list_is_empty() {
+test_noop_launchd_list_is_empty_and_does_not_invoke_crontab() {
+  # Place a tripwire stub that records any invocation; noop backend must
+  # never call it. If `ceo_scheduler_list`'s noop arm is reverted to fall
+  # through to the crontab branch, the tripwire fires and the assertion
+  # on the witness file's absence fails.
+  cat > "$TEST_HOME/tripwire-crontab" <<STUB
+#!/bin/bash
+touch "$TEST_HOME/tripwire-fired"
+STUB
+  chmod +x "$TEST_HOME/tripwire-crontab"
+  export CEO_CRONTAB_BIN="$TEST_HOME/tripwire-crontab"
   export CEO_SCHEDULER=noop-launchd
-  local out
-  out=$(ceo_scheduler_list 2>&1)
+  local out rc=0
+  out=$(ceo_scheduler_list 2>&1) || rc=$?
+  assert_eq "$rc" "0" "noop-launchd list must succeed"
   assert_eq "$out" "" "noop-launchd list must produce empty output"
+  if [ -f "$TEST_HOME/tripwire-fired" ]; then
+    assert_eq "tripwire" "untouched" "noop backend must not invoke CEO_CRONTAB_BIN"
+  fi
 }
+
+test_unknown_ceo_scheduler_fails_loud() {
+  export CEO_SCHEDULER=noop-luanchd
+  local out rc=0
+  out=$(ceo_scheduler_backend 2>&1) || rc=$?
+  assert_eq "$rc" "1" "unknown CEO_SCHEDULER must return rc=1"
+  assert_contains "$out" "unknown CEO_SCHEDULER='noop-luanchd'" "must surface typo to user"
+  # _list and _install must propagate the rc, not masquerade as empty/zero
+  rc=0; out=$(ceo_scheduler_list 2>&1) || rc=$?
+  assert_eq "$rc" "1" "ceo_scheduler_list must propagate unknown-backend rc=1"
+  rc=0; out=$(ceo_scheduler_install "x" 2>&1) || rc=$?
+  assert_eq "$rc" "1" "ceo_scheduler_install must propagate unknown-backend rc=1"
+}
+
+test_playbook_scan_propagates_rc_2_from_noop_backend() {
+  # The public API at ceo-scheduler.sh advertises rc=2 for the noop backend.
+  # Callers must preserve it instead of collapsing to rc=1.
+  : > "$CEO_DIR/inbox.md"
+  cat > "$CEO_DIR/registry.json" <<'EOF'
+{"schema_version": 3, "generated": "1970-01-01T00:00:00Z", "playbooks": []}
+EOF
+  export CEO_SCHEDULER=noop-launchd
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "2" "playbook scan must propagate rc=2 from noop-launchd backend"
+}
+
+test_macos_sniffer_picks_crontab_only_under_bun_bin() {
+  # Stub ceo_detect_os in this shell to force the macos branch.
+  ceo_detect_os() { echo "macos"; }
+  # Stub under the documented test path → expect crontab backend.
+  mkdir -p "$TEST_HOME/.bun/bin"
+  cat > "$TEST_HOME/.bun/bin/crontab" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/crontab"
+  PATH="$TEST_HOME/.bun/bin:$PATH" assert_eq \
+    "$(PATH="$TEST_HOME/.bun/bin:$PATH" ceo_scheduler_backend)" "crontab" \
+    "macOS + crontab under \$HOME/.bun/bin must pick crontab backend"
+
+  # Stub OUTSIDE .bun/bin (under $HOME/bin) → must NOT trigger the sniffer.
+  mkdir -p "$TEST_HOME/bin"
+  cp "$TEST_HOME/.bun/bin/crontab" "$TEST_HOME/bin/crontab"
+  rm -f "$TEST_HOME/.bun/bin/crontab"
+  assert_eq \
+    "$(PATH="$TEST_HOME/bin:$PATH" ceo_scheduler_backend)" "noop-launchd" \
+    "macOS + crontab outside \$HOME/.bun/bin must pick noop-launchd (narrow sniffer)"
+}
+
+test_macos_empty_home_fails_loud() {
+  ceo_detect_os() { echo "macos"; }
+  local rc=0
+  ( HOME="" ceo_scheduler_backend >/dev/null 2>&1 ) || rc=$?
+  assert_eq "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)" "nonzero" \
+    "empty HOME on macOS must abort (per shell-required-env-vars)"
+}
+
+# Production-entry-point payload capture is covered by
+# ceo-schedule.test.sh:test_collision_resolved_after_override (line 126) —
+# it drives `_playbook_update_crontab` through CEO_CRONTAB_BIN and asserts
+# the captured payload contains the ceo:<name> line. No duplicate test here.
 
 test_crontab_backend_install_routes_payload_to_ceo_crontab_bin() {
   local capture="$TEST_HOME/crontab-capture.out"


### PR DESCRIPTION
Closes #97

## Description (Issue Fixed & New Behavior)

Extracts `_playbook_update_crontab`'s direct `crontab(1)` calls and the three `cmd_doctor` `crontab -l` probes behind a new scheduler abstraction in `scripts/ceo-scheduler.sh`.

**Public API:**
- `ceo_scheduler_backend` — resolves the active backend name
- `ceo_scheduler_list` — prints current schedule state (crontab content on linux/wsl, empty on noop)
- `ceo_scheduler_install <payload>` — replaces the user's schedule; rc=0 ok, rc=1 backend error, rc=2 noop-launchd (not implemented)

**Backend selection priority:**
1. `CEO_SCHEDULER` env (explicit override)
2. `CEO_CRONTAB_BIN` set ⇒ crontab backend (legacy test override)
3. `ceo_detect_os`: wsl/linux ⇒ crontab; macos ⇒ noop-launchd

**Mac behavior:** `ceo playbook scan` aborts before touching `registry.json` (collision-detection-then-install ordering preserved). The new integration test verifies the registry on disk is unchanged after the aborted scan.

**Test-stub passthrough on macOS:** the macos branch in `ceo_scheduler_backend` treats a `$HOME`-rooted `crontab` binary as a test-stub signal and routes to the crontab backend. This lets the existing `ceo-cron.test.sh` and `ceo-schedule.test.sh` exercise the real install path on Mac dev hosts without modification — sniffer comment documents the WHY.

**Wiring changes in `scripts/ceo`:**
- `cmd_doctor` cron probes (3 sites) route through `ceo_scheduler_list` (cached once per invocation in `_sched_state`).
- `_playbook_update_crontab` reads existing state via `ceo_scheduler_list` and writes via `ceo_scheduler_install`. Inline `CEO_CRONTAB_BIN` and inline error-message construction removed (moved into the scheduler module).
- "Aborted: registry not updated. Resolve collisions and re-run." → "...See error above and re-run." (the scheduler can fail for non-collision reasons; abort message is now backend-agnostic).

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning scripts/ceo scripts/ceo-scheduler.sh scripts/ceo-scheduler.test.sh` — expect rc=0.
3. `bash scripts/ceo-scheduler.test.sh` — expect "All tests passed. (7 tests)". Includes: backend selection (3 tests), noop-launchd install/list (2 tests), crontab passthrough + failure (2 tests), Mac integration (`playbook scan` exits non-zero, doesn't corrupt registry).
4. `bash scripts/ceo-cron.test.sh` — must still pass without modification (verifies the macos `$HOME`-crontab sniffer).
5. `bash scripts/ceo-schedule.test.sh` — must still pass without modification (verifies `CEO_CRONTAB_BIN` legacy override).
6. Mutation check: revert the `ceo_scheduler_install` call in `_playbook_update_crontab` back to `crontab(1)` direct invocation. `ceo-scheduler.test.sh`'s `test_playbook_scan_on_noop_backend_does_not_corrupt_registry` must fail with 3 assertion errors. (Already mutation-verified locally during development.)

## Additional Notes / HelpScout Tickets

- Sub-ticket of #1.
- Depends on #95 (installer split, merged as #101).
- Parallelizable with #96 (merged as #104).
- Next sub-ticket: **#98** (launchd backend) — implement the actual launchd plist generation that this PR's noop-launchd stub describes; AC says return rc=2 until then.