### PR TITLE
feat(scheduler): cron next-fire matcher (Bun + croner) (#141)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,20 @@ jobs:
           done
           [ "$count" -ge 1 ] || { echo "no tests ran"; exit 1; }
           exit "$fail"
+  scheduler:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # Install bun via the official versioned script rather than a third-party
+      # action, matching the repo's minimal-action posture.
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.5"
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+      - name: scheduler lib — install, typecheck, test
+        working-directory: lib/scheduler
+        run: |
+          bun install --frozen-lockfile
+          bun run typecheck
+          bun test

--- a/lib/scheduler/.gitignore
+++ b/lib/scheduler/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+dist/
+*.log

--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -1,0 +1,54 @@
+# ceo-scheduler
+
+Internal CEO lib — the **cron next-fire matcher** for the `ceo-schedulerd` daemon
+(issue #136, Phase 1.5). Given a 5-field cron expression, it answers two
+questions the daemon needs:
+
+- **`nextFire(expr, from)`** — the next fire instant strictly after `from` (what
+  the daemon sleeps until), or `null` if the cron never fires again.
+- **`matchesAt(expr, when)`** — whether the cron fires during the minute
+  containing `when` (seconds ignored).
+
+It is the foundation of the dispatcher redesign: the daemon (#142) and missed-slot
+catch-up (#143) both build on it. Dispatch stays in bash (`ceo-cron.sh`); this
+module only computes *when*.
+
+## Why a module, not inline
+
+The repo previously had only a cron *enumerator* (`_ceo_cron_field_expand` in
+`scripts/ceo`), which expands a field into its values — it cannot compute a
+next-fire instant, handle day-of-month-OR-day-of-week, or reason about DST.
+
+## Engine
+
+[`croner`](https://github.com/hexagon/croner) backs the matcher, isolated behind
+the `CronMatcher` interface so it can be swapped without touching the daemon.
+croner runs in `legacyMode` (Vixie semantics): when **both** day-of-month and
+day-of-week are restricted, the cron fires if **either** matches — the behavior
+native cron and the registry's schedules assume.
+
+Only the 5-field form is accepted (croner's optional 6-field seconds form is
+rejected) to preserve the minute granularity the daemon and `matchesAt` assume.
+
+## Usage
+
+```ts
+import { createMatcher } from "@/cron";
+
+const m = createMatcher({ timezone: "America/New_York" }); // omit → host-local
+const next = m.nextFire("30 9 * * 1-5", new Date()); // next weekday 09:30 ET
+const firingNow = m.matchesAt("*/15 * * * *", new Date());
+```
+
+`createMatcher` accepts an optional IANA `timezone`; schedules are evaluated in
+that zone (defaults to host-local). Invalid or non-5-field expressions throw
+`CronExpressionError`.
+
+## Develop
+
+```bash
+bun install
+bun test            # edge-case matrix: wildcards/ranges/lists/steps, DOM-OR-DOW,
+                    # month, minute-granularity matchesAt, invalid exprs, tz, DST
+bun run typecheck
+```

--- a/lib/scheduler/bun.lock
+++ b/lib/scheduler/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ceo-scheduler",
+      "dependencies": {
+        "croner": "9.1.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "croner": ["croner@9.1.0", "", {}, "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+  }
+}

--- a/lib/scheduler/package.json
+++ b/lib/scheduler/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ceo-scheduler",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Internal CEO lib — cron next-fire matcher for the ceo-schedulerd daemon (#136 Phase 1.5). Computes next-fire and does-now-match for 5-field cron expressions (croner-backed, swappable behind the CronMatcher interface).",
+  "scripts": {
+    "typecheck": "bun tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "croner": "9.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  },
+  "engines": { "bun": ">=1.3.5" },
+  "license": "MIT"
+}

--- a/lib/scheduler/src/cron.ts
+++ b/lib/scheduler/src/cron.ts
@@ -1,0 +1,72 @@
+import { Cron } from "croner";
+
+/**
+ * Cron next-fire matcher for the ceo-schedulerd daemon (#136 Phase 1.5).
+ *
+ * The daemon reads 5-field cron schedules from registry.json, asks this module
+ * for the next fire instant, and sleeps until then. The croner dependency is
+ * isolated behind {@link CronMatcher} so the engine can be swapped without
+ * touching the daemon.
+ */
+
+/** Thrown for any expression croner cannot parse, or that is not 5-field. */
+export class CronExpressionError extends Error {
+  constructor(expr: unknown, cause?: unknown) {
+    const detail = cause instanceof Error ? ` (${cause.message})` : "";
+    super(`invalid cron expression: ${JSON.stringify(expr)}${detail}`);
+    this.name = "CronExpressionError";
+  }
+}
+
+export interface CronMatcher {
+  /** The next fire instant strictly after `from`, or null if the cron never fires again. */
+  nextFire(expr: string, from: Date): Date | null;
+  /** Whether `expr` fires during the minute containing `when` (seconds ignored). */
+  matchesAt(expr: string, when: Date): boolean;
+}
+
+export interface MatcherOptions {
+  /** IANA timezone the schedule is evaluated in (e.g. "America/New_York"). Defaults to host-local. */
+  timezone?: string;
+}
+
+const MINUTE_MS = 60_000;
+
+class CronerMatcher implements CronMatcher {
+  constructor(private readonly opts: MatcherOptions = {}) {}
+
+  private build(expr: string): Cron {
+    // Enforce the registry's 5-field contract before croner sees it: croner
+    // also accepts a 6-field seconds form, which would break the minute
+    // granularity the daemon and matchesAt() assume.
+    const fields = expr.trim().split(/\s+/);
+    if (expr.trim() === "" || fields.length !== 5) {
+      throw new CronExpressionError(expr);
+    }
+    try {
+      // legacyMode:true gives Vixie semantics — when BOTH day-of-month and
+      // day-of-week are restricted, the cron fires if EITHER matches (the
+      // behavior native cron and the registry's schedules assume).
+      return new Cron(expr, { timezone: this.opts.timezone, legacyMode: true });
+    } catch (cause) {
+      throw new CronExpressionError(expr, cause);
+    }
+  }
+
+  nextFire(expr: string, from: Date): Date | null {
+    return this.build(expr).nextRun(from);
+  }
+
+  matchesAt(expr: string, when: Date): boolean {
+    const cron = this.build(expr);
+    const minute = Math.floor(when.getTime() / MINUTE_MS) * MINUTE_MS;
+    // nextRun is strictly-after, so probe from 1ms before the minute boundary:
+    // a fire at `minute` is then returned exactly.
+    const next = cron.nextRun(new Date(minute - 1));
+    return next !== null && next.getTime() === minute;
+  }
+}
+
+export function createMatcher(opts: MatcherOptions = {}): CronMatcher {
+  return new CronerMatcher(opts);
+}

--- a/lib/scheduler/tests/cron.test.ts
+++ b/lib/scheduler/tests/cron.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import { createMatcher, CronExpressionError } from "@/cron";
+
+// All tests pin an explicit UTC timezone so they are deterministic regardless
+// of the CI/host timezone. The DST/tz section uses named zones on purpose.
+const m = createMatcher({ timezone: "UTC" });
+
+const d = (iso: string) => new Date(iso);
+
+// Collect every fire strictly after `start` and at-or-before `end`.
+function firesBetween(expr: string, start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  let cur = start;
+  // Hard cap to fail loudly rather than hang if nextFire ever stalls.
+  for (let i = 0; i < 10000; i++) {
+    const next = m.nextFire(expr, cur);
+    if (next === null || next.getTime() > end.getTime()) break;
+    out.push(next);
+    cur = next;
+  }
+  return out;
+}
+
+describe("nextFire — wildcards, ranges, lists, steps", () => {
+  test("every-minute fires at the next minute boundary", () => {
+    expect(m.nextFire("* * * * *", d("2026-06-01T12:00:30Z"))).toEqual(d("2026-06-01T12:01:00Z"));
+  });
+
+  test("nextFire is strictly after `from` (a fire minute returns the NEXT one)", () => {
+    expect(m.nextFire("* * * * *", d("2026-06-01T12:00:00Z"))).toEqual(d("2026-06-01T12:01:00Z"));
+    expect(m.nextFire("30 9 * * *", d("2026-06-01T09:30:00Z"))).toEqual(d("2026-06-02T09:30:00Z"));
+  });
+
+  test("specific minute+hour", () => {
+    expect(m.nextFire("30 9 * * *", d("2026-06-01T00:00:00Z"))).toEqual(d("2026-06-01T09:30:00Z"));
+    expect(m.nextFire("30 9 * * *", d("2026-06-01T10:00:00Z"))).toEqual(d("2026-06-02T09:30:00Z"));
+  });
+
+  test("hour range 9-17", () => {
+    const fires = firesBetween("0 9-17 * * *", d("2026-06-01T00:00:00Z"), d("2026-06-01T23:59:00Z"));
+    expect(fires).toEqual([
+      d("2026-06-01T09:00:00Z"), d("2026-06-01T10:00:00Z"), d("2026-06-01T11:00:00Z"),
+      d("2026-06-01T12:00:00Z"), d("2026-06-01T13:00:00Z"), d("2026-06-01T14:00:00Z"),
+      d("2026-06-01T15:00:00Z"), d("2026-06-01T16:00:00Z"), d("2026-06-01T17:00:00Z"),
+    ]);
+  });
+
+  test("hour list 9,12,17", () => {
+    const fires = firesBetween("0 9,12,17 * * *", d("2026-06-01T00:00:00Z"), d("2026-06-01T23:59:00Z"));
+    expect(fires).toEqual([
+      d("2026-06-01T09:00:00Z"), d("2026-06-01T12:00:00Z"), d("2026-06-01T17:00:00Z"),
+    ]);
+  });
+
+  test("minute step */15", () => {
+    const fires = firesBetween("*/15 * * * *", d("2026-06-01T12:00:00Z"), d("2026-06-01T12:59:00Z"));
+    expect(fires).toEqual([
+      d("2026-06-01T12:15:00Z"), d("2026-06-01T12:30:00Z"), d("2026-06-01T12:45:00Z"),
+    ]);
+  });
+
+  test("step within a range 0-12/3 (hours)", () => {
+    // Start 1ms before midnight so the 00:00 fire (a valid 0-12/3 occurrence)
+    // is included — firesBetween returns fires strictly AFTER its start.
+    const fires = firesBetween("0 0-12/3 * * *", d("2026-05-31T23:59:59Z"), d("2026-06-01T23:59:00Z"));
+    expect(fires).toEqual([
+      d("2026-06-01T00:00:00Z"), d("2026-06-01T03:00:00Z"), d("2026-06-01T06:00:00Z"),
+      d("2026-06-01T09:00:00Z"), d("2026-06-01T12:00:00Z"),
+    ]);
+  });
+
+  test("month field restricts to January", () => {
+    expect(m.nextFire("0 0 1 1 *", d("2026-02-01T00:00:00Z"))).toEqual(d("2027-01-01T00:00:00Z"));
+  });
+});
+
+describe("day-of-month vs day-of-week semantics (Vixie OR)", () => {
+  // 2026-01-13 is a Tuesday (the 13th, not Friday).
+  // 2026-01-16 is a Friday (the 16th, not the 13th).
+  // 2026-01-20 is a Tuesday (neither the 13th nor a Friday).
+  test("both DOM and DOW restricted → fires if EITHER matches", () => {
+    expect(m.matchesAt("0 0 13 * 5", d("2026-01-13T00:00:00Z"))).toBe(true);  // 13th (DOM)
+    expect(m.matchesAt("0 0 13 * 5", d("2026-01-16T00:00:00Z"))).toBe(true);  // Friday (DOW)
+    expect(m.matchesAt("0 0 13 * 5", d("2026-01-20T00:00:00Z"))).toBe(false); // neither
+  });
+
+  test("DOM restricted, DOW wildcard → only the 13th", () => {
+    expect(m.matchesAt("0 0 13 * *", d("2026-01-13T00:00:00Z"))).toBe(true);
+    expect(m.matchesAt("0 0 13 * *", d("2026-01-16T00:00:00Z"))).toBe(false); // Friday but not 13th
+  });
+
+  test("DOW restricted, DOM wildcard → only Fridays", () => {
+    expect(m.matchesAt("0 0 * * 5", d("2026-01-16T00:00:00Z"))).toBe(true);
+    expect(m.matchesAt("0 0 * * 5", d("2026-01-13T00:00:00Z"))).toBe(false); // 13th but Tuesday
+  });
+});
+
+describe("matchesAt — minute granularity, ignores seconds", () => {
+  test("true exactly on the fire minute", () => {
+    expect(m.matchesAt("30 9 * * *", d("2026-06-01T09:30:00Z"))).toBe(true);
+  });
+  test("ignores the seconds component", () => {
+    expect(m.matchesAt("30 9 * * *", d("2026-06-01T09:30:59Z"))).toBe(true);
+  });
+  test("false on a non-fire minute", () => {
+    expect(m.matchesAt("30 9 * * *", d("2026-06-01T09:31:00Z"))).toBe(false);
+    expect(m.matchesAt("30 9 * * *", d("2026-06-01T08:30:00Z"))).toBe(false);
+  });
+});
+
+describe("invalid expressions", () => {
+  test("nextFire throws CronExpressionError", () => {
+    expect(() => m.nextFire("not a cron", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+    expect(() => m.nextFire("99 * * * *", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+  });
+  test("matchesAt throws CronExpressionError", () => {
+    expect(() => m.matchesAt("60 * * * *", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+  });
+  test("wrong field count is rejected (5-field only)", () => {
+    expect(() => m.nextFire("* * * *", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+  });
+
+  // croner ACCEPTS the 6-field seconds form; the length guard is the only thing
+  // rejecting it. Without the guard "* * * * * *" fires every second, breaking
+  // the daemon's (and matchesAt's) minute-granularity contract. This is the
+  // guard's sole unique coverage — every other invalid input croner throws on.
+  test("6-field seconds form is rejected (minute granularity only)", () => {
+    expect(() => m.nextFire("* * * * * *", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+    expect(() => m.matchesAt("* * * * * *", d("2026-06-01T00:00:00Z"))).toThrow(CronExpressionError);
+  });
+});
+
+describe("never-fires", () => {
+  // Feb 30 is a valid expression that can never match → null (the daemon treats
+  // this as "no next fire," not an error). Pins the Date|null return contract.
+  test("nextFire returns null for an unsatisfiable schedule", () => {
+    expect(m.nextFire("0 0 30 2 *", d("2026-06-01T00:00:00Z"))).toBeNull();
+  });
+});
+
+describe("timezone handling", () => {
+  test("the same expression fires at a different UTC instant per timezone", () => {
+    const utc = createMatcher({ timezone: "UTC" });
+    const ny = createMatcher({ timezone: "America/New_York" });
+    const from = d("2026-06-01T00:00:00Z"); // EDT (UTC-4) in June
+    expect(utc.nextFire("0 12 * * *", from)).toEqual(d("2026-06-01T12:00:00Z"));
+    expect(ny.nextFire("0 12 * * *", from)).toEqual(d("2026-06-01T16:00:00Z")); // 12:00 EDT
+  });
+
+  test("default matcher (no timezone) still produces monotonic fires", () => {
+    const local = createMatcher();
+    const a = local.nextFire("*/5 * * * *", d("2026-06-01T00:00:00Z"));
+    expect(a).not.toBeNull();
+    const b = local.nextFire("*/5 * * * *", a!);
+    expect(b!.getTime()).toBeGreaterThan(a!.getTime());
+  });
+});
+
+describe("DST transitions stay monotonic (no gap stall, no fall-back replay)", () => {
+  const ny = createMatcher({ timezone: "America/New_York" });
+
+  // Spring forward: 2026-03-08, clocks jump 02:00 → 03:00 in America/New_York.
+  test("hourly schedule advances strictly through the spring-forward gap", () => {
+    let cur = d("2026-03-08T04:00:00Z"); // 23:00 EST the night before
+    let prev = cur.getTime();
+    for (let i = 0; i < 12; i++) {
+      const next = ny.nextFire("0 * * * *", cur);
+      expect(next).not.toBeNull();
+      expect(next!.getTime()).toBeGreaterThan(prev);
+      prev = next!.getTime();
+      cur = next!;
+    }
+  });
+
+  // Fall back: 2026-11-01, clocks repeat 01:00 → 01:59 twice in America/New_York.
+  test("hourly schedule does not stall or rewind across the fall-back overlap", () => {
+    let cur = d("2026-11-01T04:00:00Z"); // 00:00 EDT
+    let prev = cur.getTime();
+    for (let i = 0; i < 12; i++) {
+      const next = ny.nextFire("0 * * * *", cur);
+      expect(next).not.toBeNull();
+      expect(next!.getTime()).toBeGreaterThan(prev);
+      prev = next!.getTime();
+      cur = next!;
+    }
+  });
+
+  // Exact wall-clock policy (pins croner's gap/overlap contract — a croner
+  // upgrade that changed it must break here, not silently in the daemon).
+  test("spring-forward: a 02:00 schedule shifts to 03:00 EDT (does not skip the day)", () => {
+    // 2026-03-08 02:00 EST does not exist; croner fires at 03:00 EDT = 07:00Z.
+    expect(ny.nextFire("0 2 * * *", d("2026-03-07T12:00:00Z"))).toEqual(d("2026-03-08T07:00:00Z"));
+  });
+
+  test("fall-back: a 01:30 schedule fires once, at the first (EDT) occurrence", () => {
+    // 2026-11-01 01:30 happens twice; croner fires at 01:30 EDT = 05:30Z (not 06:30Z EST).
+    expect(ny.nextFire("30 1 * * *", d("2026-10-31T12:00:00Z"))).toEqual(d("2026-11-01T05:30:00Z"));
+  });
+});

--- a/lib/scheduler/tsconfig.json
+++ b/lib/scheduler/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "types": ["bun-types"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
Closes #141

## Description (Issue Fixed & New Behavior)

Phase 1.5 of #136 — the **long pole**. The `ceo-schedulerd` daemon (#142) and missed-slot catch-up (#143) both build on this: a net-new `lib/scheduler/` Bun/TS package that computes *when* a cron schedule fires. Dispatch stays in bash; this module only does the time math.

The repo previously had only a cron **enumerator** (`_ceo_cron_field_expand` in `scripts/ceo`, which expands a field into its values) — it cannot compute a next-fire instant, handle day-of-month-OR-day-of-week, or reason about DST. This is the first actual **matcher**.

**API (`CronMatcher`):**
- `nextFire(expr, from)` — next fire **strictly after** `from` (what the daemon sleeps until), or `null`.
- `matchesAt(expr, when)` — whether the cron fires during the minute of `when` (seconds ignored).

**Engine:** [`croner`](https://github.com/hexagon/croner) (pinned `9.1.0`), isolated behind the `CronMatcher` interface so it's swappable per the #136 design. `legacyMode` → Vixie **DOM-OR-DOW** semantics (when both day-of-month and day-of-week are restricted, fires if *either* matches — what native cron and the registry's schedules assume). **5-field only** — croner's optional 6-field seconds form is rejected to preserve the minute granularity the daemon and `matchesAt` assume. Invalid / wrong-field-count input throws `CronExpressionError`.

**CI:** added a `scheduler` job to `.github/workflows/test.yml` (bun via the official versioned installer — no new third-party action; `--frozen-lockfile` + typecheck + test) so this foundation module is CI-guarded. (value-tracker remains CI-uncovered — pre-existing, out of scope.)

## Testing Procedure
1. Check out this branch.
2. `cd lib/scheduler && bun install`
3. `bun test` — confirm **23 pass** (wildcards/ranges/lists/steps, step-in-range, month, DOM-OR-DOW vs DOM-only vs DOW-only, minute-granularity `matchesAt` incl. seconds-ignored, invalid/wrong-field-count rejection, tz NY-vs-UTC fire instants, DST spring-forward/fall-back monotonicity + exact wall-clock policy).
4. `bun run typecheck` — clean.
5. Mutation spot-check: flip `legacyMode` to `false` in `src/cron.ts` → the DOM-OR-DOW test fails; revert.

## Additional Notes / HelpScout Tickets
Independent auditor pass: no HIGH findings; ask judged answered. Applied both: pinned `croner` exact (`9.1.0`) to match #136's pin intent (was `^9.0.0`); added two exact wall-clock DST assertions pinning croner's gap/overlap policy (spring-forward `0 2 * * *` → 03:00 EDT; fall-back `30 1 * * *` fires once at the EDT occurrence). Part of #136 — next: #142 (daemon) consumes this.