### PR TITLE
scheduler: symmetric WARN on all rejected ceo:NAME lines

### DIFF
--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -237,6 +237,7 @@ _ceo_launchd_tuples_from_payload() {
     local dom mon
     read -r m h dom mon dow cmd_rest <<< "$schedule_and_cmd"
     if [ -z "$cmd_rest" ]; then
+      echo "WARN: skipping ceo:${name} (malformed schedule line; expected 'MIN HOUR DOM MON DOW CMD')" >&2
       continue
     fi
     if [ "$dom" != "*" ]; then
@@ -248,9 +249,18 @@ _ceo_launchd_tuples_from_payload() {
       continue
     fi
     local minutes hours weekdays
-    minutes="$(_ceo_cron_field_expand "$m" 0 59)" || continue
-    hours="$(_ceo_cron_field_expand "$h" 0 23)" || continue
-    weekdays="$(_ceo_cron_field_expand "$dow" 0 6)" || continue
+    if ! minutes="$(_ceo_cron_field_expand "$m" 0 59 2>/dev/null)"; then
+      echo "WARN: skipping ceo:${name} (Minute field '${m}' rejected)" >&2
+      continue
+    fi
+    if ! hours="$(_ceo_cron_field_expand "$h" 0 23 2>/dev/null)"; then
+      echo "WARN: skipping ceo:${name} (Hour field '${h}' rejected)" >&2
+      continue
+    fi
+    if ! weekdays="$(_ceo_cron_field_expand "$dow" 0 6 2>/dev/null)"; then
+      echo "WARN: skipping ceo:${name} (DOW field '${dow}' rejected)" >&2
+      continue
+    fi
     local idx=0
     local mi hi wi
     # Disable filename globbing so a bare `*` from _ceo_cron_field_expand

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -291,6 +291,59 @@ test_tuples_accepts_star_dom_and_month() {
   assert_not_contains "$err" "WARN" "happy-path must not WARN about DOM/Month"
 }
 
+# === launchd: symmetric WARN for non-DOM/Month skip branches (#117) ===
+
+# Helper for the four sibling skip branches in _ceo_launchd_tuples_from_payload
+# that historically `continue`d silently while DOM/Month emitted WARN. Each
+# branch must emit `WARN:` + the field name + the offending value to stderr,
+# and must NOT emit a tuple for that name.
+_ceo_test_assert_silent_skip_warns() {
+  local cron_line="$1" expect_field="$2" tag="$3"
+  local payload="${cron_line}  # ceo:${tag}"
+  local stderr_file out
+  stderr_file=$(mktemp)
+  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
+  local err
+  err=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  assert_not_contains "$out" "com.ceo.${tag}-" "must emit no tuples for ${tag}"
+  assert_contains "$err" "WARN" "stderr must carry WARN for ${tag}"
+  assert_contains "$err" "${expect_field}" "WARN must name field ${expect_field} for ${tag}"
+  assert_contains "$err" "ceo:${tag}" "WARN must name the offending ceo:NAME tag"
+}
+
+test_tuples_warns_on_invalid_minute() {
+  _ceo_test_assert_silent_skip_warns \
+    "99 * * * * /tmp/ceo-cron.sh foo" "Minute" "bad-min"
+}
+
+test_tuples_warns_on_invalid_hour() {
+  _ceo_test_assert_silent_skip_warns \
+    "0 25 * * * /tmp/ceo-cron.sh foo" "Hour" "bad-hour"
+}
+
+test_tuples_warns_on_invalid_dow() {
+  _ceo_test_assert_silent_skip_warns \
+    "0 9 * * 9 /tmp/ceo-cron.sh foo" "DOW" "bad-dow"
+}
+
+test_tuples_warns_on_malformed_line_missing_command() {
+  # Line tagged ceo:foo but missing command field after the 5 cron fields.
+  # The schedule_and_cmd parse yields cmd_rest="" — historically a silent
+  # continue.
+  local payload="0 9 * * *  # ceo:bad-malformed"
+  local stderr_file out
+  stderr_file=$(mktemp)
+  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
+  local err
+  err=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  assert_not_contains "$out" "com.ceo.bad-malformed-" "malformed line must not emit"
+  assert_contains "$err" "WARN" "malformed line must WARN"
+  assert_contains "$err" "ceo:bad-malformed" "WARN must name the offending tag"
+  assert_contains "$err" "malformed" "WARN must classify the reason as malformed"
+}
+
 # === launchd: install writes plists + bootstraps + cleans stale ===
 
 test_launchd_install_writes_one_plist_per_tuple() {


### PR DESCRIPTION
Closes #117

## Description

Mirror the DOM/Month WARN idiom (#109) across the remaining four silent-skip branches in \`_ceo_launchd_tuples_from_payload\`:

- \`cmd_rest\` empty (malformed line; <6 fields after the read)
- \`_ceo_cron_field_expand\` rejects Minute
- \`_ceo_cron_field_expand\` rejects Hour
- \`_ceo_cron_field_expand\` rejects DOW

Each now emits \`WARN: skipping ceo:NAME (<reason>)\` to stderr + continues. One uniform rejection contract per function — an operator monitoring stderr sees every rejected ceo:NAME entry by name, not just DOM/Month constraint typos.

## Testing Procedure

1. Check out branch, \`bash scripts/ceo-scheduler.test.sh\` → \`All tests passed. (43 tests)\`.
2. \`bash scripts/ceo-doctor.test.sh\` → \`All tests passed. (11 tests)\`.
3. Mutation: revert the implementation block in \`scripts/ceo-scheduler.sh\` (lines ~239-261) to the prior \`|| continue\` shape; rerun scheduler tests; expect \`FAILED: 12\` across \`test_tuples_warns_on_invalid_{minute,hour,dow}\` and \`test_tuples_warns_on_malformed_line_missing_command\`.

## Additional Notes

Final follow-up from the #98 panel review series. Surfaced as a MEDIUM in the #116 mini panel (silent-failure reviewer) and filed as a separate concern per safety-invariant-scope (the reviewer's invariant was \"every rejected ceo:NAME line must produce an operator-visible diagnostic\" — uniform across all skip reasons).

After this lands, the remaining #98 follow-up is #114 (5 pre-existing latent test failures across ceo-cron / ceo-value-tracker).