### PR TITLE
Record hosts: frontmatter for host-scoped scheduling (#139)

### DIFF
--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -22,6 +22,7 @@ Unknown values for enum fields are **rejected at parse time** with a `SKIP` diag
 | `bin` | no | string | If set, `ceo playbook scan` installs a `~/.local/bin/<bin-without-.sh>` symlink pointing at `scripts/<bin>`. Only created for `status: active`. |
 | `inputs` | no | JSON array | Pre-gather keys the dispatcher injects into the prompt context. Empty array = no pre-gathered context. Absent = all keys (back-compat default). Unknown keys warn-and-skip at dispatch. Valid keys: `pr_data`, `pending_count`, `today_log`, `yesterday_log`, `daily_note`, `briefings_training`, `active_domains`, `pending_ask`, `scan_data`, `blessings`. |
 | `requires` | no | JSON array of env-var names | Credentials the playbook needs (e.g. `["HUBSPOT_REFRESH_TOKEN"]`). `ceo creds check <name>` reports missing values. Non-array entries are warned and dropped. |
+| `hosts` | no | JSON array of host names | Which machines the playbook runs on. Absent or `["*"]` → all hosts. **Recorded in the registry but not yet enforced** — the Phase-1.5 daemon consumes it; see [Host scoping](#host-scoping). Malformed values (scalar, empty array, blank element) warn and default to `["*"]`. |
 | `artifact` | recommended for `runner: script` | string template | Expected output path relative to the vault. Must start with `CEO/`. Supports `{TODAY}` (YYYY-MM-DD) and `{HOST}` (short hostname). Unknown tokens reject at parse. `ceo doctor` cross-checks declared artifact vs disk for every active script that logged "completed" today. |
 | `out_pattern` | no | string | Legacy reporting pattern (output filename hint). Kept for back-compat with older playbooks. New playbooks should use `artifact`. |
 
@@ -53,6 +54,22 @@ The default is **manual**, so a bare `ceo-cron.sh <name>` is the on-demand path 
 That preview is **host-local**: `CEO/log/preview/` is excluded from Syncthing in `syncthing/shared.stignore`, so a dry-run on one host never propagates to the others. The rest of `CEO/log/` *is* synced — the daily log and the operational diagnostic journals (`cron-skips.log`, `cron-stderr.log`) — which is why the daily-log header write is also skipped in dry-run. A dry-run still appends clearly-labelled diagnostic lines to `cron-skips.log` (e.g. the `--scheduled` WARN below); that journal is the dispatcher's operational debug channel, not CEO decision-state.
 
 `--dry-run` bypasses the cooldown so it can be run iteratively, and is allowed under `--scheduled` (with a WARN to `cron-skips.log`) so a daemon can smoke-test without acting. Non-guarantee: read-only external calls still run and still cost tokens — `--dry-run` skips effects, not reads.
+
+### Host scoping
+
+The `hosts` field declares which machines a playbook may run on:
+
+| `hosts` value | Meaning |
+|---|---|
+| absent | all hosts (recorded as `["*"]`) |
+| `["*"]` | all hosts |
+| `["ml-1", "mac-mini"]` | only those named hosts (matched against the short hostname) |
+| `["*", "ml-1"]` | `*` mixed with names is reserved to mean **all hosts** — the wildcard dominates |
+| scalar / `[]` / blank element | **malformed** — `ceo playbook scan` warns and records `["*"]` |
+
+`ceo playbook scan` validates the shape at parse time and never silently scopes a playbook to nowhere or to a typo'd host: any malformed value defaults to `["*"]` with a `WARN` (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)). To stop a playbook entirely, use `status: disabled`, not an empty `hosts` list.
+
+**Phase 1 records `hosts` but does not enforce it** — every host still runs every playbook regardless of scope. Enforcement arrives with the Phase-1.5 daemon, which will bump the registry `schema_version` so a non-enforcing peer binary can't run a host-scoped playbook everywhere.
 
 ### Use draft for WIP playbooks
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -891,6 +891,27 @@ cmd_playbook_scan() {
         ;;
     esac
 
+    # `hosts` scopes which machines a playbook runs on. Absent → ["*"] (all
+    # hosts). Recorded in the registry but NOT enforced in Phase 1 — the daemon
+    # (Phase 1.5) consumes it. Validate shape at parse and default malformed
+    # values to ["*"] rather than silently scoping to nowhere or a typo'd host
+    # (per enum-config-typo-fallback). An empty array means "runs nowhere",
+    # which is a likely mistake — use status:disabled to stop a playbook.
+    hosts=$(_fm_array_json hosts "$f")
+    case "$hosts" in
+      "null"|"") hosts='["*"]' ;;
+      \[*\])
+        if ! echo "$hosts" | jq -e 'type=="array" and length>0 and all(.[]; type=="string" and test("\\S"))' >/dev/null 2>&1; then
+          echo "  WARN  $basename: 'hosts' must be a non-empty array of host names (got: $(echo "$hosts" | head -c 60)) — defaulting to [\"*\"] (all hosts)" >&2
+          hosts='["*"]'
+        fi
+        ;;
+      *)
+        echo "  WARN  $basename: 'hosts' must be an array (got: $(echo "$hosts" | head -c 60)) — defaulting to [\"*\"] (all hosts)" >&2
+        hosts='["*"]'
+        ;;
+    esac
+
     local runner_valid=0
     [ -z "$runner" ] && runner_valid=1
     for r in "${CEO_VALID_RUNNERS[@]}"; do
