### PR TITLE
fix(scan): replace yq dependency with awk frontmatter parser

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -647,35 +647,57 @@ cmd_playbook_scan() {
           print val; exit
         }
       }
-    ' "$file"
+    ' "$file" 2>/dev/null
   }
   # Extract a YAML flow-sequence field and emit as a JSON array, or "null".
   # Handles: [item1, item2] -> ["item1","item2"]. Scalars/absent -> null.
   _fm_array_json() {
     local field="$1" file="$2"
+    # Two-pass approach avoids awk function definitions (which confuse bash quoting).
+    # Pass 1: look for an inline flow sequence or scalar on the same line as the field.
+    local inline
+    inline=$(_fm_scalar "$field" "$file")
+    if [ -n "$inline" ] && [ "$inline" != "null" ]; then
+      if [ "${inline:0:1}" = "[" ] && [ "${inline: -1}" = "]" ]; then
+        # Flow sequence — convert to JSON array.
+        echo "$inline" | awk '{
+          inner = substr($0, 2, length($0)-2)
+          n = split(inner, a, /,[[:space:]]*/);
+          printf "["
+          for (i=1;i<=n;i++) {
+            gsub(/^[[:space:]]+|[[:space:]]+$/,"",a[i])
+            gsub(/^["'"'"']|["'"'"']$/,"",a[i])
+            printf "%s\"%s\"",(i>1?",":""),a[i]
+          }
+          printf "]\n"
+        }' 2>/dev/null
+      else
+        # Scalar — return raw so caller can warn "must be an array".
+        echo "$inline"
+      fi
+      return
+    fi
+    # Pass 2: look for a block sequence (field: on its own line, then "  - item" lines).
     awk -v f="$field" '
       /^---[[:space:]]*$/ { fence++; next }
       fence >= 2 { exit }
-      fence == 1 {
-        if (match($0, "^" f ":")) {
-          val = substr($0, RSTART + length(f) + 1)
-          gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
-          if (val == "" || val == "null") { print "null"; exit }
-          if (substr(val,1,1) == "[" && substr(val,length(val),1) == "]") {
-            inner = substr(val, 2, length(val)-2)
-            n = split(inner, items, /,[[:space:]]*/);
-            printf "["
-            for (i=1; i<=n; i++) {
-              gsub(/^[[:space:]]+|[[:space:]]+$/, "", items[i])
-              gsub(/^["'"'"']|["'"'"']$/, "", items[i])
-              printf "%s\"%s\"", (i>1?",":""), items[i]
-            }
-            printf "]\n"; exit
-          }
-          print "null"; exit
-        }
+      fence == 1 && !found && match($0, "^" f ":") {
+        val = substr($0, RSTART+length(f)+1); gsub(/^[[:space:]]+/,"",val)
+        if (val == "" || val == "null") { found=1 }
       }
-    ' "$file"
+      found && /^[[:space:]]+-[[:space:]]/ {
+        item=$0; gsub(/^[[:space:]]+-[[:space:]]+/,"",item)
+        gsub(/^[[:space:]]+|[[:space:]]+$/,"",item)
+        items[++n]=item
+      }
+      found && n>0 && !/^[[:space:]]+-[[:space:]]/ && !/^---/ && !/^[[:space:]]*$/ && !match($0,"^"f":") { exit }
+      END {
+        if (n==0) { print "null"; exit }
+        printf "["
+        for(i=1;i<=n;i++) printf "%s\"%s\"",(i>1?",":""),items[i]
+        printf "]\n"
+      }
+    ' "$file" 2>/dev/null
   }
 
   local dry_run=0

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -632,11 +632,51 @@ cmd_playbook_diff() {
 }
 
 cmd_playbook_scan() {
-  if ! command -v yq &>/dev/null; then
-    echo "ERROR: yq is required for playbook scanning."
-    echo "Install: brew install yq (macOS) or snap install yq (Linux)"
-    exit 1
-  fi
+  # Extract a scalar field from YAML frontmatter without requiring yq.
+  # Handles quoted and unquoted values; returns empty string if absent.
+  _fm_scalar() {
+    local field="$1" file="$2"
+    awk -v f="$field" '
+      /^---[[:space:]]*$/ { fence++; next }
+      fence >= 2 { exit }
+      fence == 1 {
+        if (match($0, "^" f ":")) {
+          val = substr($0, RSTART + length(f) + 1)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+          gsub(/^["'"'"']|["'"'"']$/, "", val)
+          print val; exit
+        }
+      }
+    ' "$file"
+  }
+  # Extract a YAML flow-sequence field and emit as a JSON array, or "null".
+  # Handles: [item1, item2] -> ["item1","item2"]. Scalars/absent -> null.
+  _fm_array_json() {
+    local field="$1" file="$2"
+    awk -v f="$field" '
+      /^---[[:space:]]*$/ { fence++; next }
+      fence >= 2 { exit }
+      fence == 1 {
+        if (match($0, "^" f ":")) {
+          val = substr($0, RSTART + length(f) + 1)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+          if (val == "" || val == "null") { print "null"; exit }
+          if (substr(val,1,1) == "[" && substr(val,length(val),1) == "]") {
+            inner = substr(val, 2, length(val)-2)
+            n = split(inner, items, /,[[:space:]]*/);
+            printf "["
+            for (i=1; i<=n; i++) {
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "", items[i])
+              gsub(/^["'"'"']|["'"'"']$/, "", items[i])
+              printf "%s\"%s\"", (i>1?",":""), items[i]
+            }
+            printf "]\n"; exit
+          }
+          print "null"; exit
+        }
+      }
+    ' "$file"
+  }
 
   local dry_run=0
   for arg in "$@"; do
