### PR TITLE
Add cron run-modes: scheduled enforces active, manual allows draft (#137)

### DIFF
--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -35,9 +35,22 @@ Unknown values for enum fields are **rejected at parse time** with a `SKIP` diag
 | missing / empty | yes | no (treated as inactive) | yes (`status: -`) | no special surface |
 | anything else | **rejected at parse** with `SKIP <basename> (unknown status: ...)` — entry is dropped from the registry, no fallback to a default | — | — | — |
 
+### Run modes — on-demand vs scheduled
+
+`ceo-cron.sh` distinguishes who is invoking it:
+
+| Invocation | Mode | Status enforcement |
+|---|---|---|
+| `ceo-cron.sh <name>` (bare) or `--manual` | manual (on-demand) | runs any valid status — the "on-demand" column above |
+| `ceo-cron.sh <name> --scheduled` | scheduled (cron/daemon) | runs `status: active` only; `draft` / `disabled` / missing are skipped |
+
+The default is **manual**, so a bare `ceo-cron.sh <name>` is the on-demand path the table documents. The scheduler (the Phase-1.5 daemon, and any cron line that opts in) passes `--scheduled` to enforce `active`. Because `ceo playbook scan` installs cron lines for `active` playbooks only, a real cron line never targets a non-active playbook regardless of mode.
+
+`--scheduled` and `--manual` are mutually exclusive. `--force` (manual-only) bypasses the per-trigger cooldown for iterative smoke-testing; it is rejected with `--scheduled`.
+
 ### Use draft for WIP playbooks
 
-`draft` exists for "exists, runnable on demand, not ready for cron." Author iteratively via `bash scripts/ceo-cron.sh <name>` until happy with the behavior, then flip frontmatter to `status: active` and re-run `ceo playbook scan` to install.
+`draft` exists for "exists, runnable on demand, not ready for cron." Author iteratively via `bash scripts/ceo-cron.sh <name>` (optionally `--force` to bypass the cooldown between runs) until happy with the behavior, then flip frontmatter to `status: active` and re-run `ceo playbook scan` to install.
 
 ### Use disabled to durably tear down
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -13,7 +13,37 @@ set -euo pipefail
 #
 # High-stakes actions are written to CEO/approvals/pending.md, not executed.
 
-TRIGGER="${1:?Usage: ceo-cron.sh <trigger>}"
+# One positional trigger plus optional run-mode flags. RUN_MODE defaults to
+# "scheduled" (safe-fail): a bare invocation — as every existing crontab line
+# uses — enforces status:active exactly as before. A human passes --manual to
+# run a draft; forgetting the flag fails safe rather than auto-running a draft.
+RUN_MODE="scheduled"
+TRIGGER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --scheduled) RUN_MODE="scheduled" ;;
+    --manual)    RUN_MODE="manual" ;;
+    --force)     CEO_FORCE=1 ;;
+    -*)
+      echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force)" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$TRIGGER" ]; then
+        echo "ERROR: unexpected extra argument '$1' (only one trigger allowed)" >&2
+        exit 1
+      fi
+      TRIGGER="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$TRIGGER" ]; then
+  echo "Usage: ceo-cron.sh <trigger> [--scheduled|--manual] [--force]" >&2
+  exit 1
+fi
+
 # Gates filesystem path (.last-run-${TRIGGER}), env export (CEO_PLAYBOOK_ID),
 # and LLM prompt JSON interpolation against quote/escape/traversal injection.
 if [[ ! "$TRIGGER" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
@@ -410,7 +440,7 @@ else
   fi
 fi
 
-# --- Per-trigger runaway protection (skip with --force) ---
+# --- Per-trigger runaway protection (bypass with --force or CEO_FORCE=1) ---
 if [ "${CEO_FORCE:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then
   LAST_RUN=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo 0)
   case "$LAST_RUN" in (''|*[!0-9]*) LAST_RUN=0 ;; esac
@@ -599,10 +629,23 @@ if [ ! -f "$PLAYBOOK_FILE" ]; then
   exit 1
 fi
 
-if [ "$STATUS" != "active" ]; then
-  echo "$(date): Playbook '$TRIGGER' is not active (status: $STATUS)" >> "$LOG_DIR/cron-skips.log"
-  exit 0
-fi
+# Run-mode gate (#137): scheduled invocations enforce status:active; manual
+# (human, --manual) invocations may also run a draft for smoke-testing. disabled
+# and any unexpected status never auto-run. STATUS is validated against
+# CEO_VALID_STATUSES at scan time and RUN_MODE at arg-parse; the catch-all is
+# defense-in-depth against a hand-edited registry.
+case "$RUN_MODE:$STATUS" in
+  scheduled:active|manual:active|manual:draft)
+    ;;
+  scheduled:draft|scheduled:disabled|manual:disabled)
+    echo "$(date): Playbook '$TRIGGER' not runnable in $RUN_MODE mode (status: $STATUS)" >> "$LOG_DIR/cron-skips.log"
+    exit 0
+    ;;
+  *)
+    echo "$(date): Playbook '$TRIGGER' not runnable — unexpected run-mode:status '$RUN_MODE:$STATUS'" >> "$LOG_DIR/cron-skips.log"
+    exit 0
+    ;;
+esac
 
 # --- Run preflight check ---
 PREFLIGHT_FN="preflight_${PREFLIGHT}"

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -13,17 +13,29 @@ set -euo pipefail
 #
 # High-stakes actions are written to CEO/approvals/pending.md, not executed.
 