@@ -964,8 +985,9 @@ cmd_playbook_scan() {
       --arg artifact "$artifact" \
       --argjson inputs "$inputs" \
       --argjson requires "$requires" \
+      --argjson hosts "$hosts" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, inputs:$inputs, requires:$requires, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3408,4 +3408,144 @@ SH
   rm -f "$SCRIPT_DIR/dr-trunc.sh"
 }
 
+# --- #139: hosts: frontmatter (host-scoped scheduling, recorded not enforced) ---
+_hosts_in_registry() {
+  jq -r --arg n "$1" '.playbooks[] | select(.name==$n) | .hosts | tojson' "$CEO_DIR/registry.json" 2>/dev/null
+}
+
+# Absent hosts → recorded as ["*"] (all hosts), the backward-compatible default.
+test_hosts_absent_defaults_to_wildcard() {
+  cat > "$CEO_DIR/playbooks/h-absent.md" << 'PB'
+---
+name: h-absent
+description: no hosts field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_eq "$(_hosts_in_registry h-absent)" '["*"]' "absent hosts must default to [\"*\"]"
+}
+
+# Explicit flow-sequence host list is recorded verbatim.
+test_hosts_explicit_list_recorded() {
+  cat > "$CEO_DIR/playbooks/h-list.md" << 'PB'
+---
+name: h-list
+description: explicit host list
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: ["ml-1", "mac-mini"]
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_eq "$(_hosts_in_registry h-list)" '["ml-1","mac-mini"]' "explicit hosts list must be recorded verbatim"
+}
+
+# Block-sequence YAML form is parsed identically.
+test_hosts_block_sequence_recorded() {
+  cat > "$CEO_DIR/playbooks/h-block.md" << 'PB'
+---
+name: h-block
+description: block-sequence host list
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts:
+  - ml-1
+  - wsl-carla
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_eq "$(_hosts_in_registry h-block)" '["ml-1","wsl-carla"]' "block-sequence hosts must parse to a JSON array"
+}
+
+# A scalar (non-array) hosts value must warn and default to ["*"], never silently
+# scope to a single host (enum-config-typo-fallback: don't coerce a typo).
+test_hosts_non_array_warns_and_defaults() {
+  cat > "$CEO_DIR/playbooks/h-scalar.md" << 'PB'
+---
+name: h-scalar
+description: scalar hosts
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: ml-1
+---
+PB
+  local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  assert_contains "$out" "must be an array" "scan must warn when hosts is not an array"
+  assert_eq "$(_hosts_in_registry h-scalar)" '["*"]' "non-array hosts must default to [\"*\"]"
+}
+
+# An empty array would mean "runs nowhere" — a likely mistake that would silently
+# disable the playbook. Warn and default to all; use status:disabled to stop one.
+test_hosts_empty_array_warns_and_defaults() {
+  cat > "$CEO_DIR/playbooks/h-empty.md" << 'PB'
+---
+name: h-empty
+description: empty hosts array
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: []
+---
+PB
+  local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  assert_contains "$out" "hosts" "scan must warn on empty hosts array"
+  assert_eq "$(_hosts_in_registry h-empty)" '["*"]' "empty hosts array must default to [\"*\"]"
+}
+
+# An empty/whitespace element is malformed → warn and default to all.
+test_hosts_empty_element_warns_and_defaults() {
+  cat > "$CEO_DIR/playbooks/h-blank.md" << 'PB'
+---
+name: h-blank
+description: hosts with an empty element
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: ["ml-1", ""]
+---
+PB
+  local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  assert_contains "$out" "hosts" "scan must warn on a blank host element"
+  assert_eq "$(_hosts_in_registry h-blank)" '["*"]' "a blank host element must default to [\"*\"]"
+}
+
+# Phase 1 records hosts but does NOT enforce them: a playbook scoped to a
+# different host still dispatches here. Enforcement arrives with the daemon (1.5).
+test_hosts_recorded_but_not_enforced_in_phase1() {
+  cat > "$CEO_DIR/playbooks/h-other.md" << 'PB'
+---
+name: h-other
+description: scoped to a host that is not this one
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: ["definitely-not-this-host"]
+---
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_eq "$(_hosts_in_registry h-other)" '["definitely-not-this-host"]' "off-host scope must still be recorded"
+  bash "$CRON" h-other --scheduled >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "Phase 1 must NOT enforce hosts — playbook still dispatches"
+}
+
 run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3504,7 +3504,7 @@ hosts: []
 ---
 PB
   local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