@@ -715,7 +755,7 @@ cmd_playbook_scan() {
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
     local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual
-    name=$(yq --front-matter=extract '.name // ""' "$f" 2>/dev/null || echo "")
+    name=$(_fm_scalar name "$f")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
       skipped=$((skipped + 1))
@@ -751,25 +791,25 @@ cmd_playbook_scan() {
       seen_names_vault="${seen_names_vault}${name}"$'\n'
     fi
 
-    description=$(yq --front-matter=extract '.description // ""' "$f" 2>/dev/null || echo "")
-    trigger=$(yq --front-matter=extract '.trigger // ""' "$f" 2>/dev/null || echo "")
-    schedule=$(yq --front-matter=extract '.schedule // ""' "$f" 2>/dev/null || echo "")
-    model=$(yq --front-matter=extract '.model // ""' "$f" 2>/dev/null || echo "")
-    preflight=$(yq --front-matter=extract '.preflight // ""' "$f" 2>/dev/null || echo "")
-    tier=$(yq --front-matter=extract '.tier // ""' "$f" 2>/dev/null || echo "")
-    status=$(yq --front-matter=extract '.status // ""' "$f" 2>/dev/null || echo "")
+    description=$(_fm_scalar description "$f")
+    trigger=$(_fm_scalar trigger "$f")
+    schedule=$(_fm_scalar schedule "$f")
+    model=$(_fm_scalar model "$f")
+    preflight=$(_fm_scalar preflight "$f")
+    tier=$(_fm_scalar tier "$f")
+    status=$(_fm_scalar status "$f")
     if [ -n "$status" ] && ! ceo_status_valid "$status"; then
       echo "  SKIP  $basename (unknown status: '$status', expected: ${CEO_VALID_STATUSES[*]})" >&2
       skipped=$((skipped + 1))
       invalid_status=$((invalid_status + 1))
       continue
     fi
-    bin=$(yq --front-matter=extract '.bin // ""' "$f" 2>/dev/null || echo "")
-    runner=$(yq --front-matter=extract '.runner // ""' "$f" 2>/dev/null || echo "")
-    script=$(yq --front-matter=extract '.script // ""' "$f" 2>/dev/null || echo "")
-    skill=$(yq --front-matter=extract '.skill // ""' "$f" 2>/dev/null || echo "")
-    out_pattern=$(yq --front-matter=extract '.out_pattern // ""' "$f" 2>/dev/null || echo "")
-    artifact=$(yq --front-matter=extract '.artifact // ""' "$f" 2>/dev/null || echo "")
+    bin=$(_fm_scalar bin "$f")
+    runner=$(_fm_scalar runner "$f")
+    script=$(_fm_scalar script "$f")
+    skill=$(_fm_scalar skill "$f")
+    out_pattern=$(_fm_scalar out_pattern "$f")
+    artifact=$(_fm_scalar artifact "$f")
     # Validate at parse time per enum-config-typo-fallback: an artifact
     # template must be vault-relative ("CEO/...") and reference only the
     # supported tokens {TODAY} and {HOST}. Reject anything else with a warn,
@@ -793,7 +833,7 @@ cmd_playbook_scan() {
           ;;
       esac
     fi
-    requires=$(yq --front-matter=extract --output-format=json '.requires // null' "$f" 2>/dev/null || echo "null")
+    requires=$(_fm_array_json requires "$f")
     case "$requires" in
       "null"|"") requires="null" ;;
       \[*\]) ;;
@@ -806,7 +846,7 @@ cmd_playbook_scan() {
     # Absent → all keys (backward-compatible default). [] → none. Non-array →
     # warn and treat as absent (per enum-config-typo-fallback rule). yq emits
     # a JSON array as a "compact" string when shaped right; we capture raw JSON.
-    inputs=$(yq --front-matter=extract --output-format=json '.inputs // null' "$f" 2>/dev/null || echo "null")
+    inputs=$(_fm_array_json inputs "$f")
     case "$inputs" in
       "null"|"") inputs="null" ;;
       \[*\])

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2929,7 +2929,6 @@ requires: [gh]
 PB
 
   # Remove yq from stubbed PATH to simulate a machine without it installed.
