### PR TITLE
Add --dry-run preview mode to ceo-cron.sh (#138)

### DIFF
--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -48,6 +48,8 @@ The default is **manual**, so a bare `ceo-cron.sh <name>` is the on-demand path 
 
 `--scheduled` and `--manual` are mutually exclusive. `--force` (manual-only) bypasses the per-trigger cooldown for iterative smoke-testing; it is rejected with `--scheduled`.
 
+`--dry-run` is a preview mode, orthogonal to run-mode. It runs every **read-only** phase (gather, the PLAN call, a read-tier model call) but performs **no side effect**: the EXECUTE phase is skipped, `runner: script` / `runner: skill` are not executed, and nothing is written to the approvals queue, Discord, the report intake, `.last-run`, or the fail-counter. What *would* happen is written to a host-local, non-synced preview file at `CEO/log/preview/<trigger>-<TODAY>.md`. It bypasses the cooldown so it can be run iteratively, and is allowed under `--scheduled` (with a WARN to `cron-skips.log`) so a daemon can smoke-test without acting. Non-guarantee: read-only external calls still run and still cost tokens — `--dry-run` skips effects, not reads.
+
 ### Use draft for WIP playbooks
 
 `draft` exists for "exists, runnable on demand, not ready for cron." Author iteratively via `bash scripts/ceo-cron.sh <name>` (optionally `--force` to bypass the cooldown between runs) until happy with the behavior, then flip frontmatter to `status: active` and re-run `ceo playbook scan` to install.

--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -48,7 +48,11 @@ The default is **manual**, so a bare `ceo-cron.sh <name>` is the on-demand path 
 
 `--scheduled` and `--manual` are mutually exclusive. `--force` (manual-only) bypasses the per-trigger cooldown for iterative smoke-testing; it is rejected with `--scheduled`.
 
-`--dry-run` is a preview mode, orthogonal to run-mode. It runs every **read-only** phase (gather, the PLAN call, a read-tier model call) but performs **no side effect**: the EXECUTE phase is skipped, `runner: script` / `runner: skill` are not executed, and nothing is written to the approvals queue, Discord, the report intake, `.last-run`, or the fail-counter. What *would* happen is written to a host-local, non-synced preview file at `CEO/log/preview/<trigger>-<TODAY>.md`. It bypasses the cooldown so it can be run iteratively, and is allowed under `--scheduled` (with a WARN to `cron-skips.log`) so a daemon can smoke-test without acting. Non-guarantee: read-only external calls still run and still cost tokens — `--dry-run` skips effects, not reads.
+`--dry-run` is a preview mode, orthogonal to run-mode. It runs every **read-only** phase (gather, the PLAN call, a read-tier model call) but mutates **no CEO state**: the EXECUTE phase is skipped, `runner: script` / `runner: skill` are not executed, and nothing is written to the approvals queue, Discord, the report intake, the host inbox, the synced daily log (`CEO/log/<TODAY>.md`), `.last-run`, `.last-scan`, the fail-counter, or `cron-runs.log`. What *would* happen is written to a preview file at `CEO/log/preview/<trigger>-<TODAY>.md`.
+
+That preview is **host-local**: `CEO/log/preview/` is excluded from Syncthing in `syncthing/shared.stignore`, so a dry-run on one host never propagates to the others. The rest of `CEO/log/` *is* synced — the daily log and the operational diagnostic journals (`cron-skips.log`, `cron-stderr.log`) — which is why the daily-log header write is also skipped in dry-run. A dry-run still appends clearly-labelled diagnostic lines to `cron-skips.log` (e.g. the `--scheduled` WARN below); that journal is the dispatcher's operational debug channel, not CEO decision-state.
+
+`--dry-run` bypasses the cooldown so it can be run iteratively, and is allowed under `--scheduled` (with a WARN to `cron-skips.log`) so a daemon can smoke-test without acting. Non-guarantee: read-only external calls still run and still cost tokens — `--dry-run` skips effects, not reads.
 
 ### Use draft for WIP playbooks
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -941,7 +941,10 @@ done
 mkdir -p "$LOG_DIR"
 
 # --- Create log file header if new ---
-if [ ! -f "$LOG_FILE" ]; then
+# Skipped in dry-run: $LOG_FILE lives in the synced CEO/log/ tree, and a dry-run
+# must not create a synced-vault artifact. The shell never writes run content
+# here anyway (the model emits the LOG_ENTRY); this only seeds an empty header.
+if [ "${CEO_DRY_RUN:-}" != "1" ] && [ ! -f "$LOG_FILE" ]; then
   cat > "$LOG_FILE" << LOGEOF
 ---
 date: $TODAY

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 RUN_MODE="manual"
 _mode_set=""
 FORCE_REQUESTED=0
+DRY_RUN=0
 TRIGGER=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -36,8 +37,9 @@ while [ $# -gt 0 ]; do
       RUN_MODE="$_m"; _mode_set="$_m"
       ;;
     --force) FORCE_REQUESTED=1 ;;
+    --dry-run) DRY_RUN=1 ;;
     -*)
