### PR TITLE
setup: harden 4 inherited interactivity assumptions

### DIFF
--- a/scripts/ceo-setup.test.sh
+++ b/scripts/ceo-setup.test.sh
@@ -141,6 +141,52 @@ test_setup_wsl_refuses_non_tty_invocation() {
   _assert_installer_refuses_non_tty setup-wsl.sh
 }
 
+# === ceo_setup_gh_auth — distinguish authed vs not-authed vs error (#102 item 2) ===
+
+# Helper to install a `gh` stub at $TEST_HOME/stubs/gh with given behavior.
+_install_gh_stub() {
+  local rc="$1" stderr="$2"
+  cat > "$TEST_HOME/stubs/gh" <<STUB
+#!/bin/bash
+if [ "\$1" = "auth" ] && [ "\$2" = "status" ]; then
+  printf '%s\n' "${stderr}" >&2
+  exit ${rc}
+fi
+# Other gh invocations (e.g. \`gh auth login\` fall-through) are no-ops.
+exit 0
+STUB
+  chmod +x "$TEST_HOME/stubs/gh"
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+}
+
+test_gh_auth_helper_reports_authed_on_rc_zero() {
+  _install_gh_stub 0 "Logged in to github.com account testuser"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local out rc=0
+  out=$(ceo_setup_gh_auth "[2/10]" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "authed path must return 0"
+  assert_contains "$out" "[2/10] gh already authenticated" "must echo authed-line with prefix"
+}
+
+test_gh_auth_helper_invokes_auth_login_on_not_logged_message() {
+  _install_gh_stub 1 "You are not logged into any GitHub hosts. To log in, run: gh auth login"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local out rc=0
+  out=$(ceo_setup_gh_auth "[2/10]" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "not-logged path must succeed (stub exits 0 on the login call)"
+  assert_contains "$out" "[2/10] Authenticating gh CLI" "must transition to auth login"
+}
+
+test_gh_auth_helper_refuses_on_network_failure() {
+  _install_gh_stub 1 "Get \"https://api.github.com\": dial tcp: lookup api.github.com: no such host"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local out rc=0
+  out=$(ceo_setup_gh_auth "[2/10]" 2>&1) || rc=$?
+  assert_eq "$rc" "1" "transient/network failure must NOT fall through to auth login"
+  assert_contains "$out" "transient network" "must surface the network/transient classification"
+  assert_contains "$out" "no such host" "must include the captured stderr context"
+}
+
 # Mac/Linux tools-check exit-1 path is deferred — running setup-mac.sh
 # end-to-end past step 1 requires either reaching the interactive ssh-key
 # prompt (which hangs CI) or a portable PATH that excludes git/jq but

--- a/scripts/ceo-setup.test.sh
+++ b/scripts/ceo-setup.test.sh
@@ -177,6 +177,80 @@ test_gh_auth_helper_invokes_auth_login_on_not_logged_message() {
   assert_contains "$out" "[2/10] Authenticating gh CLI" "must transition to auth login"
 }
 
+test_is_yes_helper_accepts_y_yes_uppercase_mixedcase() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local v
+  for v in y Y yes YES Yes yEs; do
+    if ! _ceo_is_yes "$v"; then
+      printf '  FAIL [%s] _ceo_is_yes must accept %q as yes\n' "$CURRENT_TEST" "$v"
+      FAILS=$((FAILS + 1))
+    fi
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  done
+}
+
+test_is_yes_helper_rejects_n_no_empty_other() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local v
+  for v in n N no NO No "" yep ya whatever 1 0; do
+    if _ceo_is_yes "$v"; then
+      printf '  FAIL [%s] _ceo_is_yes must reject %q as no\n' "$CURRENT_TEST" "$v"
+      FAILS=$((FAILS + 1))
+    fi
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  done
+}
+
+# `ceo_setup_cron` interpretation: `Y` / `yes` / `YES` route to scan;
+# anything else surfaces the "interpreted as no" diagnostic. The cron
+# scan itself shells out to `bash $SCRIPT_DIR/ceo playbook scan` which
+# would need a full environment to run; we point ceo at a stub that
+# echoes a marker so the test verifies routing without invoking real
+# scan logic.
+_install_ceo_stub_for_cron_test() {
+  cat > "$TEST_HOME/stubs/yq" << 'STUB'
+#!/bin/bash
+echo "yq stub 4.0.0"
+exit 0
+STUB
+  chmod +x "$TEST_HOME/stubs/yq"
+  # Stub `ceo` next to the test sandbox; SCRIPT_DIR is reset to TEST_HOME
+  # so the function picks up THIS ceo, not the real one.
+  cat > "$TEST_HOME/ceo" << 'STUB'
+#!/bin/bash
+echo "STUB_CEO_RAN:$*"
+STUB
+  chmod +x "$TEST_HOME/ceo"
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  # Override SCRIPT_DIR in the sourced function's view by re-pointing it
+  # after the source. The function reads $SCRIPT_DIR at call time.
+  SCRIPT_DIR="$TEST_HOME"
+}
+
+test_cron_setup_runs_scan_on_uppercase_Y() {
+  _install_ceo_stub_for_cron_test
+  local out
+  out=$(echo "Y" | ceo_setup_cron 2>&1)
+  assert_contains "$out" "STUB_CEO_RAN:playbook scan" "uppercase Y must run playbook scan"
+  assert_not_contains "$out" "interpreted as no" "Y must NOT route to the skipped branch"
+}
+
+test_cron_setup_runs_scan_on_yes_word() {
+  _install_ceo_stub_for_cron_test
+  local out
+  out=$(echo "yes" | ceo_setup_cron 2>&1)
+  assert_contains "$out" "STUB_CEO_RAN:playbook scan" "literal 'yes' must run playbook scan"
+}
+
+test_cron_setup_skips_with_diagnostic_on_typo() {
+  _install_ceo_stub_for_cron_test
+  local out
+  out=$(echo "ya" | ceo_setup_cron 2>&1)
+  assert_not_contains "$out" "STUB_CEO_RAN" "typo must NOT run scan"
+  assert_contains "$out" "interpreted as no" "typo must surface the interpretation in the skip line"
+}
+
 test_gh_auth_helper_refuses_on_network_failure() {
   _install_gh_stub 1 "Get \"https://api.github.com\": dial tcp: lookup api.github.com: no such host"
   _source_common_with_stubs "$SCRIPT_DIR"

--- a/scripts/ceo-setup.test.sh
+++ b/scripts/ceo-setup.test.sh
@@ -251,6 +251,62 @@ test_cron_setup_skips_with_diagnostic_on_typo() {
   assert_contains "$out" "interpreted as no" "typo must surface the interpretation in the skip line"
 }
 
+# === ceo_setup_vault — empty vault is a missing-config event (#102 item 4) ===
+
+# Drive ceo_setup_vault with an empty stdin (simulating Enter pressed with
+# no detected vault). The function must:
+#   - NOT write ~/.ceo/config
+#   - push "CEO_VAULT" onto MISSING_CONFIG
+#   - return 0 (the missing-config sweep is the canonical exit-1 site;
+#     vault is just one input)
+test_setup_vault_pushes_to_missing_config_on_empty_input() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  # No CEO directory anywhere — auto-detect candidate list is empty,
+  # function falls into the "no vault auto-detected" prompt.
+  rm -rf "$TEST_HOME/Documents" "$TEST_HOME/Obsidian"
+  : > "$TEST_HOME/.ceo-pretest-marker"  # ensure HOME points at TEST_HOME
+  local out
+  out=$(printf '\n' | ceo_setup_vault 2>&1)
+  local cfg="$TEST_HOME/.ceo/config"
+  if [ -f "$cfg" ] && grep -q 'CEO_VAULT=""' "$cfg"; then
+    printf '  FAIL [%s] ~/.ceo/config must NOT be written with CEO_VAULT="" (got: %s)\n' \
+      "$CURRENT_TEST" "$(cat "$cfg")"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_contains "$out" "empty vault path" "must surface the empty-vault diagnostic"
+  # MISSING_CONFIG was mutated inside the subshell — assert via a re-source
+  # in-process so we can read the array.
+  MISSING_CONFIG=()
+  # Use heredoc (not a pipe) so ceo_setup_vault runs in the current shell
+  # and MISSING_CONFIG mutations are visible here.
+  ceo_setup_vault >/dev/null 2>&1 <<< ""
+  local joined="${MISSING_CONFIG[*]:-}"
+  assert_contains "$joined" "CEO_VAULT" \
+    "MISSING_CONFIG must contain CEO_VAULT after empty-vault input"
+}
+
+# Counter-control: a real vault path written into config exits the empty-vault
+# branch and lands a config file.
+test_setup_vault_writes_config_on_non_empty_input() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  mkdir -p "$TEST_HOME/myvault/CEO"
+  : > "$TEST_HOME/myvault/CEO/inbox.md"
+  rm -f "$TEST_HOME/.ceo/config"
+  MISSING_CONFIG=()
+  ceo_setup_vault <<< "$TEST_HOME/myvault" >/dev/null 2>&1
+  assert_file_exists "$TEST_HOME/.ceo/config" "config must be written on valid vault input"
+  local cfg
+  cfg=$(cat "$TEST_HOME/.ceo/config")
+  assert_contains "$cfg" "CEO_VAULT=\"$TEST_HOME/myvault\"" "config must persist the typed path"
+  local joined="${MISSING_CONFIG[*]:-}"
+  if [[ "$joined" == *"CEO_VAULT"* ]]; then
+    printf '  FAIL [%s] MISSING_CONFIG must NOT contain CEO_VAULT on valid input\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_gh_auth_helper_refuses_on_network_failure() {
   _install_gh_stub 1 "Get \"https://api.github.com\": dial tcp: lookup api.github.com: no such host"
   _source_common_with_stubs "$SCRIPT_DIR"

