### PR TITLE
setup: extract ceo_setup_check_required_tools helper + tests

### DIFF
--- a/scripts/ceo-setup.test.sh
+++ b/scripts/ceo-setup.test.sh
@@ -141,6 +141,66 @@ test_setup_wsl_refuses_non_tty_invocation() {
   _assert_installer_refuses_non_tty setup-wsl.sh
 }
 
+# === ceo_setup_check_required_tools — extracted from mac/linux installers (#122) ===
+
+test_check_required_tools_passes_when_all_present() {
+  local t
+  for t in tool_a tool_b; do
+    printf '#!/bin/bash\nexit 0\n' > "$TEST_HOME/stubs/$t"
+    chmod +x "$TEST_HOME/stubs/$t"
+  done
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local err_file rc=0
+  err_file=$(mktemp)
+  ceo_setup_check_required_tools "Check pkg output above." tool_a tool_b 2>"$err_file" || rc=$?
+  local err
+  err=$(cat "$err_file"); rm -f "$err_file"
+  assert_eq "$rc" "0" "all tools present must return 0"
+  assert_eq "$err" "" "no stderr when nothing missing"
+}
+
+test_check_required_tools_returns_one_with_diagnostic_on_missing() {
+  printf '#!/bin/bash\nexit 0\n' > "$TEST_HOME/stubs/tool_a"
+  chmod +x "$TEST_HOME/stubs/tool_a"
+  # tool_b NOT stubbed → missing.
+  export PATH="$TEST_HOME/stubs:$PATH_BACKUP"
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local err_file rc=0
+  err_file=$(mktemp)
+  ceo_setup_check_required_tools "Check pkg output above." tool_a tool_b 2>"$err_file" || rc=$?
+  local err
+  err=$(cat "$err_file"); rm -f "$err_file"
+  assert_eq "$rc" "1" "missing tool must return 1"
+  assert_contains "$err" "Missing after install: tool_b" "diagnostic must name the missing tool"
+  assert_contains "$err" "Check pkg output above" "followup hint must be propagated"
+}
+
+test_check_required_tools_skipped_under_dry_run() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  # Scope the empty PATH to the helper call only so the test shell keeps
+  # its own utilities (mktemp/rm/cat etc.). Use the env-var-prefix form
+  # so the override is local to the single function call.
+  local rc=0
+  # shellcheck disable=SC2123  # intentional: scope PATH to this one call
+  PATH="$TEST_HOME/empty_bin" CEO_SETUP_DRY_RUN=1 \
+    ceo_setup_check_required_tools "hint" tool_a tool_b >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "dry-run must skip the fail-when-missing path"
+}
+
+test_check_required_tools_lists_all_missing_tools() {
+  _source_common_with_stubs "$SCRIPT_DIR"
+  local err_file rc=0
+  err_file=$(mktemp)
+  # shellcheck disable=SC2123
+  PATH="$TEST_HOME/empty_bin" \
+    ceo_setup_check_required_tools "hint" git gh jq 2>"$err_file" || rc=$?
+  local err
+  err=$(cat "$err_file"); rm -f "$err_file"
+  assert_eq "$rc" "1" "any missing must return 1"
+  assert_contains "$err" "git gh jq" "all 3 missing tools must appear in the diagnostic"
+}
+
 # === ceo_setup_gh_auth — distinguish authed vs not-authed vs error (#102 item 2) ===
 
 # Helper to install a `gh` stub at $TEST_HOME/stubs/gh with given behavior.

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -23,6 +23,27 @@ ceo_setup_print_or_run() {
   fi
 }
 