-      echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force)" >&2
+      echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force, --dry-run)" >&2
       exit 1
       ;;
     *)
@@ -52,7 +54,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$TRIGGER" ]; then
-  echo "Usage: ceo-cron.sh <trigger> [--scheduled|--manual] [--force]" >&2
+  echo "Usage: ceo-cron.sh <trigger> [--scheduled|--manual] [--force] [--dry-run]" >&2
   exit 1
 fi
 
@@ -65,6 +67,19 @@ if [ "$FORCE_REQUESTED" = "1" ]; then
     exit 1
   fi
   CEO_FORCE=1
+fi
+
+# --dry-run is a preview mode, orthogonal to run-mode: it runs every read-only
+# phase (gather, PLAN, read-tier model call) but performs NO side effect —
+# EXECUTE is skipped, scripts/skills are not run, nothing is written to the
+# approvals queue, Discord, the report intake, .last-run, or the fail-counter.
+# What WOULD happen is written to a host-local, non-synced preview file.
+# It bypasses the cooldown so it can be run iteratively, and is allowed under
+# --scheduled (with a WARN) so a daemon can smoke-test without acting.
+# Non-guarantee: read-only external calls (gather, PLAN, read-tier call) still
+# run and still cost tokens — dry-run skips effects, not reads.
+if [ "$DRY_RUN" = "1" ]; then
+  export CEO_DRY_RUN=1
 fi
 
 # Gates filesystem path (.last-run-${TRIGGER}), env export (CEO_PLAYBOOK_ID),
@@ -91,15 +106,56 @@ LOG_FILE="$LOG_DIR/$TODAY.md"
 LOCK_FILE="${CEO_LOCK_FILE:-$CEO_DIR/log/ceo-cron.lock}"
 LAST_RUN_FILE="$LOG_DIR/.last-run-${TRIGGER}"
 FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
+# Host-local, non-synced preview scratch (see output-locations.md). A dry-run
+# overwrites this per (trigger, day) so repeated previews don't accumulate.
+PREVIEW_DIR="$LOG_DIR/preview"
+PREVIEW_FILE="$PREVIEW_DIR/${TRIGGER}-${TODAY}.md"
 
 # --- Verbose mode (set CEO_VERBOSE=1 for stdout progress) ---
 _v() { [ "${CEO_VERBOSE:-}" = "1" ] && echo "  $*" || true; }
