### PR TITLE
feat(cron): add --test-all fleet dry-run sweep (#140)

### DIFF
--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -55,6 +55,30 @@ That preview is **host-local**: `CEO/log/preview/` is excluded from Syncthing in
 
 `--dry-run` bypasses the cooldown so it can be run iteratively, and is allowed under `--scheduled` (with a WARN to `cron-skips.log`) so a daemon can smoke-test without acting. Non-guarantee: read-only external calls still run and still cost tokens — `--dry-run` skips effects, not reads.
 
+### Fleet sweep — `--test-all`
+
+`ceo-cron.sh --test-all` dry-runs **every registered playbook** in one pass and writes a single aggregate report. It takes no positional trigger and always implies `--dry-run` (it never performs a side effect). Each playbook is swept by re-invoking `ceo-cron.sh <name> --dry-run --depth <depth>`, so it reuses the same preview/no-side-effect machinery as a single dry-run.
+
+```bash
+ceo-cron.sh --test-all                       # cheap fleet health check (preflight depth)
+ceo-cron.sh --test-all --depth deep          # exercise every model call
+ceo-cron.sh --test-all --depth deep --model haiku   # …against an override model
+```
+
+| Flag | Meaning |
+|---|---|
+| `--depth preflight` | **Default.** Stop after each playbook's preflight passes — answers "would this fire right now?" with **no model call, no tokens spent**. |
+| `--depth plan` | Run the planning phase where one exists: tier:write playbooks make their PLAN call; read-tier playbooks preview the call they *would* make without spending tokens. |
+| `--depth deep` | Full dry-run: read-tier playbooks make their read-only call; write-tier playbooks run PLAN+FILTER. EXECUTE is still skipped (it's a dry-run). |
+| `--model <tag>` | Override the model for any playbook that makes a model call (plan/deep depth). The override is applied uniformly; passing a model incompatible with a playbook's runner (e.g. an Ollama tag to a claude-runner playbook) surfaces as a `FAILED` row — which is the intended smoke-test signal ("this config wouldn't run"), not a dispatcher bug. Unset = each playbook's configured `model:`. |
+| `--all-hosts` | **Phase-1.5 stub.** Warns it is not yet implemented and sweeps the local host only. (Cross-host fan-out arrives with the daemon.) |
+
+Unknown `--depth` values are rejected at parse (no silent default). `--depth` / `--model` / `--all-hosts` are preview-only and require `--dry-run` or `--test-all`.
+
+**Output:** `CEO/log/preview/test-all/<TODAY>.md` — host-local (under the stignored `CEO/log/preview/` tree, like a single dry-run's preview), so a fleet smoke-test stays on the host that ran it. The report has a per-playbook result table (`would run` / `skip: no work` / `FAILED`) plus each playbook's individual preview inline.
+
+> **Note on `--model` vs the original design.** The issue proposed "unset → local Ollama default." Forcing Ollama globally would break tier:write playbooks (the three-phase pipeline requires Claude; Ollama is rejected for non-read tiers), so unset keeps each playbook's configured model. The cheap-sweep goal is met by the `preflight` default, which makes no model call at all.
+
 ### Host scoping
 
 The `hosts` field declares which machines a playbook may run on:

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -25,6 +25,10 @@ RUN_MODE="manual"
 _mode_set=""
 FORCE_REQUESTED=0
 DRY_RUN=0
+TEST_ALL=0
+ALL_HOSTS=0
+DEPTH=""
+MODEL_OVERRIDE=""
 TRIGGER=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -38,8 +42,20 @@ while [ $# -gt 0 ]; do
       ;;
     --force) FORCE_REQUESTED=1 ;;
     --dry-run) DRY_RUN=1 ;;
+    --test-all) TEST_ALL=1 ;;
+    --all-hosts) ALL_HOSTS=1 ;;
+    --depth)
+      shift
+      [ $# -gt 0 ] || { echo "ERROR: --depth requires a value (preflight|plan|deep)" >&2; exit 1; }
+      DEPTH="$1"
+      ;;
+    --model)
+      shift
+      [ $# -gt 0 ] || { echo "ERROR: --model requires a value" >&2; exit 1; }
+      MODEL_OVERRIDE="$1"
+      ;;
     -*)
