### PR TITLE
tests: fix 5 pre-existing failures surfaced by harness propagation

### DIFF
--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2218,11 +2218,6 @@ PB
 }
 
 test_vault_playbook_shadows_repo_playbook_with_same_name() {
-  # TODO(#114): pre-existing failure surfaced by the test-harness fix in
-  # PR #113. Was always failing but silently passing before the harness
-  # propagated assert_* failures. Out of scope for #107.
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  return 0
   local repo_dir="$TEST_HOME/repo-pb"
   local repo_pb="$repo_dir/_test-shadow.md"
   mkdir -p "$repo_dir"
@@ -2245,7 +2240,7 @@ description: Vault override
 trigger: chat
 preflight: none
 tier: read
-status: inactive
+status: disabled
 ---
 PB
 
@@ -2259,7 +2254,7 @@ PB
   desc=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .description' "$CEO_DIR/registry.json")
   status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$CEO_DIR/registry.json")
   assert_eq "$desc" "Vault override" "vault entry must win on collision"
-  assert_eq "$status" "inactive" "vault status must override repo status"
+  assert_eq "$status" "disabled" "vault status must override repo status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -37,7 +37,7 @@ done
 if [ -n "$vault" ]; then
   note_dir="$vault/CEO/reports/value-tracker"
   mkdir -p "$note_dir"
-  printf '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+  printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
 fi
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
@@ -71,9 +71,6 @@ teardown() {
 }
 
 test_appends_inbox_line_and_invokes_bun() {
-  # TODO(#114): pre-existing failure surfaced by PR #113's test-harness fix.
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  return 0
   local output
   output=$(bash "$TRACKER" 2>&1)
 
@@ -97,9 +94,6 @@ test_appends_inbox_line_and_invokes_bun() {
 }
 
 test_idempotent_inbox_append() {
-  # TODO(#114): pre-existing failure surfaced by PR #113's test-harness fix.
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  return 0
   bash "$TRACKER" >/dev/null 2>&1
   bash "$TRACKER" >/dev/null 2>&1
 
@@ -113,9 +107,6 @@ test_idempotent_inbox_append() {
 }
 
 test_idempotent_preserves_checked_off_line() {
-  # TODO(#114): pre-existing failure surfaced by PR #113's test-harness fix.
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  return 0
   bash "$TRACKER" >/dev/null 2>&1
 
   local today inbox
@@ -201,9 +192,6 @@ test_fails_when_entry_missing() {
 }
 
 test_two_hosts_write_to_disjoint_files() {
-  # TODO(#114): pre-existing failure surfaced by PR #113's test-harness fix.
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  return 0
   bash "$TRACKER" >/dev/null 2>&1
   CEO_HOSTNAME="otherhost" bash "$TRACKER" >/dev/null 2>&1
 


### PR DESCRIPTION
Closes #114

## Description

PR #113 fixed the test harness so per-test \`assert_*\` failures propagate through the subshell boundary instead of being silently lost. That fix surfaced 5 pre-existing test failures across two files. PR #113 temporarily skipped them with early \`return 0\` + ASSERTION_COUNT++ markers to keep CI green; this PR investigates each one and applies the minimal correct fix.

**Both root causes were test-fixture bugs, not production bugs.**

### `scripts/ceo-cron.test.sh::test_vault_playbook_shadows_repo_playbook_with_same_name`

Fixture wrote \`status: inactive\` for the vault playbook. \`CEO_VALID_STATUSES=(active draft disabled)\` in \`ceo-config.sh\` — \`inactive\` is not a valid status enum value. The scan correctly rejected it at parse time (\"unknown status: 'inactive'\"), the vault playbook never made it into \`registry.json\`, and jq selectors returned \`''\`. Production code is correct per the \`enum-config-typo-fallback\` rule. Fixture corrected to \`status: disabled\`; assertion updated to match.

### `scripts/ceo-value-tracker.test.sh` — 4 tests

The bun stub used \`printf '---\\ndate...'\` to write the daily note. Bash builtin \`printf\` interprets the leading \`---\` as option syntax — the first \`-\` triggers option parsing, \`--\` is not a printf option, exit 2 + \`printf: --: invalid option\`. The daily note was never written, the tracker's fail-closed \`# value-tracker\` h1 check killed the run before the inbox append, and 4 downstream tests saw an empty inbox directory. Stub corrected to \`printf --\` so the leading dashes are treated as literal format. Tests pass unchanged.

## Testing Procedure

1. Check out branch, \`bash scripts/ceo-value-tracker.test.sh\` → \`All tests passed. (12 tests)\`.
2. \`bash scripts/ceo-cron.test.sh\` → \`All tests passed. (78 tests)\`.
3. \`bash scripts/ceo-scheduler.test.sh\` → \`All tests passed. (39 tests)\`.
4. Mutation per-fix: \`sed -i.bak \"s/printf -- '---/printf '---/\" scripts/ceo-value-tracker.test.sh && bash scripts/ceo-value-tracker.test.sh\` → \`FAILED: 10\`. Restore.
5. Mutation per-fix: \`sed -i.bak 's/status: disabled/status: inactive/' scripts/ceo-cron.test.sh && TEST_FILTER=test_vault_playbook_shadows bash scripts/ceo-cron.test.sh\` → \`FAILED: 2\`. Restore.

## Additional Notes

This closes the final follow-up from the #98 panel review series. All 5 originally-skipped tests now run for real, with 0 production code change required.

The #98 panel umbrella's follow-up state at this point:

- #107 ✓ doctor cross-check (merged via #113)
- #108 ✓ plutil-extract reconstruction (merged via #115)
- #109 ✓ DOM/Month reject + install-level safety gate (merged via #116)
- #110 ✓ e2e doctor count (merged via #118)
- #111 ✓ destructive empty-payload semantics (merged via #118)
- #112 ✓ xmllint plist validation (merged via #118)
- #114 → this PR
- #117 ✓ symmetric WARN sweep (merged via #119)