-# One positional trigger plus optional run-mode flags. RUN_MODE defaults to
-# "scheduled" (safe-fail): a bare invocation — as every existing crontab line
-# uses — enforces status:active exactly as before. A human passes --manual to
-# run a draft; forgetting the flag fails safe rather than auto-running a draft.
-RUN_MODE="scheduled"
+# One positional trigger plus optional run-mode flags.
+#   - manual (default, or --manual): the human on-demand path. Runs any valid
+#     status — active, draft, or disabled — per docs/playbooks/SCHEMA.md, so a
+#     bare `ceo-cron.sh <name>` smoke-tests a draft exactly as the schema documents.
+#   - scheduled (--scheduled): the cron/daemon path. Enforces status:active.
+# `ceo playbook scan` installs cron lines for active playbooks only, so a bare
+# cron line never targets a draft; the Phase-1.5 daemon fires from the registry
+# and passes --scheduled to enforce active itself.
+RUN_MODE="manual"
+_mode_set=""
+FORCE_REQUESTED=0
 TRIGGER=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --scheduled) RUN_MODE="scheduled" ;;
-    --manual)    RUN_MODE="manual" ;;
-    --force)     CEO_FORCE=1 ;;
+    --scheduled|--manual)
+      _m="${1#--}"
+      if [ -n "$_mode_set" ] && [ "$_mode_set" != "$_m" ]; then
+        echo "ERROR: --scheduled and --manual are mutually exclusive" >&2
+        exit 1
+      fi
+      RUN_MODE="$_m"; _mode_set="$_m"
+      ;;
+    --force) FORCE_REQUESTED=1 ;;
     -*)
       echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force)" >&2
       exit 1
@@ -42,6 +54,17 @@ done
 if [ -z "$TRIGGER" ]; then
   echo "Usage: ceo-cron.sh <trigger> [--scheduled|--manual] [--force]" >&2
   exit 1
+fi
+
+# --force is a manual-only smoke-test escape hatch from the per-trigger cooldown.
+# Honouring it on scheduled runs would let a stray crontab/daemon flag defeat the
+# runaway-protection invariant, so it is rejected outside manual mode.
+if [ "$FORCE_REQUESTED" = "1" ]; then
+  if [ "$RUN_MODE" != "manual" ]; then
+    echo "ERROR: --force is only valid with manual (on-demand) runs, not --scheduled" >&2
+    exit 1
+  fi
+  CEO_FORCE=1
 fi
 
 # Gates filesystem path (.last-run-${TRIGGER}), env export (CEO_PLAYBOOK_ID),
@@ -569,7 +592,8 @@ MODEL=$(echo "$ENTRY" | jq -r '.model // ""')
 # claude-default fallback below. Empty string = no override.
 MODEL_FROM_FRONTMATTER="$MODEL"
 PREFLIGHT=$(echo "$ENTRY" | jq -r '.preflight // "none"')
-STATUS=$(echo "$ENTRY" | jq -r '.status // "active"')
+STATUS=$(echo "$ENTRY" | jq -r '.status // "unset"')
+[ -z "$STATUS" ] && STATUS="unset"
 TRIGGER_TYPE=$(echo "$ENTRY" | jq -r '.trigger // "cron"')
 TIER=$(echo "$ENTRY" | jq -r '.tier // "read"')
 RUNNER=$(echo "$ENTRY" | jq -r '.runner // ""')
