### PR TITLE
feat(triage-autopilot): route ticket-triage by repo owner; re-enable playbook

### DIFF
--- a/docs/playbooks/ticket-triage-autopilot.md
+++ b/docs/playbooks/ticket-triage-autopilot.md
@@ -1,11 +1,11 @@
 ---
 name: ticket-triage-autopilot
-description: Poll for merged PRs every 30 min; on new merges spawn ticket-triage and append top-3 adjacency-scored tickets to inbox.md
+description: Poll for merged PRs every 30 min; on new merges route ticket-triage by repo owner (ZenHub for AM, GitHub issues for personal) and append top-3 adjacency-scored tickets to inbox.md
 trigger: cron
 schedule: "*/30 * * * *"
 preflight: none
 tier: low-stakes write
-status: disabled
+status: active
 runner: script
 script: ceo-triage-autopilot.sh
 ---
@@ -15,6 +15,18 @@ script: ceo-triage-autopilot.sh
 Shell-only playbook. Every 30 minutes it checks for newly merged PRs by the configured author across the repos in `~/.config/branch-cleanup/repos.md`. If any new merges are seen since the last check, it spawns `claude --print` to invoke the `/ticket-triage` skill, parses a strict JSON contract from the output, and appends the top-3 tickets to `$CEO_VAULT/CEO/inbox.md`.
 
 State machine, not signal generator. A cron tick with no new merges writes the state file and a log line and does nothing else.
