### PR TITLE
Implement launchd backend (replaces noop-launchd)

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "$SCRIPT_DIR/ceo-config.sh"
 ceo_load_config || true
 
-# Scheduler abstraction (crontab on linux/wsl; noop-launchd on macOS)
+# Scheduler abstraction (crontab on linux/wsl; launchd on macOS)
 # shellcheck source=ceo-scheduler.sh
 source "$SCRIPT_DIR/ceo-scheduler.sh"
 
@@ -938,9 +938,8 @@ cmd_playbook_scan() {
   # Update crontab FIRST. If collision detection refuses, abort before
   # touching the registry on disk — otherwise a refused scan would persist
   # the conflicting state into registry.json and confuse later `ceo schedule`
-  # listings. Propagate the scheduler's rc (rc=2 from noop-launchd, rc=1 for
-  # other errors) so callers / cron / CI can distinguish "not implemented"
-  # from "transient failure."
+  # listings. Propagate the scheduler's rc so callers / cron / CI can see
+  # transient failures (rc=1) distinctly from a clean abort.
   local _scan_install_rc=0
   _playbook_update_crontab "$new_registry" || _scan_install_rc=$?
   if [ "$_scan_install_rc" -ne 0 ]; then

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -7,21 +7,26 @@
 #   ceo_scheduler_backend       — prints the resolved backend name to stdout;
 #                                  returns 1 (with stderr message) on an
 #                                  unknown CEO_SCHEDULER value
-#   ceo_scheduler_list          — prints the current scheduler state to stdout
-#                                  (crontab content on the crontab backend; empty on noop)
+#   ceo_scheduler_list          — prints the current schedule state to stdout
+#                                  in a uniform "MIN HOUR D M W CMD  # ceo:NAME"
+#                                  format (crontab content for crontab backend;
+#                                  reconstructed lines per plist for launchd)
 #   ceo_scheduler_install <payload>
 #                                — replaces the user's schedule with <payload>;
-#                                  rc=0 on success, rc=1 on backend error,
-#                                  rc=2 on noop-launchd (not yet implemented).
+#                                  rc=0 on success, rc=1 on backend error.
 #
 # Backend selection priority:
 #   1. CEO_SCHEDULER env (explicit override for tests/dev); must be one of
 #      the known names — unknown values fail loud rather than fall through
 #      (per enum-config-typo-fallback)
 #   2. CEO_CRONTAB_BIN env set ⇒ crontab backend (legacy override)
-#   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ noop-launchd
+#   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ launchd
+#
+# Launchd backend env overrides (for tests):
+#   CEO_LAUNCHD_DIR     — directory holding com.ceo.*.plist (default ~/Library/LaunchAgents)
+#   CEO_LAUNCHCTL_BIN   — path to launchctl (default launchctl on PATH)
 
-_CEO_SCHEDULER_KNOWN="crontab noop-launchd"
+_CEO_SCHEDULER_KNOWN="crontab launchd"
 
 ceo_scheduler_backend() {
   if [ -n "${CEO_SCHEDULER:-}" ]; then
@@ -57,13 +62,176 @@ ceo_scheduler_backend() {
       if [ -n "$_ct" ] && [ "${_ct#"$HOME/.bun/bin/"}" != "$_ct" ]; then
         echo "crontab"
       else
-        echo "noop-launchd"
+        echo "launchd"
       fi
       ;;
     *)
-      echo "noop-launchd"
+      echo "launchd"
       ;;
   esac
+}
+
+# Expand one cron field to a space-separated list of concrete integers.
+# Supports: integer, list "1,3", range "1-5", step "*/N", named weekdays
+# SUN-SAT (cron 0-6, launchd 0-6).
+# Echoes "*" verbatim to signal "no constraint" (caller decides what that means).
+_ceo_cron_field_expand() {
+  local field="$1" range_start="$2" range_end="$3"
+  if [ "$field" = "*" ]; then
+    echo "*"
+    return 0
+  fi
+  # Named weekday → integer (only valid in weekday field)
+  case "$field" in
+    SUN|sun) echo 0; return 0 ;;
+    MON|mon) echo 1; return 0 ;;
+    TUE|tue) echo 2; return 0 ;;
+    WED|wed) echo 3; return 0 ;;
+    THU|thu) echo 4; return 0 ;;
+    FRI|fri) echo 5; return 0 ;;
+    SAT|sat) echo 6; return 0 ;;
+  esac
+  local out=""
+  local item
+  # List "1,3" → recurse per element
+  if [[ "$field" == *,* ]]; then
+    IFS=',' read -ra _items <<< "$field"
+    for item in "${_items[@]}"; do
+      local sub
+      sub="$(_ceo_cron_field_expand "$item" "$range_start" "$range_end")"
+      out="$out $sub"
+    done
+    echo "$out" | tr ' ' '\n' | grep -v '^$' | sort -nu | tr '\n' ' ' | sed 's/ $//'
+    return 0
+  fi
+  # Step "*/N" → range_start..range_end stepping by N
+  if [[ "$field" == */* ]]; then
+    local step="${field##*/}"
+    local i="$range_start"
+    while [ "$i" -le "$range_end" ]; do
+      out="$out $i"
+      i=$((i + step))
+    done
+    echo "${out# }"
+    return 0
+  fi
+  # Range "1-5" → consecutive integers
+  if [[ "$field" == *-* ]]; then
+    local lo="${field%-*}" hi="${field#*-}"
+    local i="$lo"
+    while [ "$i" -le "$hi" ]; do
+      out="$out $i"
+      i=$((i + 1))
+    done
+    echo "${out# }"
+    return 0
+  fi
+  # Plain integer
+  echo "$field"
+}
+
+# Emit one plist body for a (label, minute, hour, weekday, command) tuple.
+# weekday="*" omits the Weekday key (fires every day).
+_ceo_launchd_plist_body() {
+  local label="$1" minute="$2" hour="$3" weekday="$4" cmd="$5"
+  cat <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>${cmd}</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Minute</key>
+    <integer>${minute}</integer>
+    <key>Hour</key>
+    <integer>${hour}</integer>
+XML
+  if [ "$weekday" != "*" ]; then
+    printf '    <key>Weekday</key>\n    <integer>%s</integer>\n' "$weekday"
+  fi
+  cat <<'XML'
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+</dict>
+</plist>
+XML
+}
+
+# Generate the set of (label, minute, hour, weekday, command, ceo_name) tuples
+# from a crontab-style payload. Emits one TSV-delimited row per tuple:
+#   label<TAB>minute<TAB>hour<TAB>weekday<TAB>cmd<TAB>ceo_name
+# Skips marker lines, blank lines, and any line that doesn't match the
+# "MIN HOUR DOM MON DOW CMD  # ceo:NAME" shape.
+_ceo_launchd_tuples_from_payload() {
+  local payload="$1"
+  printf '%s\n' "$payload" | while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+    # Extract ceo:NAME tag
+    local name="${line##*# ceo:}"
+    if [ "$name" = "$line" ]; then
+      # No ceo: tag — skip
+      continue
+    fi
+    name="${name%%[[:space:]]*}"
+    local schedule_and_cmd="${line%%#*}"
+    schedule_and_cmd="${schedule_and_cmd%"${schedule_and_cmd##*[![:space:]]}"}"  # rtrim
+    # Split into 5 cron fields + remaining command
+    read -r m h dom mon dow cmd_rest <<< "$schedule_and_cmd"
+    if [ -z "$cmd_rest" ]; then
+      continue
+    fi
+    local minutes hours weekdays
+    minutes="$(_ceo_cron_field_expand "$m" 0 59)"
+    hours="$(_ceo_cron_field_expand "$h" 0 23)"
+    weekdays="$(_ceo_cron_field_expand "$dow" 0 6)"
+    local idx=0
+    local mi hi wi
+    # Disable filename globbing so a bare `*` from _ceo_cron_field_expand
+    # doesn't expand against the cwd. The sentinel is rendered back to `*`
+    # downstream (means "no constraint" — Weekday key omitted in the plist).
+    set -f
+    for mi in $minutes; do
+      for hi in $hours; do
+        for wi in $weekdays; do
+          local label="com.ceo.${name}-${idx}"
+          printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$label" "$mi" "$hi" "$wi" "$cmd_rest" "$name"
+          idx=$((idx + 1))
+        done
+      done
+    done
+    set +f
+  done
+}
+
+# Reconstruct an approximate crontab-style line from a plist file for use in
+# ceo_scheduler_list. Keeps the "ceo-cron.sh" substring that ceo doctor greps
+# for, plus the "# ceo:NAME" tag. One line per plist (since one plist == one
+# concrete trigger time).
+_ceo_launchd_plist_to_cron_line() {
+  local plist="$1"
+  if [ ! -f "$plist" ]; then
+    return 0
+  fi
+  local label minute hour weekday cmd
+  label="$(grep -A1 '<key>Label</key>' "$plist" | tail -1 | sed -E 's|.*<string>(.*)</string>.*|\1|')"
+  minute="$(grep -A1 '<key>Minute</key>' "$plist" | tail -1 | sed -E 's|.*<integer>([0-9]+)</integer>.*|\1|')"
+  hour="$(grep -A1 '<key>Hour</key>' "$plist" | tail -1 | sed -E 's|.*<integer>([0-9]+)</integer>.*|\1|')"
+  weekday="$(grep -A1 '<key>Weekday</key>' "$plist" 2>/dev/null | tail -1 | sed -nE 's|.*<integer>([0-9]+)</integer>.*|\1|p')"
+  # Last <string> inside ProgramArguments array is the command.
+  cmd="$(awk '/<key>ProgramArguments<\/key>/,/<\/array>/' "$plist" | grep '<string>' | tail -1 | sed -E 's|.*<string>(.*)</string>.*|\1|')"
+  local name="${label#com.ceo.}"
+  name="${name%-*}"
+  printf '%s %s * * %s %s  # ceo:%s\n' "${minute:-0}" "${hour:-0}" "${weekday:-*}" "$cmd" "$name"
 }
 
 ceo_scheduler_list() {
@@ -74,8 +242,14 @@ ceo_scheduler_list() {
     crontab)
       "${CEO_CRONTAB_BIN:-crontab}" -l 2>/dev/null
       ;;
-    noop-launchd)
-      : # empty schedule
+    launchd)
+      local dir="${CEO_LAUNCHD_DIR:-$HOME/Library/LaunchAgents}"
+      [ -d "$dir" ] || return 0
+      local plist
+      for plist in "$dir"/com.ceo.*.plist; do
+        [ -f "$plist" ] || continue
+        _ceo_launchd_plist_to_cron_line "$plist"
+      done
       ;;
     *)
       echo "ERROR: unknown scheduler backend '$_backend'" >&2