@@ -629,16 +653,19 @@ if [ ! -f "$PLAYBOOK_FILE" ]; then
   exit 1
 fi
 
-# Run-mode gate (#137): scheduled invocations enforce status:active; manual
-# (human, --manual) invocations may also run a draft for smoke-testing. disabled
-# and any unexpected status never auto-run. STATUS is validated against
-# CEO_VALID_STATUSES at scan time and RUN_MODE at arg-parse; the catch-all is
+# Run-mode gate (#137):
+#   - scheduled (cron/daemon): runs status:active only.
+#   - manual (default / --manual, on-demand): runs any valid status
+#     (active|draft|disabled) per docs/playbooks/SCHEMA.md status-semantics.
+# A missing status normalises to "unset" above and is treated as "not active":
+# runnable on-demand but never under a scheduler. Non-empty STATUS is validated
+# against CEO_VALID_STATUSES at scan time (scripts/ceo); the catch-all is
 # defense-in-depth against a hand-edited registry.
 case "$RUN_MODE:$STATUS" in
-  scheduled:active|manual:active|manual:draft)
-    ;;
-  scheduled:draft|scheduled:disabled|manual:disabled)
-    echo "$(date): Playbook '$TRIGGER' not runnable in $RUN_MODE mode (status: $STATUS)" >> "$LOG_DIR/cron-skips.log"
+  scheduled:active) ;;
+  manual:active|manual:draft|manual:disabled|manual:unset) ;;
+  scheduled:draft|scheduled:disabled|scheduled:unset)
+    echo "$(date): Playbook '$TRIGGER' not runnable in scheduled mode (status: $STATUS)" >> "$LOG_DIR/cron-skips.log"
     exit 0
     ;;
   *)

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2948,7 +2948,9 @@ STUB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
 }
 
