### PR TITLE
Add ceo-schedulerd daemon + Linux keep-alive + liveness (#142)

### DIFF
--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -93,7 +93,7 @@ The `hosts` field declares which machines a playbook may run on:
 
 `ceo playbook scan` validates the shape at parse time and never silently scopes a playbook to nowhere or to a typo'd host: any malformed value defaults to `["*"]` with a `WARN` (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)). To stop a playbook entirely, use `status: disabled`, not an empty `hosts` list.
 
-**Phase 1 records `hosts` but does not enforce it** — every host still runs every playbook regardless of scope. Enforcement arrives with the Phase-1.5 daemon, which will bump the registry `schema_version` so a non-enforcing peer binary can't run a host-scoped playbook everywhere.
+**Enforcement depends on the scheduler backend.** The Phase-1.5 daemon (`ceo-schedulerd`, `lib/scheduler/`) enforces `hosts` — it only dispatches playbooks whose `hosts` includes `"*"` or this host's short hostname (`selectRunnable`). The Phase-1 **native-cron** install path (`_playbook_update_crontab`) still records `hosts` without enforcing it, so a host running via crontab rather than the daemon runs every playbook regardless of scope. The deferred registry `schema_version` bump (which would stop a non-enforcing peer binary from running a host-scoped playbook everywhere) is tracked separately and is **not** part of the daemon change.
 
 ### Use draft for WIP playbooks
 

--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -44,11 +44,61 @@ const firingNow = m.matchesAt("*/15 * * * *", new Date());
 that zone (defaults to host-local). Invalid or non-5-field expressions throw
 `CronExpressionError`.
 
+## The daemon (`ceo-schedulerd`, #142)
+
+`src/main.ts` is the long-lived daemon. Each tick it re-reads
+`$CEO_VAULT/CEO/registry.json`, selects the playbooks **this host** runs on a
+schedule, dispatches every due one, writes a heartbeat, and sleeps until the
+soonest next fire (capped at 60s so registry edits and clock skew self-heal).
+
+Pipeline, all of it unit-tested behind injected side effects:
+
+- `registry.ts` — `parseRegistry(text)` → `{playbooks, warnings}`. Skips entries
+  missing a required field (logs a warning) instead of failing the whole load;
+  normalizes `hosts` exactly like the bash scanner (absent/null/malformed → `["*"]`).
+- `select.ts` — pure decisions: `selectRunnable(playbooks, host)` (this is where
+  **`hosts:` is enforced** — Phase 1 only recorded it), `dueAt(playbooks, when, matcher)`,
+  `nextWake(playbooks, from, matcher, capMs)`.
+- `daemon.ts` — `runForever(deps)`: the loop, plus the **double-fire guard**. The
+  "last dispatched minute" per playbook is persisted in the heartbeat and restored
+  at startup, so a `Restart=always` crash inside a fire-minute does not re-run a
+  playbook.
+- `heartbeat-store.ts` — durable read/write of the heartbeat
+  (`~/.ceo/schedulerd/heartbeat.json`, host-local, **not** the synced vault).
+  Corrupt/missing → guard starts empty, no crash.
+- `runtime.ts` — path/host/argv helpers and the `MAX_SLEEP_MS` / `HEARTBEAT_STALE_MS`
+  constants. Dispatch spawns `ceo-cron.sh <name> --scheduled` directly (no shell),
+  with `CEO_VAULT` passed via the spawn environment.
+
+Schedules evaluate in the **host's local timezone** (the matcher is created with no
+timezone; registry schedules carry no per-entry tz). A second host in a different
+zone would need a per-entry tz — out of scope until that exists.
+
+Catch-up for slots missed while the daemon was **down** is a separate issue (#143);
+this daemon intentionally does not replay missed slots.
+
+### Run / keep-alive (Linux/WSL)
+
+```bash
+CEO_VAULT=~/Documents/Obsidian bun run src/main.ts   # foreground
+```
+
+For keep-alive, install the systemd **user** unit template at
+`deploy/ceo-schedulerd.service` (see the header comments in that file). macOS
+keep-alive is Phase 2 (#144). **Not yet smoke-tested on a live always-on Linux
+host** (ML-1 GPU-down) — the loop, guard, and heartbeat are verified via
+fake-clock tests and a local start/SIGTERM smoke; only `Restart=always` is
+hardware-unverified.
+
+### Liveness
+
+`ceo doctor` reads the heartbeat and reports the daemon alive / stale (>10 min) /
+malformed / not-running. The 10-min threshold mirrors `HEARTBEAT_STALE_MS`.
+
 ## Develop
 
 ```bash
 bun install
-bun test            # edge-case matrix: wildcards/ranges/lists/steps, DOM-OR-DOW,
-                    # month, minute-granularity matchesAt, invalid exprs, tz, DST
+bun test            # matcher edge matrix + registry/select/daemon/runtime/heartbeat
 bun run typecheck
 ```

--- a/lib/scheduler/deploy/ceo-schedulerd.service
+++ b/lib/scheduler/deploy/ceo-schedulerd.service
@@ -1,0 +1,41 @@
+# ceo-schedulerd — systemd USER unit template (Linux/WSL keep-alive, #142).
+#
+# This is a TEMPLATE: edit the three paths below, then install as a user unit.
+# It has NOT been smoke-tested on a live always-on Linux host (ML-1 is GPU-down
+# as of 2026-06-07); the Restart=always semantics are unverified on hardware.
+#
+# Install (user scope, no root):
+#   mkdir -p ~/.config/systemd/user
+#   cp ceo-schedulerd.service ~/.config/systemd/user/
+#   # edit the paths in the copy
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now ceo-schedulerd.service
+#   loginctl enable-linger "$USER"   # keep it running when you're logged out
+#   systemctl --user status ceo-schedulerd
+#   journalctl --user -u ceo-schedulerd -f
+#
+# Verify liveness independently of systemd:  ceo doctor   (reads the heartbeat).
+
+[Unit]
+Description=CEO playbook scheduler daemon (ceo-schedulerd)
+After=network-online.target
+Wants=network-online.target
+# Cap respawn storms: at most 10 restarts per 5 min, then stop and surface it.
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Type=simple
+# EDIT: absolute path to bun and to this repo's lib/scheduler/src/main.ts.
+ExecStart=%h/.bun/bin/bun run %h/code/claude-ceo/lib/scheduler/src/main.ts
+# EDIT: the synced Obsidian vault root that contains CEO/registry.json.
+Environment=CEO_VAULT=%h/Documents/Obsidian
+# EDIT (optional): pin the dispatch binary if ceo-cron.sh is not on PATH.
+# Environment=CEO_CRON_BIN=%h/code/claude-ceo/scripts/ceo-cron.sh
+Restart=always
+RestartSec=10
+# Give SIGTERM time for the loop to finish its current tick and exit cleanly.
+TimeoutStopSec=70
+
+[Install]
+WantedBy=default.target

--- a/lib/scheduler/package.json
+++ b/lib/scheduler/package.json
@@ -2,10 +2,11 @@
   "name": "ceo-scheduler",
   "version": "0.1.0",
   "private": true,
-  "description": "Internal CEO lib — cron next-fire matcher for the ceo-schedulerd daemon (#136 Phase 1.5). Computes next-fire and does-now-match for 5-field cron expressions (croner-backed, swappable behind the CronMatcher interface).",
+  "description": "Internal CEO lib — the ceo-schedulerd daemon (#136 Phase 1.5): reads registry.json, sleeps until next-fire, dispatches ceo-cron.sh <name> --scheduled, enforces hosts:, and heartbeats for liveness. Cron matching is croner-backed behind the swappable CronMatcher interface.",
   "scripts": {
     "typecheck": "bun tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "start": "bun run src/main.ts"
   },
   "dependencies": {
     "croner": "9.1.0"

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -76,9 +76,8 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     }
 
     const runnable = selectRunnable(playbooks, deps.host);
-    for (const p of dueAt(runnable, now, deps.matcher)) {
-      if (guard.get(p.name) === minute) continue;
-      deps.dispatch(p.name);
+    const toDispatch = dueAt(runnable, now, deps.matcher).filter((p) => guard.get(p.name) !== minute);
+    for (const p of toDispatch) {
       guard.set(p.name, minute);
       recent.push({ name: p.name, ts: now.getTime() });
     }
@@ -89,6 +88,9 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     for (const [name, mn] of guard) if (mn < minute - 1) guard.delete(name);
 
     const wake = nextWake(runnable, now, deps.matcher, deps.maxSleepMs);
+    // Persist the guard BEFORE firing. A crash between here and the spawn must
+    // not re-fire on restart, so dispatch is at-most-once: a crash drops a fire
+    // rather than doubling it (the safer direction for write-tier playbooks).
     deps.writeHeartbeat({
       ts: now.getTime(),
       host: deps.host,
@@ -97,6 +99,7 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
       last_dispatch: [...recent],
       dispatched_minute: Object.fromEntries(guard),
     });
+    for (const p of toDispatch) deps.dispatch(p.name);
 
     await deps.sleep(wake);
   }

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -1,0 +1,103 @@
+/**
+ * The ceo-schedulerd control loop (#136 Phase 1.5, issue #142).
+ *
+ * Every tick: re-read the registry, pick the playbooks this host runs now, fire
+ * each due one via the injected `dispatch` (a non-blocking spawn of
+ * `ceo-cron.sh <name> --scheduled`), write a liveness heartbeat, then sleep
+ * until the soonest next fire (capped so the loop re-reads the registry and
+ * self-heals clock skew).
+ *
+ * All side effects are injected via {@link DaemonDeps} so the loop is tested
+ * with a fake clock and recorders — no real sleeping or spawning. The
+ * double-fire guard is persisted in the heartbeat and restored at startup so a
+ * `Restart=always` crash inside a fire-minute does not re-run a playbook.
+ */
+import type { CronMatcher } from "@/cron";
+import { dueAt, nextWake, selectRunnable } from "@/select";
+import type { Playbook } from "@/registry";
+
+const MINUTE_MS = 60_000;
+/** How many recent dispatches to retain in the heartbeat for observability. */
+const MAX_RECENT_DISPATCH = 20;
+
+export interface DispatchRecord {
+  name: string;
+  ts: number;
+}
+
+export interface Heartbeat {
+  ts: number;
+  host: string;
+  runnable_count: number;
+  next_wake_ts: number;
+  last_dispatch: DispatchRecord[];
+  /** playbook name → epoch-minute it was last dispatched (the durable double-fire guard). */
+  dispatched_minute: Record<string, number>;
+}
+
+export interface DaemonDeps {
+  now(): Date;
+  sleep(ms: number): Promise<void>;
+  loadRegistry(): { playbooks: Playbook[]; warnings: string[] };
+  /** Fire-and-forget spawn of the dispatch command; must not block the loop. */
+  dispatch(name: string): void;
+  /** Prior heartbeat (if any) used to restore the guard across restarts. */
+  readHeartbeat(): Heartbeat | null;
+  writeHeartbeat(hb: Heartbeat): void;
+  log(msg: string): void;
+  host: string;
+  matcher: CronMatcher;
+  maxSleepMs: number;
+  shouldContinue(): boolean;
+}
+
+function epochMinute(when: Date): number {
+  return Math.floor(when.getTime() / MINUTE_MS);
+}
+
+export async function runForever(deps: DaemonDeps): Promise<void> {
+  const prior = deps.readHeartbeat();
+  const guard = new Map<string, number>(prior ? Object.entries(prior.dispatched_minute) : []);
+  const recent: DispatchRecord[] = prior ? [...prior.last_dispatch] : [];
+  let lastGood: Playbook[] = [];
+
+  while (deps.shouldContinue()) {
+    const now = deps.now();
+    const minute = epochMinute(now);
+
+    let playbooks = lastGood;
+    try {
+      const loaded = deps.loadRegistry();
+      playbooks = loaded.playbooks;
+      lastGood = playbooks;
+      for (const w of loaded.warnings) deps.log(`registry: ${w}`);
+    } catch (err) {
+      deps.log(`registry load failed, reusing last-good: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const runnable = selectRunnable(playbooks, deps.host);
+    for (const p of dueAt(runnable, now, deps.matcher)) {
+      if (guard.get(p.name) === minute) continue;
+      deps.dispatch(p.name);
+      guard.set(p.name, minute);
+      recent.push({ name: p.name, ts: now.getTime() });
+    }
+    if (recent.length > MAX_RECENT_DISPATCH) recent.splice(0, recent.length - MAX_RECENT_DISPATCH);
+
+    // Drop guard entries older than the previous minute — only the current
+    // minute (and a same-minute restart) can produce a double-fire.
+    for (const [name, mn] of guard) if (mn < minute - 1) guard.delete(name);
+
+    const wake = nextWake(runnable, now, deps.matcher, deps.maxSleepMs);
+    deps.writeHeartbeat({
+      ts: now.getTime(),
+      host: deps.host,
+      runnable_count: runnable.length,
+      next_wake_ts: now.getTime() + wake,
+      last_dispatch: [...recent],
+      dispatched_minute: Object.fromEntries(guard),
+    });
+
+    await deps.sleep(wake);
+  }
+}

--- a/lib/scheduler/src/heartbeat-store.ts
+++ b/lib/scheduler/src/heartbeat-store.ts
@@ -1,0 +1,40 @@
+/**
+ * Durable persistence for the daemon heartbeat. The heartbeat doubles as the
+ * double-fire guard's backing store (H1): on startup the daemon restores
+ * `dispatched_minute` from here, so a `Restart=always` crash inside a fire-minute
+ * does not re-run a playbook. A corrupt or missing file reads as `null` — the
+ * guard starts empty rather than crashing the daemon at boot.
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { DispatchRecord, Heartbeat } from "@/daemon";
+
+export function readHeartbeatFile(path: string): Heartbeat | null {
+  if (!existsSync(path)) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.ts !== "number") return null;
+  if (typeof r.dispatched_minute !== "object" || r.dispatched_minute === null) return null;
+  const lastDispatch = Array.isArray(r.last_dispatch) ? (r.last_dispatch as DispatchRecord[]) : [];
+  return {
+    ts: r.ts,
+    host: typeof r.host === "string" ? r.host : "",
+    runnable_count: typeof r.runnable_count === "number" ? r.runnable_count : 0,
+    next_wake_ts: typeof r.next_wake_ts === "number" ? r.next_wake_ts : 0,
+    last_dispatch: lastDispatch,
+    dispatched_minute: r.dispatched_minute as Record<string, number>,
+  };
+}
+
+export function writeHeartbeatFile(path: string, hb: Heartbeat): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(hb, null, 2));
+  renameSync(tmp, path);
+}

--- a/lib/scheduler/src/heartbeat-store.ts
+++ b/lib/scheduler/src/heartbeat-store.ts
@@ -22,13 +22,20 @@ export function readHeartbeatFile(path: string): Heartbeat | null {
   if (typeof r.ts !== "number") return null;
   if (typeof r.dispatched_minute !== "object" || r.dispatched_minute === null) return null;
   const lastDispatch = Array.isArray(r.last_dispatch) ? (r.last_dispatch as DispatchRecord[]) : [];
+  // Drop any non-numeric guard value: a string slipping in would never `===`
+  // the current epoch-minute, silently disabling the double-fire guard for that
+  // playbook. Keep parity with the registry path's strictness.
+  const dispatchedMinute: Record<string, number> = {};
+  for (const [name, mn] of Object.entries(r.dispatched_minute as Record<string, unknown>)) {
+    if (typeof mn === "number") dispatchedMinute[name] = mn;
+  }
   return {
     ts: r.ts,
     host: typeof r.host === "string" ? r.host : "",
     runnable_count: typeof r.runnable_count === "number" ? r.runnable_count : 0,
     next_wake_ts: typeof r.next_wake_ts === "number" ? r.next_wake_ts : 0,
     last_dispatch: lastDispatch,
-    dispatched_minute: r.dispatched_minute as Record<string, number>,
+    dispatched_minute: dispatchedMinute,
   };
 }
 

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -69,14 +69,22 @@ async function main(): Promise<void> {
       }),
     loadRegistry: () => parseRegistry(readFileSync(regPath, "utf8")),
     dispatch: (name) => {
-      const proc = Bun.spawn(dispatchArgv(cronBin, name), {
-        env: { ...process.env, CEO_VAULT: vault },
-        stdout: "ignore",
-        stderr: "ignore",
-        stdin: "ignore",
-      });
-      proc.unref();
-      log(`dispatched ${name}`);
+      // Bun.spawn throws synchronously on e.g. ENOENT (cronBin not on PATH).
+      // Swallow + log so one bad dispatch can't crash-loop the daemon; the
+      // guard is already persisted, so this playbook is simply skipped this
+      // minute and fires again at its next slot.
+      try {
+        const proc = Bun.spawn(dispatchArgv(cronBin, name), {
+          env: { ...process.env, CEO_VAULT: vault },
+          stdout: "ignore",
+          stderr: "ignore",
+          stdin: "ignore",
+        });
+        proc.unref();
+        log(`dispatched ${name}`);
+      } catch (err) {
+        log(`dispatch failed for ${name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     },
     readHeartbeat: () => readHeartbeatFile(hbPath),
     writeHeartbeat: (hb) => writeHeartbeatFile(hbPath, hb),

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+/**
+ * ceo-schedulerd entrypoint (#142). Composition root: resolves the environment,
+ * wires real clock / spawn / filesystem into the tested {@link runForever} loop,
+ * and shuts down cleanly on SIGINT/SIGTERM. All scheduling logic lives in the
+ * unit-tested modules; this file is intentionally thin.
+ *
+ * Required env: `CEO_VAULT` (registry root), `HOME` (heartbeat dir).
+ * Optional env: `CEO_HOSTNAME` (host id override), `CEO_CRON_BIN` (dispatch
+ * binary, default `ceo-cron.sh` on PATH).
+ *
+ * Schedules evaluate in the host's local timezone (the matcher is created with
+ * no timezone, matching `new Date()`); registry schedules carry no per-entry tz.
+ */
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { createMatcher } from "@/cron";
+import { type DaemonDeps, runForever } from "@/daemon";
+import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
+import { parseRegistry } from "@/registry";
+import { dispatchArgv, heartbeatPath, MAX_SLEEP_MS, registryPath, resolveHost } from "@/runtime";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (v === undefined || v.trim() === "") {
+    throw new Error(`${name} must be set before starting ceo-schedulerd`);
+  }
+  return v;
+}
+
+function nowStamp(): string {
+  return new Date().toISOString();
+}
+
+async function main(): Promise<void> {
+  const vault = requireEnv("CEO_VAULT");
+  const home = requireEnv("HOME");
+  const cronBin = process.env.CEO_CRON_BIN?.trim() || "ceo-cron.sh";
+  const host = resolveHost({ CEO_HOSTNAME: process.env.CEO_HOSTNAME }, hostname().split(".")[0] ?? "unknown");
+  const regPath = registryPath(vault);
+  const hbPath = heartbeatPath(home);
+
+  let running = true;
+  let wakeEarly: (() => void) | null = null;
+  const stop = (sig: string) => {
+    process.stderr.write(`[${nowStamp()}] ceo-schedulerd: ${sig} received, shutting down\n`);
+    running = false;
+    wakeEarly?.();
+  };
+  process.on("SIGTERM", () => stop("SIGTERM"));
+  process.on("SIGINT", () => stop("SIGINT"));
+
+  const log = (msg: string) => process.stderr.write(`[${nowStamp()}] ceo-schedulerd: ${msg}\n`);
+
+  const deps: DaemonDeps = {
+    now: () => new Date(),
+    sleep: (ms) =>
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          wakeEarly = null;
+          resolve();
+        }, ms);
+        // A shutdown signal cancels the sleep so exit is prompt, not up to 60s late.
+        wakeEarly = () => {
+          clearTimeout(timer);
+          wakeEarly = null;
+          resolve();
+        };
+      }),
+    loadRegistry: () => parseRegistry(readFileSync(regPath, "utf8")),
+    dispatch: (name) => {
+      const proc = Bun.spawn(dispatchArgv(cronBin, name), {
+        env: { ...process.env, CEO_VAULT: vault },
+        stdout: "ignore",
+        stderr: "ignore",
+        stdin: "ignore",
+      });
+      proc.unref();
+      log(`dispatched ${name}`);
+    },
+    readHeartbeat: () => readHeartbeatFile(hbPath),
+    writeHeartbeat: (hb) => writeHeartbeatFile(hbPath, hb),
+    log,
+    host,
+    matcher: createMatcher(),
+    maxSleepMs: MAX_SLEEP_MS,
+    shouldContinue: () => running,
+  };
+
+  log(`started — host=${host} vault=${vault} registry=${regPath}`);
+  await runForever(deps);
+  log("stopped");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[${nowStamp()}] ceo-schedulerd: fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/lib/scheduler/src/registry.ts
+++ b/lib/scheduler/src/registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Registry reader for the ceo-schedulerd daemon (#136 Phase 1.5).
+ *
+ * The on-disk registry (`$CEO_VAULT/CEO/registry.json`, schema v3) is written by
+ * `ceo playbook scan`. This module projects each entry down to the fields the
+ * daemon needs and normalizes `hosts` the same way the bash scanner does
+ * (absent / null / malformed → `["*"]`). Entries missing a required field are
+ * skipped with a warning rather than failing the whole load — one bad hand-edit
+ * shouldn't take the scheduler down.
+ */
+
+/** A playbook projected to the fields the daemon's scheduling logic consumes. */
+export interface Playbook {
+  name: string;
+  schedule: string;
+  status: string;
+  trigger: string;
+  hosts: string[];
+}
+
+export interface ParsedRegistry {
+  playbooks: Playbook[];
+  warnings: string[];
+}
+
+/** Thrown when the registry text is unparseable or structurally wrong. */
+export class RegistryParseError extends Error {
+  constructor(message: string) {
+    super(`invalid registry: ${message}`);
+    this.name = "RegistryParseError";
+  }
+}
+
+function normalizeHosts(raw: unknown, name: string, warnings: string[]): string[] {
+  if (raw === undefined || raw === null) return ["*"];
+  if (
+    !Array.isArray(raw) ||
+    raw.length === 0 ||
+    !raw.every((h) => typeof h === "string" && h.trim() !== "")
+  ) {
+    warnings.push(`${name}: 'hosts' must be a non-empty array of host names — defaulting to ["*"]`);
+    return ["*"];
+  }
+  return raw as string[];
+}
+
+export function parseRegistry(text: string): ParsedRegistry {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(text);
+  } catch (cause) {
+    throw new RegistryParseError(cause instanceof Error ? cause.message : "JSON parse failed");
+  }
+  if (typeof doc !== "object" || doc === null) {
+    throw new RegistryParseError("top-level value is not an object");
+  }
+  const rawPlaybooks = (doc as Record<string, unknown>).playbooks;
+  if (rawPlaybooks === undefined) return { playbooks: [], warnings: [] };
+  if (!Array.isArray(rawPlaybooks)) {
+    throw new RegistryParseError("'playbooks' is not an array");
+  }
+
+  const playbooks: Playbook[] = [];
+  const warnings: string[] = [];
+  for (const entry of rawPlaybooks) {
+    if (typeof entry !== "object" || entry === null) {
+      warnings.push("skipped a non-object playbook entry");
+      continue;
+    }
+    const e = entry as Record<string, unknown>;
+    const name = typeof e.name === "string" ? e.name : undefined;
+    const label = name ?? "<unnamed>";
+    if (
+      name === undefined ||
+      typeof e.schedule !== "string" ||
+      typeof e.status !== "string" ||
+      typeof e.trigger !== "string"
+    ) {
+      warnings.push(`${label}: missing a required field (name/schedule/status/trigger) — skipped`);
+      continue;
+    }
+    playbooks.push({
+      name,
+      schedule: e.schedule,
+      status: e.status,
+      trigger: e.trigger,
+      hosts: normalizeHosts(e.hosts, name, warnings),
+    });
+  }
+  return { playbooks, warnings };
+}

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -1,0 +1,36 @@
+/**
+ * Real-environment helpers for ceo-schedulerd, kept pure so they are unit-tested
+ * without touching the filesystem. `main.ts` composes them with Bun's spawn/fs.
+ */
+
+/** Cap on a single sleep: the loop re-reads the registry at least this often. */
+export const MAX_SLEEP_MS = 60_000;
+
+/**
+ * How long without a heartbeat before `ceo doctor` reports the daemon stale.
+ * Comfortably larger than {@link MAX_SLEEP_MS} so a single missed wake never
+ * trips it. Keep in sync with the threshold in `ceo doctor` (scripts/ceo).
+ */
+export const HEARTBEAT_STALE_MS = 600_000; // 10 minutes
+
+export function registryPath(vault: string): string {
+  return `${vault}/CEO/registry.json`;
+}
+
+export function heartbeatPath(home: string): string {
+  return `${home}/.ceo/schedulerd/heartbeat.json`;
+}
+
+export function resolveHost(env: { CEO_HOSTNAME?: string }, osHost: string): string {
+  const override = env.CEO_HOSTNAME?.trim();
+  return override ? override : osHost;
+}
+
+/**
+ * Argv for one scheduled dispatch. Spawned without a shell (no `bash -lc`) so
+ * there is no quoting/injection surface and no profile-sourcing surprise under
+ * systemd; `CEO_VAULT`/`PATH` are passed via the spawn environment instead.
+ */
+export function dispatchArgv(cronBin: string, name: string): string[] {
+  return [cronBin, name, "--scheduled"];
+}

--- a/lib/scheduler/src/select.ts
+++ b/lib/scheduler/src/select.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure scheduling decisions for the ceo-schedulerd daemon (#136 Phase 1.5).
+ *
+ * These functions hold no clock, filesystem, or process state — the daemon loop
+ * injects `now` and a {@link CronMatcher}. That keeps the scheduling logic
+ * exhaustively unit-testable without sleeping or spawning.
+ */
+import type { CronMatcher } from "@/cron";
+import type { Playbook } from "@/registry";
+
+function hostMatches(hosts: string[], host: string): boolean {
+  return hosts.includes("*") || hosts.includes(host);
+}
+
+/**
+ * The playbooks this host may run on a schedule: cron-triggered, active, with a
+ * non-blank schedule, whose `hosts` includes `"*"` or this host. This is where
+ * `hosts:` is enforced (Phase 1 only recorded it).
+ */
+export function selectRunnable(playbooks: Playbook[], host: string): Playbook[] {
+  return playbooks.filter(
+    (p) =>
+      p.trigger === "cron" &&
+      p.status === "active" &&
+      p.schedule.trim() !== "" &&
+      hostMatches(p.hosts, host),
+  );
+}
+
+/** Playbooks firing during the minute containing `when`. Invalid schedules are skipped. */
+export function dueAt(playbooks: Playbook[], when: Date, matcher: CronMatcher): Playbook[] {
+  return playbooks.filter((p) => {
+    try {
+      return matcher.matchesAt(p.schedule, when);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Milliseconds to sleep until the soonest next fire across `playbooks`, clamped
+ * to `maxSleepMs`. The cap means the loop re-reads the registry at least that
+ * often (picking up edits and self-healing clock skew). Returns the cap when
+ * nothing is scheduled or every schedule never fires again. Invalid schedules
+ * are ignored.
+ */
+export function nextWake(
+  playbooks: Playbook[],
+  from: Date,
+  matcher: CronMatcher,
+  maxSleepMs: number,
+): number {
+  let soonest = Infinity;
+  for (const p of playbooks) {
+    let next: Date | null;
+    try {
+      next = matcher.nextFire(p.schedule, from);
+    } catch {
+      continue;
+    }
+    if (next !== null) soonest = Math.min(soonest, next.getTime());
+  }
+  if (soonest === Infinity) return maxSleepMs;
+  return Math.max(0, Math.min(soonest - from.getTime(), maxSleepMs));
+}

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { createMatcher } from "@/cron";
+import type { Playbook } from "@/registry";
+import { type DaemonDeps, type Heartbeat, runForever } from "@/daemon";
+
+const m = createMatcher({ timezone: "UTC" });
+const d = (iso: string) => new Date(iso);
+
+const pb = (over: Partial<Playbook>): Playbook => ({
+  name: "p",
+  schedule: "0 9 * * *",
+  status: "active",
+  trigger: "cron",
+  hosts: ["*"],
+  ...over,
+});
+
+interface HarnessOpts {
+  nows: Date[];
+  playbooks: Playbook[] | (() => { playbooks: Playbook[]; warnings: string[] });
+  startHeartbeat?: Heartbeat | null;
+  host?: string;
+  cap?: number;
+}
+
+function harness(opts: HarnessOpts) {
+  let i = 0;
+  const dispatched: string[] = [];
+  const sleeps: number[] = [];
+  const heartbeats: Heartbeat[] = [];
+  const logs: string[] = [];
+  const loader =
+    typeof opts.playbooks === "function"
+      ? opts.playbooks
+      : () => ({ playbooks: opts.playbooks as Playbook[], warnings: [] });
+
+  const deps: DaemonDeps = {
+    now: () => opts.nows[i++]!,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+    loadRegistry: loader,
+    dispatch: (name) => {
+      dispatched.push(name);
+    },
+    readHeartbeat: () => opts.startHeartbeat ?? null,
+    writeHeartbeat: (hb) => {
+      heartbeats.push(hb);
+    },
+    log: (msg) => {
+      logs.push(msg);
+    },
+    host: opts.host ?? "ml-1",
+    matcher: m,
+    maxSleepMs: opts.cap ?? 60_000,
+    shouldContinue: () => i < opts.nows.length,
+  };
+  return { deps, dispatched, sleeps, heartbeats, logs };
+}
+
+describe("runForever — dispatch + sleep", () => {
+  test("dispatches every due playbook once per tick and sleeps the computed wake", async () => {
+    const h = harness({
+      nows: [d("2026-06-01T09:00:00Z")],
+      playbooks: [pb({ name: "nine", schedule: "0 9 * * *" }), pb({ name: "ten", schedule: "0 10 * * *" })],
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["nine"]);
+    // next fire after 09:00 is "nine" at 09:00 tomorrow vs "ten" at 10:00 today → 10:00 today (3600s), capped.
+    expect(h.sleeps).toEqual([60_000]);
+  });
+
+  test("a mid-minute tick still fires that minute's due set (H2 minute granularity)", async () => {
+    const h = harness({ nows: [d("2026-06-01T09:00:43Z")], playbooks: [pb({ name: "nine", schedule: "0 9 * * *" })] });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["nine"]);
+  });
+
+  test("writes a liveness heartbeat every tick even when nothing is due", async () => {
+    const h = harness({ nows: [d("2026-06-01T09:30:00Z")], playbooks: [pb({ schedule: "0 9 * * *" })] });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual([]);
+    expect(h.heartbeats).toHaveLength(1);
+    expect(h.heartbeats[0]!.runnable_count).toBe(1);
+    expect(h.heartbeats[0]!.ts).toBe(d("2026-06-01T09:30:00Z").getTime());
+    expect(h.heartbeats[0]!.next_wake_ts).toBe(d("2026-06-01T09:30:00Z").getTime() + 60_000);
+  });
+});
+
+describe("double-fire guard", () => {
+  test("does not re-dispatch the same playbook twice within one minute", async () => {
+    // Two ticks 20s apart, both inside the 09:00 minute, every-minute schedule.
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:00:25Z")],
+      playbooks: [pb({ name: "ev", schedule: "* * * * *" })],
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["ev"]);
+  });
+
+  test("fires again in the next minute", async () => {
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:01:05Z")],
+      playbooks: [pb({ name: "ev", schedule: "* * * * *" })],
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["ev", "ev"]);
+  });
+
+  test("durable guard: a restart inside the same fire-minute does not re-dispatch (H1)", async () => {
+    const minute = Math.floor(d("2026-06-01T09:00:00Z").getTime() / 60_000);
+    const h = harness({
+      nows: [d("2026-06-01T09:00:30Z")],
+      playbooks: [pb({ name: "ev", schedule: "* * * * *" })],
+      startHeartbeat: {
+        ts: d("2026-06-01T09:00:02Z").getTime(),
+        host: "ml-1",
+        runnable_count: 1,
+        next_wake_ts: 0,
+        last_dispatch: [{ name: "ev", ts: d("2026-06-01T09:00:02Z").getTime() }],
+        dispatched_minute: { ev: minute },
+      },
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual([]);
+  });
+
+  test("the heartbeat carries the dispatched-minute guard forward", async () => {
+    const minute = Math.floor(d("2026-06-01T09:00:00Z").getTime() / 60_000);
+    const h = harness({ nows: [d("2026-06-01T09:00:05Z")], playbooks: [pb({ name: "ev", schedule: "* * * * *" })] });
+    await runForever(h.deps);
+    expect(h.heartbeats[0]!.dispatched_minute.ev).toBe(minute);
+    expect(h.heartbeats[0]!.last_dispatch.map((x) => x.name)).toEqual(["ev"]);
+  });
+});
+
+describe("registry resilience", () => {
+  test("a load failure keeps the last-good registry and logs, without crashing the loop", async () => {
+    let call = 0;
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:01:05Z")],
+      playbooks: () => {
+        call++;
+        if (call === 2) throw new Error("invalid registry: boom");
+        return { playbooks: [pb({ name: "ev", schedule: "* * * * *" })], warnings: [] };
+      },
+    });
+    await runForever(h.deps);
+    // Tick 1 loads ev and dispatches; tick 2's load throws → reuse ev → dispatch again (new minute).
+    expect(h.dispatched).toEqual(["ev", "ev"]);
+    expect(h.logs.some((l) => l.includes("boom"))).toBe(true);
+  });
+});

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -29,6 +29,11 @@ function harness(opts: HarnessOpts) {
   const sleeps: number[] = [];
   const heartbeats: Heartbeat[] = [];
   const logs: string[] = [];
+  let lastHb: Heartbeat | null = null;
+  // For each dispatch, the guard minute already persisted to the heartbeat at
+  // the moment dispatch is called. undefined ⇒ the guard was NOT yet durable
+  // (ordering bug: a crash here would re-fire on restart).
+  const guardAtDispatch: Record<string, number | undefined> = {};
   const loader =
     typeof opts.playbooks === "function"
       ? opts.playbooks
@@ -41,11 +46,13 @@ function harness(opts: HarnessOpts) {
     },
     loadRegistry: loader,
     dispatch: (name) => {
+      guardAtDispatch[name] = lastHb?.dispatched_minute[name];
       dispatched.push(name);
     },
     readHeartbeat: () => opts.startHeartbeat ?? null,
     writeHeartbeat: (hb) => {
       heartbeats.push(hb);
+      lastHb = hb;
     },
     log: (msg) => {
       logs.push(msg);
@@ -55,7 +62,7 @@ function harness(opts: HarnessOpts) {
     maxSleepMs: opts.cap ?? 60_000,
     shouldContinue: () => i < opts.nows.length,
   };
-  return { deps, dispatched, sleeps, heartbeats, logs };
+  return { deps, dispatched, sleeps, heartbeats, logs, guardAtDispatch: () => guardAtDispatch };
 }
 
 describe("runForever — dispatch + sleep", () => {
@@ -123,6 +130,14 @@ describe("double-fire guard", () => {
     });
     await runForever(h.deps);
     expect(h.dispatched).toEqual([]);
+  });
+
+  test("persists the guard to the heartbeat BEFORE dispatching (no crash-window double-fire)", async () => {
+    const minute = Math.floor(d("2026-06-01T09:00:00Z").getTime() / 60_000);
+    const h = harness({ nows: [d("2026-06-01T09:00:05Z")], playbooks: [pb({ name: "ev", schedule: "* * * * *" })] });
+    await runForever(h.deps);
+    // If the heartbeat were written after dispatch, this would be undefined.
+    expect(h.guardAtDispatch().ev).toBe(minute);
   });
 
   test("the heartbeat carries the dispatched-minute guard forward", async () => {

--- a/lib/scheduler/tests/heartbeat-store.test.ts
+++ b/lib/scheduler/tests/heartbeat-store.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Heartbeat } from "@/daemon";
+import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
+
+const dir = mkdtempSync(join(tmpdir(), "ceo-hb-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const hb: Heartbeat = {
+  ts: 1_780_000_000_000,
+  host: "ml-1",
+  runnable_count: 3,
+  next_wake_ts: 1_780_000_060_000,
+  last_dispatch: [{ name: "morning-scan", ts: 1_780_000_000_000 }],
+  dispatched_minute: { "morning-scan": 29_666_666 },
+};
+
+describe("heartbeat round-trip", () => {
+  test("writes then reads back an identical heartbeat (creates ~/.ceo/schedulerd)", () => {
+    const path = join(dir, "schedulerd", "heartbeat.json");
+    writeHeartbeatFile(path, hb);
+    expect(readHeartbeatFile(path)).toEqual(hb);
+  });
+
+  test("missing file reads as null (guard simply starts empty)", () => {
+    expect(readHeartbeatFile(join(dir, "nope.json"))).toBeNull();
+  });
+
+  test("malformed JSON reads as null rather than throwing at startup", () => {
+    const path = join(dir, "corrupt.json");
+    writeFileSync(path, "{ this is not json");
+    expect(readHeartbeatFile(path)).toBeNull();
+  });
+
+  test("structurally wrong heartbeat (no dispatched_minute) reads as null", () => {
+    const path = join(dir, "wrong.json");
+    writeFileSync(path, JSON.stringify({ ts: 1, host: "x" }));
+    expect(readHeartbeatFile(path)).toBeNull();
+  });
+});

--- a/lib/scheduler/tests/heartbeat-store.test.ts
+++ b/lib/scheduler/tests/heartbeat-store.test.ts
@@ -39,4 +39,13 @@ describe("heartbeat round-trip", () => {
     writeFileSync(path, JSON.stringify({ ts: 1, host: "x" }));
     expect(readHeartbeatFile(path)).toBeNull();
   });
+
+  test("non-numeric dispatched_minute values are dropped so the guard never holds a string", () => {
+    const path = join(dir, "badguard.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ ts: 1, host: "x", dispatched_minute: { good: 5, bad: "abc", alsobad: null } }),
+    );
+    expect(readHeartbeatFile(path)!.dispatched_minute).toEqual({ good: 5 });
+  });
 });

--- a/lib/scheduler/tests/registry.test.ts
+++ b/lib/scheduler/tests/registry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { parseRegistry, RegistryParseError } from "@/registry";
+
+const ENTRY = {
+  name: "morning-scan",
+  description: "scan inbox",
+  trigger: "cron",
+  schedule: "50 8 * * 1-5",
+  model: "mistral-small3.2:24b",
+  tier: "read",
+  status: "active",
+  runner: "ollama",
+  hosts: ["ml-1"],
+  file: "playbooks/morning-scan.md",
+};
+
+const registry = (...playbooks: unknown[]) =>
+  JSON.stringify({ schema_version: 3, generated: "2026-06-07T00:00:00Z", playbooks });
+
+describe("parseRegistry", () => {
+  test("maps the daemon-relevant fields from a well-formed entry", () => {
+    const { playbooks, warnings } = parseRegistry(registry(ENTRY));
+    expect(warnings).toEqual([]);
+    expect(playbooks).toEqual([
+      { name: "morning-scan", schedule: "50 8 * * 1-5", status: "active", trigger: "cron", hosts: ["ml-1"] },
+    ]);
+  });
+
+  test("tolerates unknown extra fields", () => {
+    const { playbooks } = parseRegistry(registry({ ...ENTRY, future_field: 42 }));
+    expect(playbooks).toHaveLength(1);
+    expect(playbooks[0]!.name).toBe("morning-scan");
+  });
+
+  test("missing playbooks key yields an empty list, no throw", () => {
+    expect(parseRegistry(JSON.stringify({ schema_version: 3 }))).toEqual({ playbooks: [], warnings: [] });
+  });
+
+  test("throws RegistryParseError on invalid JSON (loop keeps last-good)", () => {
+    expect(() => parseRegistry("{not json")).toThrow(RegistryParseError);
+  });
+
+  test("throws RegistryParseError when playbooks is not an array", () => {
+    expect(() => parseRegistry(JSON.stringify({ playbooks: "nope" }))).toThrow(RegistryParseError);
+  });
+
+  test("skips an entry missing a required field, keeps the rest, and warns", () => {
+    const noSchedule = { ...ENTRY, name: "broken" };
+    delete (noSchedule as Record<string, unknown>).schedule;
+    const { playbooks, warnings } = parseRegistry(registry(ENTRY, noSchedule));
+    expect(playbooks.map((p) => p.name)).toEqual(["morning-scan"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("broken");
+  });
+
+  test("absent or null hosts normalizes to ['*']", () => {
+    const noHosts = { ...ENTRY, name: "a" };
+    delete (noHosts as Record<string, unknown>).hosts;
+    const nullHosts = { ...ENTRY, name: "b", hosts: null };
+    const { playbooks } = parseRegistry(registry(noHosts, nullHosts));
+    expect(playbooks[0]!.hosts).toEqual(["*"]);
+    expect(playbooks[1]!.hosts).toEqual(["*"]);
+  });
+
+  test("malformed hosts (scalar / empty / blank element) normalizes to ['*'] with a warning", () => {
+    const scalar = { ...ENTRY, name: "s", hosts: "ml-1" };
+    const empty = { ...ENTRY, name: "e", hosts: [] };
+    const blank = { ...ENTRY, name: "k", hosts: ["ml-1", "  "] };
+    const { playbooks, warnings } = parseRegistry(registry(scalar, empty, blank));
+    expect(playbooks.map((p) => p.hosts)).toEqual([["*"], ["*"], ["*"]]);
+    expect(warnings).toHaveLength(3);
+  });
+});

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  dispatchArgv,
+  HEARTBEAT_STALE_MS,
+  heartbeatPath,
+  MAX_SLEEP_MS,
+  registryPath,
+  resolveHost,
+} from "@/runtime";
+
+describe("path resolution", () => {
+  test("registry lives under <vault>/CEO/registry.json", () => {
+    expect(registryPath("/Users/x/Obsidian")).toBe("/Users/x/Obsidian/CEO/registry.json");
+  });
+
+  test("heartbeat is host-local under ~/.ceo, never the synced vault", () => {
+    expect(heartbeatPath("/home/nhang")).toBe("/home/nhang/.ceo/schedulerd/heartbeat.json");
+  });
+});
+
+describe("resolveHost", () => {
+  test("CEO_HOSTNAME overrides the OS hostname", () => {
+    expect(resolveHost({ CEO_HOSTNAME: "ml-1" }, "macbook")).toBe("ml-1");
+  });
+  test("blank or absent CEO_HOSTNAME falls back to the OS hostname", () => {
+    expect(resolveHost({ CEO_HOSTNAME: "  " }, "macbook")).toBe("macbook");
+    expect(resolveHost({}, "macbook")).toBe("macbook");
+  });
+});
+
+describe("dispatchArgv", () => {
+  test("invokes the cron binary with the playbook name and --scheduled, no shell", () => {
+    expect(dispatchArgv("ceo-cron.sh", "morning-scan")).toEqual(["ceo-cron.sh", "morning-scan", "--scheduled"]);
+  });
+});
+
+describe("staleness threshold is comfortably larger than the wake cap", () => {
+  test("a single missed wake cannot trip a stale alert", () => {
+    expect(HEARTBEAT_STALE_MS).toBeGreaterThanOrEqual(5 * MAX_SLEEP_MS);
+  });
+});

--- a/lib/scheduler/tests/select.test.ts
+++ b/lib/scheduler/tests/select.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { createMatcher } from "@/cron";
+import type { Playbook } from "@/registry";
+import { dueAt, nextWake, selectRunnable } from "@/select";
+
+const m = createMatcher({ timezone: "UTC" });
+const d = (iso: string) => new Date(iso);
+
+const pb = (over: Partial<Playbook>): Playbook => ({
+  name: "p",
+  schedule: "0 9 * * *",
+  status: "active",
+  trigger: "cron",
+  hosts: ["*"],
+  ...over,
+});
+
+describe("selectRunnable — host + status + trigger gating", () => {
+  test("keeps active cron playbooks whose hosts include this host", () => {
+    const pbs = [
+      pb({ name: "wild", hosts: ["*"] }),
+      pb({ name: "mine", hosts: ["ml-1"] }),
+      pb({ name: "theirs", hosts: ["mac-mini"] }),
+    ];
+    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["wild", "mine"]);
+  });
+
+  test("drops non-active status", () => {
+    const pbs = [pb({ name: "a", status: "draft" }), pb({ name: "b", status: "disabled" }), pb({ name: "c", status: "active" })];
+    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["c"]);
+  });
+
+  test("drops non-cron triggers", () => {
+    const pbs = [pb({ name: "a", trigger: "manual" }), pb({ name: "b", trigger: "cron" })];
+    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["b"]);
+  });
+
+  test("drops entries with a blank schedule", () => {
+    const pbs = [pb({ name: "a", schedule: "   " }), pb({ name: "b", schedule: "0 9 * * *" })];
+    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["b"]);
+  });
+
+  test("wildcard host matches any host id", () => {
+    expect(selectRunnable([pb({ hosts: ["*"] })], "whatever").map((p) => p.name)).toEqual(["p"]);
+  });
+});
+
+describe("dueAt — minute-granular fire set", () => {
+  test("returns only playbooks firing during the given minute", () => {
+    const pbs = [
+      pb({ name: "nine", schedule: "0 9 * * *" }),
+      pb({ name: "every15", schedule: "*/15 * * * *" }),
+      pb({ name: "noon", schedule: "0 12 * * *" }),
+    ];
+    expect(dueAt(pbs, d("2026-06-01T09:00:00Z"), m).map((p) => p.name)).toEqual(["nine", "every15"]);
+  });
+
+  test("fires regardless of the seconds component (minute granularity)", () => {
+    expect(dueAt([pb({ schedule: "0 9 * * *" })], d("2026-06-01T09:00:43Z"), m)).toHaveLength(1);
+  });
+
+  test("a playbook with an invalid schedule is silently skipped, not crashing the tick", () => {
+    const pbs = [pb({ name: "bad", schedule: "not a cron" }), pb({ name: "ok", schedule: "0 9 * * *" })];
+    expect(dueAt(pbs, d("2026-06-01T09:00:00Z"), m).map((p) => p.name)).toEqual(["ok"]);
+  });
+});
+
+describe("nextWake — ms until the soonest next fire, capped", () => {
+  const CAP = 60_000;
+
+  test("sleeps exactly until the soonest next-fire when under the cap", () => {
+    const pbs = [pb({ schedule: "*/5 * * * *" })];
+    // from 12:00:00 → next */5 fire is 12:05:00 → 300_000ms, capped at 60_000.
+    expect(nextWake(pbs, d("2026-06-01T12:00:00Z"), m, CAP)).toBe(CAP);
+    // from 12:04:00 → next fire 12:05:00 → 60_000ms, exactly the cap boundary.
+    expect(nextWake(pbs, d("2026-06-01T12:04:00Z"), m, CAP)).toBe(60_000);
+    // from 12:04:30 → next fire 12:05:00 → 30_000ms, under the cap.
+    expect(nextWake(pbs, d("2026-06-01T12:04:30Z"), m, CAP)).toBe(30_000);
+  });
+
+  test("takes the minimum across all playbooks", () => {
+    const pbs = [pb({ name: "hourly", schedule: "0 * * * *" }), pb({ name: "soon", schedule: "*/5 * * * *" })];
+    // from 12:01:00 → hourly fires 13:00 (3540s), */5 fires 12:05 (240s) → 240_000, capped to 60_000.
+    expect(nextWake(pbs, d("2026-06-01T12:01:00Z"), m, CAP)).toBe(CAP);
+    // from 12:04:10 → */5 fires 12:05:00 → 50_000ms (< cap), wins over hourly.
+    expect(nextWake(pbs, d("2026-06-01T12:04:10Z"), m, CAP)).toBe(50_000);
+  });
+
+  test("falls back to the cap when nothing is scheduled (or all never-fire)", () => {
+    expect(nextWake([], d("2026-06-01T12:00:00Z"), m, CAP)).toBe(CAP);
+    expect(nextWake([pb({ schedule: "0 0 30 2 *" })], d("2026-06-01T12:00:00Z"), m, CAP)).toBe(CAP);
+  });
+
+  test("ignores invalid schedules rather than throwing", () => {
+    const pbs = [pb({ name: "bad", schedule: "99 * * * *" }), pb({ name: "ok", schedule: "*/5 * * * *" })];
+    expect(nextWake(pbs, d("2026-06-01T12:04:30Z"), m, CAP)).toBe(30_000);
+  });
+});

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -439,7 +439,10 @@ cmd_doctor() {
       echo "  ✗ ceo-schedulerd heartbeat malformed (no numeric ts) — check the daemon"
       fail=$((fail + 1))
     else
-      local _hb_age_s=$(( $(date +%s) - _hb_ts / 1000 ))
+      local _hb_age_s=$(( $(date +%s) - (_hb_ts / 1000) ))
+      # Clock skew between hosts can put the daemon's ts ahead of this host;
+      # clamp a negative age to 0 rather than print "alive (-Ns ago)".
+      [ "$_hb_age_s" -lt 0 ] && _hb_age_s=0
       if [ "$_hb_age_s" -gt "$_hb_stale_s" ]; then
         echo "  ✗ ceo-schedulerd heartbeat stale (${_hb_age_s}s old, > ${_hb_stale_s}s) — daemon may be down"
         fail=$((fail + 1))

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -432,8 +432,11 @@ cmd_doctor() {
   else
     local _hb_ts
     _hb_ts=$(jq -r '.ts // empty' "$_hb_file" 2>/dev/null)
+    case "$_hb_ts" in
+      ''|*[!0-9]*) _hb_ts="" ;;
+    esac
     if [ -z "$_hb_ts" ]; then
-      echo "  ✗ ceo-schedulerd heartbeat malformed (no ts) — check the daemon"
+      echo "  ✗ ceo-schedulerd heartbeat malformed (no numeric ts) — check the daemon"
       fail=$((fail + 1))
     else
       local _hb_age_s=$(( $(date +%s) - _hb_ts / 1000 ))

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -419,6 +419,34 @@ cmd_doctor() {
     fi
   fi
 
+  # ceo-schedulerd liveness — host-local heartbeat at ~/.ceo/schedulerd/heartbeat.json
+  # (never the synced vault). Threshold mirrors HEARTBEAT_STALE_MS in
+  # lib/scheduler/src/runtime.ts (600s); keep the two in sync.
+  local _hb_file="${HOME:?HOME must be set for the schedulerd heartbeat check}/.ceo/schedulerd/heartbeat.json"
+  local _hb_stale_s=600
+  if [ ! -f "$_hb_file" ]; then
+    echo "  ? ceo-schedulerd not running on this host (no heartbeat) — optional Phase-1.5 daemon"
+  elif ! command -v jq &>/dev/null; then
+    echo "  ⚠ schedulerd heartbeat check skipped: jq not on PATH"
+    warn=$((warn + 1))
+  else
+    local _hb_ts
+    _hb_ts=$(jq -r '.ts // empty' "$_hb_file" 2>/dev/null)
+    if [ -z "$_hb_ts" ]; then
+      echo "  ✗ ceo-schedulerd heartbeat malformed (no ts) — check the daemon"
+      fail=$((fail + 1))
+    else
+      local _hb_age_s=$(( $(date +%s) - _hb_ts / 1000 ))
+      if [ "$_hb_age_s" -gt "$_hb_stale_s" ]; then
+        echo "  ✗ ceo-schedulerd heartbeat stale (${_hb_age_s}s old, > ${_hb_stale_s}s) — daemon may be down"
+        fail=$((fail + 1))
+      else
+        echo "  ✓ ceo-schedulerd alive (heartbeat ${_hb_age_s}s ago)"
+        ok=$((ok + 1))
+      fi
+    fi
+  fi
+
   echo ""
   echo "Result: $ok ok, $warn warnings, $fail failures"
   [ "$fail" -gt 0 ] && return 1

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -442,4 +442,17 @@ test_doctor_flags_malformed_schedulerd_heartbeat() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_doctor_flags_nonnumeric_schedulerd_ts() {
+  mkdir -p "$HOME/.ceo/schedulerd"
+  printf '{"ts":"abc","host":"testhost","dispatched_minute":{}}\n' > "$HOME/.ceo/schedulerd/heartbeat.json"
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "heartbeat malformed" "doctor must flag a non-numeric ts as malformed, not error on arithmetic"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on non-numeric ts (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -412,7 +412,7 @@ test_doctor_flags_stale_schedulerd_heartbeat() {
   assert_contains "$output" "heartbeat stale" "doctor must flag a stale heartbeat"
   if [ "$rc" = "0" ]; then
     printf '  FAIL [%s] doctor must return non-zero on stale heartbeat (got rc=0)\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
+    _record_assertion_fail
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -422,11 +422,7 @@ test_doctor_notes_schedulerd_absent_without_failing() {
   local output
   output=$("$CEO_BIN" doctor 2>&1 || true)
   assert_contains "$output" "ceo-schedulerd not running" "doctor must note an absent daemon"
-  if echo "$output" | grep -qF "heartbeat stale"; then
-    printf '  FAIL [%s] absent daemon must not be reported stale\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_not_contains "$output" "heartbeat stale" "absent daemon must not be reported stale"
 }
 
 test_doctor_flags_malformed_schedulerd_heartbeat() {
@@ -437,7 +433,7 @@ test_doctor_flags_malformed_schedulerd_heartbeat() {
   assert_contains "$output" "heartbeat malformed" "doctor must flag a heartbeat with no ts"
   if [ "$rc" = "0" ]; then
     printf '  FAIL [%s] doctor must return non-zero on malformed heartbeat (got rc=0)\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
+    _record_assertion_fail
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -450,9 +446,22 @@ test_doctor_flags_nonnumeric_schedulerd_ts() {
   assert_contains "$output" "heartbeat malformed" "doctor must flag a non-numeric ts as malformed, not error on arithmetic"
   if [ "$rc" = "0" ]; then
     printf '  FAIL [%s] doctor must return non-zero on non-numeric ts (got rc=0)\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
+    _record_assertion_fail
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_clamps_future_schedulerd_heartbeat_to_alive() {
+  mkdir -p "$HOME/.ceo/schedulerd"
+  # ts in the future (clock skew between hosts) must not read as a negative age
+  # nor as stale — clamp to 0 and report alive.
+  local future_ms=$(( ($(date +%s) + 700) * 1000 ))
+  printf '{"ts": %s, "host":"testhost","dispatched_minute":{}}\n' "$future_ms" \
+    > "$HOME/.ceo/schedulerd/heartbeat.json"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "ceo-schedulerd alive" "future-dated heartbeat must clamp to alive, not stale"
+  assert_not_contains "$output" "(heartbeat -" "future-dated heartbeat age must not be negative"
 }
 
 run_tests

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -390,4 +390,56 @@ STUB
     "doctor must confirm loaded-vs-plist parity at N=3"
 }
 
+# --- ceo-schedulerd liveness (#142) ---
+
+test_doctor_reports_schedulerd_alive_on_fresh_heartbeat() {
+  mkdir -p "$HOME/.ceo/schedulerd"
+  local now_ms=$(( $(date +%s) * 1000 ))
+  printf '{"ts": %s, "host":"testhost","dispatched_minute":{}}\n' "$now_ms" \
+    > "$HOME/.ceo/schedulerd/heartbeat.json"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "ceo-schedulerd alive" "doctor must report a fresh heartbeat as alive"
+}
+
+test_doctor_flags_stale_schedulerd_heartbeat() {
+  mkdir -p "$HOME/.ceo/schedulerd"
+  local old_ms=$(( ($(date +%s) - 700) * 1000 ))
+  printf '{"ts": %s, "host":"testhost","dispatched_minute":{}}\n' "$old_ms" \
+    > "$HOME/.ceo/schedulerd/heartbeat.json"
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "heartbeat stale" "doctor must flag a stale heartbeat"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on stale heartbeat (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_notes_schedulerd_absent_without_failing() {
+  rm -rf "$HOME/.ceo/schedulerd"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "ceo-schedulerd not running" "doctor must note an absent daemon"
+  if echo "$output" | grep -qF "heartbeat stale"; then
+    printf '  FAIL [%s] absent daemon must not be reported stale\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_flags_malformed_schedulerd_heartbeat() {
+  mkdir -p "$HOME/.ceo/schedulerd"
+  printf '{"host":"testhost","dispatched_minute":{}}\n' > "$HOME/.ceo/schedulerd/heartbeat.json"
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "heartbeat malformed" "doctor must flag a heartbeat with no ts"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on malformed heartbeat (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests


### PR DESCRIPTION
Closes #142

## Description (Issue Fixed & New Behavior)
Phase 1.5 of #136. Introduces **`ceo-schedulerd`**, a long-lived Bun daemon in `lib/scheduler/` that owns cron matching so the OS scheduler only has to keep one process alive (the redesign that retires the O(slots) launchd fan-out).

Each tick the daemon: re-reads `$CEO_VAULT/CEO/registry.json` → selects the playbooks **this host** runs (cron-triggered, `active`, non-blank schedule, `hosts` includes `*` or the short hostname) → dispatches every due one via `ceo-cron.sh <name> --scheduled` → writes a host-local heartbeat → sleeps until the soonest next fire (capped at 60s so registry edits and clock skew self-heal).

Key behaviors:
- **`hosts:` is now enforced** (`selectRunnable`). Phase 1 only recorded it; the daemon is the first path to actually gate on it. The native-cron install path still records-only — documented in SCHEMA. No `schema_version` bump (deferred cross-host item).
- **Durable double-fire guard.** The per-playbook "last dispatched minute" is persisted in the heartbeat and restored at startup, so a `Restart=always` crash inside a fire-minute does not re-run a playbook.
- **Liveness.** Heartbeat at `~/.ceo/schedulerd/heartbeat.json` (host-local, never the synced vault). `ceo doctor` reports alive / stale (>10 min) / malformed / not-running.
- **Keep-alive.** systemd **user**-unit template at `lib/scheduler/deploy/ceo-schedulerd.service` (`Restart=always`, respawn-storm cap, lingering). macOS keep-alive is Phase 2 (#144).
- Schedules evaluate in **host-local time**; missed-while-down catch-up is a separate issue (#143) and intentionally not implemented here.
- Bun pinned (`engines.bun >=1.3.5`), `croner` pinned `9.1.0`, matcher swappable behind `CronMatcher` (from #141).

Module layout (all scheduling logic unit-tested behind injected side effects): `registry.ts` (parse), `select.ts` (pure decisions), `daemon.ts` (`runForever` + guard), `heartbeat-store.ts` (durable read/write), `runtime.ts` (paths/host/argv + constants), `main.ts` (composition root: real spawn/fs/signals).

Reviewed by an independent design auditor (pre-implementation; folded the durable-guard and minute-alignment fixes) and an implementation auditor (post-implementation: no HIGH/MEDIUM; two LOW corrupt-heartbeat findings hardened in the second commit).

**Not verified on hardware:** `Restart=always` respawn semantics are untested on a live always-on Linux host (ML-1 is GPU-down). Shipped as a documented template; the loop, guard, heartbeat, and shutdown were validated via fake-clock tests and a local start/SIGTERM smoke on macOS.

## Testing Procedure
1. Check out this branch.
2. `cd lib/scheduler && bun install --frozen-lockfile`
3. `bun test` — expect **64 pass** (cron matcher + registry/select/daemon/runtime/heartbeat). `bun run typecheck` — clean.
4. From the repo root: `bash scripts/ceo-doctor.test.sh` — expect **16 tests pass** (includes the 5 new `ceo-schedulerd` liveness cases).
5. `shellcheck --severity=warning scripts/ceo` — clean.
6. Real smoke (no always-on host needed): with a temp `CEO_VAULT` containing `CEO/registry.json` = `{"schema_version":3,"playbooks":[]}`, run `CEO_VAULT=<tmp> HOME=<tmp> bun run lib/scheduler/src/main.ts`. Confirm `~/.ceo/schedulerd/heartbeat.json` is written within a tick, then `kill -TERM` the process and confirm it logs `stopped` and exits 0 promptly (sleep is cancelled on signal).
7. Liveness: with a fresh heartbeat present, `ceo doctor` prints `✓ ceo-schedulerd alive`; backdate `ts` by >600s and it prints `✗ ... heartbeat stale` and returns non-zero.

## Additional Notes
Part of #136 Phase 1.5. Next: #143 (missed-slot catch-up, consumes this daemon), then Phase 2 #144 (macOS keep-alive; retire #98, resolve #109).