+
+## Owner routing (#146)
+
+ZenHub and the `nhangenam` account are AM-only; personal `nhangen/*` repos have no ZenHub board, so their tickets come from GitHub issues (the `ticket-triage` skill's GitHub source, #133). On a tick with new merges, each merge's repo is classified by owner:
+
+| Owner class (default) | Source | Spawn |
+|---|---|---|
+| `awesomemotive`, `nhangenam` | ZenHub pipeline (`CEO_TRIAGE_PIPELINE`) | One spawn covering all AM merges — the OM ZenHub workspace is "All Products", unified across optinmonster/trustpulse/beacon/comment-converter, so a single pipeline triage serves every AM repo. |
+| `nhangen` | GitHub issues for that repo | One spawn per distinct personal repo (the skill takes a single `owner/repo` slug). |
+| anything else (e.g. `altamira2`) | — | Skipped with a logged reason. The merge still advances the cursor so it is not re-evaluated every tick. |
+
+A tick is `firing` only if at least one triage spawn ran. Skip-only ticks are `clear` and advance the cursor. If **any** spawned source fails, the cursor is held (the existing retry-cap give-up still applies on the aggregate failure count) so a failed source's merge window is not dropped — re-running next tick is cheap because inbox markers dedup already-written tickets.
 
 ## Origin
 
@@ -45,7 +57,9 @@ Issue #125. Initial design used a Stop hook on `pr-review-panel` — that doesn'
 - `CEO_GH_BIN` — substitute `gh` binary. Tests inject a stub.
 - `CEO_TRIAGE_CLAUDE_BIN` — substitute `claude` binary. Tests inject a stub emitting canned JSON.
 - `CEO_TRIAGE_REPO_LIST` — substitute repo-list markdown file (default `~/.config/branch-cleanup/repos.md`).
-- `CEO_TRIAGE_PIPELINE` — pipeline alias to pass to `/ticket-triage` (default `inbox`).
+- `CEO_TRIAGE_PIPELINE` — ZenHub pipeline alias to pass to `/ticket-triage` for AM repos (default `inbox`).
+- `CEO_TRIAGE_ZENHUB_OWNERS` — space-separated repo owners routed to the ZenHub source (default `awesomemotive nhangenam`).
+- `CEO_TRIAGE_GITHUB_OWNERS` — space-separated repo owners routed to the GitHub-issues source (default `nhangen`).
 
 ## The JSON contract with claude
 
@@ -63,4 +77,4 @@ Up to 3 entries. The wrapper extracts the first JSON block, validates `tickets` 
 
 ## Disable
 
-Set `status: inactive` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/ticket-triage-autopilot.md`) and re-scan.
+Set `status: disabled` in this file (or in a vault override at `$CEO_VAULT/CEO/playbooks/ticket-triage-autopilot.md`) and re-scan **on ML-1** (`ceo playbook scan` installs host-local schedulers + rewrites the synced `registry.json`, so it runs only on ML-1 — see the `ceo-scan-only-on-ml1` rule). Editing this file activates nothing on its own; the next ML-1 scan picks up the status change.

--- a/scripts/ceo-triage-autopilot.sh
+++ b/scripts/ceo-triage-autopilot.sh
@@ -201,8 +201,10 @@ PROMPT_EOF
 # to the inbox. Updates TICKETS_WRITTEN; returns 0 on success, 1 on any failure.
 _triage_spawn() {  # $1 = prompt text
   local prompt="$1" claude_out json_block marker line
+  local prompt_tsv
   if ! claude_out=$("$CLAUDE_BIN" --print "$prompt" 2>/dev/null); then
     printf 'WARN: ceo-triage-autopilot: claude invocation failed\n' >&2
+    LAST_ERROR="claude_failed"
     return 1
   fi
   json_block=$(printf '%s\n' "$claude_out" | awk '
@@ -212,6 +214,15 @@ _triage_spawn() {  # $1 = prompt text
   ' | tail -c 65536)
   if [ -z "$json_block" ] || ! printf '%s' "$json_block" | jq -e '.tickets | type == "array" and length <= 3' >/dev/null 2>&1; then
     printf 'WARN: ceo-triage-autopilot: claude output had no valid tickets JSON block\n' >&2
+    LAST_ERROR="bad_tickets_json"
+    return 1
+  fi
+  # Extract rows once, checking jq status — a mid-stream jq failure (e.g. a
+  # ticket element with a non-string field) must be a recorded failure that
+  # holds the cursor, not a silent zero-row "success" that advances it.
+  if ! prompt_tsv=$(printf '%s' "$json_block" | jq -r '.tickets[] | [.id, .title, .url, (.score|tostring), .reason] | @tsv' 2>/dev/null); then
+    printf 'WARN: ceo-triage-autopilot: ticket extraction failed\n' >&2
+    LAST_ERROR="ticket_extract_failed"
     return 1
   fi
   while IFS=$'\t' read -r tid title url score reason; do
@@ -228,7 +239,7 @@ _triage_spawn() {  # $1 = prompt text
       LAST_ERROR="inbox_append_failed"
       return 1
     fi
-  done < <(printf '%s' "$json_block" | jq -r '.tickets[] | [.id, .title, .url, (.score|tostring), .reason] | @tsv')
+  done <<< "$prompt_tsv"
   return 0
 }
 
@@ -254,8 +265,16 @@ if [ "$NEW_MERGE_COUNT" -gt 0 ]; then
     | [.[] | (.repo | split("/")[0]) as $own | select(($o | index($own)) != null)]' 2>/dev/null || printf '[]')
   if [ "$(printf '%s' "$zenhub_merges" | jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; then
     SPAWNS_ATTEMPTED=$((SPAWNS_ATTEMPTED + 1))
-    _ml=$(printf '%s' "$zenhub_merges" | _merge_lines)
-    if ! _triage_spawn "$(_zenhub_prompt "$_ml")"; then SPAWNS_FAILED=$((SPAWNS_FAILED + 1)); fi
+    # Guard the assignment: a _merge_lines failure must not abort the whole tick
+    # under `set -e` after SPAWNS_ATTEMPTED was bumped (the tick still owes a
+    # state file + log line). Treat it as a spawn failure that holds the cursor.
+    if ! _ml=$(printf '%s' "$zenhub_merges" | _merge_lines); then
+      printf 'WARN: ceo-triage-autopilot: merge-line render failed (zenhub)\n' >&2
+      LAST_ERROR="merge_lines_failed"
+      SPAWNS_FAILED=$((SPAWNS_FAILED + 1))
+    elif ! _triage_spawn "$(_zenhub_prompt "$_ml")"; then
+      SPAWNS_FAILED=$((SPAWNS_FAILED + 1))
+    fi
   fi
 
   # GitHub: one spawn per distinct personal repo (each needs its own slug).
@@ -263,8 +282,13 @@ if [ "$NEW_MERGE_COUNT" -gt 0 ]; then
     [ "$(_classify_owner "$_slug")" = "github" ] || continue
     SPAWNS_ATTEMPTED=$((SPAWNS_ATTEMPTED + 1))
     _rm=$(printf '%s' "$NEW_MERGES_JSON" | jq -c --arg r "$_slug" '[.[] | select(.repo == $r)]' 2>/dev/null || printf '[]')
-    _ml=$(printf '%s' "$_rm" | _merge_lines)
-    if ! _triage_spawn "$(_github_prompt "$_slug" "$_ml")"; then SPAWNS_FAILED=$((SPAWNS_FAILED + 1)); fi
+    if ! _ml=$(printf '%s' "$_rm" | _merge_lines); then
+      printf 'WARN: ceo-triage-autopilot: merge-line render failed (%s)\n' "$_slug" >&2
+      LAST_ERROR="merge_lines_failed"
+      SPAWNS_FAILED=$((SPAWNS_FAILED + 1))
+    elif ! _triage_spawn "$(_github_prompt "$_slug" "$_ml")"; then
+      SPAWNS_FAILED=$((SPAWNS_FAILED + 1))
+    fi
   done
 
   # Skipped owners: log, no spawn. Their merges still advance the cursor.

--- a/scripts/ceo-triage-autopilot.sh
+++ b/scripts/ceo-triage-autopilot.sh
@@ -145,22 +145,31 @@ if [ "$FIRST_RUN" -eq 0 ] && [ "${#REPO_PATHS[@]}" -gt 0 ]; then
   fi
 fi
 
-# ---- Spawn triage if new merges seen. -----------------------------------
-TRIAGE_RAN=0
-TRIAGE_OK=0
-TICKETS_WRITTEN=0
-CONSEC_FAILURES="$PRIOR_FAILS"
+# ---- Classify merges by repo owner, triage per source. ------------------
+# ZenHub and the nhangenam account are AM-only; personal nhangen/* repos have
+# no ZenHub board so they triage from GitHub issues (#133). Owners in neither
+# set are skipped (logged) — their merges still advance the cursor so they are
+# not re-evaluated every tick.
+ZENHUB_OWNERS="${CEO_TRIAGE_ZENHUB_OWNERS:-awesomemotive nhangenam}"
+GITHUB_OWNERS="${CEO_TRIAGE_GITHUB_OWNERS:-nhangen}"
 
-if [ "$NEW_MERGE_COUNT" -gt 0 ]; then
-  TRIAGE_RAN=1
-  # Build the merge list outside the heredoc so PR titles can't shell-expand.
-  merge_lines=$(printf '%s' "$NEW_MERGES_JSON" \
-    | jq -r '.[] | "- \(.repo)#\(.number): \(.title)"' 2>/dev/null \
-    | sed 's/`/'\''/g; s/\$/_/g')
-  PROMPT=$(cat <<PROMPT_EOF
+_classify_owner() {  # $1 = owner/repo slug -> zenhub | github | skip
+  local owner="${1%%/*}"
+  case " $ZENHUB_OWNERS " in *" $owner "*) printf 'zenhub'; return 0 ;; esac
+  case " $GITHUB_OWNERS " in *" $owner "*) printf 'github'; return 0 ;; esac
+  printf 'skip'
+}
+
+_merge_lines() {  # stdin = merges JSON array -> shell-safe "- repo#n: title" lines
+  jq -r '.[] | "- \(.repo)#\(.number): \(.title)"' 2>/dev/null \
+    | sed 's/`/'\''/g; s/\$/_/g'
+}
+
+_zenhub_prompt() {  # $1 = merge_lines
+  cat <<PROMPT_EOF
 You are running on behalf of an automated playbook. Newly merged PRs since the last triage:
 
-${merge_lines}
+$1
 
 Invoke the /ticket-triage skill against the "${PIPELINE}" pipeline. Output exactly one fenced JSON block at the end of your response with this schema, and nothing else after it:
 
@@ -170,47 +179,115 @@ Invoke the /ticket-triage skill against the "${PIPELINE}" pipeline. Output exact
 
 At most 3 tickets. If triage cannot run (auth failure, no candidates), emit \`{"tickets":[]}\`. Do not emit any other JSON block.
 PROMPT_EOF
-)
-  if claude_out=$("$CLAUDE_BIN" --print "$PROMPT" 2>/dev/null); then
-    # Extract the last fenced ```json ... ``` block.
-    json_block=$(printf '%s\n' "$claude_out" | awk '
-      /^```json[[:space:]]*$/ { capture=1; buf=""; next }
-      /^```[[:space:]]*$/ && capture { print buf; capture=0; buf=""; next }
-      capture { buf = buf $0 "\n" }
-    ' | tail -c 65536)
-    if [ -n "$json_block" ] && printf '%s' "$json_block" | jq -e '.tickets | type == "array" and length <= 3' >/dev/null 2>&1; then
+}
+
+_github_prompt() {  # $1 = owner/repo slug, $2 = merge_lines
+  cat <<PROMPT_EOF
+You are running on behalf of an automated playbook. Newly merged PRs since the last triage:
+
+$2
+
+Invoke the /ticket-triage skill against the "$1" repo (GitHub-issues source — a personal repo with no ZenHub board). Output exactly one fenced JSON block at the end of your response with this schema, and nothing else after it:
+
+\`\`\`json
+{"tickets":[{"id":"<ticket-id>","title":"<short title>","url":"<url>","score":<0..1>,"reason":"<one-line>"}]}
+\`\`\`
+
+At most 3 tickets. If triage cannot run (no candidates), emit \`{"tickets":[]}\`. Do not emit any other JSON block.
+PROMPT_EOF
+}
+
+# Spawn one triage, parse the fenced tickets JSON, append up to 3 deduped lines
+# to the inbox. Updates TICKETS_WRITTEN; returns 0 on success, 1 on any failure.
+_triage_spawn() {  # $1 = prompt text
+  local prompt="$1" claude_out json_block marker line
+  if ! claude_out=$("$CLAUDE_BIN" --print "$prompt" 2>/dev/null); then
+    printf 'WARN: ceo-triage-autopilot: claude invocation failed\n' >&2
+    return 1
+  fi
+  json_block=$(printf '%s\n' "$claude_out" | awk '
+    /^```json[[:space:]]*$/ { capture=1; buf=""; next }
+    /^```[[:space:]]*$/ && capture { print buf; capture=0; buf=""; next }
+    capture { buf = buf $0 "\n" }
+  ' | tail -c 65536)
+  if [ -z "$json_block" ] || ! printf '%s' "$json_block" | jq -e '.tickets | type == "array" and length <= 3' >/dev/null 2>&1; then
+    printf 'WARN: ceo-triage-autopilot: claude output had no valid tickets JSON block\n' >&2
+    return 1
+  fi
+  while IFS=$'\t' read -r tid title url score reason; do
+    [ -z "$tid" ] && continue
+    marker="<!-- triage-autopilot:$tid -->"
+    if grep -qF -- "$marker" "$INBOX_FILE" 2>/dev/null; then
+      continue
+    fi
+    line="- [ ] Triage: **$tid** — $title (score $score; $reason) [$url] $marker"
+    if printf '%s\n' "$line" >> "$INBOX_FILE"; then
+      TICKETS_WRITTEN=$((TICKETS_WRITTEN + 1))
+    else
+      printf 'ERROR: ceo-triage-autopilot: failed to append to %s\n' "$INBOX_FILE" >&2
+      LAST_ERROR="inbox_append_failed"
+      return 1
+    fi
+  done < <(printf '%s' "$json_block" | jq -r '.tickets[] | [.id, .title, .url, (.score|tostring), .reason] | @tsv')
+  return 0
+}
+
+# ---- Spawn triage if new merges seen. -----------------------------------
+TRIAGE_RAN=0
+TRIAGE_OK=0
+TICKETS_WRITTEN=0
+CONSEC_FAILURES="$PRIOR_FAILS"
+SPAWNS_ATTEMPTED=0
+SPAWNS_FAILED=0
+
+if [ "$NEW_MERGE_COUNT" -gt 0 ]; then
+  # Distinct slugs among this tick's merges.
+  SLUGS=()
+  while IFS= read -r _slug; do
+    [ -n "$_slug" ] && SLUGS+=("$_slug")
+  done < <(printf '%s' "$NEW_MERGES_JSON" | jq -r '[.[].repo] | unique[]' 2>/dev/null)
+
+  # ZenHub: one spawn covering all AM merges — the OM board is unified across
+  # products, so a single pipeline triage serves every AM repo.
+  zenhub_merges=$(printf '%s' "$NEW_MERGES_JSON" | jq -c --arg owners "$ZENHUB_OWNERS" '
+    ($owners | split(" ")) as $o
+    | [.[] | (.repo | split("/")[0]) as $own | select(($o | index($own)) != null)]' 2>/dev/null || printf '[]')
+  if [ "$(printf '%s' "$zenhub_merges" | jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; then
+    SPAWNS_ATTEMPTED=$((SPAWNS_ATTEMPTED + 1))
+    _ml=$(printf '%s' "$zenhub_merges" | _merge_lines)
+    if ! _triage_spawn "$(_zenhub_prompt "$_ml")"; then SPAWNS_FAILED=$((SPAWNS_FAILED + 1)); fi
+  fi
+
+  # GitHub: one spawn per distinct personal repo (each needs its own slug).
+  for _slug in "${SLUGS[@]}"; do
+    [ "$(_classify_owner "$_slug")" = "github" ] || continue
+    SPAWNS_ATTEMPTED=$((SPAWNS_ATTEMPTED + 1))
+    _rm=$(printf '%s' "$NEW_MERGES_JSON" | jq -c --arg r "$_slug" '[.[] | select(.repo == $r)]' 2>/dev/null || printf '[]')
+    _ml=$(printf '%s' "$_rm" | _merge_lines)
+    if ! _triage_spawn "$(_github_prompt "$_slug" "$_ml")"; then SPAWNS_FAILED=$((SPAWNS_FAILED + 1)); fi
+  done
+
+  # Skipped owners: log, no spawn. Their merges still advance the cursor.
+  for _slug in "${SLUGS[@]}"; do
+    [ "$(_classify_owner "$_slug")" = "skip" ] || continue
+    printf 'INFO: ceo-triage-autopilot: skipping %s (owner not routed to zenhub or github)\n' "$_slug" >&2
+  done
+
+  if [ "$SPAWNS_ATTEMPTED" -gt 0 ]; then
+    TRIAGE_RAN=1
+    if [ "$SPAWNS_FAILED" -eq 0 ]; then
       TRIAGE_OK=1
       CONSEC_FAILURES=0
-      # Write up to 3 lines, dedup by marker.
-      while IFS=$'\t' read -r tid title url score reason; do
-        [ -z "$tid" ] && continue
-        marker="<!-- triage-autopilot:$tid -->"
-        if grep -qF -- "$marker" "$INBOX_FILE" 2>/dev/null; then
-          continue
-        fi
-        line="- [ ] Triage: **$tid** — $title (score $score; $reason) [$url] $marker"
-        if printf '%s\n' "$line" >> "$INBOX_FILE"; then
-          TICKETS_WRITTEN=$((TICKETS_WRITTEN + 1))
-        else
-          printf 'ERROR: ceo-triage-autopilot: failed to append to %s\n' "$INBOX_FILE" >&2
-          TRIAGE_OK=0
-          CONSEC_FAILURES=$((CONSEC_FAILURES + 1))
-          LAST_ERROR="inbox_append_failed"
-          break
-        fi
-      done < <(printf '%s' "$json_block" | jq -r '.tickets[] | [.id, .title, .url, (.score|tostring), .reason] | @tsv')
     else
-      printf 'WARN: ceo-triage-autopilot: claude output had no valid tickets JSON block\n' >&2
       CONSEC_FAILURES=$((CONSEC_FAILURES + 1))
     fi
-  else
-    printf 'WARN: ceo-triage-autopilot: claude invocation failed\n' >&2
-    CONSEC_FAILURES=$((CONSEC_FAILURES + 1))
   fi
 fi
 
 # ---- Resolve CURRENT_STATUS + last_merge_check advancement. ---------------
-if [ "$NEW_MERGE_COUNT" -gt 0 ]; then
+# Fire only when a triage actually ran; merges that were all skip-routed (no
+# spawn) are a clear tick that still advances the cursor.
+if [ "$SPAWNS_ATTEMPTED" -gt 0 ]; then
   CURRENT_STATUS="firing"
 else
   CURRENT_STATUS="clear"
@@ -228,7 +305,8 @@ elif [ "$TICK_HAD_ERRORS" -eq 1 ]; then
   # otherwise drop the failed repo's merge window permanently. Re-running
   # triage next tick is cheap (marker dedup no-ops already-written tickets).
   NEW_LAST_CHECK="$PRIOR_LAST_CHECK"
-elif [ "$NEW_MERGE_COUNT" -eq 0 ] || [ "$TRIAGE_OK" -eq 1 ]; then
+elif [ "$SPAWNS_ATTEMPTED" -eq 0 ] || [ "$TRIAGE_OK" -eq 1 ]; then
+  # No merges, all-skip merges, or every spawned source succeeded.
   NEW_LAST_CHECK="$NOW"
 elif [ "$CONSEC_FAILURES" -ge "$MAX_RETRIES" ]; then
   NEW_LAST_CHECK="$NOW"

--- a/scripts/ceo-triage-autopilot.test.sh
+++ b/scripts/ceo-triage-autopilot.test.sh
@@ -190,6 +190,7 @@ EOF
   # GitHub-issues prompt (exercises per-source partial failure).
   cat > "$TEST_HOME/stubs/fake-claude-failgithub" << 'EOF'
 #!/bin/bash
+case "$1" in --print) ;; *) echo "fake-claude-failgithub: bad argv: $*" >&2; exit 99 ;; esac
 printf '%s\n----\n' "$2" >> "${CLAUDE_PROMPT_LOG:-/dev/null}"
 if printf '%s' "$2" | grep -q "GitHub-issues source"; then
   echo "fake-claude-failgithub: simulated github triage failure" >&2; exit 1
@@ -201,6 +202,19 @@ cat <<OUT
 OUT
 EOF
   chmod +x "$TEST_HOME/stubs/fake-claude-failgithub"
+
+  # claude stub: tickets array passes the type/length validation but an element
+  # has a non-scalar field, so the @tsv extraction errors mid-stream.
+  cat > "$TEST_HOME/stubs/fake-claude-badrow" << 'EOF'
+#!/bin/bash
+case "$1" in --print) ;; *) echo "fake-claude-badrow: bad argv: $*" >&2; exit 99 ;; esac
+cat <<OUT
+\`\`\`json
+{"tickets":[{"id":"OM-9","title":"bad","url":{"nested":"object"},"score":0.5,"reason":"r"}]}
+\`\`\`
+OUT
+EOF
+  chmod +x "$TEST_HOME/stubs/fake-claude-badrow"
 
   export CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-empty"
   export CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-ok"
@@ -542,6 +556,54 @@ test_partial_source_failure_holds_cursor() {
   assert_eq "$(state_field last_merge_check)" "2026-01-01T00:00:00+0000" \
     "a failed github spawn must hold the cursor (don't drop the merge window)"
   assert_eq "$(state_field consec_failures)" "1" "partial failure counts as one failure"
+  # Prove it's genuinely PARTIAL, not total: the surviving ZenHub source must
+  # have written its ticket even though the GitHub source failed. Without this,
+  # the test passes identically when both sources fail.
+  assert_eq "$(state_field tickets_written)" "1" "surviving zenhub source still wrote its ticket"
+  if ! grep -qF -- '<!-- triage-autopilot:OM-1 -->' "$CEO_DIR/inbox.md"; then
+    printf '  FAIL [%s] zenhub ticket OM-1 must be in inbox despite github failure\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  # The held-cursor tick must record WHICH failure occurred, not last_error: none.
+  if [ "$(state_field last_error)" = "none" ]; then
+    printf '  FAIL [%s] spawn failure must set last_error, got none\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_spawn_cardinality_one_zenhub_spawn_per_tick() {
+  # Two AM repos in one tick -> exactly ONE ZenHub spawn (unified board), and
+  # two personal repos -> one GitHub spawn each. Prompts are '----'-separated
+  # in the recording stub's log.
+  reset_repo_list_with "awesomemotive/a" "nhangenam/b" "nhangen/p1" "nhangen/p2"
+  export CLAUDE_PROMPT_LOG="$TEST_HOME/prompts.log"; : > "$CLAUDE_PROMPT_LOG"
+  run_autopilot   # baseline
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-record" run_autopilot
+  local zenhub_spawns github_spawns
+  zenhub_spawns=$(grep -c '"inbox" pipeline' "$CLAUDE_PROMPT_LOG")
+  github_spawns=$(grep -c 'GitHub-issues source' "$CLAUDE_PROMPT_LOG")
+  assert_eq "$zenhub_spawns" "1" "two AM repos collapse to one ZenHub spawn"
+  assert_eq "$github_spawns" "2" "two personal repos get one GitHub spawn each"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_validated_tickets_with_bad_row_is_failure_not_silent_advance() {
+  # tickets array passes type/length validation but a row breaks @tsv. This must
+  # be a recorded failure (cursor held), NOT a silent zero-row "success" that
+  # advances the cursor and drops the merge window.
+  reset_repo_list_with "test/sample"
+  run_autopilot   # baseline
+  sed -i.bak 's/^last_merge_check: .*/last_merge_check: 2026-01-01T00:00:00+0000/' \
+    "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md"
+  rm -f "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md.bak"
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-badrow" run_autopilot
+  assert_eq "$(state_field last_merge_check)" "2026-01-01T00:00:00+0000" \
+    "bad ticket row must hold the cursor, not silently advance"
+  assert_eq "$(state_field consec_failures)" "1" "bad ticket row counts as a failure"
+  assert_eq "$(state_field tickets_written)" "0" "no tickets written from a broken row"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-triage-autopilot.test.sh
+++ b/scripts/ceo-triage-autopilot.test.sh
@@ -158,8 +158,56 @@ OUT
 EOF
   chmod +x "$TEST_HOME/stubs/fake-claude-malformed"
 
+  # gh stub that returns one deterministic merge for ANY --repo slug, so
+  # routing tests can seed merges for arbitrary owners.
+  cat > "$TEST_HOME/stubs/fake-gh-any" << 'EOF'
+#!/bin/bash
+slug=""; prev=""
+for a in "$@"; do [ "$prev" = "--repo" ] && slug="$a"; prev="$a"; done
+case "$*" in
+  *"pr list"*"--repo "*"--search "*"--json "*)
+    n=$(printf '%s' "$slug" | cksum | cut -d' ' -f1); n=$((n % 900 + 100))
+    printf '[{"number":%s,"title":"Merge in %s","mergedAt":"2026-06-01T00:00:00Z","url":"https://github.com/%s/pull/%s"}]\n' "$n" "$slug" "$slug" "$n" ;;
+  *) echo "fake-gh-any: unexpected argv: $*" >&2; exit 99 ;;
+esac
+EOF
+  chmod +x "$TEST_HOME/stubs/fake-gh-any"
+
+  # claude stub that records the prompt it was handed, then emits valid JSON.
+  cat > "$TEST_HOME/stubs/fake-claude-record" << 'EOF'
+#!/bin/bash
+case "$1" in --print) ;; *) echo "fake-claude-record: bad argv: $*" >&2; exit 99 ;; esac
+printf '%s\n----\n' "$2" >> "${CLAUDE_PROMPT_LOG:-/dev/null}"
+cat <<OUT
+\`\`\`json
+{"tickets":[{"id":"OM-1","title":"First","url":"https://zenhub/1","score":0.9,"reason":"adjacent"}]}
+\`\`\`
+OUT
+EOF
+  chmod +x "$TEST_HOME/stubs/fake-claude-record"
+
+  # claude stub: records prompt; succeeds for ZenHub prompts, FAILS for the
+  # GitHub-issues prompt (exercises per-source partial failure).
+  cat > "$TEST_HOME/stubs/fake-claude-failgithub" << 'EOF'
+#!/bin/bash
+printf '%s\n----\n' "$2" >> "${CLAUDE_PROMPT_LOG:-/dev/null}"
+if printf '%s' "$2" | grep -q "GitHub-issues source"; then
+  echo "fake-claude-failgithub: simulated github triage failure" >&2; exit 1
+fi
+cat <<OUT
+\`\`\`json
+{"tickets":[{"id":"OM-1","title":"First","url":"https://zenhub/1","score":0.9,"reason":"adjacent"}]}
+\`\`\`
+OUT
+EOF
+  chmod +x "$TEST_HOME/stubs/fake-claude-failgithub"
+
   export CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-empty"
   export CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-ok"
+  # Route the test owner (`test/*`) to ZenHub so existing tests are unaffected;
+  # `nhangen/*` to GitHub. Other owners fall through to skip.
+  export CEO_TRIAGE_ZENHUB_OWNERS="awesomemotive nhangenam test"
+  export CEO_TRIAGE_GITHUB_OWNERS="nhangen"
 }
 
 teardown() {
@@ -167,7 +215,25 @@ teardown() {
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
   unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP \
-        CEO_GH_BIN CEO_TRIAGE_CLAUDE_BIN CEO_TRIAGE_REPO_LIST
+        CEO_GH_BIN CEO_TRIAGE_CLAUDE_BIN CEO_TRIAGE_REPO_LIST \
+        CEO_TRIAGE_ZENHUB_OWNERS CEO_TRIAGE_GITHUB_OWNERS CLAUDE_PROMPT_LOG
+}
+
+# Reset the repo list to exactly the given slugs (git-inits each repo).
+reset_repo_list_with() {
+  cat > "$TEST_HOME/repo-list.md" << 'EOF'
+| Repo | Local Path |
+|------|------------|
+EOF
+  local slug name dir
+  for slug in "$@"; do
+    name=$(basename "$slug")
+    dir="$TEST_HOME/repos/$name"
+    git init -q "$dir"
+    git -C "$dir" remote remove origin 2>/dev/null || true
+    git -C "$dir" remote add origin "git@github.com:${slug}.git"
+    printf '| `%s` | `%s` |\n' "$name" "$dir" >> "$TEST_HOME/repo-list.md"
+  done
 }
 
 run_autopilot() {
@@ -410,6 +476,72 @@ test_log_line_records_status_tokens() {
   assert_contains "$body" "status=" "log line must record status"
   assert_contains "$body" "new_merges=" "log line must record new_merges count"
   assert_contains "$body" "triage_ran=" "log line must record triage_ran"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_personal_owner_routes_to_github_source() {
+  reset_repo_list_with "nhangen/personal-x"
+  export CLAUDE_PROMPT_LOG="$TEST_HOME/prompts.log"; : > "$CLAUDE_PROMPT_LOG"
+  run_autopilot   # baseline
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-record" run_autopilot
+  assert_eq "$(state_field triage_ran)" "1" "personal merge should spawn triage"
+  local prompts; prompts=$(cat "$CLAUDE_PROMPT_LOG")
+  assert_contains "$prompts" "nhangen/personal-x" "github prompt must name the repo slug"
+  assert_contains "$prompts" "GitHub-issues source" "github prompt must declare the github source"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_am_owner_routes_to_zenhub_pipeline() {
+  reset_repo_list_with "awesomemotive/optin-monster-app"
+  export CLAUDE_PROMPT_LOG="$TEST_HOME/prompts.log"; : > "$CLAUDE_PROMPT_LOG"
+  run_autopilot   # baseline
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-record" run_autopilot
+  assert_eq "$(state_field triage_ran)" "1" "AM merge should spawn triage"
+  local prompts; prompts=$(cat "$CLAUDE_PROMPT_LOG")
+  assert_contains "$prompts" "pipeline" "zenhub prompt must target a pipeline"
+  if printf '%s' "$prompts" | grep -q "GitHub-issues source"; then
+    printf '  FAIL [%s] AM repo must NOT use the github source\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_unknown_owner_is_skipped_but_advances_cursor() {
+  reset_repo_list_with "altamira2/some-thing"
+  export CLAUDE_PROMPT_LOG="$TEST_HOME/prompts.log"; : > "$CLAUDE_PROMPT_LOG"
+  run_autopilot   # baseline
+  sed -i.bak 's/^last_merge_check: .*/last_merge_check: 2026-01-01T00:00:00+0000/' \
+    "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md"
+  rm -f "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md.bak"
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-record" run_autopilot
+  assert_eq "$(state_field triage_ran)" "0" "unknown-owner merge must NOT spawn triage"
+  assert_eq "$(state_field status)" "clear" "skip-only tick is clear"
+  if [ -s "$CLAUDE_PROMPT_LOG" ]; then
+    printf '  FAIL [%s] skipped owner must not invoke claude\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  if [ "$(state_field last_merge_check)" = "2026-01-01T00:00:00+0000" ]; then
+    printf '  FAIL [%s] skip-only merges must still advance the cursor\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_partial_source_failure_holds_cursor() {
+  reset_repo_list_with "test/sample" "nhangen/personal-x"
+  export CLAUDE_PROMPT_LOG="$TEST_HOME/prompts.log"; : > "$CLAUDE_PROMPT_LOG"
+  run_autopilot   # baseline
+  sed -i.bak 's/^last_merge_check: .*/last_merge_check: 2026-01-01T00:00:00+0000/' \
+    "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md"
+  rm -f "$CEO_DIR/alerts/triage-autopilot-$CEO_HOSTNAME.md.bak"
+  CEO_GH_BIN="$TEST_HOME/stubs/fake-gh-any" \
+    CEO_TRIAGE_CLAUDE_BIN="$TEST_HOME/stubs/fake-claude-failgithub" run_autopilot
+  assert_eq "$(state_field last_merge_check)" "2026-01-01T00:00:00+0000" \
+    "a failed github spawn must hold the cursor (don't drop the merge window)"
+  assert_eq "$(state_field consec_failures)" "1" "partial failure counts as one failure"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #146

## Description
The autopilot spawned a single ZenHub triage for *any* merge regardless of owner — which is why it was disabled (ZenHub is AM-only, useless on personal repos). With the skill's new GitHub-issues source (nhangen/llm-tools#59), it now routes per repo owner:

- **`awesomemotive` / `nhangenam`** → ZenHub pipeline. One spawn covers all AM merges — the OM ZenHub workspace is "OptinMonster — All Products", unified across optinmonster/trustpulse/beacon/comment-converter, so a single pipeline triage serves every AM repo.
- **`nhangen`** → GitHub-issues source, one spawn per distinct personal repo (the skill takes a single `owner/repo` slug).
- **anything else** (e.g. `altamira2`) → skipped with a logged reason; the merge still advances the cursor so it isn't re-evaluated every tick.

Owner sets are configurable via `CEO_TRIAGE_ZENHUB_OWNERS` / `CEO_TRIAGE_GITHUB_OWNERS`.

A tick is `firing` only when a triage actually ran; skip-only ticks are `clear` and advance the cursor. If **any** spawned source fails, the cursor is held (the existing retry-cap give-up still applies on the aggregate failure count) so a failed source's merge window isn't dropped — re-running next tick is cheap because inbox markers dedup already-written tickets.

Re-enables the playbook (`status: active`) and documents the routing + new env seams.

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-triage-autopilot.test.sh` → **All tests passed (22 tests)** — includes 4 new routing tests (personal→github, AM→zenhub, unknown-owner skip + cursor-advance, partial-source-failure holds cursor). Reverting the owner gate fails the routing tests.
3. `shellcheck scripts/ceo-triage-autopilot.sh` → clean.

## Additional Notes / Activation
Activation is **inert until `ceo playbook scan` runs on ML-1** — scan installs host-local schedulers and rewrites the synced `registry.json`, so it runs only on ML-1, never the MacBook (`ceo-scan-only-on-ml1`). ML-1 is currently down, so the autopilot will not fire until it's back and scanned. Depends on nhangen/llm-tools#59.