-  assert_contains "$out" "hosts" "scan must warn on empty hosts array"
+  assert_contains "$out" "must be a non-empty array" "scan must warn on empty hosts array"
   assert_eq "$(_hosts_in_registry h-empty)" '["*"]' "empty hosts array must default to [\"*\"]"
 }
 
@@ -3523,8 +3523,29 @@ hosts: ["ml-1", ""]
 ---
 PB
   local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
-  assert_contains "$out" "hosts" "scan must warn on a blank host element"
+  assert_contains "$out" "must be a non-empty array" "scan must warn on a blank host element"
   assert_eq "$(_hosts_in_registry h-blank)" '["*"]' "a blank host element must default to [\"*\"]"
+}
+
+# A whitespace-only element pins the test("\\S") clause specifically (distinct
+# from the empty-string case above) — if someone simplifies \S to !="" this
+# test is the only thing that catches the regression.
+test_hosts_whitespace_element_warns_and_defaults() {
+  cat > "$CEO_DIR/playbooks/h-ws.md" << 'PB'
+---
+name: h-ws
+description: hosts with a whitespace-only element
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+hosts: ["ml-1", "  "]
+---
+PB
+  local out; out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  assert_contains "$out" "must be a non-empty array" "scan must warn on a whitespace-only host element"
+  assert_eq "$(_hosts_in_registry h-ws)" '["*"]' "a whitespace-only element must default to [\"*\"]"
 }
 
 # Phase 1 records hosts but does NOT enforce them: a playbook scoped to a


### PR DESCRIPTION
Closes #139

## Description (Issue Fixed & New Behavior)

Adds a `hosts:` frontmatter field that scopes which machines a playbook runs on. `ceo playbook scan` parses it (via `_fm_array_json`, the list-aware parser — the issue said `_fm_scalar`, but `hosts` is a list, and the array helper calls `_fm_scalar` internally for the inline-flow case) and records it in `registry.json`.

- **Absent or `["*"]` → all hosts.** An explicit list (`["ml-1", "mac-mini"]`) scopes to those short hostnames. Both flow (`["a","b"]`) and block-sequence YAML forms parse.
- **Shape is validated at parse time** (`enum-config-typo-fallback`): a scalar, an empty array, or a blank/whitespace element warns and defaults to `["*"]` — never silently scoping to nowhere or a typo'd host. To stop a playbook, use `status: disabled`, not an empty `hosts`.
- `["*", "ml-1"]` (wildcard mixed with names) is reserved to mean **all hosts** — documented so the 1.5 matcher isn't an unscoped edge case.

**Recorded but NOT enforced in Phase 1** — every host still runs every playbook regardless of scope. The Phase-1.5 daemon consumes `hosts`. No registry `schema_version` bump now: the field is additive and inert, so a mixed-binary fleet interoperates safely (an old binary ignores the key; a new binary defaults absence to `["*"]`). The bump lands *with* enforcement in 1.5.

## Testing Procedure

1. Check out this branch (off `main`).
2. Run the cron/scan suite: `bash scripts/ceo-cron.test.sh` — confirm **123 tests pass** (7 `test_hosts_*`).
3. Run the rest: `for t in scripts/*.test.sh; do bash "$t"; done` — all green (verifies the new registry field doesn't break any suite that reads `registry.json`).
4. Lint: `shellcheck --severity=warning scripts/ceo scripts/ceo-cron.sh scripts/ceo-cron.test.sh` — clean.
5. Mutation check: neuter the `hosts` validator (`if false; then`) — `test_hosts_empty_array_warns_and_defaults` must fail (records `[]` instead of `["*"]`).
6. Manual: register a playbook with `hosts: ["other-host"]` active, run it `--scheduled` — it still dispatches (Phase 1 records, doesn't enforce).

## Additional Notes / HelpScout Tickets

Phase 1 of #136. Branched off `main` after #137 (#145) and #138 (#150) merged.

**Deferred decision for Phase 1.5 (flagged by the pre-push auditor, LOW):** malformed `hosts` currently defaults to `["*"]` — *fail-open* (runs everywhere). For Phase 1 that's the correct backward-compatible default and is moot (nothing enforces). When 1.5 adds enforcement, we should decide whether a malformed/typo'd scope should instead **fail-closed** (skip the playbook) so a typo doesn't silently widen a playbook to the whole fleet. Recorded here so it's a conscious call when enforcement lands, not a silent inheritance.

**Known gaps (panel, both LOW / latent — non-enforced in Phase 1):**
- *First-scan churn:* the first `ceo playbook scan` after this lands re-hashes every entry (the new `hosts` key changes each entry's checksum), so every existing playbook shows once as `UPD`. Cosmetic — the hash only drives the ADD/UPD/DEL display tally.
- *Quoted-scalar coercion:* a quoted scalar whose contents look like a list, e.g. `hosts: "[bad]"`, is coerced by `_fm_array_json` to `["bad"]` and recorded without a WARN (pre-existing behavior shared with `requires`/`inputs`). Latent until 1.5 enforcement; flagged so the daemon work doesn't inherit a silent mis-scope.