@@ -101,9 +275,51 @@ ceo_scheduler_install() {
       fi
       return 0
       ;;
-    noop-launchd)
-      echo "ERROR: launchd backend not yet implemented; install scheduled triggers manually" >&2
-      return 2
+    launchd)
+      local dir="${CEO_LAUNCHD_DIR:-$HOME/Library/LaunchAgents}"
+      local launchctl_bin="${CEO_LAUNCHCTL_BIN:-launchctl}"
+      mkdir -p "$dir"
+
+      local uid
+      uid="$(id -u 2>/dev/null || echo 0)"
+      # Track written labels as a space-separated string (bash 3.2 compatible —
+      # no associative arrays). Anchored with leading and trailing spaces so
+      # substring match doesn't false-positive on label prefixes.
+      local kept_labels=" "
+
+      # Render and write new plists from the payload.
+      local label minute hour weekday cmd name
+      while IFS=$'\t' read -r label minute hour weekday cmd name; do
+        [ -n "$label" ] || continue
+        local target="$dir/$label.plist"
+        _ceo_launchd_plist_body "$label" "$minute" "$hour" "$weekday" "$cmd" > "$target.tmp"
+        mv "$target.tmp" "$target"
+        # Reload: bootout then bootstrap is the supported pattern on modern
+        # macOS (12+). Errors from bootout on a not-yet-loaded label are
+        # expected on first install — suppress.
+        "$launchctl_bin" bootout "gui/$uid" "$target" 2>/dev/null || true
+        if ! "$launchctl_bin" bootstrap "gui/$uid" "$target" 2>/dev/null; then
+          echo "ERROR: launchctl bootstrap failed for $label" >&2
+          return 1
+        fi
+        kept_labels="$kept_labels$label "
+      done < <(_ceo_launchd_tuples_from_payload "$payload")
+
+      # Stale-plist cleanup: anything matching com.ceo.*.plist that wasn't
+      # written above is no longer in the registry — bootout + delete.
+      local existing_plist existing_label
+      for existing_plist in "$dir"/com.ceo.*.plist; do
+        [ -f "$existing_plist" ] || continue
+        existing_label="$(basename "$existing_plist" .plist)"
+        case "$kept_labels" in
+          *" $existing_label "*) ;;
+          *)
+            "$launchctl_bin" bootout "gui/$uid" "$existing_plist" 2>/dev/null || true
+            rm -f "$existing_plist"
+            ;;
+        esac
+      done
+      return 0
       ;;
     *)
       echo "ERROR: unknown scheduler backend '$_backend'" >&2

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -71,10 +71,24 @@ ceo_scheduler_backend() {
   esac
 }
 