--- a/scripts/ceo-setup.test.sh
+++ b/scripts/ceo-setup.test.sh
@@ -107,6 +107,40 @@ test_setup_common_sources_cleanly_when_missing_config_declared() {
   assert_eq "$rc" "0" "sourcing with MISSING_CONFIG declared must succeed"
 }
 
+# === TTY check at installer entrypoints (#102 item 1) ===
+
+# Non-TTY invocation (curl-install | bash, CI, < /dev/null) must refuse to
+# proceed rather than silently fall through interactive `read` prompts and
+# persist a broken config. The check belongs at each installer's entry
+# point per safety-invariant-scope (gate at the function, not at each
+# read site).
+_assert_installer_refuses_non_tty() {
+  local installer="$1"
+  local rc=0 out
+  # </dev/null forces non-TTY stdin even when the test harness itself
+  # runs under a TTY.
+  out=$(bash "$SCRIPT_DIR/$installer" </dev/null 2>&1) || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] %s under </dev/null must exit non-zero (got rc=0)\n' "$CURRENT_TEST" "$installer"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$out" "interactive terminal" \
+    "$installer must surface the 'interactive terminal' diagnostic"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_setup_mac_refuses_non_tty_invocation() {
+  _assert_installer_refuses_non_tty setup-mac.sh
+}
+
+test_setup_linux_refuses_non_tty_invocation() {
+  _assert_installer_refuses_non_tty setup-linux.sh
+}
+
+test_setup_wsl_refuses_non_tty_invocation() {
+  _assert_installer_refuses_non_tty setup-wsl.sh
+}
+
 # Mac/Linux tools-check exit-1 path is deferred — running setup-mac.sh
 # end-to-end past step 1 requires either reaching the interactive ssh-key
 # prompt (which hangs CI) or a portable PATH that excludes git/jq but

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -62,6 +62,18 @@ ceo_setup_gh_auth() {
   esac
 }
 