-      echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force, --dry-run)" >&2
+      echo "ERROR: unknown flag '$1' (expected: --scheduled, --manual, --force, --dry-run, --test-all, --depth, --model, --all-hosts)" >&2
       exit 1
       ;;
     *)
@@ -53,9 +69,47 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-if [ -z "$TRIGGER" ]; then
+# --test-all is a fleet sweep (#140): it sweeps every registered playbook, takes
+# no positional trigger, and implies --dry-run (it never performs a side effect).
+if [ "$TEST_ALL" = "1" ]; then
+  if [ -n "$TRIGGER" ]; then
+    echo "ERROR: --test-all sweeps all playbooks and takes no trigger argument (got '$TRIGGER')" >&2
+    exit 1
+  fi
+  DRY_RUN=1
+fi
+
+if [ "$TEST_ALL" != "1" ] && [ -z "$TRIGGER" ]; then
   echo "Usage: ceo-cron.sh <trigger> [--scheduled|--manual] [--force] [--dry-run]" >&2
+  echo "       ceo-cron.sh --test-all [--depth preflight|plan|deep] [--model <tag>] [--all-hosts]" >&2
   exit 1
+fi
+
+# --depth selects how far a dry-run sweep goes (enum, no silent default per
+# enum-config-typo-fallback). It is meaningful only in a preview context, so
+# requiring it without --dry-run/--test-all would be a silent no-op — reject.
+case "$DEPTH" in
+  preflight|plan|deep|"") ;;
+  *) echo "ERROR: --depth must be one of: preflight, plan, deep (got '$DEPTH')" >&2; exit 1 ;;
+esac
+if [ -n "$DEPTH" ] && [ "$DRY_RUN" != "1" ] && [ "$TEST_ALL" != "1" ]; then
+  echo "ERROR: --depth requires --dry-run or --test-all (it controls how far a preview goes)" >&2
+  exit 1
+fi
+if [ -n "$MODEL_OVERRIDE" ] && [ "$DRY_RUN" != "1" ] && [ "$TEST_ALL" != "1" ]; then
+  echo "ERROR: --model requires --dry-run or --test-all (it overrides the model for a preview sweep)" >&2
+  exit 1
+fi
+if [ "$ALL_HOSTS" = "1" ] && [ "$TEST_ALL" != "1" ]; then
+  echo "ERROR: --all-hosts requires --test-all" >&2
+  exit 1
+fi
+
+# Resolve the effective sweep depth: --test-all defaults to the cheap preflight
+# health check (no model calls); a plain --dry-run defaults to deep (the full
+# #138 preview that makes read-only calls).
+if [ -z "$DEPTH" ]; then
+  if [ "$TEST_ALL" = "1" ]; then DEPTH="preflight"; else DEPTH="deep"; fi
 fi
 
 # --force is a manual-only smoke-test escape hatch from the per-trigger cooldown.
@@ -80,11 +134,14 @@ fi
 # run and still cost tokens — dry-run skips effects, not reads.
 if [ "$DRY_RUN" = "1" ]; then
   export CEO_DRY_RUN=1
+  export CEO_DRY_RUN_DEPTH="$DEPTH"
+  [ -n "$MODEL_OVERRIDE" ] && export CEO_MODEL_OVERRIDE="$MODEL_OVERRIDE"
 fi
 
 # Gates filesystem path (.last-run-${TRIGGER}), env export (CEO_PLAYBOOK_ID),
 # and LLM prompt JSON interpolation against quote/escape/traversal injection.