-  local saved_path="$PATH"
   rm -f "$TEST_HOME/.bun/bin/yq"
   local rc=0
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2913,4 +2913,40 @@ EOF
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_playbook_scan_succeeds_without_yq() {
+  cat > "$CEO_DIR/playbooks/no-yq-test.md" << 'PB'
+---
+name: no-yq-test
+description: Verify scan works without yq
+trigger: cron
+schedule: "0 9 * * *"
+runner: script
+script: fake-no-yq.sh
+tier: read
+status: active
+requires: [gh]
+---
+PB
+
+  # Remove yq from stubbed PATH to simulate a machine without it installed.
+  local saved_path="$PATH"
+  rm -f "$TEST_HOME/.bun/bin/yq"
+  local rc=0
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ceo playbook scan must succeed even when yq is not on PATH"
+  assert_file_exists "$CEO_DIR/registry.json" "registry.json must be written without yq"
+  local reg_name
+  reg_name=$(jq -r '.playbooks[] | select(.name=="no-yq-test") | .name' "$CEO_DIR/registry.json" 2>/dev/null)
+  assert_eq "$reg_name" "no-yq-test" "playbook must be registered without yq"
+
+  # Restore yq stub for subsequent tests.
+  cat > "$TEST_HOME/.bun/bin/yq" << 'STUB'
+#!/bin/bash
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/yq"
+  rm -f "$CEO_DIR/playbooks/no-yq-test.md"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
+}
+
 run_tests


### PR DESCRIPTION
Closes #131

## Description

ceo playbook scan hard-exited if yq was not installed, but ceo setup only warns about missing yq without installing it. Any machine that completed setup without yq would have all crons break whenever the registry needed regenerating.

All playbook frontmatter fields are simple scalars or YAML flow sequences parseable with POSIX awk. Adds _fm_scalar and _fm_array_json helpers inside cmd_playbook_scan, replacing all 15 yq calls. Removes the hard yq guard entirely.

## Testing Procedure

1. Check out on a machine without yq installed
2. Run ceo playbook scan --dry-run — should list all playbooks
3. Run ceo playbook scan — should write registry.json at schema_version 3
4. Confirm ceo-cron.sh disk-monitor exits 0

## Additional Notes

Verified on ML-1 (WSL, no yq): scan produced 17 playbooks, registry written at schema_version 3.