+# Treat y / Y / yes / YES / Yes / 'y ' (trailing whitespace) all as yes; any
+# other input (including empty / n / N / no / typos) as no. Bash 3.2 has no
+# `${var,,}` so we route through tr for the lowercase fold.
+_ceo_is_yes() {
+  local _v
+  _v="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$_v" in
+    y|yes) return 0 ;;
+    *)     return 1 ;;
+  esac
+}
+
 ceo_setup_ssh_key() {
   local host_label="$1"
   [ -n "$host_label" ] || host_label="host"
@@ -257,10 +269,10 @@ ceo_setup_cron() {
     echo "[10/10] Cron Setup"
     local install_cron
     read -p "  Scan playbooks and install cron entries? (y/n) " install_cron
-    if [ "$install_cron" = "y" ]; then
+    if _ceo_is_yes "$install_cron"; then
       bash "$ceo_cli" playbook scan
     else
-      echo "  Skipped. Run 'ceo playbook scan' later to install cron entries."
+      echo "  Skipped ('${install_cron}' interpreted as no). Run 'ceo playbook scan' later to install cron entries."
     fi
   else
     echo ""
@@ -288,7 +300,7 @@ ceo_setup_path_symlink() {
     echo "  This creates a symlink in ~/.local/bin/ so you can run 'ceo' from anywhere."
     local add_path
     read -p "  Add to PATH? (y/n) " add_path
-    if [ "$add_path" = "y" ]; then
+    if _ceo_is_yes "$add_path"; then
       mkdir -p "$HOME/.local/bin"
       ln -sf "$ceo_cli" "$HOME/.local/bin/ceo"
       echo "  Symlinked: ~/.local/bin/ceo → $ceo_cli"
@@ -297,6 +309,8 @@ ceo_setup_path_symlink() {
         echo "  Add this to your ~/.bashrc or ~/.zshrc:"
         echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
       fi
+    else
+      echo "  Skipped ('${add_path}' interpreted as no). Add the alias manually if needed."
     fi
   fi
 }

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -235,6 +235,20 @@ ceo_setup_vault() {
     read -rp "  Vault path (e.g. $_example_path): " VAULT
   fi
 
+  # Empty vault is a missing-required-config event, not a default. Writing
+  # CEO_VAULT="" to ~/.ceo/config silently breaks every downstream helper
+  # (doctor probe, value-tracker, scheduler install) and the user has no
+  # signal until something else fails far from the cause. Push onto
+  # MISSING_CONFIG; ceo_setup_exit_if_missing surfaces it at the bottom
+  # of the installer.
+  if [ -z "$VAULT" ]; then
+    echo "  ERROR: empty vault path." >&2
+    echo "  CEO_VAULT must be set explicitly. Re-run 'ceo setup' and enter the full path." >&2
+    MISSING_CONFIG+=("CEO_VAULT")
+    export VAULT CEO_OS
+    return 0
+  fi
+
   if [ -f "$VAULT/CEO/inbox.md" ]; then
     echo "  Vault OK — CEO/inbox.md found at $VAULT/CEO/"
   else

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -23,6 +23,45 @@ ceo_setup_print_or_run() {
   fi
 }
 
+# Authenticate gh, distinguishing "not logged in" from "network/transient
+# failure". Pre-#102 each installer used `gh auth status &>/dev/null` and
+# fell through to `gh auth login` on any non-zero exit — including DNS
+# failures and 5xx — silently restarting the interactive auth flow when
+# the real fix was retrying later. command-v-presence-vs-success applied
+# to rc.
+#
+# Contract:
+#   rc=0 → already authed; echo "$1 gh already authenticated" and return 0
+#   rc=1 + stderr contains "not logged" or "not authenticated" → echo
+#     "$1 Authenticating gh CLI..." then `gh auth login`; return its rc
+#   otherwise → echo a network/error diagnostic with the captured stderr
+#     and return 1 without invoking `gh auth login`
+#
+# $1 is the step prefix the caller wants on the success/auth-prompt lines
+# ("[2/10]" on mac/linux; "  " on wsl).
+ceo_setup_gh_auth() {
+  local prefix="${1:-}"
+  local _err _rc=0
+  _err=$(gh auth status 2>&1 >/dev/null) || _rc=$?
+  if [ "$_rc" = "0" ]; then
+    echo "${prefix} gh already authenticated"
+    return 0
+  fi
+  case "$_err" in
+    *"not logged"*|*"not authenticated"*)
+      echo "${prefix} Authenticating gh CLI..."
+      gh auth login
+      return $?
+      ;;
+    *)
+      echo "${prefix} ERROR: gh auth status failed and did not indicate 'not logged in'." >&2
+      echo "  Likely a transient network / GitHub API failure — re-run later." >&2
+      echo "  gh stderr: ${_err}" >&2
+      return 1
+      ;;
+  esac
+}
+
 ceo_setup_ssh_key() {
   local host_label="$1"
   [ -n "$host_label" ] || host_label="host"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -26,6 +26,18 @@ for _arg in "$@"; do
 done
 export CEO_SETUP_DRY_RUN
 
+# Refuse to proceed on a non-interactive stdin unless the caller is just
+# previewing the package plan. Several steps below use `read -p`; without
+# a TTY they silently accept empty input and persist a broken config
+# (CEO_VAULT="") to ~/.ceo/config. Gate at the installer entrypoint per
+# safety-invariant-scope so no read site can opt out.
+if [ "$CEO_SETUP_DRY_RUN" = "0" ] && [ ! -t 0 ]; then
+  echo "ceo setup requires an interactive terminal." >&2
+  echo "  Re-run from a terminal (not piped, not </dev/null, not CI)." >&2
+  echo "  For non-interactive package planning, pass --dry-run." >&2
+  exit 1
+fi
+
 echo "=== CEO Agent — Linux Setup ==="
 echo ""
 

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -72,13 +72,8 @@ if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
   exit 1
 fi
 
-# 2. gh authentication
-if gh auth status &>/dev/null; then
-  echo "[2/10] gh already authenticated"
-else
-  echo "[2/10] Authenticating gh CLI..."
-  gh auth login
-fi
+# 2. gh authentication — disambiguate not-authed from transient network failures.
+ceo_setup_gh_auth "[2/10]"
 
 ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo linux)"
 ceo_setup_git_config

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -26,6 +26,18 @@ for _arg in "$@"; do
 done
 export CEO_SETUP_DRY_RUN
 
+# Refuse to proceed on a non-interactive stdin unless the caller is just
+# previewing the package plan. Several steps below use `read -p`; without
+# a TTY they silently accept empty input and persist a broken config
+# (CEO_VAULT="") to ~/.ceo/config. Gate at the installer entrypoint per
+# safety-invariant-scope so no read site can opt out.
+if [ "$CEO_SETUP_DRY_RUN" = "0" ] && [ ! -t 0 ]; then
+  echo "ceo setup requires an interactive terminal." >&2
+  echo "  Re-run from a terminal (not piped, not </dev/null, not CI)." >&2
+  echo "  For non-interactive package planning, pass --dry-run." >&2
+  exit 1
+fi
+
 echo "=== CEO Agent — Mac Setup ==="
 echo ""
 

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -59,13 +59,8 @@ if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
   exit 1
 fi
 
-# 2. gh authentication
-if gh auth status &>/dev/null; then
-  echo "[2/10] gh already authenticated"
-else
-  echo "[2/10] Authenticating gh CLI..."
-  gh auth login
-fi
+# 2. gh authentication — disambiguate not-authed from transient network failures.
+ceo_setup_gh_auth "[2/10]"
 
 ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo mac)"
 ceo_setup_git_config

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -26,6 +26,18 @@ for _arg in "$@"; do
 done
 export CEO_SETUP_DRY_RUN
 
+# Refuse to proceed on a non-interactive stdin unless the caller is just
+# previewing the package plan. Several steps below use `read -p`; without
+# a TTY they silently accept empty input and persist a broken config
+# (CEO_VAULT="") to ~/.ceo/config. Gate at the installer entrypoint per
+# safety-invariant-scope so no read site can opt out.
+if [ "$CEO_SETUP_DRY_RUN" = "0" ] && [ ! -t 0 ]; then
+  echo "ceo setup requires an interactive terminal." >&2
+  echo "  Re-run from a terminal (not piped, not </dev/null, not CI)." >&2
+  echo "  For non-interactive package planning, pass --dry-run." >&2
+  exit 1
+fi
+
 echo "=== CEO Agent — WSL Setup ==="
 echo ""
 

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -65,12 +65,8 @@ else
   fi
 fi
 
-if gh auth status &>/dev/null; then
-  echo "  gh already authenticated"
-else
-  echo "  Authenticating gh CLI..."
-  gh auth login
-fi
+# gh authentication — disambiguate not-authed from transient network failures.
+ceo_setup_gh_auth " "
 
 ceo_setup_ssh_key "$(hostname -s 2>/dev/null || echo wsl)"
 ceo_setup_git_config


### PR DESCRIPTION
Closes #102

## Description

Four interactivity hardenings that were inherited from the pre-#95 \`setup-wsl.sh\` and grouped together for the platform split. Each commit addresses one independent concern with its own test + mutation pair, per the implementing-review-feedback rule.

### Item 1 — Non-TTY guard at installer entrypoints (commit \`e88c8fd\`)

Each of \`setup-{mac,linux,wsl}.sh\` now refuses to proceed when stdin is not a TTY (curl-install pipe, CI, \`< /dev/null\`) unless \`--dry-run\` was passed. The check is placed after arg parsing so \`--dry-run\` from a non-TTY remains supported (existing \`setup-scripts.test.sh\` relies on this for the dry-run goldens). Without the guard, the vault prompt silently accepts an empty Enter and persists \`CEO_VAULT=\"\"\` to \`~/.ceo/config\`. Gate at the entrypoint per \`safety-invariant-scope\` so no \`read\` site can opt out.

### Item 2 — \`ceo_setup_gh_auth\` helper (commit \`26d9d6a\`)

\`gh auth status &>/dev/null\` conflated \"not authed\" with transient/network failures. All three installers fell into \`gh auth login\` on any non-zero exit, including DNS failures, 5xx responses, gh binary corruption — silently restarting the interactive auth flow when the right behavior is to surface the error and let the user re-run. Pattern matches \`command-v-presence-vs-success\` applied to rc.

New \`ceo_setup_gh_auth <prefix>\` in \`setup-common.sh\` captures stderr and routes:

- \`rc=0\` → \"already authenticated\"
- \`rc!=0\` + stderr matches \`not logged\` / \`not authenticated\` → \`gh auth login\`
- otherwise → ERROR with captured stderr, return 1

Three call sites collapse to one helper invocation each.

### Item 3 — y/Y/yes normalization (commit \`f054dd9\`)

\`ceo_setup_cron\` and \`ceo_setup_path_symlink\` only matched a bare lowercase \`y\`. \`Y\`, \`yes\`, \`YES\`, \`Yes\` all routed silently to the \"Skipped\" branch with no signal that the input was interpreted as \"no\". A user who answered \`Y\` to the cron prompt would walk away thinking playbooks were scanned.

New \`_ceo_is_yes\` helper (bash 3.2 compatible via \`tr\`, no \`\${var,,}\`) folds the input to lowercase and accepts \`y\` / \`yes\`. The skip branch now surfaces the interpreted value: \`Skipped ('ya' interpreted as no)\`.

### Item 4 — Empty vault → MISSING_CONFIG (commit \`0f9a411\`)

Even with the TTY guard from item 1, a reflexive Enter at the vault prompt would persist \`CEO_VAULT=\"\"\` to \`~/.ceo/config\` silently. Empty \`\$VAULT\` after the read now pushes \`CEO_VAULT\` onto \`MISSING_CONFIG\` and returns 0 without writing the config file. \`ceo_setup_exit_if_missing\` surfaces it at the bottom of the installer alongside the rest of the missing-config sweep.

## Testing Procedure

1. Check out branch.
2. \`bash scripts/ceo-setup.test.sh\` → \`All tests passed. (26 tests)\`.
3. \`bash scripts/setup-scripts.test.sh\` → \`All tests passed. (4 tests)\` (sibling unchanged).
4. \`bash scripts/ceo-scheduler.test.sh && bash scripts/ceo-doctor.test.sh\` — both green.
5. Mutation per item (revert the named commit's production change, rerun \`ceo-setup.test.sh\`):
   - \`e88c8fd\` revert → 3 fails (\`test_setup_{mac,linux,wsl}_refuses_non_tty_invocation\` hang then time out; kill installer processes)
   - \`26d9d6a\` revert → 7 fails across \`test_gh_auth_helper_*\`
   - \`f054dd9\` revert → 3 routing fails + the acceptance assertions in \`_ceo_is_yes\`
   - \`0f9a411\` revert → 2 fails (\`test_setup_vault_pushes_to_missing_config_on_empty_input\`)

## Additional Notes

After this lands, only #122 (mac/linux tools-check exit-1 path follow-up filed during #121) remains open on the repo.

\`ceo-setup.test.sh\` now has 26 tests, ~2s runtime, no CI hangs. The TTY guard happens to also resolve the \"installer end-to-end hangs CI\" risk that motivated #122's deferral — a future #122 PR can rely on the TTY exit path to dodge ssh-keygen interactivity entirely.