+
+# _preview <heading-line> [body]: append a section to the dry-run preview file.
+# No-op outside dry-run. First write of a run truncates the per-day file so a
+# re-run shows the latest preview rather than stacking onto stale ones.
+_preview() {
+  [ "${CEO_DRY_RUN:-}" = "1" ] || return 0
+  mkdir -p "$PREVIEW_DIR"
+  if [ -z "${_preview_started:-}" ]; then
+    {
+      echo "# DRY-RUN preview — $TRIGGER ($TODAY $NOW)"
+      echo "# No side effects performed. Read-only phases (gather/PLAN/read call) may still have run."
+      echo ""
+    } > "$PREVIEW_FILE"
+    _preview_started=1
+  fi
+  {
+    printf -- '- %s\n' "$1"
+    [ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/    /'
+    echo ""
+  } >> "$PREVIEW_FILE"
+}
+
+# _report <subcommand> <trigger> <content>: single chokepoint for ceo-report.sh.
+# In dry-run the report (and its Discord side-channel) is folded into the
+# preview file instead of being posted/written, so no path can leak a dry-run
+# to Discord or the report intake.
+_report() {
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "Report (${1}) that would post to Discord / report intake:" "${3:-}"
+    return 0
+  fi
+  "$SCRIPT_DIR/ceo-report.sh" "$@"
+}
 
 # Single source of truth for terminal-exit bookkeeping. Every success path
 # calls _record_success; every failure path calls _record_failure. Deferral
 # paths (chat-only, status-not-active, missing playbook, preflight no-work)
 # are not failures and exit directly without invoking either helper.
 _record_success() {
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "Would record SUCCESS (no .last-run / fail-count reset / cron-runs.log / notify)."
+    return 0
+  fi
   echo 0 > "$FAIL_COUNT_FILE"
   date +%s > "$LAST_RUN_FILE"
   [ "$TRIGGER" = "morning-scan" ] && touch "$LOG_DIR/.last-scan"
@@ -112,6 +168,11 @@ _record_success() {
 
 _record_failure() {
   local reason="$1"
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    echo "$(date): DRY-RUN — would record failure: $reason" >> "$LOG_DIR/cron-skips.log"
+    _preview "Would record FAILURE: $reason (no fail-count increment / pending alert / notify / .last-run)."
+    return 0
+  fi
   echo "$(date): ERROR — $reason" >> "$LOG_DIR/cron-skips.log"
   local fails
   fails=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
@@ -159,7 +220,7 @@ _check_rate_limit() {
     fi
 
     _v "SKIPPED (rate-limited in $phase)"
-    "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** skipped: rate-limited
+    _report action "$TRIGGER" "**Status:** skipped: rate-limited
 **Playbook:** $PLAYBOOK_REL
 **Note:** Claude API session limit reached. Raw output saved to cron-raw.log."
     echo "$(date) [$TRIGGER] Rate-limited ($phase):" >> "$LOG_DIR/cron-skips.log"
@@ -186,7 +247,7 @@ _dispatch_single_output() {
 
   if [ -z "$log_entry" ]; then
     _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
-    "$SCRIPT_DIR/ceo-report.sh" action "$trigger" "**Status:** completed (unparseable output)
+    _report action "$trigger" "**Status:** completed (unparseable output)
 **Playbook:** $PLAYBOOK_REL
 **Note:** Execution succeeded but log format could not be parsed ($model_label)."
     printf '%s [%s] Unparseable output (%s):\n%s\n---\n' "$(date)" "$trigger" "$model_label" "$output" >> "$LOG_DIR/cron-raw.log"
@@ -208,7 +269,7 @@ _dispatch_single_output() {
   if [ "$trigger" = "pending-drip" ] && [ "$self_reported_failed" -eq 0 ]; then
     _append_pending_drip_to_inbox "$log_entry"
   else
-    "$SCRIPT_DIR/ceo-report.sh" intake "$trigger" "$log_entry"
+    _report intake "$trigger" "$log_entry"
   fi
 
   if [ "$self_reported_failed" -eq 1 ]; then
@@ -265,6 +326,11 @@ _escape_tag() {
 
 _append_pending_drip_to_inbox() {
   local log_entry="$1"
+
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "pending-drip — would append questions to the host inbox (skipped: dry-run):" "$log_entry"
+    return 0
+  fi
 
   if printf '%s\n' "$log_entry" | grep -Eiq 'no relevant .*questions?'; then
     _v "Pending drip found no relevant questions; inbox unchanged."
@@ -463,8 +529,8 @@ else
   fi
 fi
 
-# --- Per-trigger runaway protection (bypass with --force or CEO_FORCE=1) ---
-if [ "${CEO_FORCE:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then
+# --- Per-trigger runaway protection (bypass with --force, CEO_FORCE=1, or --dry-run) ---
+if [ "${CEO_FORCE:-}" != "1" ] && [ "${CEO_DRY_RUN:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then
   LAST_RUN=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo 0)
   case "$LAST_RUN" in (''|*[!0-9]*) LAST_RUN=0 ;; esac
   NOW_EPOCH=$(date +%s)
@@ -674,13 +740,23 @@ case "$RUN_MODE:$STATUS" in
     ;;
 esac
 
+# A scheduler firing in dry-run does no work — surface it so a cron/daemon stuck
+# in dry-run is observable rather than silently inert.
+if [ "${CEO_DRY_RUN:-}" = "1" ] && [ "$RUN_MODE" = "scheduled" ]; then
+  echo "$(date): WARN — $TRIGGER invoked with --dry-run under --scheduled; previewing only, no side effects" >> "$LOG_DIR/cron-skips.log"
+fi
+
 # --- Run preflight check ---
 PREFLIGHT_FN="preflight_${PREFLIGHT}"
 if type "$PREFLIGHT_FN" &>/dev/null; then
   if ! "$PREFLIGHT_FN"; then
     _v "Preflight '$PREFLIGHT' says no work to do. Skipping."
     echo "$(date): Skipping $TRIGGER — preflight '$PREFLIGHT' returned no-work" >> "$LOG_DIR/cron-skips.log"
-    date +%s > "$LAST_RUN_FILE"
+    if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+      _preview "Preflight '$PREFLIGHT' returned no-work — a real run would skip here (no .last-run stamp in dry-run)."
+    else
+      date +%s > "$LAST_RUN_FILE"
+    fi
     exit 0
   fi
   _v "Preflight '$PREFLIGHT' passed"
@@ -717,6 +793,10 @@ if [ "$RUNNER" = "script" ]; then
     echo "$(date): ERROR — Script not executable: $SCRIPT_FULL (playbook: $TRIGGER)" >> "$LOG_DIR/cron-skips.log"
     _v "ERROR: Script not executable at $SCRIPT_FULL"
     exit 1
+  fi
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "runner:script — would exec scripts/$SCRIPT_PATH (skipped: dry-run)."
+    exit 0
   fi
   _v "Runner: script — exec $SCRIPT_PATH"
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
@@ -781,8 +861,12 @@ if [ "$RUNNER" = "skill" ]; then
     exit 1
   fi
 
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "runner:skill — would exec $SKILL_SCRIPT → $OUT_PATTERN (skipped: dry-run)."
+    exit 0
+  fi
   _v "Runner: skill — exec $SKILL_SCRIPT"
-  
+
   TMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TMP_DIR"' EXIT
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
@@ -922,7 +1006,7 @@ if [ "$TIER" = "read" ]; then
     
     if [ "$CEO_GATHER_STATUS" = "failed" ] || [ "$CEO_GATHER_STATUS" = "empty" ]; then
       _v "SKIPPED (gather phase $CEO_GATHER_STATUS)"
-      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** skipped: gather-$CEO_GATHER_STATUS
+      _report action "$TRIGGER" "**Status:** skipped: gather-$CEO_GATHER_STATUS
 **Playbook:** $PLAYBOOK_REL
 **Note:** $CEO_GATHER_REASONS. Skipping run to prevent empty confident brief."
       exit 0
@@ -1114,7 +1198,7 @@ END_LOG_ENTRY"
   if [ $SINGLE_EXIT -ne 0 ]; then
     _check_rate_limit "$SINGLE_OUTPUT" "single-call"
     _v "FAILED (exit: $SINGLE_EXIT)"
-    "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** failed
+    _report action "$TRIGGER" "**Status:** failed
 **Playbook:** $PLAYBOOK_REL
 **Note:** Single-call execution failed (exit: $SINGLE_EXIT). Raw output saved to cron-raw.log."
     echo "$(date) [$TRIGGER] Single-call output:" >> "$LOG_DIR/cron-raw.log"
@@ -1201,20 +1285,31 @@ _v "  Safe actions: $SAFE_COUNT | High-stakes (deferred): $HIGH_COUNT"
 
 # Write high-stakes proposals to pending.md
 if [ -n "$HIGH_STAKES" ]; then
-  PENDING="$CEO_DIR/approvals/pending.md"
-  {
-    echo ""
-    echo "## $TODAY $NOW"
-    echo ""
-    while IFS= read -r line; do
-      DESC=$(echo "$line" | awk -F'|' '{print $3}' | xargs)
-      CMD=$(echo "$line" | awk -F'|' '{print $4}' | xargs)
-      echo "- [ ] **$DESC**"
-      echo "  - playbook: $TRIGGER"
-      echo "  - command: \`$CMD\`"
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "Would defer $HIGH_COUNT high-stakes action(s) to approvals/pending.md:" "$HIGH_STAKES"
+  else
+    PENDING="$CEO_DIR/approvals/pending.md"
+    {
       echo ""
-    done <<< "$HIGH_STAKES"
-  } >> "$PENDING"
+      echo "## $TODAY $NOW"
+      echo ""
+      while IFS= read -r line; do
+        DESC=$(echo "$line" | awk -F'|' '{print $3}' | xargs)
+        CMD=$(echo "$line" | awk -F'|' '{print $4}' | xargs)
+        echo "- [ ] **$DESC**"
+        echo "  - playbook: $TRIGGER"
+        echo "  - command: \`$CMD\`"
+        echo ""
+      done <<< "$HIGH_STAKES"
+    } >> "$PENDING"
+  fi
+fi
+
+# In dry-run, PLAN+FILTER have produced the safe/high-stakes split above; the
+# EXECUTE phase (the only write-capable claude call) is skipped entirely.
+if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+  _preview "Would EXECUTE $SAFE_COUNT safe action(s) (claude EXECUTE phase skipped: dry-run):" "${SAFE_ACTIONS:-none}"
+  exit 0
 fi
 
 # --- Phase 3: EXECUTE (only safe actions) ---
@@ -1222,7 +1317,7 @@ if [ -z "$SAFE_ACTIONS" ]; then
   _v "No safe actions to execute (all high-stakes). Done."
   _v ""
   _v "All actions were high-stakes — written to CEO/approvals/pending.md"
-  "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** completed (no safe actions to execute)
+  _report action "$TRIGGER" "**Status:** completed (no safe actions to execute)
 **Playbook:** $PLAYBOOK_REL
 **Actions:** none (all actions were high-stakes, written to approvals)"
 else
@@ -1281,7 +1376,7 @@ END_LOG_ENTRY"
   if [ $EXEC_EXIT -ne 0 ]; then
     _check_rate_limit "$EXEC_OUTPUT" "exec"
     _v "FAILED — raw output saved to cron-raw.log"
-    "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** failed
+    _report action "$TRIGGER" "**Status:** failed
 **Playbook:** $PLAYBOOK_REL
 **Note:** Execution phase failed (exit: $EXEC_EXIT). Raw output saved to cron-raw.log."
     echo "$(date) [$TRIGGER] Exec output:" >> "$LOG_DIR/cron-raw.log"
@@ -1299,10 +1394,10 @@ END_LOG_ENTRY"
       [ "${CEO_VERBOSE:-}" = "1" ] && echo "$LOG_ENTRY"
       _v "--- End ---"
       _v ""
-      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "$LOG_ENTRY"
+      _report action "$TRIGGER" "$LOG_ENTRY"
     else
       _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
-      "$SCRIPT_DIR/ceo-report.sh" action "$TRIGGER" "**Status:** completed (unparseable output)
+      _report action "$TRIGGER" "**Status:** completed (unparseable output)
 **Playbook:** $PLAYBOOK_REL
 **Note:** Execution succeeded but log format could not be parsed. Raw output saved to cron-raw.log."
       echo "$(date) [$TRIGGER] Unparseable exec output:" >> "$LOG_DIR/cron-raw.log"

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -170,6 +170,10 @@ _record_failure() {
   local reason="$1"
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
     echo "$(date): DRY-RUN — would record failure: $reason" >> "$LOG_DIR/cron-skips.log"
+    # Surface to stderr too: a dry-run exits 0, so without this an operator
+    # smoke-testing a broken gh/registry would see "preview written" and miss
+    # that a real run would have failed and escalated.
+    echo "DRY-RUN: would record FAILURE — $reason" >&2
     _preview "Would record FAILURE: $reason (no fail-count increment / pending alert / notify / .last-run)."
     return 0
   fi

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3248,6 +3248,67 @@ STUB
   assert_contains "$(cat "$pf" 2>/dev/null)" "check the status" "preview must list the safe action that would execute"
 }
 
+# runner:skill in dry-run must NOT exec the skill or write its out_pattern;
+# it previews the would-run skill instead.
+test_dry_run_skill_runner_skips_exec_and_previews() {
+  cat > "$CEO_DIR/playbooks/dr-skill.md" << 'PB'
+---
+name: dr-skill
+description: dry-run skill fixture
+trigger: cron
+status: active
+tier: read
+runner: skill
+skill: dr-skill-test
+out_pattern: CEO/reports/test/dr-skill-out.md
+---
+PB
+  mkdir -p "$HOME/.claude/skills/dr-skill-test/scripts"
+  cat > "$HOME/.claude/skills/dr-skill-test/scripts/run-report.sh" << EOF
+#!/bin/bash
+echo "ran" > "$TEST_HOME/dr-skill-fired.txt"
+EOF
+  chmod +x "$HOME/.claude/skills/dr-skill-test/scripts/run-report.sh"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  bash "$CRON" dr-skill --dry-run >/dev/null 2>&1 || true
+
+  assert_fails "dry-run must NOT exec the skill" test -f "$TEST_HOME/dr-skill-fired.txt"
+  assert_fails "dry-run must NOT write the skill out_pattern" test -f "$CEO_DIR/reports/test/dr-skill-out.md"
+  assert_contains "$(cat "$(_preview_file dr-skill)" 2>/dev/null)" "dr-skill-test" "preview must name the would-run skill"
+}
+
+# When a dry-run hits a preflight that returns no-work, it must preview the skip
+# WITHOUT stamping .last-run (a real run stamps it; a dry-run must not).
+test_dry_run_preflight_no_work_does_not_stamp_last_run() {
+  cat > "$CEO_DIR/playbooks/dr-pf.md" << 'PB'
+---
+name: dr-pf
+description: dry-run preflight fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: has_pending_items
+tier: read
+status: active
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  # has_pending_items is false (no PENDING_ASK_QUESTIONS), so preflight returns no-work.
+  bash "$CRON" dr-pf --dry-run >/dev/null 2>&1 || true
+  assert_fails "dry-run preflight-skip must not stamp .last-run" test -f "$CEO_DIR/log/.last-run-dr-pf"
+  assert_contains "$(cat "$(_preview_file dr-pf)" 2>/dev/null)" "no-work" "preview must record the preflight no-work skip"
+}
+
+# The preview dir lives under CEO/log/, which is a SYNCED vault tree (only the
+# dotfiles in shared.stignore are host-local). For the preview to be the
+# host-local scratch the design promises, CEO/log/preview/ must be excluded from
+# sync — otherwise a dry-run on one host propagates its preview to every host.
+test_dry_run_preview_dir_excluded_from_sync() {
+  local stignore="$SCRIPT_DIR/../syncthing/shared.stignore"
+  assert_file_exists "$stignore" "shared.stignore must exist"
+  assert_contains "$(cat "$stignore" 2>/dev/null)" "CEO/log/preview/" "preview dir must be stignored so dry-run output stays host-local"
+}
+
 # Dry-run is allowed under --scheduled (e.g. a daemon smoke-test) but must warn,
 # so a cron stuck in dry-run is observable rather than silently doing nothing.
 test_dry_run_under_scheduled_warns() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3209,6 +3209,7 @@ STUB
   local pf; pf=$(_preview_file dr-read)
   assert_contains "$(cat "$pf" 2>/dev/null)" "Preview body from the read model." "preview must capture the model output"
   assert_not_contains "$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null)" "dr-read completed" "dry-run must not append to cron-runs.log"
+  assert_fails "dry-run must not create the synced daily log file CEO/log/<TODAY>.md" test -f "$CEO_DIR/log/$(date +%Y-%m-%d).md"
 
   unset CURL_CAPTURE_DIR
 }

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3242,6 +3242,7 @@ STUB
   bash "$CRON" dr-write --dry-run >/dev/null 2>&1 || true
 
   assert_eq "$(wc -l < "$HOME/claude-calls.log" 2>/dev/null | tr -d ' ')" "1" "dry-run tier:write must run PLAN only — EXECUTE must be skipped"
+  assert_fails "write-tier dry-run must not stamp .last-run" test -f "$CEO_DIR/log/.last-run-dr-write"
   assert_not_contains "$(cat "$CEO_DIR/approvals/pending.md" 2>/dev/null)" "deploy the thing" "dry-run must not append high-stakes proposals to the approvals queue"
   local pf; pf=$(_preview_file dr-write)
   assert_contains "$(cat "$pf" 2>/dev/null)" "deploy the thing" "preview must list the deferred high-stakes action"
@@ -3316,6 +3317,95 @@ test_dry_run_under_scheduled_warns() {
   bash "$CRON" dr-sched --scheduled --dry-run >/dev/null 2>&1 || true
   assert_file_exists "$(_preview_file dr-sched)" "dry-run under scheduled must still preview"
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "dry-run" "a dry-run under --scheduled must emit a WARN"
+}
+
+# Failure path: a dry-run that hits a failure must NOT increment the fail-count,
+# stamp .last-run, fire the pending alert, or notify — it previews the would-fail.
+# (read-tier claude exit 1 reaches _record_failure.)
+test_dry_run_failure_path_has_no_side_effects() {
+  _register_status_playbook dr-fail active
+  echo 3 > "$CEO_DIR/log/.fail-count"
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+exit 1
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+
+  bash "$CRON" dr-fail --dry-run >/dev/null 2>&1 || true
+
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null)" "3" "dry-run failure must not increment the fail-count"
+  assert_fails "dry-run failure must not stamp .last-run" test -f "$CEO_DIR/log/.last-run-dr-fail"
+  assert_contains "$(cat "$(_preview_file dr-fail)" 2>/dev/null)" "Would record FAILURE" "preview must record the would-be failure"
+}
+
+# pending-drip writes to the host inbox (a CEO decision-state mutation). A dry-run
+# must preview that instead of mutating the inbox.
+test_dry_run_pending_drip_does_not_write_inbox() {
+  cat > "$CEO_DIR/playbooks/pending-drip.md" << 'PB'
+---
+name: pending-drip
+description: dry-run pending-drip fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+cat << 'OUT'
+LOG_ENTRY:
+## 09:00 — pending-drip
+**Status:** completed
+**Playbook:** playbooks/pending-drip.md
+**Output:**
+- A genuine pending question to surface.
+**Errors:**
+- none
+END_LOG_ENTRY
+OUT
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  bash "$CRON" pending-drip --dry-run >/dev/null 2>&1 || true
+
+  assert_fails "dry-run must not create the host inbox" test -d "$CEO_DIR/inbox"
+  assert_contains "$(cat "$(_preview_file pending-drip)" 2>/dev/null)" "inbox" "preview must note the would-be inbox append"
+}
+
+# _preview truncates the per-day file on the first write of each run, so a second
+# dry-run of the same trigger/day REPLACES rather than appends.
+test_dry_run_preview_truncates_per_run() {
+  cat > "$CEO_DIR/playbooks/dr-trunc.md" << 'PB'
+---
+name: dr-trunc
+description: dry-run truncation fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: dr-trunc.sh
+---
+PB
+  cat > "$SCRIPT_DIR/dr-trunc.sh" << 'SH'
+#!/bin/bash
+true
+SH
+  chmod +x "$SCRIPT_DIR/dr-trunc.sh"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  bash "$CRON" dr-trunc --dry-run >/dev/null 2>&1 || true
+  bash "$CRON" dr-trunc --dry-run >/dev/null 2>&1 || true
+
+  assert_eq "$(grep -c '# DRY-RUN preview' "$(_preview_file dr-trunc)" 2>/dev/null | tr -d ' ')" "1" "a re-run must replace the preview, not append a second header"
+
+  rm -f "$SCRIPT_DIR/dr-trunc.sh"
 }
 
 run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3097,4 +3097,163 @@ test_cron_catchall_skips_unknown_status() {
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unexpected run-mode:status" "catch-all must emit its distinct diagnostic"
 }
 
+# --- #138: --dry-run preview mode ---
+# Preview file lives in non-synced host-local scratch: $CEO_DIR/log/preview/<trigger>-<TODAY>.md
+_preview_file() { echo "$CEO_DIR/log/preview/$1-$(date +%Y-%m-%d).md"; }
+
+# A runner:script playbook in dry-run must NOT exec the script; it previews the
+# would-run command instead. This is the core "show what would happen, do nothing".
+test_dry_run_script_runner_skips_exec_and_previews() {
+  cat > "$CEO_DIR/playbooks/dr-script.md" << 'PB'
+---
+name: dr-script
+description: dry-run script fixture
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: dr-script.sh
+---
+PB
+  cat > "$SCRIPT_DIR/dr-script.sh" << SH
+#!/bin/bash
+echo "ran" > "$TEST_HOME/dr-script-fired.txt"
+SH
+  chmod +x "$SCRIPT_DIR/dr-script.sh"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  bash "$CRON" dr-script --dry-run >/dev/null 2>&1 || true
+
+  assert_fails "dry-run must NOT exec the script" test -f "$TEST_HOME/dr-script-fired.txt"
+  local pf; pf=$(_preview_file dr-script)
+  assert_file_exists "$pf" "dry-run must write a preview file"
+  assert_contains "$(cat "$pf" 2>/dev/null)" "dr-script.sh" "preview must name the would-run script"
+
+  rm -f "$SCRIPT_DIR/dr-script.sh"
+}
+
+# Cooldown integrity: a dry-run must not stamp .last-run, or it would silently
+# suppress the next real scheduled run.
+test_dry_run_does_not_write_last_run() {
+  _register_status_playbook dr-nolastrun active
+  bash "$CRON" dr-nolastrun --dry-run >/dev/null 2>&1 || true
+  assert_fails "dry-run must not write the .last-run stamp" test -f "$CEO_DIR/log/.last-run-dr-nolastrun"
+  assert_file_exists "$(_preview_file dr-nolastrun)" "dry-run must still produce a preview"
+}
+
+# A dry-run must bypass the per-trigger cooldown so it can be run iteratively
+# right after a real run.
+test_dry_run_bypasses_cooldown() {
+  _register_status_playbook dr-cool active
+  bash "$CRON" dr-cool --manual >/dev/null 2>&1 || true
+  assert_file_exists "$CEO_DIR/log/.last-run-dr-cool" "real run must stamp last-run"
+  bash "$CRON" dr-cool --dry-run >/dev/null 2>&1 || true
+  assert_file_exists "$(_preview_file dr-cool)" "dry-run must run despite a recent real run (cooldown bypassed)"
+}
+
+# read-tier dry-run: the read-only model call may happen, but its output is
+# routed to the preview file — NOT posted to Discord and NOT recorded as a run.
+test_dry_run_read_tier_no_discord_and_previews_output() {
+  cat > "$CEO_DIR/playbooks/dr-read.md" << 'PB'
+---
+name: dr-read
+description: dry-run read fixture
+trigger: cron
+schedule: "0 9 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+---
+PB
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+cat << 'OUT'
+LOG_ENTRY:
+## 09:00 — dr-read
+**Status:** completed
+**Playbook:** playbooks/dr-read.md
+**Output:**
+Preview body from the read model.
+**Errors:**
+- none
+END_LOG_ENTRY
+OUT
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+
+  mkdir -p "$TEST_HOME/curl"
+  export CURL_CAPTURE_DIR="$TEST_HOME/curl"
+  cat > "$HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+out="$CURL_CAPTURE_DIR/payload.json"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d) shift; printf '%s' "$1" > "$out" ;;
+  esac
+  shift || true
+done
+exit 0
+STUB
+  chmod +x "$HOME/.bun/bin/curl"
+  mkdir -p "$HOME/.config/claude-ceo"
+  echo '{"discord_report_webhook":"http://127.0.0.1/report-channel"}' > "$HOME/.config/claude-ceo/secrets.json"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" dr-read --dry-run >/dev/null 2>&1 || true
+
+  assert_fails "dry-run must not post to Discord" test -f "$CURL_CAPTURE_DIR/payload.json"
+  local pf; pf=$(_preview_file dr-read)
+  assert_contains "$(cat "$pf" 2>/dev/null)" "Preview body from the read model." "preview must capture the model output"
+  assert_not_contains "$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null)" "dr-read completed" "dry-run must not append to cron-runs.log"
+
+  unset CURL_CAPTURE_DIR
+}
+
+# tier:write dry-run: PLAN runs (read-only) but EXECUTE is skipped, and the
+# high-stakes proposal is previewed rather than appended to the approvals queue.
+test_dry_run_write_tier_skips_execute_and_pending() {
+  cat > "$CEO_DIR/playbooks/dr-write.md" << 'PB'
+---
+name: dr-write
+description: dry-run write fixture
+trigger: cron
+schedule: "0 9 * * *"
+model: sonnet
+preflight: none
+tier: high-stakes
+status: active
+---
+PB
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+echo "call" >> "$HOME/claude-calls.log"
+cat >/dev/null
+echo "ACTION: 1 | high-stakes | deploy the thing | gh deploy"
+echo "ACTION: 2 | read | check the status | n/a"
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" dr-write --dry-run >/dev/null 2>&1 || true
+
+  assert_eq "$(wc -l < "$HOME/claude-calls.log" 2>/dev/null | tr -d ' ')" "1" "dry-run tier:write must run PLAN only — EXECUTE must be skipped"
+  assert_not_contains "$(cat "$CEO_DIR/approvals/pending.md" 2>/dev/null)" "deploy the thing" "dry-run must not append high-stakes proposals to the approvals queue"
+  local pf; pf=$(_preview_file dr-write)
+  assert_contains "$(cat "$pf" 2>/dev/null)" "deploy the thing" "preview must list the deferred high-stakes action"
+  assert_contains "$(cat "$pf" 2>/dev/null)" "check the status" "preview must list the safe action that would execute"
+}
+
+# Dry-run is allowed under --scheduled (e.g. a daemon smoke-test) but must warn,
+# so a cron stuck in dry-run is observable rather than silently doing nothing.
+test_dry_run_under_scheduled_warns() {
+  _register_status_playbook dr-sched active
+  bash "$CRON" dr-sched --scheduled --dry-run >/dev/null 2>&1 || true
+  assert_file_exists "$(_preview_file dr-sched)" "dry-run under scheduled must still preview"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "dry-run" "a dry-run under --scheduled must emit a WARN"
+}
+
 run_tests

--- a/syncthing/shared.stignore
+++ b/syncthing/shared.stignore
@@ -30,3 +30,5 @@ CEO/log/.last-run-*
 CEO/log/.retry-*.json
 CEO/log/.config-hash
 CEO/log/.fail-count
+// --dry-run preview output is host-local scratch (see ceo-cron.sh --dry-run)
+CEO/log/preview/


### PR DESCRIPTION
Closes #138

## Description (Issue Fixed & New Behavior)

Introduces a `--dry-run` preview mode for `ceo-cron.sh`. It runs every **read-only** phase of the pipeline (gather, the PLAN call, a read-tier model call) but mutates **no CEO state**, then writes what *would* happen to a preview file.

In dry-run the dispatcher:
- **skips the EXECUTE phase** (the only write-capable `claude` call) on tier:write playbooks — PLAN + FILTER still run so the preview shows the real safe/high-stakes split;
- **does not exec** `runner: script` / `runner: skill` playbooks;
- **writes nothing** to the approvals queue (`pending.md`), Discord / report intake, the host inbox, the synced daily log (`CEO/log/<TODAY>.md`), `.last-run`, `.last-scan`, `.fail-count`, or `cron-runs.log`;
- **sends no notifications** (`ceo-notify.sh` is reached only through the gated `_record_*` helpers).

### Preview location & the sync boundary

The would-run plan is written to **`CEO/log/preview/<trigger>-<TODAY>.md`**. This diverges from the issue's literal `CEO/reports/_preview/` deliberately — but the divergence only works because of an explicit Syncthing exclusion:

- `CEO/log/preview/` is added to `syncthing/shared.stignore`, so the preview is **host-local** — a dry-run on one machine never propagates to the others.
- The rest of `CEO/log/` **is** synced (the daily log and the operational diagnostic journals `cron-skips.log` / `cron-stderr.log`). That's why the daily-log header write is also skipped in dry-run.
- A dry-run still appends clearly-labelled diagnostic lines to `cron-skips.log` (e.g. the `--scheduled` WARN). That journal is the dispatcher's operational debug channel — the same place #137's run-mode gate logs skips — not CEO decision-state.

`--dry-run` is orthogonal to run-mode: it bypasses the per-trigger cooldown (iterative use) and is allowed under `--scheduled` (with a `WARN`) so the Phase-1.5 daemon can smoke-test without acting.

**Non-guarantee (documented):** read-only external calls (gather, PLAN, read-tier model call) still run and still cost tokens — `--dry-run` skips effects, not reads.

**Implementation:** all `ceo-report.sh` invocations funnel through a single `_report` chokepoint that folds output into the preview in dry-run, so no path can leak to Discord. `_record_success` / `_record_failure` early-return their durable writes (and surface would-be failures to stderr so a broken gh/registry isn't masked by a clean exit 0). The FILTER `pending.md` write, the Phase-3 EXECUTE block, the script/skill exec, the pending-drip inbox append, the preflight `.last-run` stamp, and the daily-log header write are each gated.

Also includes a `docs/playbooks/SCHEMA.md` update documenting the flag and the sync boundary in the "Run modes" subsection.

## Testing Procedure

1. Check out this branch (stacked on `nh/feat/137-run-modes`; retarget to `main` once #145 merges).
2. Run the suite: `bash scripts/ceo-cron.test.sh` — confirm **116 tests pass** (14 of them `test_dry_run_*`).
3. Lint: `shellcheck --severity=warning scripts/ceo-cron.sh scripts/ceo-cron.test.sh` — confirm clean.
4. Mutation check (proves the tests guard the fix): revert the `exit 0` in the Phase-3 dry-run gate — `test_dry_run_write_tier_skips_execute_and_pending` must fail (claude is called twice instead of once). Remove `CEO/log/preview/` from `shared.stignore` — `test_dry_run_preview_dir_excluded_from_sync` must fail.
5. Manual smoke (optional): register a draft script playbook, run `bash scripts/ceo-cron.sh <name> --dry-run`, confirm the script did **not** execute and a preview appeared under `$CEO_VAULT/CEO/log/preview/`.

## Additional Notes / HelpScout Tickets

Phase 1 of #136. Stacked on #145 (#137 run-modes), which introduced the `ceo-cron.sh` flag parser this builds on.

Review history:
- Pre-push auditor flagged one HIGH (ungated synced daily-log write) — fixed in `54a1b7f`.
- Mini PR panel (silent-failure-hunter + ask-alignment + test-analyzer) found that the preview dir itself was synced (the divergence was a false promise) — fixed in `4f94b6b` by stignoring `CEO/log/preview/`, correcting the SCHEMA wording, adding stderr surfacing for masked failures, and backfilling skill/preflight dry-run coverage.


---
_Supersedes #148 (closed when its stacked base `nh/feat/137-run-modes` was deleted on merge of #145; rebased onto `main`, diff is now #138-only)._