-# --- #137 run-modes: scheduled enforces active; manual allows draft ---
+# --- #137 run-modes: scheduled (cron/daemon, --scheduled) enforces active;
+#     manual (default / --manual, on-demand) runs any valid status per
+#     docs/playbooks/SCHEMA.md status-semantics. ---
 
 _register_status_playbook() {
   cat > "$CEO_DIR/playbooks/$1.md" << PB
@@ -2971,6 +2973,21 @@ test_cron_manual_mode_runs_draft_playbook() {
   assert_file_exists "$HOME/claude-invoked.txt" "manual run of a draft playbook must dispatch"
 }
 
+# SCHEMA: bare ceo-cron.sh <name> IS the on-demand path. Default mode is manual,
+# so a bare invocation runs a draft. Fails on the old gate and on a default=scheduled impl.
+test_cron_default_mode_runs_draft_playbook() {
+  _register_status_playbook rm-draft-d draft
+  bash "$CRON" rm-draft-d >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "bare (default=manual) run of a draft must dispatch (SCHEMA on-demand)"
+}
+
+# SCHEMA: on-demand runs disabled too (explicit human force-run).
+test_cron_manual_mode_runs_disabled_playbook() {
+  _register_status_playbook rm-disabled disabled
+  bash "$CRON" rm-disabled --manual >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "manual run of a disabled playbook must dispatch (SCHEMA on-demand)"
+}
+
 test_cron_scheduled_mode_skips_draft_playbook() {
   _register_status_playbook rm-draft2 draft
   bash "$CRON" rm-draft2 --scheduled >/dev/null 2>&1 || true
@@ -2978,16 +2995,10 @@ test_cron_scheduled_mode_skips_draft_playbook() {
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "rm-draft2" "draft skip must be logged"
 }
 
-test_cron_default_mode_skips_draft_playbook() {
-  _register_status_playbook rm-draft3 draft
-  bash "$CRON" rm-draft3 >/dev/null 2>&1 || true
-  assert_fails "bare invocation (default=scheduled) of a draft must NOT dispatch" test -f "$HOME/claude-invoked.txt"
-}
-
-test_cron_manual_mode_skips_disabled_playbook() {
-  _register_status_playbook rm-disabled disabled
-  bash "$CRON" rm-disabled --manual >/dev/null 2>&1 || true
-  assert_fails "manual run of a disabled playbook must NOT dispatch" test -f "$HOME/claude-invoked.txt"
+test_cron_scheduled_mode_skips_disabled_playbook() {
+  _register_status_playbook rm-disabled2 disabled
+  bash "$CRON" rm-disabled2 --scheduled >/dev/null 2>&1 || true
+  assert_fails "scheduled run of a disabled playbook must NOT dispatch" test -f "$HOME/claude-invoked.txt"
 }
 
 test_cron_scheduled_mode_runs_active_playbook() {
@@ -2996,32 +3007,94 @@ test_cron_scheduled_mode_runs_active_playbook() {
   assert_file_exists "$HOME/claude-invoked.txt" "scheduled run of an active playbook must dispatch"
 }
 
+# Missing status: SCHEMA treats it as "not active". The old `// "active"`
+# coercion would wrongly run it under --scheduled; it must skip.
+test_cron_scheduled_mode_skips_missing_status() {
+  cat > "$CEO_DIR/playbooks/rm-nostatus.md" << 'PB'
+---
+name: rm-nostatus
+description: run-mode fixture, no status field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_contains "$(jq -r '.playbooks[].name' "$CEO_DIR/registry.json" 2>/dev/null)" "rm-nostatus" "missing-status playbook must be registered (so the gate, not a missing entry, is what skips it)"
+  bash "$CRON" rm-nostatus --scheduled >/dev/null 2>&1 || true
+  assert_fails "scheduled run of a missing-status playbook must NOT dispatch (SCHEMA: missing = not active)" test -f "$HOME/claude-invoked.txt"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "not runnable in scheduled mode" "skip must come from the run-mode gate, not a missing registry entry"
+}
+
+test_cron_flag_before_trigger_is_accepted() {
+  _register_status_playbook rm-order draft
+  bash "$CRON" --manual rm-order >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "flags before the trigger must parse (order-independent)"
+}
+
 test_cron_rejects_unknown_run_mode_flag() {
   _register_status_playbook rm-active2 active
   local rc=0
   bash "$CRON" rm-active2 --bogus >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
   assert_eq "$rc" "1" "unknown flag must be rejected with non-zero exit"
   assert_contains "$(cat "$TEST_HOME/cron-stderr")" "unknown" "stderr must explain the rejected flag"
+  assert_fails "a rejected invocation must not dispatch" test -f "$HOME/claude-invoked.txt"
 }
 
+test_cron_rejects_conflicting_run_modes() {
+  _register_status_playbook rm-active3 active
+  local rc=0
+  bash "$CRON" rm-active3 --scheduled --manual >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
+  assert_eq "$rc" "1" "--scheduled and --manual together must be rejected"
+  assert_fails "a rejected invocation must not dispatch" test -f "$HOME/claude-invoked.txt"
+}
+
+test_cron_rejects_empty_trigger() {
+  local rc=0
+  bash "$CRON" --manual >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
+  assert_eq "$rc" "1" "a flag with no trigger must exit non-zero"
+  assert_contains "$(cat "$TEST_HOME/cron-stderr")" "Usage" "stderr must print usage"
+}
+
+test_cron_rejects_double_trigger() {
+  local rc=0
+  bash "$CRON" alpha beta >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
+  assert_eq "$rc" "1" "two positional triggers must be rejected"
+}
+
+# --force is a manual-only smoke-test escape hatch; it must not weaken the
+# runaway-protection invariant on scheduled (cron/daemon) runs.
+test_cron_rejects_force_on_scheduled() {
+  _register_status_playbook rm-active4 active
+  local rc=0
+  bash "$CRON" rm-active4 --scheduled --force >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
+  assert_eq "$rc" "1" "--force with --scheduled must be rejected"
+}
+
+# Isolate --force: all three runs are manual+active, so only --force can explain
+# the third dispatch surviving the cooldown.
 test_cron_force_flag_bypasses_cooldown() {
   _register_status_playbook rm-cool active
-  bash "$CRON" rm-cool --scheduled >/dev/null 2>&1 || true
+  bash "$CRON" rm-cool --manual >/dev/null 2>&1 || true
   assert_file_exists "$HOME/claude-invoked.txt" "first run must dispatch and record last-run"
   rm -f "$HOME/claude-invoked.txt"
-  bash "$CRON" rm-cool --scheduled >/dev/null 2>&1 || true
-  assert_fails "second run within cooldown must be skipped" test -f "$HOME/claude-invoked.txt"
+  bash "$CRON" rm-cool --manual >/dev/null 2>&1 || true
+  assert_fails "second manual run within cooldown must be skipped" test -f "$HOME/claude-invoked.txt"
   bash "$CRON" rm-cool --manual --force >/dev/null 2>&1 || true
   assert_file_exists "$HOME/claude-invoked.txt" "--force must bypass the per-trigger cooldown"
 }
 
+# The catch-all arm must skip an out-of-set status (hand-edited registry) AND emit
+# its distinct diagnostic — not the message any non-active status produced under
+# the old gate (that would be a tautology passing on pre-change code).
 test_cron_catchall_skips_unknown_status() {
   _register_status_playbook rm-weird active
   local reg="$CEO_DIR/registry.json"
   jq '(.playbooks[] | select(.name=="rm-weird") | .status) = "bogus"' "$reg" > "$reg.tmp" && mv "$reg.tmp" "$reg"
   bash "$CRON" rm-weird --manual >/dev/null 2>&1 || true
   assert_fails "out-of-set status must never dispatch (defense-in-depth catch-all)" test -f "$HOME/claude-invoked.txt"
-  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "rm-weird" "catch-all skip must be logged"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unexpected run-mode:status" "catch-all must emit its distinct diagnostic"
 }
 
 run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2948,4 +2948,80 @@ STUB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
 }
 
+# --- #137 run-modes: scheduled enforces active; manual allows draft ---
+
+_register_status_playbook() {
+  cat > "$CEO_DIR/playbooks/$1.md" << PB
+---
+name: $1
+description: run-mode fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: $2
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+}
+
+test_cron_manual_mode_runs_draft_playbook() {
+  _register_status_playbook rm-draft draft
+  bash "$CRON" rm-draft --manual >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "manual run of a draft playbook must dispatch"
+}
+
+test_cron_scheduled_mode_skips_draft_playbook() {
+  _register_status_playbook rm-draft2 draft
+  bash "$CRON" rm-draft2 --scheduled >/dev/null 2>&1 || true
+  assert_fails "scheduled run of a draft must NOT dispatch" test -f "$HOME/claude-invoked.txt"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "rm-draft2" "draft skip must be logged"
+}
+
+test_cron_default_mode_skips_draft_playbook() {
+  _register_status_playbook rm-draft3 draft
+  bash "$CRON" rm-draft3 >/dev/null 2>&1 || true
+  assert_fails "bare invocation (default=scheduled) of a draft must NOT dispatch" test -f "$HOME/claude-invoked.txt"
+}
+
+test_cron_manual_mode_skips_disabled_playbook() {
+  _register_status_playbook rm-disabled disabled
+  bash "$CRON" rm-disabled --manual >/dev/null 2>&1 || true
+  assert_fails "manual run of a disabled playbook must NOT dispatch" test -f "$HOME/claude-invoked.txt"
+}
+
+test_cron_scheduled_mode_runs_active_playbook() {
+  _register_status_playbook rm-active active
+  bash "$CRON" rm-active --scheduled >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "scheduled run of an active playbook must dispatch"
+}
+
+test_cron_rejects_unknown_run_mode_flag() {
+  _register_status_playbook rm-active2 active
+  local rc=0
+  bash "$CRON" rm-active2 --bogus >/dev/null 2>"$TEST_HOME/cron-stderr" || rc=$?
+  assert_eq "$rc" "1" "unknown flag must be rejected with non-zero exit"
+  assert_contains "$(cat "$TEST_HOME/cron-stderr")" "unknown" "stderr must explain the rejected flag"
+}
+
+test_cron_force_flag_bypasses_cooldown() {
+  _register_status_playbook rm-cool active
+  bash "$CRON" rm-cool --scheduled >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "first run must dispatch and record last-run"
+  rm -f "$HOME/claude-invoked.txt"
+  bash "$CRON" rm-cool --scheduled >/dev/null 2>&1 || true
+  assert_fails "second run within cooldown must be skipped" test -f "$HOME/claude-invoked.txt"
+  bash "$CRON" rm-cool --manual --force >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "--force must bypass the per-trigger cooldown"
+}
+
+test_cron_catchall_skips_unknown_status() {
+  _register_status_playbook rm-weird active
+  local reg="$CEO_DIR/registry.json"
+  jq '(.playbooks[] | select(.name=="rm-weird") | .status) = "bogus"' "$reg" > "$reg.tmp" && mv "$reg.tmp" "$reg"
+  bash "$CRON" rm-weird --manual >/dev/null 2>&1 || true
+  assert_fails "out-of-set status must never dispatch (defense-in-depth catch-all)" test -f "$HOME/claude-invoked.txt"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "rm-weird" "catch-all skip must be logged"
+}
+
 run_tests


### PR DESCRIPTION
Closes #137

## Description (Issue Fixed & New Behavior)
Phase 1 of #136. Adds a run-mode distinction to the `ceo-cron.sh` dispatcher and replaces the `status != active` catch-all (old line ~602) with an exhaustive gate, resolving the long-standing mismatch where the gate blocked the on-demand draft runs that `docs/playbooks/SCHEMA.md` documents.

**Run modes** (net-new arg-parsing layer; `ceo-cron.sh` previously took a single bare positional):
- **manual (default, or `--manual`)** — the human on-demand path. Runs **any valid status** (`active` / `draft` / `disabled`), matching the SCHEMA status-semantics "on-demand" column. So a bare `ceo-cron.sh <name>` smoke-tests a draft exactly as SCHEMA's "author iteratively" guidance says.
- **scheduled (`--scheduled`)** — the cron/daemon path. Enforces `status: active`; `draft` / `disabled` / missing are skipped and logged.

**Why default=manual is safe:** `ceo playbook scan` installs cron lines for `active` playbooks only, so a real cron line never targets a non-active playbook regardless of mode. The Phase-1.5 daemon fires from the registry and passes `--scheduled` to enforce `active` itself. The runtime gate is defense-in-depth on top of that.

**Gate** — exhaustive `case "$RUN_MODE:$STATUS"`:
- `scheduled:active`, `manual:{active,draft,disabled,unset}` → run
- `scheduled:{draft,disabled,unset}` → skip (logged)
- `*` → skip (logged with a distinct diagnostic) — defense-in-depth against a hand-edited registry

**Hardening:**
- Missing status normalises to `unset` (was coerced to `active`), so a scheduled run never auto-runs a status-less playbook.
- `--scheduled` and `--manual` are mutually exclusive (was silent last-wins).
- `--force` bypasses the per-trigger 1800s cooldown for iterative smoke-tests, but is **manual-only** — rejected with `--scheduled` so a stray scheduler flag can't defeat runaway protection.
- Unknown flags, empty trigger, and a second positional are all rejected with exit 1.

Downstream lock acquisition, cooldown, `.last-run-$TRIGGER`, the trigger-regex validation, and all exit paths are unchanged — they remain keyed on `$TRIGGER`.

`docs/playbooks/SCHEMA.md` gains a "Run modes" subsection documenting the flags.

**Relationship to #135:** unblocks the reconcile playbook's draft smoke-test via `ceo-cron.sh reconcile --manual` (it's propose-only, writing to `CEO/approvals/pending.md`). Note #135 also lists `--dry-run` (#138) as part of its smoke-test story; that ships separately in Phase 1.

**Scope note:** `--force` is not in the literal #137 ask. It's included because the manual-smoke-test use case (#135) hits the cooldown on repeat runs; it's a flag alias for the existing `CEO_FORCE=1` env var, now scoped to manual mode.

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-cron.test.sh` — confirm `All tests passed. (104 tests)`.
3. `shellcheck --severity=warning scripts/ceo-cron.sh scripts/ceo-cron.test.sh` — confirm no findings.
4. Spot-check: `TEST_FILTER=_mode_ bash scripts/ceo-cron.test.sh` and `TEST_FILTER=force bash scripts/ceo-cron.test.sh`.
5. Revert checks: `test_cron_default_mode_runs_draft_playbook` and `test_cron_manual_mode_runs_disabled_playbook` fail against the old `!= active` gate; `test_cron_rejects_force_on_scheduled` and `test_cron_rejects_conflicting_run_modes` fail if the parser hardening is removed.

## Additional Notes
- Design recorded in Obsidian (`…/nhangen/claude-ceo/specs/ceo-dispatcher-design.md`); see #136 for the phased dispatcher plan.
- Independently audited pre-push, then reviewed by a 3-agent panel (safety / test-quality / ask-alignment). The panel caught an inverted default (was scheduled, now manual per SCHEMA), a missing-status fail-open, and a `--force`/cooldown gap on scheduled runs — all addressed in the second commit.