+# Verify each <tool> is on PATH; on any missing, echo a diagnostic with the
+# caller-supplied follow-up hint (e.g. "Check brew output above for errors.")
+# and return 1. Returns 0 if all tools present, or if CEO_SETUP_DRY_RUN=1
+# (dry-run doesn't install anything, so don't fail it on a fresh shell).
+# Helper does NOT exit — callers must propagate.
+#
+# Sites collapsed from setup-mac.sh + setup-linux.sh per #122.
+ceo_setup_check_required_tools() {
+  local followup_hint="$1"; shift
+  local _missing=() _tool
+  for _tool in "$@"; do
+    command -v "$_tool" &>/dev/null || _missing+=("$_tool")
+  done
+  if [ "${#_missing[@]}" -gt 0 ] && [ "${CEO_SETUP_DRY_RUN:-0}" = "0" ]; then
+    echo "  Missing after install: ${_missing[*]}" >&2
+    echo "  $followup_hint" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Authenticate gh, distinguishing "not logged in" from "network/transient
 # failure". Pre-#102 each installer used `gh auth status &>/dev/null` and
 # fell through to `gh auth login` on any non-zero exit — including DNS

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -62,15 +62,7 @@ fi
 echo "[1/10] Installing required CLIs via $_pkg_mgr..."
 ceo_setup_print_or_run "${_pkg_install[@]}" "${_pkg_argv[@]}"
 
-_missing_tools=()
-for _tool in git gh jq; do
-  command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
-done
-if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
-  echo "  Missing after install: ${_missing_tools[*]}" >&2
-  echo "  Check $_pkg_mgr output above. On Ubuntu, 'gh' may require https://cli.github.com/." >&2
-  exit 1
-fi
+ceo_setup_check_required_tools "Check $_pkg_mgr output above. On Ubuntu, 'gh' may require https://cli.github.com/." git gh jq || exit 1
 
 # 2. gh authentication — disambiguate not-authed from transient network failures.
 ceo_setup_gh_auth "[2/10]"

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -49,15 +49,7 @@ fi
 echo "[1/10] Installing required CLIs via brew..."
 ceo_setup_print_or_run brew install git gh jq yq
 
-_missing_tools=()
-for _tool in git gh jq; do
-  command -v "$_tool" &>/dev/null || _missing_tools+=("$_tool")
-done
-if [ "${#_missing_tools[@]}" -gt 0 ] && [ "$CEO_SETUP_DRY_RUN" = "0" ]; then
-  echo "  Missing after install: ${_missing_tools[*]}" >&2
-  echo "  Check brew output above for errors." >&2
-  exit 1
-fi
+ceo_setup_check_required_tools "Check brew output above for errors." git gh jq || exit 1
 
 # 2. gh authentication — disambiguate not-authed from transient network failures.
 ceo_setup_gh_auth "[2/10]"


### PR DESCRIPTION
Closes #122

## Description

Pre-#122 the tools-presence check was duplicated inline in \`setup-mac.sh\` and \`setup-linux.sh\` as a five-line \`_missing_tools=()\` loop. The two versions differed only in the follow-up hint string. End-to-end testing of the exit-1 path required either reaching the interactive ssh-keygen prompt (which hangs CI — surfaced during PR #121) or a portable PATH that excludes git/gh/jq but includes shell utilities (impossible on both macOS and Ubuntu since \`/usr/bin\` ships them all).

Extract \`ceo_setup_check_required_tools <followup_hint> <tool>...\` to \`setup-common.sh\`. Helper returns 1 on missing (non-dry-run); callers propagate via \`|| exit 1\`. Dry-run path returns 0 to preserve the package-plan inspection contract from #96 (\`setup-scripts.test.sh\` asserts the dry-run goldens).

## Coverage (4 new tests, 30 total in \`ceo-setup.test.sh\`)

- All-present → rc=0, no stderr.
- Missing tool → rc=1 + \"Missing after install: tool_b\" + follow-up hint propagated.
- Dry-run with everything missing → rc=0 (the package-plan contract).
- Multiple missing → all listed in the diagnostic.

PATH override scoped to the helper call via subshell so the test process keeps \`mktemp\`/\`rm\`/\`cat\`. Mutation reverts the helper → 8 fails across the 4 new tests.

## Testing Procedure

1. Check out branch.
2. \`bash scripts/ceo-setup.test.sh\` → \`All tests passed. (30 tests)\`.
3. \`bash scripts/setup-scripts.test.sh\` → \`All tests passed. (4 tests)\` (sibling dry-run path unchanged).
4. Mutation: \`git stash push scripts/setup-common.sh -m mut\` + rerun ceo-setup tests → expect \`FAILED: 8\` across \`test_check_required_tools_*\`. Restore.
5. Sanity: \`bash setup-mac.sh --dry-run </dev/null\` still produces the same dry-run output (now via the helper's dry-run bypass).

## Additional Notes

Last open follow-up on the repo. After this lands, every #98 panel review item plus the #102 interactivity hardenings plus the #103 dispatch tests plus the #122 helper extraction are complete. Loop empty.