### PR TITLE
Add missed-slot catch-up to ceo-schedulerd (#143)

### DIFF
--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -95,6 +95,15 @@ drops a fire rather than doubling it. (This is a deliberate divergence from #143
 for write-tier playbooks, and dispatch is a fire-and-forget spawn whose completion
 the daemon can't observe anyway.)
 
+The look-back is **one global value** (`CATCHUP_LOOKBACK_MS`, default 1h),
+overridable per host via the `CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS` env var (a
+non-numeric/zero/negative value falls back to the default). A single global value
+is a known limitation: it suits sub-hourly playbooks but is wrong for the
+daily-report playbooks that dominate the registry — a daily slot missed by more
+than the look-back is **not** replayed (by design, so a morning job doesn't run
+late at night). A daily-heavy host should raise the env var; per-playbook (or
+per-cadence) look-back is the fuller fix, tracked as a follow-up.
+
 ### Run / keep-alive (Linux/WSL)
 
 ```bash

--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -66,16 +66,34 @@ Pipeline, all of it unit-tested behind injected side effects:
 - `heartbeat-store.ts` — durable read/write of the heartbeat
   (`~/.ceo/schedulerd/heartbeat.json`, host-local, **not** the synced vault).
   Corrupt/missing → guard starts empty, no crash.
+- `catchup.ts` — `newestMissedSlot` / `catchUpFires`: when a downtime or suspend
+  gap means slots were skipped, fire **once** for the newest missed slot per
+  playbook and skip the rest (no replay storm), bounded by `CATCHUP_LOOKBACK_MS`
+  so a stale slot isn't run late. Driven by `last_fired` in the heartbeat (#143).
 - `runtime.ts` — path/host/argv helpers and the `MAX_SLEEP_MS` / `HEARTBEAT_STALE_MS`
-  constants. Dispatch spawns `ceo-cron.sh <name> --scheduled` directly (no shell),
-  with `CEO_VAULT` passed via the spawn environment.
+  / `CATCHUP_LOOKBACK_MS` constants. Dispatch spawns `ceo-cron.sh <name> --scheduled`
+  directly (no shell), with `CEO_VAULT` passed via the spawn environment.
 
 Schedules evaluate in the **host's local timezone** (the matcher is created with no
 timezone; registry schedules carry no per-entry tz). A second host in a different
 zone would need a per-entry tz — out of scope until that exists.
 
-Catch-up for slots missed while the daemon was **down** is a separate issue (#143);
-this daemon intentionally does not replay missed slots.
+### Missed-slot catch-up (#143)
+
+The live loop only fires the current minute, so slots that should have fired while
+the daemon was **down** (or a sleep overshot on suspend) would be lost. On each
+tick the daemon also computes catch-up fires: for a playbook that owes fires since
+its `last_fired`, it dispatches **once** for the newest missed slot within the
+look-back window (default 1h) and skips the rest. A playbook already firing this
+minute is not also caught up, and a first-seen playbook (no `last_fired` baseline)
+is initialized to "now" rather than replayed.
+
+`last_fired` is persisted in the same pre-dispatch heartbeat write as the
+double-fire guard, so catch-up keeps #142's **at-most-once** invariant: a crash
+drops a fire rather than doubling it. (This is a deliberate divergence from #143's
+"persist after dispatch confirms" wording — at-most-once is the safer guarantee
+for write-tier playbooks, and dispatch is a fire-and-forget spawn whose completion
+the daemon can't observe anyway.)
 
 ### Run / keep-alive (Linux/WSL)
 

--- a/lib/scheduler/src/catchup.ts
+++ b/lib/scheduler/src/catchup.ts
@@ -1,0 +1,77 @@
+/**
+ * Missed-slot catch-up for ceo-schedulerd (#136 Phase 1.5, issue #143).
+ *
+ * When the daemon was down or a sleep overshot (suspend), schedules that should
+ * have fired during the gap were skipped — the live loop only fires the current
+ * minute via `matchesAt`. Catch-up fires **once** for the newest missed slot of
+ * each playbook and skips the rest (no replay storm), bounded by a look-back
+ * window so a slot that is too stale to be useful is not replayed.
+ *
+ * Pure: the daemon injects `now`, the matcher, and the look-back. The current
+ * minute is deliberately excluded — that is the live dueAt path's responsibility.
+ */
+import type { CronMatcher } from "@/cron";
+import type { Playbook } from "@/registry";
+
+const MINUTE_MS = 60_000;
+/** Bound on forward iteration when scanning for missed fires (defensive). */
+const MAX_SCAN = 100_000;
+
+/**
+ * The newest fire strictly after `lastFired` (clamped to `now - lookbackMs`) and
+ * strictly before the start of the minute containing `now`, or `null` if none.
+ * An unparseable schedule yields `null` rather than throwing.
+ */
+export function newestMissedSlot(
+  schedule: string,
+  lastFired: number,
+  now: Date,
+  matcher: CronMatcher,
+  lookbackMs: number,
+): Date | null {
+  const floor = Math.max(lastFired, now.getTime() - lookbackMs);
+  const currentMinuteStart = Math.floor(now.getTime() / MINUTE_MS) * MINUTE_MS;
+  if (floor >= currentMinuteStart) return null;
+
+  let cursor = new Date(floor);
+  let newest: Date | null = null;
+  for (let i = 0; i < MAX_SCAN; i++) {
+    let next: Date | null;
+    try {
+      next = matcher.nextFire(schedule, cursor);
+    } catch {
+      return null;
+    }
+    if (next === null || next.getTime() >= currentMinuteStart) break;
+    newest = next;
+    cursor = next;
+  }
+  return newest;
+}
+
+export interface CatchUpFire {
+  playbook: Playbook;
+  slot: Date;
+}
+
+/**
+ * Catch-up fires for a set of playbooks. A playbook with no `last_fired` baseline
+ * is skipped — the daemon has no basis to claim a slot was missed before it
+ * started watching, so first-sight never triggers a replay.
+ */
+export function catchUpFires(
+  playbooks: Playbook[],
+  lastFired: Record<string, number>,
+  now: Date,
+  matcher: CronMatcher,
+  lookbackMs: number,
+): CatchUpFire[] {
+  const fires: CatchUpFire[] = [];
+  for (const p of playbooks) {
+    const baseline = lastFired[p.name];
+    if (baseline === undefined) continue;
+    const slot = newestMissedSlot(p.schedule, baseline, now, matcher, lookbackMs);
+    if (slot !== null) fires.push({ playbook: p, slot });
+  }
+  return fires;
+}

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -85,16 +85,20 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     const minuteStart = minute * MINUTE_MS;
 
     // Current-minute fires (live path), then catch-up fires for slots missed
-    // while the daemon was down — excluding any playbook already firing now, so
-    // a single tick never dispatches a playbook twice.
+    // while the daemon was down. The dueNames filter is defensive: catch-up only
+    // returns slots strictly before the current minute, so it can't already
+    // overlap `due` today — but it keeps a single tick from double-dispatching a
+    // playbook if that exclusion ever changes.
     const due = dueAt(runnable, now, deps.matcher).filter((p) => guard.get(p.name) !== minute);
     const dueNames = new Set(due.map((p) => p.name));
     const catches = catchUpFires(runnable, lastFired, now, deps.matcher, deps.catchupLookbackMs).filter(
       (f) => !dueNames.has(f.playbook.name),
     );
 
-    // Rebuild last_fired keyed by current runnable set (prunes removed playbooks).
-    // A first-seen playbook with no baseline initializes to now — never a replay.
+    // Rebuild last_fired keyed by the current runnable set, which prunes removed
+    // playbooks. A first-seen playbook (or one that briefly left the runnable set
+    // — draft/host-scope flip) has no baseline and initializes to now, so it is
+    // treated as first-seen and never replayed: at-most-once over double-fire.
     const nextLastFired: Record<string, number> = {};
     for (const p of runnable) nextLastFired[p.name] = lastFired[p.name] ?? now.getTime();
     for (const p of due) {

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -12,6 +12,7 @@
  * double-fire guard is persisted in the heartbeat and restored at startup so a
  * `Restart=always` crash inside a fire-minute does not re-run a playbook.
  */
+import { catchUpFires } from "@/catchup";
 import type { CronMatcher } from "@/cron";
 import { dueAt, nextWake, selectRunnable } from "@/select";
 import type { Playbook } from "@/registry";
@@ -33,6 +34,8 @@ export interface Heartbeat {
   last_dispatch: DispatchRecord[];
   /** playbook name → epoch-minute it was last dispatched (the durable double-fire guard). */
   dispatched_minute: Record<string, number>;
+  /** playbook name → epoch-ms of the newest slot fired (drives missed-slot catch-up, #143). */
+  last_fired: Record<string, number>;
 }
 
 export interface DaemonDeps {
@@ -48,6 +51,8 @@ export interface DaemonDeps {
   host: string;
   matcher: CronMatcher;
   maxSleepMs: number;
+  /** Look-back window for missed-slot catch-up; a missed slot older than this is too stale to replay. */
+  catchupLookbackMs: number;
   shouldContinue(): boolean;
 }
 
@@ -59,6 +64,7 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
   const prior = deps.readHeartbeat();
   const guard = new Map<string, number>(prior ? Object.entries(prior.dispatched_minute) : []);
   const recent: DispatchRecord[] = prior ? [...prior.last_dispatch] : [];
+  let lastFired: Record<string, number> = prior ? { ...prior.last_fired } : {};
   let lastGood: Playbook[] = [];
 
   while (deps.shouldContinue()) {
@@ -76,11 +82,31 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     }
 
     const runnable = selectRunnable(playbooks, deps.host);
-    const toDispatch = dueAt(runnable, now, deps.matcher).filter((p) => guard.get(p.name) !== minute);
-    for (const p of toDispatch) {
+    const minuteStart = minute * MINUTE_MS;
+
+    // Current-minute fires (live path), then catch-up fires for slots missed
+    // while the daemon was down — excluding any playbook already firing now, so
+    // a single tick never dispatches a playbook twice.
+    const due = dueAt(runnable, now, deps.matcher).filter((p) => guard.get(p.name) !== minute);
+    const dueNames = new Set(due.map((p) => p.name));
+    const catches = catchUpFires(runnable, lastFired, now, deps.matcher, deps.catchupLookbackMs).filter(
+      (f) => !dueNames.has(f.playbook.name),
+    );
+
+    // Rebuild last_fired keyed by current runnable set (prunes removed playbooks).
+    // A first-seen playbook with no baseline initializes to now — never a replay.
+    const nextLastFired: Record<string, number> = {};
+    for (const p of runnable) nextLastFired[p.name] = lastFired[p.name] ?? now.getTime();
+    for (const p of due) {
       guard.set(p.name, minute);
+      nextLastFired[p.name] = minuteStart;
       recent.push({ name: p.name, ts: now.getTime() });
     }
+    for (const f of catches) {
+      nextLastFired[f.playbook.name] = Math.max(nextLastFired[f.playbook.name] ?? 0, f.slot.getTime());
+      recent.push({ name: f.playbook.name, ts: now.getTime() });
+    }
+    lastFired = nextLastFired;
     if (recent.length > MAX_RECENT_DISPATCH) recent.splice(0, recent.length - MAX_RECENT_DISPATCH);
 
     // Drop guard entries older than the previous minute — only the current
@@ -88,9 +114,11 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     for (const [name, mn] of guard) if (mn < minute - 1) guard.delete(name);
 
     const wake = nextWake(runnable, now, deps.matcher, deps.maxSleepMs);
-    // Persist the guard BEFORE firing. A crash between here and the spawn must
-    // not re-fire on restart, so dispatch is at-most-once: a crash drops a fire
-    // rather than doubling it (the safer direction for write-tier playbooks).
+    // Persist the guard and last_fired BEFORE firing. A crash between here and
+    // the spawn must not re-fire on restart, so dispatch is at-most-once: a
+    // crash drops a fire rather than doubling it (safer for write-tier
+    // playbooks). NB this diverges from #143's "persist after dispatch confirms"
+    // wording in favour of #142's panel-approved at-most-once invariant.
     deps.writeHeartbeat({
       ts: now.getTime(),
       host: deps.host,
@@ -98,8 +126,10 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
       next_wake_ts: now.getTime() + wake,
       last_dispatch: [...recent],
       dispatched_minute: Object.fromEntries(guard),
+      last_fired: lastFired,
     });
-    for (const p of toDispatch) deps.dispatch(p.name);
+    for (const p of due) deps.dispatch(p.name);
+    for (const f of catches) deps.dispatch(f.playbook.name);
 
     await deps.sleep(wake);
   }

--- a/lib/scheduler/src/heartbeat-store.ts
+++ b/lib/scheduler/src/heartbeat-store.ts
@@ -25,10 +25,10 @@ export function readHeartbeatFile(path: string): Heartbeat | null {
   // Drop any non-numeric guard value: a string slipping in would never `===`
   // the current epoch-minute, silently disabling the double-fire guard for that
   // playbook. Keep parity with the registry path's strictness.
-  const dispatchedMinute: Record<string, number> = {};
-  for (const [name, mn] of Object.entries(r.dispatched_minute as Record<string, unknown>)) {
-    if (typeof mn === "number") dispatchedMinute[name] = mn;
-  }
+  const dispatchedMinute = numericMap(r.dispatched_minute);
+  // last_fired drives catch-up; same numeric filter, and absent (pre-#143
+  // heartbeats) reads as empty so the daemon simply re-baselines.
+  const lastFired = numericMap(r.last_fired);
   return {
     ts: r.ts,
     host: typeof r.host === "string" ? r.host : "",
@@ -36,7 +36,20 @@ export function readHeartbeatFile(path: string): Heartbeat | null {
     next_wake_ts: typeof r.next_wake_ts === "number" ? r.next_wake_ts : 0,
     last_dispatch: lastDispatch,
     dispatched_minute: dispatchedMinute,
+    last_fired: lastFired,
   };
+}
+
+// Drop any non-numeric value: a string slipping into the guard or last_fired
+// would never compare correctly, silently disabling it for that playbook.
+function numericMap(raw: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (typeof raw === "object" && raw !== null) {
+    for (const [name, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof v === "number") out[name] = v;
+    }
+  }
+  return out;
 }
 
 export function writeHeartbeatFile(path: string, hb: Heartbeat): void {

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -18,7 +18,14 @@ import { createMatcher } from "@/cron";
 import { type DaemonDeps, runForever } from "@/daemon";
 import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
 import { parseRegistry } from "@/registry";
-import { dispatchArgv, heartbeatPath, MAX_SLEEP_MS, registryPath, resolveHost } from "@/runtime";
+import {
+  CATCHUP_LOOKBACK_MS,
+  dispatchArgv,
+  heartbeatPath,
+  MAX_SLEEP_MS,
+  registryPath,
+  resolveHost,
+} from "@/runtime";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -92,6 +99,7 @@ async function main(): Promise<void> {
     host,
     matcher: createMatcher(),
     maxSleepMs: MAX_SLEEP_MS,
+    catchupLookbackMs: CATCHUP_LOOKBACK_MS,
     shouldContinue: () => running,
   };
 

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -19,11 +19,11 @@ import { type DaemonDeps, runForever } from "@/daemon";
 import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
 import { parseRegistry } from "@/registry";
 import {
-  CATCHUP_LOOKBACK_MS,
   dispatchArgv,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
+  resolveCatchupLookbackMs,
   resolveHost,
 } from "@/runtime";
 
@@ -99,7 +99,7 @@ async function main(): Promise<void> {
     host,
     matcher: createMatcher(),
     maxSleepMs: MAX_SLEEP_MS,
-    catchupLookbackMs: CATCHUP_LOOKBACK_MS,
+    catchupLookbackMs: resolveCatchupLookbackMs(process.env.CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS),
     shouldContinue: () => running,
   };
 

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -20,6 +20,20 @@ export const HEARTBEAT_STALE_MS = 600_000; // 10 minutes
  */
 export const CATCHUP_LOOKBACK_MS = 3_600_000; // 1 hour
 
+/**
+ * Resolve the catch-up look-back from an optional env override
+ * (`CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS`), defaulting to {@link CATCHUP_LOOKBACK_MS}.
+ * A non-numeric / zero / negative value falls back to the default rather than
+ * silently installing a wrong window — a host with daily playbooks can raise it
+ * (e.g. to several hours) without a registry/schema change. Per-playbook
+ * look-back is the fuller fix, tracked separately.
+ */
+export function resolveCatchupLookbackMs(raw: string | undefined): number {
+  if (raw === undefined) return CATCHUP_LOOKBACK_MS;
+  const n = Number(raw.trim());
+  return Number.isInteger(n) && n > 0 ? n : CATCHUP_LOOKBACK_MS;
+}
+
 export function registryPath(vault: string): string {
   return `${vault}/CEO/registry.json`;
 }

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -13,6 +13,13 @@ export const MAX_SLEEP_MS = 60_000;
  */
 export const HEARTBEAT_STALE_MS = 600_000; // 10 minutes
 
+/**
+ * Missed-slot catch-up look-back (#143). On wake after a downtime/suspend gap,
+ * a missed slot older than this is too stale to replay. One hour: long enough to
+ * cover a brief outage, short enough that an hours-old slot isn't run late.
+ */
+export const CATCHUP_LOOKBACK_MS = 3_600_000; // 1 hour
+
 export function registryPath(vault: string): string {
   return `${vault}/CEO/registry.json`;
 }

--- a/lib/scheduler/tests/catchup.test.ts
+++ b/lib/scheduler/tests/catchup.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { catchUpFires, newestMissedSlot } from "@/catchup";
+import { createMatcher } from "@/cron";
+import type { Playbook } from "@/registry";
+
+const m = createMatcher({ timezone: "UTC" });
+const d = (iso: string) => new Date(iso);
+const ms = (iso: string) => d(iso).getTime();
+const HOUR = 3_600_000;
+
+const pb = (over: Partial<Playbook>): Playbook => ({
+  name: "p",
+  schedule: "*/5 * * * *",
+  status: "active",
+  trigger: "cron",
+  hosts: ["*"],
+  ...over,
+});
+
+describe("newestMissedSlot", () => {
+  test("no gap → null (last fire is recent, nothing missed before the current minute)", () => {
+    // */5, last fired 09:00, now 09:03 — next fire is 09:05, nothing missed.
+    expect(newestMissedSlot("*/5 * * * *", ms("2026-06-01T09:00:00Z"), d("2026-06-01T09:03:00Z"), m, HOUR)).toBeNull();
+  });
+
+  test("gap → the NEWEST missed slot, skipping the rest", () => {
+    // down since 09:00, back at 09:17:30 — 09:05/09:10/09:15 were missed; fire once for 09:15.
+    expect(newestMissedSlot("*/5 * * * *", ms("2026-06-01T09:00:00Z"), d("2026-06-01T09:17:30Z"), m, HOUR)).toEqual(
+      d("2026-06-01T09:15:00Z"),
+    );
+  });
+
+  test("excludes the current minute (that is the live dueAt path's job)", () => {
+    // every minute, last fired 09:00, now exactly on the 09:05 fire — newest *missed* is 09:04.
+    expect(newestMissedSlot("* * * * *", ms("2026-06-01T09:00:00Z"), d("2026-06-01T09:05:00Z"), m, HOUR)).toEqual(
+      d("2026-06-01T09:04:00Z"),
+    );
+  });
+
+  test("look-back bound: a slot older than now-lookback is too stale to replay", () => {
+    const lastFired = ms("2026-05-31T09:00:00Z"); // yesterday
+    // daily 09:00; back at 11:00 with a 1h look-back → 09:00 today is >1h stale → null.
+    expect(newestMissedSlot("0 9 * * *", lastFired, d("2026-06-01T11:00:00Z"), m, HOUR)).toBeNull();
+    // back at 09:30 → 09:00 today is within the look-back → replay it once.
+    expect(newestMissedSlot("0 9 * * *", lastFired, d("2026-06-01T09:30:00Z"), m, HOUR)).toEqual(
+      d("2026-06-01T09:00:00Z"),
+    );
+  });
+
+  test("look-back floor wins over a very stale last_fired (only recent misses replay)", () => {
+    // last fired 30 days ago, */5, now 09:17:30, 1h look-back → newest missed within the hour is 09:15.
+    expect(newestMissedSlot("*/5 * * * *", ms("2026-05-01T00:00:00Z"), d("2026-06-01T09:17:30Z"), m, HOUR)).toEqual(
+      d("2026-06-01T09:15:00Z"),
+    );
+  });
+
+  test("invalid schedule → null, never throws", () => {
+    expect(newestMissedSlot("not a cron", ms("2026-06-01T09:00:00Z"), d("2026-06-01T09:30:00Z"), m, HOUR)).toBeNull();
+  });
+
+  test("backward-DST (fall-back) stays monotonic and replays a real prior slot", () => {
+    const ny = createMatcher({ timezone: "America/New_York" });
+    // 2026-11-01 fall-back. Hourly. Down since 04:00Z, back at 07:30Z.
+    const slot = newestMissedSlot("0 * * * *", ms("2026-11-01T04:00:00Z"), d("2026-11-01T07:30:00Z"), ny, HOUR);
+    expect(slot).not.toBeNull();
+    // Newest fire strictly before the 07:00Z minute, after the look-back floor (06:30Z) → 07:00Z.
+    expect(slot).toEqual(d("2026-11-01T07:00:00Z"));
+  });
+});
+
+describe("catchUpFires", () => {
+  test("includes playbooks with a missed slot, excludes those without a last_fired baseline", () => {
+    const pbs = [pb({ name: "seen" }), pb({ name: "fresh" })];
+    const lastFired = { seen: ms("2026-06-01T09:00:00Z") }; // 'fresh' has no baseline yet
+    const fires = catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, HOUR);
+    expect(fires.map((f) => f.playbook.name)).toEqual(["seen"]);
+    expect(fires[0]!.slot).toEqual(d("2026-06-01T09:15:00Z"));
+  });
+
+  test("excludes a playbook with no gap", () => {
+    const pbs = [pb({ name: "current" })];
+    const lastFired = { current: ms("2026-06-01T09:15:00Z") };
+    expect(catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, HOUR)).toEqual([]);
+  });
+});

--- a/lib/scheduler/tests/catchup.test.ts
+++ b/lib/scheduler/tests/catchup.test.ts
@@ -66,6 +66,15 @@ describe("newestMissedSlot", () => {
     // Newest fire strictly before the 07:00Z minute, after the look-back floor (06:30Z) → 07:00Z.
     expect(slot).toEqual(d("2026-11-01T07:00:00Z"));
   });
+
+  test("forward-DST (spring-forward) replays the correct prior slot across the gap", () => {
+    const ny = createMatcher({ timezone: "America/New_York" });
+    // 2026-03-08 spring-forward (02:00→03:00 local; the 02:00 wall-clock hour does
+    // not exist). Hourly, 2h look-back. Down since 05:00Z (00:00 EST), back at
+    // 08:30Z (04:30 EDT) — newest fire before the 08:30Z minute is 08:00Z (04:00 EDT).
+    const slot = newestMissedSlot("0 * * * *", ms("2026-03-08T05:00:00Z"), d("2026-03-08T08:30:00Z"), ny, 2 * HOUR);
+    expect(slot).toEqual(d("2026-03-08T08:00:00Z"));
+  });
 });
 
 describe("catchUpFires", () => {

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -35,6 +35,10 @@ function harness(opts: HarnessOpts) {
   // the moment dispatch is called. undefined ⇒ the guard was NOT yet durable
   // (ordering bug: a crash here would re-fire on restart).
   const guardAtDispatch: Record<string, number | undefined> = {};
+  // Same idea for last_fired: the value already persisted to the heartbeat when
+  // dispatch is called. Proves catch-up keeps at-most-once even if the two
+  // fields are ever split into separate heartbeat writes.
+  const lastFiredAtDispatch: Record<string, number | undefined> = {};
   const loader =
     typeof opts.playbooks === "function"
       ? opts.playbooks
@@ -48,6 +52,7 @@ function harness(opts: HarnessOpts) {
     loadRegistry: loader,
     dispatch: (name) => {
       guardAtDispatch[name] = lastHb?.dispatched_minute[name];
+      lastFiredAtDispatch[name] = lastHb?.last_fired[name];
       dispatched.push(name);
     },
     readHeartbeat: () => opts.startHeartbeat ?? null,
@@ -64,7 +69,15 @@ function harness(opts: HarnessOpts) {
     catchupLookbackMs: opts.lookback ?? 3_600_000,
     shouldContinue: () => i < opts.nows.length,
   };
-  return { deps, dispatched, sleeps, heartbeats, logs, guardAtDispatch: () => guardAtDispatch };
+  return {
+    deps,
+    dispatched,
+    sleeps,
+    heartbeats,
+    logs,
+    guardAtDispatch: () => guardAtDispatch,
+    lastFiredAtDispatch: () => lastFiredAtDispatch,
+  };
 }
 
 describe("runForever — dispatch + sleep", () => {
@@ -242,17 +255,18 @@ describe("missed-slot catch-up (#143)", () => {
     expect(h.dispatched).toEqual([]);
   });
 
-  test("the catch-up fire is persisted to last_fired BEFORE dispatch (at-most-once)", async () => {
+  test("advances last_fired to the missed slot and persists it BEFORE dispatch (at-most-once)", async () => {
     const h = harness({
       nows: [d("2026-06-01T09:17:30Z")],
       playbooks: [pb({ name: "ev", schedule: "*/5 * * * *" })],
       startHeartbeat: hbWith({ ev: d("2026-06-01T09:00:00Z").getTime() }),
     });
     await runForever(h.deps);
-    // Heartbeat carrying the advanced last_fired was written before the dispatch fired.
-    expect(h.heartbeats).toHaveLength(1);
-    expect(h.heartbeats[0]!.last_fired.ev).toBe(d("2026-06-01T09:15:00Z").getTime());
     expect(h.dispatched).toEqual(["ev"]);
+    // Real ordering assertion: at the moment dispatch was called, the advanced
+    // last_fired was ALREADY in the persisted heartbeat. Fails if writeHeartbeat
+    // moves after dispatch (even if last_fired ends up correct).
+    expect(h.lastFiredAtDispatch().ev).toBe(d("2026-06-01T09:15:00Z").getTime());
   });
 
   test("prunes last_fired for playbooks no longer runnable", async () => {

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -21,6 +21,7 @@ interface HarnessOpts {
   startHeartbeat?: Heartbeat | null;
   host?: string;
   cap?: number;
+  lookback?: number;
 }
 
 function harness(opts: HarnessOpts) {
@@ -60,6 +61,7 @@ function harness(opts: HarnessOpts) {
     host: opts.host ?? "ml-1",
     matcher: m,
     maxSleepMs: opts.cap ?? 60_000,
+    catchupLookbackMs: opts.lookback ?? 3_600_000,
     shouldContinue: () => i < opts.nows.length,
   };
   return { deps, dispatched, sleeps, heartbeats, logs, guardAtDispatch: () => guardAtDispatch };
@@ -126,6 +128,7 @@ describe("double-fire guard", () => {
         next_wake_ts: 0,
         last_dispatch: [{ name: "ev", ts: d("2026-06-01T09:00:02Z").getTime() }],
         dispatched_minute: { ev: minute },
+        last_fired: {},
       },
     });
     await runForever(h.deps);
@@ -164,5 +167,101 @@ describe("registry resilience", () => {
     // Tick 1 loads ev and dispatches; tick 2's load throws → reuse ev → dispatch again (new minute).
     expect(h.dispatched).toEqual(["ev", "ev"]);
     expect(h.logs.some((l) => l.includes("boom"))).toBe(true);
+  });
+});
+
+describe("missed-slot catch-up (#143)", () => {
+  const hbWith = (lastFired: Record<string, number>): Heartbeat => ({
+    ts: 0,
+    host: "ml-1",
+    runnable_count: 0,
+    next_wake_ts: 0,
+    last_dispatch: [],
+    dispatched_minute: {},
+    last_fired: lastFired,
+  });
+
+  test("fires once for the newest missed slot after a downtime gap and advances last_fired", async () => {
+    // Restored last_fired = 09:00; back at 09:17:30; */5 → 09:05/09:10/09:15 missed; fire 09:15 once.
+    const h = harness({
+      nows: [d("2026-06-01T09:17:30Z")],
+      playbooks: [pb({ name: "ev", schedule: "*/5 * * * *" })],
+      startHeartbeat: hbWith({ ev: d("2026-06-01T09:00:00Z").getTime() }),
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["ev"]);
+    expect(h.heartbeats[0]!.last_fired.ev).toBe(d("2026-06-01T09:15:00Z").getTime());
+  });
+
+  test("a playbook due now AND owing a missed slot fires once (not twice)", async () => {
+    // every minute, last_fired 09:00, now exactly on the 09:05 fire.
+    const minuteStart = Math.floor(d("2026-06-01T09:05:00Z").getTime() / 60_000) * 60_000;
+    const h = harness({
+      nows: [d("2026-06-01T09:05:00Z")],
+      playbooks: [pb({ name: "ev", schedule: "* * * * *" })],
+      startHeartbeat: hbWith({ ev: d("2026-06-01T09:00:00Z").getTime() }),
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["ev"]);
+    expect(h.heartbeats[0]!.last_fired.ev).toBe(minuteStart);
+  });
+
+  test("a first-seen playbook (no baseline) gets no catch-up; last_fired initializes to now", async () => {
+    const now = d("2026-06-01T09:30:00Z");
+    const h = harness({
+      nows: [now],
+      playbooks: [pb({ name: "ev", schedule: "*/5 * * * *" })], // 09:30 is a fire, but no prior baseline
+      startHeartbeat: null,
+    });
+    await runForever(h.deps);
+    // It IS due at 09:30 (live path), so it fires once for the current minute — but NOT a catch-up replay.
+    expect(h.dispatched).toEqual(["ev"]);
+    expect(h.heartbeats[0]!.last_fired.ev).toBe(now.getTime());
+  });
+
+  test("no catch-up replay for a brand-new, not-currently-due playbook", async () => {
+    const now = d("2026-06-01T09:32:00Z"); // not a */5 fire
+    const h = harness({
+      nows: [now],
+      playbooks: [pb({ name: "ev", schedule: "*/5 * * * *" })],
+      startHeartbeat: null,
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual([]);
+    expect(h.heartbeats[0]!.last_fired.ev).toBe(now.getTime());
+  });
+
+  test("a slot too stale for the look-back window is not replayed", async () => {
+    // daily 09:00, down since yesterday, back at 11:00 with default 1h look-back → no replay.
+    const h = harness({
+      nows: [d("2026-06-01T11:00:00Z")],
+      playbooks: [pb({ name: "daily", schedule: "0 9 * * *" })],
+      startHeartbeat: hbWith({ daily: d("2026-05-31T09:00:00Z").getTime() }),
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual([]);
+  });
+
+  test("the catch-up fire is persisted to last_fired BEFORE dispatch (at-most-once)", async () => {
+    const h = harness({
+      nows: [d("2026-06-01T09:17:30Z")],
+      playbooks: [pb({ name: "ev", schedule: "*/5 * * * *" })],
+      startHeartbeat: hbWith({ ev: d("2026-06-01T09:00:00Z").getTime() }),
+    });
+    await runForever(h.deps);
+    // Heartbeat carrying the advanced last_fired was written before the dispatch fired.
+    expect(h.heartbeats).toHaveLength(1);
+    expect(h.heartbeats[0]!.last_fired.ev).toBe(d("2026-06-01T09:15:00Z").getTime());
+    expect(h.dispatched).toEqual(["ev"]);
+  });
+
+  test("prunes last_fired for playbooks no longer runnable", async () => {
+    const h = harness({
+      nows: [d("2026-06-01T09:30:00Z")],
+      playbooks: [pb({ name: "stillhere", schedule: "0 9 * * *" })],
+      startHeartbeat: hbWith({ stillhere: d("2026-06-01T09:00:00Z").getTime(), gone: 123 }),
+    });
+    await runForever(h.deps);
+    expect(Object.keys(h.heartbeats[0]!.last_fired)).toEqual(["stillhere"]);
   });
 });

--- a/lib/scheduler/tests/heartbeat-store.test.ts
+++ b/lib/scheduler/tests/heartbeat-store.test.ts
@@ -15,6 +15,7 @@ const hb: Heartbeat = {
   next_wake_ts: 1_780_000_060_000,
   last_dispatch: [{ name: "morning-scan", ts: 1_780_000_000_000 }],
   dispatched_minute: { "morning-scan": 29_666_666 },
+  last_fired: { "morning-scan": 1_780_000_000_000 },
 };
 
 describe("heartbeat round-trip", () => {
@@ -47,5 +48,20 @@ describe("heartbeat round-trip", () => {
       JSON.stringify({ ts: 1, host: "x", dispatched_minute: { good: 5, bad: "abc", alsobad: null } }),
     );
     expect(readHeartbeatFile(path)!.dispatched_minute).toEqual({ good: 5 });
+  });
+
+  test("a pre-#143 heartbeat with no last_fired reads as empty (re-baselines, no crash)", () => {
+    const path = join(dir, "prev143.json");
+    writeFileSync(path, JSON.stringify({ ts: 1, host: "x", dispatched_minute: { a: 5 } }));
+    expect(readHeartbeatFile(path)!.last_fired).toEqual({});
+  });
+
+  test("non-numeric last_fired values are dropped", () => {
+    const path = join(dir, "badlastfired.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ ts: 1, host: "x", dispatched_minute: {}, last_fired: { good: 99, bad: "x" } }),
+    );
+    expect(readHeartbeatFile(path)!.last_fired).toEqual({ good: 99 });
   });
 });

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CATCHUP_LOOKBACK_MS,
   dispatchArgv,
   HEARTBEAT_STALE_MS,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
+  resolveCatchupLookbackMs,
   resolveHost,
 } from "@/runtime";
 
@@ -37,5 +39,20 @@ describe("dispatchArgv", () => {
 describe("staleness threshold is comfortably larger than the wake cap", () => {
   test("a single missed wake cannot trip a stale alert", () => {
     expect(HEARTBEAT_STALE_MS).toBeGreaterThanOrEqual(5 * MAX_SLEEP_MS);
+  });
+});
+
+describe("resolveCatchupLookbackMs", () => {
+  test("absent env → the default", () => {
+    expect(resolveCatchupLookbackMs(undefined)).toBe(CATCHUP_LOOKBACK_MS);
+  });
+  test("a positive integer override is honored", () => {
+    expect(resolveCatchupLookbackMs("21600000")).toBe(21_600_000);
+  });
+  test("non-numeric / zero / negative falls back to the default (never a wrong window)", () => {
+    expect(resolveCatchupLookbackMs("abc")).toBe(CATCHUP_LOOKBACK_MS);
+    expect(resolveCatchupLookbackMs("0")).toBe(CATCHUP_LOOKBACK_MS);
+    expect(resolveCatchupLookbackMs("-5")).toBe(CATCHUP_LOOKBACK_MS);
+    expect(resolveCatchupLookbackMs("  ")).toBe(CATCHUP_LOOKBACK_MS);
   });
 });


### PR DESCRIPTION
Closes #143

## Description (Issue Fixed & New Behavior)
Phase 1.5 of #136, building directly on the #142 daemon. The live loop only fires the **current** minute (`matchesAt`), so any slot that should have fired while the daemon was **down** — or while a sleep overshot on suspend — is lost. This adds catch-up: on each tick the daemon also replays the **newest missed slot** for each playbook, **once**, and skips the rest (no replay storm), bounded by a look-back window so a stale slot isn't run hours late.

- **`catchup.ts`** (pure, exhaustively unit-tested): `newestMissedSlot(schedule, lastFired, now, matcher, lookbackMs)` returns the newest fire strictly after `max(lastFired, now − lookback)` and strictly before the current minute, or `null`. `catchUpFires(...)` maps that over the runnable set. The current minute is deliberately excluded (that's the live `dueAt` path); a first-seen playbook with no `last_fired` baseline is never replayed; an invalid schedule yields `null`; backward-DST (fall-back) stays monotonic via the matcher.
- **`daemon.ts`**: each tick computes catch-up alongside `dueAt`, **de-duped** so a playbook firing this minute is not also caught up; `last_fired` is restored at startup and rebuilt against the current runnable set each tick (pruning removed playbooks); a first-seen playbook initializes its baseline to "now".
- **At-most-once preserved.** `last_fired` rides in the **same pre-dispatch heartbeat write** as the #142 double-fire guard. This is a **deliberate divergence** from the issue's "persist `last_fired` after dispatch confirms" wording: #142's panel approved persist-before-dispatch as the safer direction for write-tier playbooks (a crash drops a fire rather than doubling it), and dispatch is a fire-and-forget spawn whose completion the daemon cannot observe anyway. Documented in the loop comment and README.
- **`heartbeat-store.ts`**: reads/writes `last_fired` with the same numeric filter as the guard; a pre-#143 heartbeat (no `last_fired`) re-baselines cleanly rather than crashing.
- `CATCHUP_LOOKBACK_MS` (1 h) in `runtime.ts`; README catch-up section.

No bash/`ceo doctor` changes — this is entirely within `lib/scheduler/`.

## Testing Procedure
1. Check out this branch.
2. `cd lib/scheduler && bun install --frozen-lockfile`
3. `bun test` — expect **83 pass** (9 new `catchup` cases, 7 new daemon catch-up cases, 2 new heartbeat-store cases, plus the existing matcher/registry/select/runtime suites). `bun run typecheck` — clean.
4. Catch-up unit behavior: in `tests/catchup.test.ts`, confirm a gap (last fired 09:00, now 09:17:30, `*/5`) replays **only** 09:15; a daily-09:00 slot is **not** replayed at 11:00 (1 h look-back); a fall-back-DST hourly slot replays the correct prior instant.
5. Daemon integration: in `tests/daemon.test.ts` → "missed-slot catch-up (#143)", confirm one dispatch after a gap with `last_fired` advanced, no double-dispatch when a playbook is both due-now and owing a slot, no replay for a first-seen playbook, and `last_fired` pruned for removed playbooks.
6. Smoke (no host needed): run `CEO_VAULT=<tmp> HOME=<tmp> bun run lib/scheduler/src/main.ts` against an empty registry; confirm the heartbeat now includes `"last_fired": {}` and `kill -TERM` exits cleanly.

## Additional Notes
Part of #136 Phase 1.5. With #141/#142/#143 the daemon is feature-complete on Linux; next is Phase 2 #144 (macOS keep-alive; retire #98, resolve #109). The `last_fired` persist-ordering divergence from the issue text is intentional and called out above for review.