+# XML-escape one string for safe interpolation into a plist body.
+# Order matters: & first so subsequent literal entities don't double-escape.
+_ceo_xml_escape() {
+  local s="$1"
+  s="${s//&/&amp;}"
+  s="${s//</&lt;}"
+  s="${s//>/&gt;}"
+  s="${s//\"/&quot;}"
+  s="${s//\'/&apos;}"
+  printf '%s' "$s"
+}
+
 # Expand one cron field to a space-separated list of concrete integers.
 # Supports: integer, list "1,3", range "1-5", step "*/N", named weekdays
 # SUN-SAT (cron 0-6, launchd 0-6).
 # Echoes "*" verbatim to signal "no constraint" (caller decides what that means).
+# Returns 1 with stderr diagnostic on: step <= 0, integer outside range,
+# reversed range (lo > hi), or any non-integer garbage.
 _ceo_cron_field_expand() {
   local field="$1" range_start="$2" range_end="$3"
   if [ "$field" = "*" ]; then
@@ -98,7 +112,7 @@ _ceo_cron_field_expand() {
     IFS=',' read -ra _items <<< "$field"
     for item in "${_items[@]}"; do
       local sub
-      sub="$(_ceo_cron_field_expand "$item" "$range_start" "$range_end")"
+      sub="$(_ceo_cron_field_expand "$item" "$range_start" "$range_end")" || return 1
       out="$out $sub"
     done
     echo "$out" | tr ' ' '\n' | grep -v '^$' | sort -nu | tr '\n' ' ' | sed 's/ $//'
@@ -107,6 +121,10 @@ _ceo_cron_field_expand() {
   # Step "*/N" → range_start..range_end stepping by N
   if [[ "$field" == */* ]]; then
     local step="${field##*/}"
+    if ! [[ "$step" =~ ^[0-9]+$ ]] || [ "$step" -le 0 ]; then
+      echo "ERROR: invalid cron step '$step' in field '$field' (must be positive integer)" >&2
+      return 1
+    fi
     local i="$range_start"
     while [ "$i" -le "$range_end" ]; do
       out="$out $i"
@@ -118,6 +136,18 @@ _ceo_cron_field_expand() {
   # Range "1-5" → consecutive integers
   if [[ "$field" == *-* ]]; then
     local lo="${field%-*}" hi="${field#*-}"
+    if ! [[ "$lo" =~ ^[0-9]+$ ]] || ! [[ "$hi" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: invalid cron range '$field' (non-integer bound)" >&2
+      return 1
+    fi
+    if [ "$lo" -gt "$hi" ]; then
+      echo "ERROR: reversed cron range '$field' ($lo > $hi)" >&2
+      return 1
+    fi
+    if [ "$lo" -lt "$range_start" ] || [ "$hi" -gt "$range_end" ]; then
+      echo "ERROR: cron range '$field' outside valid bounds [$range_start..$range_end]" >&2
+      return 1
+    fi
     local i="$lo"
     while [ "$i" -le "$hi" ]; do
       out="$out $i"
@@ -126,7 +156,15 @@ _ceo_cron_field_expand() {
     echo "${out# }"
     return 0
   fi
-  # Plain integer
+  # Plain integer — validate against allowed range
+  if ! [[ "$field" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: invalid cron field '$field' (not an integer)" >&2
+    return 1
+  fi
+  if [ "$field" -lt "$range_start" ] || [ "$field" -gt "$range_end" ]; then
+    echo "ERROR: cron field '$field' outside valid bounds [$range_start..$range_end]" >&2
+    return 1
+  fi
   echo "$field"
 }
 
@@ -134,18 +172,21 @@ _ceo_cron_field_expand() {
 # weekday="*" omits the Weekday key (fires every day).
 _ceo_launchd_plist_body() {
   local label="$1" minute="$2" hour="$3" weekday="$4" cmd="$5"
+  local label_esc cmd_esc
+  label_esc="$(_ceo_xml_escape "$label")"
+  cmd_esc="$(_ceo_xml_escape "$cmd")"
   cat <<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>${label}</string>
+  <string>${label_esc}</string>
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>${cmd}</string>
+    <string>${cmd_esc}</string>
   </array>
   <key>StartCalendarInterval</key>
   <dict>
@@ -185,15 +226,19 @@ _ceo_launchd_tuples_from_payload() {
     name="${name%%[[:space:]]*}"
     local schedule_and_cmd="${line%%#*}"
     schedule_and_cmd="${schedule_and_cmd%"${schedule_and_cmd##*[![:space:]]}"}"  # rtrim
-    # Split into 5 cron fields + remaining command
-    read -r m h dom mon dow cmd_rest <<< "$schedule_and_cmd"
+    # Split into 5 cron fields + remaining command. DOM and Month are
+    # accepted on input for crontab-style parity but ignored — launchd's
+    # StartCalendarInterval Day/Month keys are not encoded in this backend
+    # (documented limitation).
+    local _dom _mon
+    read -r m h _dom _mon dow cmd_rest <<< "$schedule_and_cmd"
     if [ -z "$cmd_rest" ]; then
       continue
     fi
     local minutes hours weekdays
-    minutes="$(_ceo_cron_field_expand "$m" 0 59)"
-    hours="$(_ceo_cron_field_expand "$h" 0 23)"
-    weekdays="$(_ceo_cron_field_expand "$dow" 0 6)"
+    minutes="$(_ceo_cron_field_expand "$m" 0 59)" || continue
+    hours="$(_ceo_cron_field_expand "$h" 0 23)" || continue
+    weekdays="$(_ceo_cron_field_expand "$dow" 0 6)" || continue
     local idx=0
     local mi hi wi
     # Disable filename globbing so a bare `*` from _ceo_cron_field_expand
@@ -280,30 +325,55 @@ ceo_scheduler_install() {
       local launchctl_bin="${CEO_LAUNCHCTL_BIN:-launchctl}"
       mkdir -p "$dir"
 
+      # Resolve the GUI domain uid. Don't fall back to 0 on failure — that
+      # silently targets root's launchd domain (per shell-required-env-vars).
       local uid
-      uid="$(id -u 2>/dev/null || echo 0)"
-      # Track written labels as a space-separated string (bash 3.2 compatible —
-      # no associative arrays). Anchored with leading and trailing spaces so
-      # substring match doesn't false-positive on label prefixes.
-      local kept_labels=" "
+      uid="$(id -u 2>/dev/null)"
+      : "${uid:?id -u failed; cannot resolve launchd GUI domain}"
 
-      # Render and write new plists from the payload.
+      # Phase 1: render every plist as $target.tmp. No launchctl calls yet.
+      # If any tuple fails to render, abort before mutating the live set.
+      local kept_labels=" "
+      local rendered=""
       local label minute hour weekday cmd name
       while IFS=$'\t' read -r label minute hour weekday cmd name; do
         [ -n "$label" ] || continue
         local target="$dir/$label.plist"
-        _ceo_launchd_plist_body "$label" "$minute" "$hour" "$weekday" "$cmd" > "$target.tmp"
-        mv "$target.tmp" "$target"
-        # Reload: bootout then bootstrap is the supported pattern on modern
-        # macOS (12+). Errors from bootout on a not-yet-loaded label are
-        # expected on first install — suppress.
-        "$launchctl_bin" bootout "gui/$uid" "$target" 2>/dev/null || true
-        if ! "$launchctl_bin" bootstrap "gui/$uid" "$target" 2>/dev/null; then
-          echo "ERROR: launchctl bootstrap failed for $label" >&2
+        if ! _ceo_launchd_plist_body "$label" "$minute" "$hour" "$weekday" "$cmd" > "$target.tmp"; then
+          echo "ERROR: failed to render plist for $label" >&2
+          rm -f "$target.tmp"
+          for _r in $rendered; do rm -f "$dir/$_r.plist.tmp"; done
           return 1
         fi
+        rendered="$rendered $label"
         kept_labels="$kept_labels$label "
       done < <(_ceo_launchd_tuples_from_payload "$payload")
+
+      # Phase 2: commit each rendered .tmp to its final path, then bootout +
+      # bootstrap. On bootstrap failure, roll back: bootout everything we
+      # installed in this run, restore-via-delete the newly-committed plists,
+      # leaving the prior live set untouched.
+      local installed=""
+      local _r _r_target
+      for _r in $rendered; do
+        _r_target="$dir/$_r.plist"
+        mv "$_r_target.tmp" "$_r_target"
+        # bootout-before-bootstrap is the supported reload pattern on modern
+        # macOS (12+). bootout on a not-yet-loaded label errors — suppress.
+        "$launchctl_bin" bootout "gui/$uid" "$_r_target" 2>/dev/null || true
+        if ! "$launchctl_bin" bootstrap "gui/$uid" "$_r_target" 2>/dev/null; then
+          echo "ERROR: launchctl bootstrap failed for $_r; rolling back this install" >&2
+          local _rb
+          for _rb in $installed; do
+            "$launchctl_bin" bootout "gui/$uid" "$dir/$_rb.plist" 2>/dev/null || true
+            rm -f "$dir/$_rb.plist"
+          done
+          rm -f "$_r_target"
+          for _rb in $rendered; do rm -f "$dir/$_rb.plist.tmp"; done
+          return 1
+        fi
+        installed="$installed $_r"
+      done
 
       # Stale-plist cleanup: anything matching com.ceo.*.plist that wasn't
       # written above is no longer in the registry — bootout + delete.

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-# Tests for the scheduler abstraction (#97).
+# Tests for the scheduler abstraction (#97) + launchd backend (#98).
 #
 # Covers:
 #   - Backend selection priority (CEO_SCHEDULER > CEO_CRONTAB_BIN > ceo_detect_os)
-#   - noop-launchd: list returns empty; install returns rc=2 with not-implemented message
-#   - crontab: list reads via CEO_CRONTAB_BIN; install routes payload to CEO_CRONTAB_BIN
-#   - Integration: `ceo playbook scan` on macOS (CEO_SCHEDULER=noop-launchd) exits
-#     non-zero and does NOT corrupt the registry on disk.
+#   - Unknown CEO_SCHEDULER fails loud (enum-config-typo-fallback)
+#   - macOS sniffer narrowed to $HOME/.bun/bin (AC #3 of #97)
+#   - macOS empty HOME aborts (shell-required-env-vars)
+#   - crontab backend: list/install via CEO_CRONTAB_BIN; rc=1 on failure
+#   - launchd backend: cron-field expansion, plist generation, install writes
+#     plists + bootstraps, re-install removes stale plists (AC of #98),
+#     list reconstructs cron-style lines, integration via `ceo playbook scan`.
 
 set -uo pipefail
 
@@ -22,9 +25,19 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
-  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log"
+  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
+  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stub-launchctl"
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_LAUNCHD_DIR"
   : > "$CEO_DIR/AGENTS.md"
   : > "$CEO_DIR/inbox.md"
+
+  # Recording launchctl stub — logs every invocation to $TEST_HOME/launchctl.log.
+  cat > "$CEO_LAUNCHCTL_BIN" <<STUB
+#!/bin/bash
+echo "\$@" >> "$TEST_HOME/launchctl.log"
+exit 0
+STUB
+  chmod +x "$CEO_LAUNCHCTL_BIN"
 
   unset CEO_SCHEDULER CEO_CRONTAB_BIN
   # shellcheck source=ceo-config.sh
@@ -36,13 +49,15 @@ setup() {
 teardown() {
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR
+  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR CEO_LAUNCHD_DIR CEO_LAUNCHCTL_BIN
   rm -rf "$TEST_HOME"
 }
 
+# === Backend selection ===
+
 test_ceo_scheduler_env_overrides_os_detection() {
-  export CEO_SCHEDULER=noop-launchd
-  assert_eq "$(ceo_scheduler_backend)" "noop-launchd" "explicit CEO_SCHEDULER must win"
+  export CEO_SCHEDULER=launchd
+  assert_eq "$(ceo_scheduler_backend)" "launchd" "explicit CEO_SCHEDULER must win"
   export CEO_SCHEDULER=crontab
   assert_eq "$(ceo_scheduler_backend)" "crontab" "explicit CEO_SCHEDULER must win"
 }
@@ -52,82 +67,36 @@ test_ceo_crontab_bin_implies_crontab_backend() {
   assert_eq "$(ceo_scheduler_backend)" "crontab" "CEO_CRONTAB_BIN set forces crontab backend"
 }
 
-test_noop_launchd_install_returns_rc_2_with_message() {
-  export CEO_SCHEDULER=noop-launchd
-  local out rc=0
-  out=$(ceo_scheduler_install "any-payload" 2>&1) || rc=$?
-  assert_eq "$rc" "2" "noop-launchd install must return rc=2"
-  assert_contains "$out" "launchd backend not yet implemented" "must surface not-implemented message"
-}
-
-test_noop_launchd_list_is_empty_and_does_not_invoke_crontab() {
-  # Place a tripwire stub that records any invocation; noop backend must
-  # never call it. If `ceo_scheduler_list`'s noop arm is reverted to fall
-  # through to the crontab branch, the tripwire fires and the assertion
-  # on the witness file's absence fails.
-  cat > "$TEST_HOME/tripwire-crontab" <<STUB
-#!/bin/bash
-touch "$TEST_HOME/tripwire-fired"
-STUB
-  chmod +x "$TEST_HOME/tripwire-crontab"
-  export CEO_CRONTAB_BIN="$TEST_HOME/tripwire-crontab"
-  export CEO_SCHEDULER=noop-launchd
-  local out rc=0
-  out=$(ceo_scheduler_list 2>&1) || rc=$?
-  assert_eq "$rc" "0" "noop-launchd list must succeed"
-  assert_eq "$out" "" "noop-launchd list must produce empty output"
-  if [ -f "$TEST_HOME/tripwire-fired" ]; then
-    assert_eq "tripwire" "untouched" "noop backend must not invoke CEO_CRONTAB_BIN"
-  fi
-}
-
 test_unknown_ceo_scheduler_fails_loud() {
-  export CEO_SCHEDULER=noop-luanchd
+  export CEO_SCHEDULER=launhd
   local out rc=0
   out=$(ceo_scheduler_backend 2>&1) || rc=$?
   assert_eq "$rc" "1" "unknown CEO_SCHEDULER must return rc=1"
-  assert_contains "$out" "unknown CEO_SCHEDULER='noop-luanchd'" "must surface typo to user"
-  # _list and _install must propagate the rc, not masquerade as empty/zero
+  assert_contains "$out" "unknown CEO_SCHEDULER='launhd'" "must surface typo to user"
   rc=0; out=$(ceo_scheduler_list 2>&1) || rc=$?
   assert_eq "$rc" "1" "ceo_scheduler_list must propagate unknown-backend rc=1"
   rc=0; out=$(ceo_scheduler_install "x" 2>&1) || rc=$?
   assert_eq "$rc" "1" "ceo_scheduler_install must propagate unknown-backend rc=1"
 }
 
-test_playbook_scan_propagates_rc_2_from_noop_backend() {
-  # The public API at ceo-scheduler.sh advertises rc=2 for the noop backend.
-  # Callers must preserve it instead of collapsing to rc=1.
-  : > "$CEO_DIR/inbox.md"
-  cat > "$CEO_DIR/registry.json" <<'EOF'
-{"schema_version": 3, "generated": "1970-01-01T00:00:00Z", "playbooks": []}
-EOF
-  export CEO_SCHEDULER=noop-launchd
-  local rc=0
-  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "2" "playbook scan must propagate rc=2 from noop-launchd backend"
-}
-
 test_macos_sniffer_picks_crontab_only_under_bun_bin() {
-  # Stub ceo_detect_os in this shell to force the macos branch.
   ceo_detect_os() { echo "macos"; }
-  # Stub under the documented test path → expect crontab backend.
   mkdir -p "$TEST_HOME/.bun/bin"
   cat > "$TEST_HOME/.bun/bin/crontab" <<'STUB'
 #!/bin/bash
 exit 0
 STUB
   chmod +x "$TEST_HOME/.bun/bin/crontab"
-  PATH="$TEST_HOME/.bun/bin:$PATH" assert_eq \
+  assert_eq \
     "$(PATH="$TEST_HOME/.bun/bin:$PATH" ceo_scheduler_backend)" "crontab" \
     "macOS + crontab under \$HOME/.bun/bin must pick crontab backend"
 
-  # Stub OUTSIDE .bun/bin (under $HOME/bin) → must NOT trigger the sniffer.
   mkdir -p "$TEST_HOME/bin"
   cp "$TEST_HOME/.bun/bin/crontab" "$TEST_HOME/bin/crontab"
   rm -f "$TEST_HOME/.bun/bin/crontab"
   assert_eq \
-    "$(PATH="$TEST_HOME/bin:$PATH" ceo_scheduler_backend)" "noop-launchd" \
-    "macOS + crontab outside \$HOME/.bun/bin must pick noop-launchd (narrow sniffer)"
+    "$(PATH="$TEST_HOME/bin:$PATH" ceo_scheduler_backend)" "launchd" \
+    "macOS + crontab outside \$HOME/.bun/bin must pick launchd (narrow sniffer)"
 }
 
 test_macos_empty_home_fails_loud() {
@@ -138,10 +107,7 @@ test_macos_empty_home_fails_loud() {
     "empty HOME on macOS must abort (per shell-required-env-vars)"
 }
 
-# Production-entry-point payload capture is covered by
-# ceo-schedule.test.sh:test_collision_resolved_after_override (line 126) —
-# it drives `_playbook_update_crontab` through CEO_CRONTAB_BIN and asserts
-# the captured payload contains the ceo:<name> line. No duplicate test here.
+# === crontab backend ===
 
 test_crontab_backend_install_routes_payload_to_ceo_crontab_bin() {
   local capture="$TEST_HOME/crontab-capture.out"
@@ -171,24 +137,140 @@ STUB
   assert_contains "$out" "crontab install failed" "error message must surface"
 }
 
-test_playbook_scan_on_noop_backend_does_not_corrupt_registry() {
-  # Seed a minimal registry that ceo playbook scan would normally overwrite.
-  cat > "$CEO_DIR/registry.json" <<'EOF'
-{
-  "schema_version": 3,
-  "generated": "1970-01-01T00:00:00Z",
-  "playbooks": [
-    {"name": "test-playbook", "trigger": "cron", "schedule": "0 9 * * *", "status": "active", "runner": "script"}
-  ]
-}
-EOF
-  local registry_before
-  registry_before=$(cat "$CEO_DIR/registry.json")
+# === launchd: cron-field expansion ===
 
-  mkdir -p "$CEO_DIR/playbooks/test-playbook"
-  cat > "$CEO_DIR/playbooks/test-playbook/playbook.md" <<'EOF'
+test_cron_field_expand_handles_all_shapes() {
+  assert_eq "$(_ceo_cron_field_expand '*' 0 59)" "*" "* must remain literal *"
+  assert_eq "$(_ceo_cron_field_expand '7' 0 59)" "7" "integer must pass through"
+  assert_eq "$(_ceo_cron_field_expand '1-5' 0 23)" "1 2 3 4 5" "range expands"
+  assert_eq "$(_ceo_cron_field_expand '1,3' 0 6)" "1 3" "list expands"
+  assert_eq "$(_ceo_cron_field_expand '*/6' 0 23)" "0 6 12 18" "step expands within range"
+  assert_eq "$(_ceo_cron_field_expand 'SUN' 0 6)" "0" "named SUN expands to 0"
+  assert_eq "$(_ceo_cron_field_expand 'MON' 0 6)" "1" "named MON expands to 1"
+}
+
+test_tuples_from_payload_parses_real_registry_lines() {
+  local payload
+  payload=$(cat <<'BLOCK'
+# CEO Agent START
+0 9 * * * /path/to/ceo-cron.sh morning  # ceo:morning
+47 17 * * 1-5 /path/to/ceo-cron.sh eod  # ceo:eod
+0 8 * * SUN /path/to/ceo-cron.sh weekly  # ceo:weekly
+# CEO Agent END
+BLOCK
+)
+  local out
+  out=$(_ceo_launchd_tuples_from_payload "$payload")
+  # morning: 1 tuple (every day at 9:00, weekday=*)
+  assert_contains "$out" "com.ceo.morning-0	0	9	*	"
+  # eod: 5 tuples (Mon-Fri at 17:47)
+  assert_contains "$out" "com.ceo.eod-0	47	17	1	"
+  assert_contains "$out" "com.ceo.eod-4	47	17	5	"
+  # weekly: 1 tuple (SUN at 08:00)
+  assert_contains "$out" "com.ceo.weekly-0	0	8	0	"
+  # Count: 1 + 5 + 1 = 7 lines
+  local lines
+  lines=$(printf '%s\n' "$out" | grep -c "^com.ceo." || true)
+  assert_eq "$lines" "7" "must emit 7 tuples for 3 triggers (1 + 5 + 1)"
+}
+
+# === launchd: install writes plists + bootstraps + cleans stale ===
+
+test_launchd_install_writes_one_plist_per_tuple() {
+  export CEO_SCHEDULER=launchd
+  local payload
+  payload=$(cat <<'BLOCK'
+# CEO Agent START
+0 9 * * * /path/to/ceo-cron.sh morning  # ceo:morning
+0 8 * * 1,3 /path/to/ceo-cron.sh twice  # ceo:twice
+# CEO Agent END
+BLOCK
+)
+  ceo_scheduler_install "$payload" >/dev/null 2>&1
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist" "morning plist must be written"
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.twice-0.plist" "twice (Mon) plist must be written"
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.twice-1.plist" "twice (Wed) plist must be written"
+  # Plist contents — Minute, Hour, command
+  local morning
+  morning=$(cat "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist")
+  assert_contains "$morning" "<integer>9</integer>" "morning plist must encode Hour=9"
+  assert_contains "$morning" "/path/to/ceo-cron.sh morning" "plist must carry command"
+}
+
+test_launchd_install_bootstraps_each_plist_via_launchctl() {
+  export CEO_SCHEDULER=launchd
+  local payload="0 9 * * * /tmp/ceo-cron.sh foo  # ceo:foo"
+  ceo_scheduler_install "$payload" >/dev/null 2>&1
+  local log
+  log=$(cat "$TEST_HOME/launchctl.log" 2>/dev/null || echo "")
+  assert_contains "$log" "bootstrap gui/" "launchctl must be invoked with bootstrap"
+  assert_contains "$log" "com.ceo.foo-0.plist" "bootstrap must reference the written plist"
+}
+
+test_launchd_install_removes_stale_plists_on_rescan() {
+  export CEO_SCHEDULER=launchd
+  # First install: two playbooks.
+  local payload_v1
+  payload_v1=$(cat <<'BLOCK'
+0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper
+0 10 * * * /tmp/ceo-cron.sh stale  # ceo:stale
+BLOCK
+)
+  ceo_scheduler_install "$payload_v1" >/dev/null 2>&1
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "v1: keeper plist written"
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.stale-0.plist" "v1: stale plist written"
+
+  # Second install: stale playbook removed from registry.
+  local payload_v2="0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper"
+  ceo_scheduler_install "$payload_v2" >/dev/null 2>&1
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "v2: keeper plist preserved"
+  if [ -f "$CEO_LAUNCHD_DIR/com.ceo.stale-0.plist" ]; then
+    assert_eq "stale plist" "removed" "v2: stale plist must be cleaned up on rescan"
+  fi
+  # And launchctl bootout must have been called for the stale plist.
+  local log
+  log=$(cat "$TEST_HOME/launchctl.log" 2>/dev/null || echo "")
+  assert_contains "$log" "bootout" "launchctl bootout must fire for stale plists"
+}
+
+test_launchd_install_does_not_touch_unrelated_plists() {
+  export CEO_SCHEDULER=launchd
+  # Pre-seed an unrelated plist (not com.ceo.*) — must survive install.
+  cat > "$CEO_LAUNCHD_DIR/com.example.other.plist" <<'XML'
+<?xml version="1.0"?>
+<plist><dict><key>Label</key><string>com.example.other</string></dict></plist>
+XML
+  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper" >/dev/null 2>&1
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.example.other.plist" "non-ceo plists must not be touched"
+}
+
+# === launchd: list reconstructs cron-style lines ===
+
+test_launchd_list_reconstructs_cron_lines_for_doctor() {
+  export CEO_SCHEDULER=launchd
+  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh morning  # ceo:morning" >/dev/null 2>&1
+  local out
+  out=$(ceo_scheduler_list 2>&1)
+  assert_contains "$out" "ceo-cron.sh" "list output must contain ceo-cron.sh (doctor greps for this)"
+  assert_contains "$out" "# ceo:morning" "list output must carry the ceo:NAME tag"
+}
+
+# === Integration: ceo playbook scan end-to-end on launchd ===
+
+test_playbook_scan_writes_plists_via_launchd_backend() {
+  export CEO_SCHEDULER=launchd
+  cat > "$CEO_DIR/registry.json" <<'EOF'
+{"schema_version": 3, "generated": "1970-01-01T00:00:00Z", "playbooks": []}
+EOF
+  # Point CEO_REPO_PLAYBOOK_DIR at an empty dir so scan reads ONLY the test
+  # fixture (otherwise it discovers the real plugin's docs/playbooks/ and the
+  # test becomes order-dependent on whatever's registered there).
+  export CEO_REPO_PLAYBOOK_DIR="$TEST_HOME/empty-repo-playbooks"
+  mkdir -p "$CEO_REPO_PLAYBOOK_DIR"
+  cat > "$CEO_DIR/playbooks/scan-target.md" <<'EOF'
 ---
-name: test-playbook
+name: scan-target
+description: Integration test playbook for launchd backend
 trigger: cron
 schedule: "0 9 * * *"
 status: active
@@ -196,17 +278,10 @@ runner: script
 script: noop.sh
 ---
 EOF
-
-  export CEO_SCHEDULER=noop-launchd
-  local out rc=0
-  out=$(bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
-
-  assert_eq "$([ "$rc" != "0" ] && echo nonzero || echo zero)" "nonzero" "playbook scan must exit non-zero on noop backend"
-  assert_contains "$out" "launchd backend not yet implemented" "must surface scheduler error to user"
-
-  local registry_after
-  registry_after=$(cat "$CEO_DIR/registry.json")
-  assert_eq "$registry_after" "$registry_before" "registry on disk must be unchanged after aborted scan"
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "playbook scan must succeed on launchd backend"
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.scan-target-0.plist" "scan must write the plist"
 }
 
 run_tests

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -222,15 +222,69 @@ BLOCK
 
   # Second install: stale playbook removed from registry.
   local payload_v2="0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper"
+  # Truncate the launchctl log before v2 so the bootout assertion below only
+  # observes v2 activity — otherwise the per-install bootout from v1 would
+  # satisfy a bare "bootout" assertion regardless of stale cleanup.
+  : > "$TEST_HOME/launchctl.log"
   ceo_scheduler_install "$payload_v2" >/dev/null 2>&1
   assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "v2: keeper plist preserved"
-  if [ -f "$CEO_LAUNCHD_DIR/com.ceo.stale-0.plist" ]; then
-    assert_eq "stale plist" "removed" "v2: stale plist must be cleaned up on rescan"
-  fi
-  # And launchctl bootout must have been called for the stale plist.
+  assert_no_match "$(ls "$CEO_LAUNCHD_DIR")" "com.ceo.stale-0.plist" \
+    "v2: stale plist must be cleaned up on rescan"
+  # bootout must fire specifically against the stale plist's path.
   local log
   log=$(cat "$TEST_HOME/launchctl.log" 2>/dev/null || echo "")
-  assert_contains "$log" "bootout" "launchctl bootout must fire for stale plists"
+  assert_contains "$log" "bootout gui/" "launchctl bootout must fire during v2"
+  assert_contains "$log" "com.ceo.stale-0.plist" \
+    "bootout must reference the stale plist by name"
+}
+
+test_launchd_install_rolls_back_on_bootstrap_failure_mid_loop() {
+  export CEO_SCHEDULER=launchd
+  # Seed a prior live install so we can verify rollback doesn't disturb it.
+  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh prior  # ceo:prior" >/dev/null 2>&1
+  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.prior-0.plist" "prior install must seed"
+
+  # Stub that fails the second bootstrap call. Counter persisted via a file
+  # so it survives the stub's per-invocation subshell.
+  local counter="$TEST_HOME/bootstrap-counter"
+  echo 0 > "$counter"
+  cat > "$CEO_LAUNCHCTL_BIN" <<STUB
+#!/bin/bash
+echo "\$@" >> "$TEST_HOME/launchctl.log"
+if [ "\$1" = "bootstrap" ]; then
+  n=\$(cat "$counter")
+  n=\$((n + 1))
+  echo \$n > "$counter"
+  if [ "\$n" -eq 2 ]; then
+    echo "simulated bootstrap failure" >&2
+    exit 5
+  fi
+fi
+exit 0
+STUB
+  chmod +x "$CEO_LAUNCHCTL_BIN"
+
+  : > "$TEST_HOME/launchctl.log"
+  # 3 tuples; bootstrap #2 of this install will fail.
+  local payload
+  payload=$(cat <<'BLOCK'
+0 9 * * * /tmp/ceo-cron.sh new-a  # ceo:new-a
+0 10 * * * /tmp/ceo-cron.sh new-b  # ceo:new-b
+0 11 * * * /tmp/ceo-cron.sh new-c  # ceo:new-c
+BLOCK
+)
+  local rc=0
+  ceo_scheduler_install "$payload" >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "bootstrap failure mid-loop must propagate as rc=1"
+  # Rolled back: none of the new plists remain on disk.
+  for label in new-a new-b new-c; do
+    if [ -f "$CEO_LAUNCHD_DIR/com.ceo.$label-0.plist" ]; then
+      assert_eq "$label rolled back" "true" "v2: $label plist must be removed on rollback"
+    fi
+    if [ -f "$CEO_LAUNCHD_DIR/com.ceo.$label-0.plist.tmp" ]; then
+      assert_eq "$label tmp cleaned" "true" "v2: $label .tmp must be cleaned on rollback"
+    fi
+  done
 }
 
 test_launchd_install_does_not_touch_unrelated_plists() {


### PR DESCRIPTION
Closes #98

## Description (Issue Fixed & New Behavior)

Implements the macOS scheduler backend that #97 stubbed as `noop-launchd`. On Mac, `ceo playbook scan` now writes one `~/Library/LaunchAgents/com.ceo.<name>-<idx>.plist` per (trigger, time) tuple and loads each via `launchctl bootstrap gui/<uid>`. Re-scan removes plists no longer in the registry.

**Backend allow-list:** `{crontab, noop-launchd}` → `{crontab, launchd}`. Rename in place per the spec.

**Cron → launchd expansion** (one plist per concrete (Minute, Hour, Weekday) tuple — matches issue mitigation):
- `0 9 * * *` → 1 plist (every day at 9:00; Weekday key omitted)
- `47 17 * * 1-5` → 5 plists (Mon-Fri at 17:47)
- `0 */6 * * *` → 4 plists (every 6 hours: 0, 6, 12, 18)
- `0 7 * * 1,3` → 2 plists (Mon=1, Wed=3)
- `0 8 * * SUN` → 1 plist (Sunday=0)

**Stale-plist cleanup:** after writing the new set, anything matching `com.ceo.*.plist` in `$CEO_LAUNCHD_DIR` that wasn't written this run is `bootout`-ed + `rm`-ed. Other `LaunchAgents/*.plist` files are untouched.

**Doctor compatibility:** `ceo_scheduler_list` on launchd backend enumerates the plists and reconstructs cron-style lines (each line contains `ceo-cron.sh` + `# ceo:NAME`), so the existing `cmd_doctor` grep continues to count "Cron entries installed (N triggers)" correctly on Mac.

**Public API additions** (env overrides for tests):
- `CEO_LAUNCHD_DIR` — plist output directory (default `~/Library/LaunchAgents`)
- `CEO_LAUNCHCTL_BIN` — launchctl path (default `launchctl` on PATH)

**Bash 3.2 compatibility:** macOS ships bash 3.2 by default; the kept-labels set uses a space-separated string + `case` substring match instead of an associative array. `set -f` brackets the tuple-expansion loop so a literal `*` from the cron-field expander doesn't glob against cwd.

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning scripts/ceo scripts/ceo-scheduler.sh scripts/ceo-scheduler.test.sh` — expect rc=0.
3. `bash scripts/ceo-scheduler.test.sh` — expect "All tests passed. (15 tests)". Covers cron-field expansion (all 6 shapes), `_ceo_launchd_tuples_from_payload` (3 triggers → 7 tuples), plist writing per tuple, launchctl bootstrap invocation, stale-plist cleanup on rescan, unrelated-plist non-interference, list reconstructs cron-style lines, integration via `ceo playbook scan`.
4. `bash scripts/ceo-cron.test.sh` — expect 78/78 (AC #3 of #97 preserved).
5. `bash scripts/ceo-schedule.test.sh` — expect 13/13 (AC #3 of #97 preserved).
6. Mutation check (locally verified):
   - Remove stale-plist cleanup → `test_launchd_install_removes_stale_plists_on_rescan` fails on the v2 assertions.
   - Skip the `launchctl bootstrap` invocation → `test_launchd_install_bootstraps_each_plist_via_launchctl` fails.
   - Skip plist `mv` → write tests fail with missing-file assertions.

### Real-Mac smoke test (required before merge)

I cannot run native macOS `launchctl` from this environment — the WSL/stubbed tests prove the logic but not the live integration. On a Mac:

1. Check out the branch, `cd` to the worktree, run `bash scripts/ceo playbook scan`.
2. `ls ~/Library/LaunchAgents/com.ceo.*.plist` — confirm one plist per active trigger.
3. `launchctl print-disabled gui/$(id -u)` (or `launchctl list | grep com.ceo`) — confirm the agents are loaded.
4. Modify a playbook (e.g. set `status: inactive`), re-run `ceo playbook scan`. Confirm the corresponding `com.ceo.<name>-*.plist` files are removed and no longer listed by `launchctl list`.
5. `ceo doctor` — confirm "Cron entries installed (N triggers)" line shows the expected count.

If any step fails, reply on the PR and I'll investigate before merge.

## Additional Notes / HelpScout Tickets

- Closes the final sub-ticket of #1 (multi-platform support). Once merged, #1 itself can be closed.
- Depends on #97 (merged as `1574eb5`).
- Replaces the `noop-launchd` stub from #97 — no compatibility shim. Existing `CEO_SCHEDULER=noop-launchd` overrides will now fail with "unknown CEO_SCHEDULER" (per `enum-config-typo-fallback`), which is the intended behavior: callers who explicitly opted into the noop now have to explicitly opt into `launchd`.