-if [[ ! "$TRIGGER" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
+# --test-all has no positional trigger, so the gate only applies to a real one.
+if [ "$TEST_ALL" != "1" ] && [[ ! "$TRIGGER" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
   echo "ERROR: invalid trigger '$TRIGGER' (must start with [A-Za-z0-9_]; allowed thereafter: A-Z a-z 0-9 . _ -)" >&2
   exit 1
 fi
@@ -491,6 +548,127 @@ mkdir -p "$LOG_DIR"
 REPORT_DIR="$CEO_DIR/reports"
 mkdir -p "$REPORT_DIR"
 
+# _run_test_all — fleet dry-run sweep (#140). Re-execs `ceo-cron.sh <name>
+# --dry-run --depth <DEPTH>` for every registered playbook, reusing #138's
+# preview/no-side-effect machinery rather than duplicating it, and aggregates
+# each outcome into one host-local report. Runs BEFORE the lock so children
+# acquire it sequentially (no parent-vs-child contention). Model override and
+# CEO_DRY_RUN_DEPTH already exported above are inherited by the children.
+_run_test_all() {
+  local registry="$CEO_DIR/registry.json"
+  local rc=0
+  ceo_registry_validate "$registry" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "ERROR: registry.json not usable (ceo_registry_validate rc=$rc). Run: ceo playbook scan" >&2
+    return 1
+  fi
+
+  if [ "$ALL_HOSTS" = "1" ]; then
+    echo "WARN: --all-hosts is not yet implemented (arrives with the Phase-1.5 daemon). Sweeping the local host only." >&2
+  fi
+
+  local host
+  host="${CEO_HOSTNAME:-$(hostname -s)}"
+  : "${host:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+
+  local out_dir="$LOG_DIR/preview/test-all"
+  local out="$out_dir/${TODAY}.md"
+  mkdir -p "$out_dir"
+  # Truncate the per-day child stdout journal so repeated same-day sweeps don't
+  # stack onto each other (per-child stderr is captured + cleaned per child).
+  : > "$out_dir/.${TODAY}.stdout"
+
+  {
+    echo "# Fleet dry-run sweep — $host ($TODAY $NOW)"
+    echo ""
+    echo "- depth: \`$DEPTH\`"
+    echo "- model override: \`${MODEL_OVERRIDE:-per-playbook configured}\`"
+    echo "- all-hosts: \`$ALL_HOSTS\` (not enforced in Phase 1 — local host only)"
+    echo ""
+    echo "| playbook | result | exit |"
+    echo "|---|---|---|"
+  } > "$out"
+
+  local names
+  names=$(jq -r '.playbooks[].name' "$registry" 2>/dev/null)
+  if [ -z "$names" ]; then
+    echo "| _(no playbooks registered)_ | — | — |" >> "$out"
+    echo "Wrote fleet sweep report: $out" >&2
+    return 0
+  fi
+
+  local details="" name child_exit child_err preview result
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    preview="$LOG_DIR/preview/${name}-${TODAY}.md"
+    # Clear any stale same-day single-dry-run preview so the classifier reads
+    # only THIS sweep's output. A child that exits 0 without writing a preview
+    # (e.g. a chat-only playbook) would otherwise inherit a stale "would run".
+    rm -f "$preview"
+    child_err="$out_dir/.${name//\//_}.stderr"
+    child_exit=0
+    bash "$0" "$name" --dry-run --depth "$DEPTH" \
+      >>"$out_dir/.${TODAY}.stdout" 2>"$child_err" || child_exit=$?
+    # Classify. A dry-run preflight that hits a dependency failure (e.g. gh
+    # down) returns 0 but leaves a "Would record FAILURE" marker in the preview
+    # AND a "returned no-work" line — it must read as FAILED, not a benign skip,
+    # or the fleet sweep gives a false all-clear (the whole point of --test-all).
+    # Anchored greps so report/PLAN body text can't trip the classifier.
+    if [ "$child_exit" -ne 0 ]; then
+      result="FAILED"
+    elif [ -f "$preview" ] && grep -q "^- Would record FAILURE" "$preview"; then
+      result="FAILED: preflight/dep"
+    elif [ -f "$preview" ] && grep -q "^- Preflight .* returned no-work" "$preview"; then
+      result="skip: no work"
+    elif [ -f "$preview" ]; then
+      result="would run"
+    else
+      result="no preview"
+    fi
+    printf '| %s | %s | %s |\n' "$name" "$result" "$child_exit" >> "$out"
+    details+="
+## $name — $result (exit $child_exit)
+
+"
+    if [ -f "$preview" ]; then
+      details+=$(cat "$preview")
+      details+="
+"
+    else
+      details+="_(no preview file produced)_
+"
+    fi
+    # Surface the child's stderr for non-clean rows — for a smoke-test, "why"
+    # matters and the per-day journal is truncated next sweep.
+    case "$result" in
+      FAILED*|"no preview")
+        if [ -s "$child_err" ]; then
+          details+="
+\`\`\`
+$(tail -n 8 "$child_err")
+\`\`\`
+"
+        fi
+        ;;
+    esac
+    rm -f "$child_err"
+  done <<< "$names"
+
+  {
+    echo ""
+    echo "---"
+    printf '%s' "$details"
+  } >> "$out"
+
+  echo "Wrote fleet sweep report: $out" >&2
+  return 0
+}
+
+if [ "$TEST_ALL" = "1" ]; then
+  _run_test_all
+  exit $?
+fi
+
 # --- Exclusive lock (prevents overlapping cron runs) ---
 if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
   exec 200>"$LOCK_FILE"
@@ -766,6 +944,14 @@ if type "$PREFLIGHT_FN" &>/dev/null; then
   _v "Preflight '$PREFLIGHT' passed"
 else
   _v "WARNING: Unknown preflight '$PREFLIGHT' — running anyway"
+fi
+
+# Depth gate (#140): at preflight depth a dry-run stops here — preflight passed,
+# so the playbook WOULD fire, but we make no runner/model call (the cheap fleet
+# health check). This fires uniformly for every runner type.
+if [ "${CEO_DRY_RUN:-}" = "1" ] && [ "${CEO_DRY_RUN_DEPTH:-deep}" = "preflight" ]; then
+  _preview "Depth=preflight: preflight '$PREFLIGHT' passed — playbook would run. Stopping before any runner/model call (no script/skill exec, no tokens spent)."
+  exit 0
 fi
 
 # --- Shared file-read helper (used by ollama branch and claude tier blocks below) ---
@@ -1113,6 +1299,14 @@ LOG_ENTRY:
 - {any errors, or 'none'}
 END_LOG_ENTRY"
 
+  # Depth gate (#140): at plan depth a read-tier playbook has no planning phase
+  # to run, so it previews the call it WOULD make without spending tokens. deep
+  # depth makes the real read-only call (#138 behavior).
+  if [ "${CEO_DRY_RUN:-}" = "1" ] && [ "${CEO_DRY_RUN_DEPTH:-deep}" = "plan" ]; then
+    _preview "Depth=plan: read-tier — would call model '${CEO_MODEL_OVERRIDE:-${MODEL:-sonnet}}' once with the single-call prompt (no call made: plan depth skips read-tier model calls)."
+    exit 0
+  fi
+
   if [ "$RUNNER" = "ollama" ] || [ "$RUNNER" = "ollama-think" ]; then
     if ! command -v ollama >/dev/null 2>&1; then
       _record_failure "ollama binary not found on PATH (playbook: $TRIGGER)"
@@ -1145,6 +1339,8 @@ END_LOG_ENTRY"
     else
       OLLAMA_MODEL="$MODEL_FROM_FRONTMATTER"
     fi
+    # --model override (#140) wins over frontmatter for a preview sweep.
+    [ -n "${CEO_MODEL_OVERRIDE:-}" ] && OLLAMA_MODEL="$CEO_MODEL_OVERRIDE"
     _v "Runner: $RUNNER — model: $OLLAMA_MODEL"
     export CEO_MODEL="$OLLAMA_MODEL"
 
@@ -1195,6 +1391,7 @@ END_LOG_ENTRY"
   fi
 
   MODEL="${MODEL:-sonnet}"
+  [ -n "${CEO_MODEL_OVERRIDE:-}" ] && MODEL="$CEO_MODEL_OVERRIDE"
   export CEO_MODEL="$MODEL"
   SINGLE_PROMPT="${SINGLE_PROMPT_PREAMBLE}${SINGLE_PROMPT_BODY}"
 
@@ -1221,6 +1418,7 @@ fi
 
 # --- Three-phase pipeline (low-stakes write and above) ---
 MODEL="${MODEL:-sonnet}"
+[ -n "${CEO_MODEL_OVERRIDE:-}" ] && MODEL="$CEO_MODEL_OVERRIDE"
 export CEO_MODEL="$MODEL"
 
 # --- Phase 1: PLAN (read-only, no tool execution) ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3569,4 +3569,211 @@ PB
   assert_file_exists "$HOME/claude-invoked.txt" "Phase 1 must NOT enforce hosts — playbook still dispatches"
 }
 
+# --- #140: --test-all (fleet dry-run sweep) ---
+_test_all_report() { echo "$CEO_DIR/log/preview/test-all/$(date +%Y-%m-%d).md"; }
+
+# Register an active read-tier playbook at a caller-chosen schedule + preflight.
+# Distinct schedules avoid the scan-time collision detector (two active cron
+# playbooks at the same minute is refused).
+_register_pb_sched() {
+  local name="$1" sched="$2" preflight="${3:-none}"
+  cat > "$CEO_DIR/playbooks/$name.md" << PB
+---
+name: $name
+description: test-all fixture
+trigger: cron
+schedule: "$sched"
+preflight: $preflight
+tier: read
+status: active
+---
+PB
+}
+
+# --test-all sweeps every registered playbook and writes one aggregate report
+# naming each playbook it touched.
+test_test_all_sweeps_all_registered_playbooks() {
+  _register_pb_sched ta-one "1 9 * * *"
+  _register_pb_sched ta-two "2 9 * * *"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" --test-all >/dev/null 2>&1 || true
+  local report; report=$(_test_all_report)
+  assert_file_exists "$report" "--test-all must write the aggregate sweep report"
+  assert_contains "$(cat "$report" 2>/dev/null)" "ta-one" "sweep report must list ta-one"
+  assert_contains "$(cat "$report" 2>/dev/null)" "ta-two" "sweep report must list ta-two"
+}
+
+# --test-all implies dry-run: no playbook may leave a real side effect —
+# no .last-run stamp, no cron-runs.log append, and no notify/Discord dispatch
+# (the dry-run chokepoints short-circuit before ceo-notify.sh).
+test_test_all_implies_dry_run_no_side_effects() {
+  _register_status_playbook ta-noeffect active
+  CEO_NOTIFY_DEBUG_LOG="$TEST_HOME/notify-debug.log" bash "$CRON" --test-all >/dev/null 2>&1 || true
+  assert_fails "--test-all must not stamp .last-run for any swept playbook" test -f "$CEO_DIR/log/.last-run-ta-noeffect"
+  assert_not_contains "$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null)" "ta-noeffect completed" "--test-all must not append to cron-runs.log"
+  assert_fails "--test-all must not invoke notify/Discord for any swept playbook" test -s "$TEST_HOME/notify-debug.log"
+}
+
+# The aggregate report lives under CEO/log/preview/, the host-local (stignored)
+# scratch tree — a fleet smoke-test stays on the host that ran it.
+test_test_all_report_is_under_host_local_preview() {
+  _register_status_playbook ta-local active
+  bash "$CRON" --test-all >/dev/null 2>&1 || true
+  local report; report=$(_test_all_report)
+  assert_contains "$report" "/log/preview/test-all/" "sweep report must live under the host-local preview tree"
+  assert_file_exists "$report" "sweep report must exist at the host-local path"
+}
+
+# --test-all takes no positional trigger; combining the two is a usage error.
+# A valid registry is scanned first so the ONLY nonzero source is the trigger
+# guard — otherwise the test would pass off the missing-registry abort and stay
+# green even if the guard were removed. We also assert the specific message.
+test_test_all_rejects_trigger_arg() {
+  _register_pb_sched ta-rt "3 9 * * *"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local err rc=0
+  err=$(bash "$CRON" --test-all some-trigger 2>&1) || rc=$?
+  assert_eq "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)" "nonzero" "--test-all with a trigger must be rejected"
+  assert_contains "$err" "takes no trigger argument" "rejection must come from the trigger guard, not a downstream registry error"
+}
+
+# Unknown --depth is rejected at parse (enum-config-typo-fallback: no silent
+# default). Registry scanned first so the enum guard is the only nonzero source.
+test_test_all_rejects_unknown_depth() {
+  _register_pb_sched ta-rd "4 9 * * *"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local err rc=0
+  err=$(bash "$CRON" --test-all --depth bogus 2>&1) || rc=$?
+  assert_eq "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)" "nonzero" "--depth with an unknown value must be rejected"
+  assert_contains "$err" "must be one of: preflight, plan, deep" "rejection must come from the depth enum guard, not a downstream error"
+}
+
+# Default sweep depth is preflight: the cheap fleet health check makes NO model
+# call — it only asks "would this playbook fire right now?".
+test_test_all_default_depth_preflight_makes_no_model_call() {
+  _register_status_playbook ta-pre active
+  bash "$CRON" --test-all >/dev/null 2>&1 || true
+  assert_fails "default --test-all (preflight depth) must not invoke the model" test -f "$HOME/claude-invoked.txt"
+}
+
+# --depth deep exercises every model call: a read-tier playbook makes its
+# single-call. (Mutation guard: if the preflight gate wrongly fired, this fails.)
+test_test_all_depth_deep_invokes_model() {
+  _register_status_playbook ta-deep active
+  bash "$CRON" --test-all --depth deep >/dev/null 2>&1 || true
+  assert_file_exists "$HOME/claude-invoked.txt" "--depth deep must invoke the read-tier model call"
+}
+
+# --all-hosts is a Phase-1.5 stub: it warns it isn't implemented and sweeps the
+# local host only, rather than silently pretending to fan out.
+test_test_all_all_hosts_warns_and_still_sweeps() {
+  _register_status_playbook ta-ah active
+  local out; out=$(bash "$CRON" --test-all --all-hosts 2>&1)
+  assert_contains "$out" "all-hosts" "--all-hosts must warn it is not yet implemented"
+  assert_file_exists "$(_test_all_report)" "--all-hosts must still produce the local sweep report"
+}
+
+# The aggregate distinguishes a playbook that WOULD run (preflight passed) from
+# one that would SKIP (preflight no-work) — the point of the fleet health check.
+test_test_all_aggregate_distinguishes_would_run_from_skip() {
+  _register_pb_sched ta-run "1 9 * * *" none
+  _register_pb_sched ta-skip "2 9 * * *" has_pending_items
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" --test-all >/dev/null 2>&1 || true
+  local body; body=$(cat "$(_test_all_report)" 2>/dev/null)
+  assert_contains "$body" "ta-run" "report must include the would-run playbook"
+  assert_contains "$body" "ta-skip" "report must include the no-work playbook"
+  assert_contains "$body" "no work" "report must mark the preflight-no-work playbook as a skip"
+}
+
+# --depth is a dry-run/test-all concept; requiring it elsewhere would be a silent
+# no-op. Reject --depth without --dry-run or --test-all. Assert the specific
+# message so the test fails when the guard is removed (a bare nonzero check would
+# pass off the unrelated "no playbook registered" abort).
+test_depth_requires_dry_run_or_test_all() {
+  local err rc=0
+  err=$(bash "$CRON" some-name --depth preflight 2>&1) || rc=$?
+  assert_eq "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)" "nonzero" "--depth without --dry-run/--test-all must be rejected"
+  assert_contains "$err" "--depth requires --dry-run or --test-all" "rejection must come from the requires-preview guard"
+}
+
+# A dry-run preflight that hits a dependency failure (gh down → preflight calls
+# _record_failure then returns 1) exits 0 with a "Would record FAILURE" marker.
+# The sweep must classify that as FAILED, not a benign "skip: no work" — else a
+# broken-dependency playbook reads as a false all-clear, defeating --test-all.
+test_test_all_preflight_dependency_failure_is_failed_not_skip() {
+  _register_pb_sched ta-dep "5 9 * * *" has_prs_to_review
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  # No gh on PATH in tests → has_prs_to_review records a failure and returns 1.
+  bash "$CRON" --test-all >/dev/null 2>&1 || true
+  local body; body=$(cat "$(_test_all_report)" 2>/dev/null)
+  assert_contains "$body" "ta-dep | FAILED" "a preflight dependency failure must classify as FAILED"
+  assert_not_contains "$body" "ta-dep | skip: no work" "a dependency failure must NOT read as a benign skip"
+}
+
+# --depth plan: a read-tier playbook has no planning phase, so it previews the
+# call it WOULD make without spending tokens (no model call).
+test_dry_run_depth_plan_read_tier_previews_without_call() {
+  _register_pb_sched dp-read "6 9 * * *" none
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" dp-read --dry-run --depth plan >/dev/null 2>&1 || true
+  assert_fails "plan depth must not invoke the read-tier model" test -f "$HOME/claude-invoked.txt"
+  assert_contains "$(cat "$(_preview_file dp-read)" 2>/dev/null)" "would call model" "plan depth must preview the would-be read-tier call"
+}
+
+# --depth plan on a tier:write playbook runs the PLAN call (planning phase
+# exists) but still skips EXECUTE (it's a dry-run).
+test_dry_run_depth_plan_write_tier_runs_plan() {
+  cat > "$CEO_DIR/playbooks/dp-write.md" << 'PB'
+---
+name: dp-write
+description: plan-depth write fixture
+trigger: cron
+schedule: "7 9 * * *"
+model: sonnet
+preflight: none
+tier: high-stakes
+status: active
+---
+PB
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+echo "call" >> "$HOME/claude-calls.log"
+cat >/dev/null
+echo "ACTION: 1 | high-stakes | deploy | gh deploy"
+echo "ACTION: 2 | read | check | n/a"
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" dp-write --dry-run --depth plan >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$HOME/claude-calls.log" 2>/dev/null | tr -d ' ')" "1" "plan depth on tier:write must run PLAN once (EXECUTE skipped)"
+  assert_fails "plan-depth write dry-run must not stamp .last-run" test -f "$CEO_DIR/log/.last-run-dp-write"
+}
+
+# --model overrides the model passed to the dispatcher's claude call (deep depth
+# makes the call). Unset would use the frontmatter/default model. The override is
+# exported as CEO_MODEL_OVERRIDE and inherited by --test-all children too.
+test_dry_run_model_override_applies_to_read_tier() {
+  _register_pb_sched mo-read "8 9 * * *" none
+  cat > "$HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+while [ $# -gt 0 ]; do [ "$1" = "--model" ] && echo "$2" > "$HOME/claude-model.txt"; shift; done
+cat >/dev/null
+echo "ACTION: 1 | read | noop | n/a"
+STUB
+  chmod +x "$HOME/.bun/bin/claude"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" mo-read --dry-run --depth deep --model haiku-override >/dev/null 2>&1 || true
+  assert_eq "$(cat "$HOME/claude-model.txt" 2>/dev/null)" "haiku-override" "--model must override the model passed to claude"
+}
+
+# --depth preflight composes with a plain --dry-run too (not only --test-all):
+# it stops after preflight, before any model call.
+test_dry_run_depth_preflight_skips_model_call() {
+  _register_status_playbook dr-pre active
+  bash "$CRON" dr-pre --dry-run --depth preflight >/dev/null 2>&1 || true
+  assert_fails "--dry-run --depth preflight must not invoke the model" test -f "$HOME/claude-invoked.txt"
+  assert_contains "$(cat "$(_preview_file dr-pre)" 2>/dev/null)" "preflight" "preview must note it stopped at preflight depth"
+}
+
 run_tests


### PR DESCRIPTION
Closes #140

## Description (Issue Fixed & New Behavior)

Adds `ceo-cron.sh --test-all` — a one-pass fleet dry-run sweep of **every registered playbook**, for smoke-testing the whole fleet without acting. Phase 1 of #136.

It re-execs `ceo-cron.sh <name> --dry-run --depth <d>` per playbook (reusing #138's preview/no-side-effect machinery rather than duplicating it) and aggregates each outcome into one host-local report.

**New flags:**
- `--test-all` — sweep all playbooks; takes no positional trigger; always implies `--dry-run`.
- `--depth preflight|plan|deep` — how far each sweep goes:
  - `preflight` (**default**): stop after preflight passes — "would this fire right now?", **zero model calls / tokens**.
  - `plan`: tier:write playbooks make their PLAN call; read-tier playbooks preview the call they *would* make (no tokens).
  - `deep`: full read-only dry-run (read-tier makes its call; write-tier runs PLAN+FILTER; EXECUTE still skipped).
  - Unknown values rejected at parse (no silent default).
- `--model <tag>` — override the model where a call is made (plan/deep). Unset = each playbook's configured `model:`.
- `--all-hosts` — Phase-1.5 stub: warns, sweeps local host only.
- `--depth` / `--model` / `--all-hosts` are preview-only and require `--dry-run` or `--test-all`.

**Output:** `CEO/log/preview/test-all/{TODAY}.md` — host-local (under the stignored `CEO/log/preview/` tree, like a single dry-run's preview), so a fleet smoke-test stays on the host that ran it. Result table (`would run` / `skip: no work` / `FAILED`) + each playbook's preview inline.

**Design note (`--model`):** #140 proposed "unset → local Ollama default." Forcing Ollama globally breaks tier:write (the three-phase pipeline requires Claude; Ollama is rejected for non-read tiers), so unset keeps each playbook's configured model and the cheap-sweep goal is met by the `preflight` default (no model call at all). An incompatible `--model` surfaces as a `FAILED` row — the intended smoke-test signal. Disclosed in `SCHEMA.md`.

Also includes a `docs/playbooks/SCHEMA.md` "Fleet sweep" subsection.

## Testing Procedure
1. Check out this branch.
2. Run the suite: `bash scripts/ceo-cron.test.sh` — confirm all pass (135+15 new).
3. From a synced vault host: `bash scripts/ceo-cron.sh --test-all` — confirm `CEO/log/preview/test-all/<TODAY>.md` is written with a per-playbook table and that no `.last-run-*` / `cron-runs.log` entries were created (no side effects).
4. `bash scripts/ceo-cron.sh --test-all --depth deep` — confirm read-tier playbooks make their model call (deep) where `--test-all` alone (preflight) made none.
5. `bash scripts/ceo-cron.sh --test-all some-trigger` and `... --depth bogus` — confirm both are rejected (exit non-zero).
6. `bash scripts/ceo-cron.sh some-name --depth preflight` (no `--dry-run`) — confirm rejected.

## Additional Notes / HelpScout Tickets
Independent auditor pass: no HIGH findings; ask judged answered. Applied the accepted fixes (truncate per-day child journals; document the `--model` incompatibility behavior). Deferred LOWs noted in the audit. Part of #136.