### PR TITLE
macOS via daemon keep-alive — retire #98 per-plist backend (#144)

### DIFF
--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -104,18 +104,37 @@ than the look-back is **not** replayed (by design, so a morning job doesn't run
 late at night). A daily-heavy host should raise the env var; per-playbook (or
 per-cadence) look-back is the fuller fix, tracked as a follow-up.
 
-### Run / keep-alive (Linux/WSL)
+### Run / keep-alive
 
 ```bash
-CEO_VAULT=~/Documents/Obsidian bun run src/main.ts   # foreground
+CEO_VAULT=~/Documents/Obsidian bun run src/main.ts   # foreground (either OS)
 ```
 
-For keep-alive, install the systemd **user** unit template at
-`deploy/ceo-schedulerd.service` (see the header comments in that file). macOS
-keep-alive is Phase 2 (#144). **Not yet smoke-tested on a live always-on Linux
-host** (ML-1 GPU-down) — the loop, guard, and heartbeat are verified via
-fake-clock tests and a local start/SIGTERM smoke; only `Restart=always` is
-hardware-unverified.
+One OS-level agent keeps the daemon alive; the daemon does all scheduling.
+
+- **Linux/WSL:** install the systemd **user** unit template at
+  `deploy/ceo-schedulerd.service` (see its header comments). **Not smoke-tested on
+  a live always-on host** (ML-1 GPU-down) — only `Restart=always` is
+  hardware-unverified; the loop/guard/heartbeat are covered by fake-clock tests.
+- **macOS (#144):** install the launchd **LaunchAgent** template at
+  `deploy/com.ceo.schedulerd.plist` (see its header). It needs a logged-in GUI
+  session (it's a LaunchAgent, not a headless LaunchDaemon, because it reads the
+  user's synced vault). `ceo playbook scan` on macOS no longer installs
+  per-playbook plists — the daemon reads the registry directly.
+
+#### Migrating off the retired per-playbook launchd backend (#98 → #144)
+
+Before #144, macOS installed one `com.ceo.<name>-N` plist per fire-time. Those
+are retired. If any remain loaded they **double-fire** alongside the daemon, so
+`ceo doctor` flags them. Remove them:
+
+```bash
+for p in ~/Library/LaunchAgents/com.ceo.*.plist; do
+  [ "$(basename "$p" .plist)" = com.ceo.schedulerd ] && continue
+  launchctl bootout "gui/$(id -u)" "$p" 2>/dev/null
+  rm -f "$p"
+done
+```
 
 ### Liveness
 

--- a/lib/scheduler/deploy/com.ceo.schedulerd.plist
+++ b/lib/scheduler/deploy/com.ceo.schedulerd.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ceo-schedulerd — macOS launchd USER agent template (#144, Phase 2 of #136).
+
+  ONE keep-alive agent runs the Bun daemon, which owns cron matching and reads
+  CEO/registry.json directly — replacing the retired per-playbook plist backend.
+
+  This is a TEMPLATE: edit the three absolute paths below, then install as a
+  user agent (no root). It has NOT been smoke-tested on a long-running host;
+  the loop/guard/heartbeat are covered by lib/scheduler tests and a throwaway
+  bootstrap smoke.
+
+  Install (user scope, logged-in GUI session required — this is a LaunchAgent,
+  not a headless LaunchDaemon, because it must read the user's synced vault):
+
+    cp com.ceo.schedulerd.plist ~/Library/LaunchAgents/
+    # edit the absolute paths in the copy
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ceo.schedulerd.plist
+    launchctl kickstart -p gui/$(id -u)/com.ceo.schedulerd   # verify it starts
+    launchctl print gui/$(id -u)/com.ceo.schedulerd          # inspect state
+
+  Stop / uninstall:
+    launchctl bootout gui/$(id -u)/com.ceo.schedulerd
+    rm ~/Library/LaunchAgents/com.ceo.schedulerd.plist
+
+  Verify liveness independently of launchd:  ceo doctor   (reads the heartbeat).
+
+  MIGRATION from the old per-playbook backend: if `ceo doctor` reports legacy
+  `com.ceo.<name>-N` agents, bootout + rm each before relying on the daemon, or
+  they will double-fire. See lib/scheduler/README.md.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ceo.schedulerd</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <!-- EDIT: absolute path to bun and to this repo's lib/scheduler/src/main.ts. -->
+    <string>/Users/CHANGEME/.bun/bin/bun</string>
+    <string>run</string>
+    <string>/Users/CHANGEME/code/claude-ceo/lib/scheduler/src/main.ts</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- EDIT: the synced Obsidian vault root that contains CEO/registry.json. -->
+    <key>CEO_VAULT</key>
+    <string>/Users/CHANGEME/Documents/Obsidian</string>
+  </dict>
+
+  <!-- Start at load and keep alive, but only respawn on a non-zero (crash) exit
+       so a clean SIGTERM shutdown (exit 0, e.g. from `launchctl bootout`) does
+       not tight-loop. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <!-- Floor between respawns (launchd's implicit minimum is ~10s; set it
+       explicitly to honor the back-off requirement). -->
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/ceo-schedulerd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/ceo-schedulerd.err.log</string>
+</dict>
+</plist>

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -208,50 +208,47 @@ cmd_doctor() {
     warn=$((warn + 1))
   fi
 
-  # cron
-  local _sched_state
-  _sched_state="$(ceo_scheduler_list 2>/dev/null || true)"
-  if printf '%s\n' "$_sched_state" | grep -q "ceo-cron.sh"; then
-    local count
-    count=$(printf '%s\n' "$_sched_state" | grep -c "ceo-cron.sh")
-    echo "  ✓ Cron entries installed ($count triggers)"
-    ok=$((ok + 1))
-
-    # Launchd-only: compare on-disk plist count to what launchd has actually
-    # loaded. Drift (orphan plist on disk, or loaded job whose plist was
-    # rm'd) is the failure mode this check exists to catch.
-    if [ "$(ceo_scheduler_backend 2>/dev/null)" = "launchd" ]; then
-      local loaded
-      loaded="$(ceo_scheduler_loaded_count 2>/dev/null || echo unknown)"
-      case "$loaded" in
-        unknown)
-          echo "  ! Launchd state unreadable — could not query launchctl"
-          warn=$((warn + 1))
-          ;;
-        "$count")
-          echo "  ✓ Launchd jobs loaded ($loaded matches plist count)"
-          ok=$((ok + 1))
-          ;;
-        *)
-          echo "  ✗ Launchd job count drift: $loaded loaded vs $count plist(s) on disk — run: ceo playbook scan"
-          fail=$((fail + 1))
-          ;;
-      esac
+  # scheduler
+  local _backend
+  _backend="$(ceo_scheduler_backend 2>/dev/null || echo unknown)"
+  if [ "$_backend" = "crontab" ]; then
+    local _sched_state
+    _sched_state="$(ceo_scheduler_list 2>/dev/null || true)"
+    if printf '%s\n' "$_sched_state" | grep -q "ceo-cron.sh"; then
+      local count
+      count=$(printf '%s\n' "$_sched_state" | grep -c "ceo-cron.sh")
+      echo "  ✓ Cron entries installed ($count triggers)"
+      ok=$((ok + 1))
+    else
+      echo "  ! No ceo-cron entries in crontab — run: ceo setup"
+      warn=$((warn + 1))
     fi
-  else
-    echo "  ! No ceo-cron entries in crontab — run: ceo setup"
-    warn=$((warn + 1))
+    # duplicate cron triggers
+    local dup_count
+    dup_count=$(printf '%s\n' "$_sched_state" | grep "ceo-cron\.sh" | sed 's/.*ceo-cron\.sh //' | sort | uniq -d | wc -l | xargs || true)
+    if [ "${dup_count:-0}" -gt 0 ]; then
+      echo "  ✗ Duplicate cron triggers detected — run: ceo playbook scan"
+      fail=$((fail + 1))
+    else
+      echo "  ✓ No duplicate cron triggers"
+      ok=$((ok + 1))
+    fi
+  elif [ "$_backend" = "daemon" ]; then
+    # macOS: scheduling is owned by ceo-schedulerd; the OS holds no per-playbook
+    # entries. Liveness is the heartbeat check below (added in #142).
+    echo "  ✓ Scheduling via ceo-schedulerd daemon (no per-playbook OS entries)"
+    ok=$((ok + 1))
   fi
 
-  # duplicate cron triggers
-  local dup_count
-  dup_count=$(printf '%s\n' "$_sched_state" | grep "ceo-cron\.sh" | sed 's/.*ceo-cron\.sh //' | sort | uniq -d | wc -l | xargs || true)
-  if [ "${dup_count:-0}" -gt 0 ]; then
-    echo "  ✗ Duplicate cron triggers detected — run: ceo playbook scan"
+  # Legacy per-playbook launchd agents (retired #98 backend). If any are still
+  # on disk / loaded they dispatch in parallel with the daemon — a double-fire.
+  local _legacy _legacy_n
+  _legacy="$(ceo_scheduler_legacy_launchd_plists 2>/dev/null || true)"
+  if [ -n "$_legacy" ]; then
+    _legacy_n=$(printf '%s\n' "$_legacy" | grep -c .)
+    echo "  ✗ $_legacy_n legacy per-playbook launchd agent(s) found (retired #98 backend) — they double-fire with the daemon"
+    echo "    Remove: for p in ~/Library/LaunchAgents/com.ceo.*.plist; do [ \"\$(basename \"\$p\" .plist)\" = com.ceo.schedulerd ] && continue; launchctl bootout gui/\$(id -u) \"\$p\" 2>/dev/null; rm -f \"\$p\"; done"
     fail=$((fail + 1))
-  else
-    echo "  ✓ No duplicate cron triggers"
-    ok=$((ok + 1))
   fi
 
   # plugin

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -95,6 +95,7 @@ teardown() {
   export PATH="$PATH_BACKUP"
   export HOME="$HOME_BACKUP"
   unset TEST_HOME PATH_BACKUP HOME_BACKUP CEO_VAULT CEO_DIR CEO_HOSTNAME CEO_PLUTIL_BIN
+  unset CEO_SCHEDULER CEO_LAUNCHD_DIR
 }
 
 _log_completed_today() {

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -215,124 +215,6 @@ EOF
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_doctor_flags_launchd_loaded_vs_plist_drift() {
-  # #107: when on the launchd backend, doctor must surface drift between
-  # plist files on disk and com.ceo.* services actually loaded by launchd.
-  export CEO_SCHEDULER=launchd
-  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
-  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stubs/launchctl"
-  mkdir -p "$CEO_LAUNCHD_DIR"
-
-  # Two plist files on disk but stub launchctl reports only one loaded.
-  for label in foo-0 bar-0; do
-    cat > "$CEO_LAUNCHD_DIR/com.ceo.$label.plist" <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.ceo.$label</string>
-  <key>ProgramArguments</key><array>
-    <string>/bin/bash</string><string>-lc</string>
-    <string>/tmp/ceo-cron.sh $label</string>
-  </array>
-  <key>StartCalendarInterval</key><dict>
-    <key>Minute</key><integer>0</integer>
-    <key>Hour</key><integer>9</integer>
-  </dict>
-</dict></plist>
-XML
-  done
-
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-if [ "$1" = "print" ]; then
-  echo "services = { 0 com.ceo.foo-0 }"
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-
-  local output rc=0
-  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
-  assert_contains "$output" "Launchd job count drift" "doctor must flag plist-vs-loaded drift on launchd"
-  assert_contains "$output" "1 loaded vs 2 plist" "drift message must name both counts"
-}
-
-test_doctor_passes_when_launchd_loaded_matches_plist_count() {
-  export CEO_SCHEDULER=launchd
-  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
-  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stubs/launchctl"
-  mkdir -p "$CEO_LAUNCHD_DIR"
-  cat > "$CEO_LAUNCHD_DIR/com.ceo.solo-0.plist" <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.ceo.solo-0</string>
-  <key>ProgramArguments</key><array>
-    <string>/bin/bash</string><string>-lc</string>
-    <string>/tmp/ceo-cron.sh solo</string>
-  </array>
-  <key>StartCalendarInterval</key><dict>
-    <key>Minute</key><integer>0</integer>
-    <key>Hour</key><integer>9</integer>
-  </dict>
-</dict></plist>
-XML
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-if [ "$1" = "print" ]; then
-  echo "services = { 0 com.ceo.solo-0 }"
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-
-  local output
-  output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_contains "$output" "Launchd jobs loaded (1 matches plist count)" "doctor must report match on launchd"
-  if echo "$output" | grep -qF "Launchd job count drift"; then
-    printf '  FAIL [%s] doctor must NOT flag drift when counts match\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-}
-
-test_doctor_warns_when_launchctl_unreadable() {
-  # When launchctl can't be queried (headless ssh, missing binary, no GUI
-  # session), the helper now returns 'unknown' instead of silently 0. Doctor
-  # must surface this as a WARN, not a false drift report.
-  export CEO_SCHEDULER=launchd
-  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
-  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stubs/launchctl"
-  mkdir -p "$CEO_LAUNCHD_DIR"
-  cat > "$CEO_LAUNCHD_DIR/com.ceo.solo-0.plist" <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.ceo.solo-0</string>
-  <key>ProgramArguments</key><array>
-    <string>/bin/bash</string><string>-lc</string>
-    <string>/tmp/ceo-cron.sh solo</string>
-  </array>
-  <key>StartCalendarInterval</key><dict>
-    <key>Minute</key><integer>0</integer>
-    <key>Hour</key><integer>9</integer>
-  </dict>
-</dict></plist>
-XML
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-echo "launchctl: domain not found" >&2
-exit 3
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-
-  local output
-  output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_contains "$output" "Launchd state unreadable" "doctor must surface unknown launchctl state as a warn"
-  if echo "$output" | grep -qF "Launchd job count drift"; then
-    printf '  FAIL [%s] doctor must NOT report drift when launchctl is unreadable\n' "$CURRENT_TEST"
-    _record_assertion_fail
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-}
-
 test_doctor_reports_platform() {
   local output
   output=$("$CEO_BIN" doctor 2>&1 || true)
@@ -344,50 +226,47 @@ test_doctor_reports_platform() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-# #110: AC #3 of #98 was "doctor reports loaded agent count parity with
-# crontab". Existing tests pin the drift sub-check line but not the outer
-# "Cron entries installed (N triggers)" line. This test installs N plists
-# via the launchd backend, runs ceo doctor end-to-end, and asserts that
-# line for N=3.
-test_doctor_reports_cron_entries_installed_count_under_launchd() {
-  export CEO_SCHEDULER=launchd
-  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
-  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stubs/launchctl"
-  mkdir -p "$CEO_LAUNCHD_DIR"
-
-  local label
-  for label in alpha-0 beta-0 gamma-0; do
-    cat > "$CEO_LAUNCHD_DIR/com.ceo.$label.plist" <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.ceo.$label</string>
-  <key>ProgramArguments</key><array>
-    <string>/bin/bash</string><string>-lc</string>
-    <string>/tmp/ceo-cron.sh $label</string>
-  </array>
-  <key>StartCalendarInterval</key><dict>
-    <key>Minute</key><integer>0</integer>
-    <key>Hour</key><integer>9</integer>
-  </dict>
-</dict></plist>
-XML
-  done
-
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-if [ "$1" = "print" ]; then
-  echo "services = { 0 com.ceo.alpha-0 1 com.ceo.beta-0 2 com.ceo.gamma-0 }"
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-
+# #144: on the daemon backend (macOS) doctor reports scheduling-via-daemon and
+# does NOT print the crontab "Cron entries installed" line (there are none).
+test_doctor_reports_daemon_scheduling_on_daemon_backend() {
+  export CEO_SCHEDULER=daemon
   local output
   output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_contains "$output" "Cron entries installed (3 triggers)" \
-    "doctor must print the outer count line with N=3 under launchd"
-  assert_contains "$output" "Launchd jobs loaded (3 matches plist count)" \
-    "doctor must confirm loaded-vs-plist parity at N=3"
+  assert_contains "$output" "Scheduling via ceo-schedulerd daemon" \
+    "doctor must report daemon-managed scheduling on the daemon backend"
+  assert_not_contains "$output" "Cron entries installed" \
+    "the crontab cron-entries line must be skipped on the daemon backend"
+}
+
+# #144 migration: doctor must flag retired per-playbook launchd agents (which
+# would double-fire with the daemon) and not flag the daemon's own agent.
+test_doctor_flags_legacy_per_playbook_launchd_agents() {
+  export CEO_SCHEDULER=daemon
+  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
+  mkdir -p "$CEO_LAUNCHD_DIR"
+  : > "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist"
+  : > "$CEO_LAUNCHD_DIR/com.ceo.schedulerd.plist"
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "legacy per-playbook launchd agent" \
+    "doctor must warn about retired per-playbook agents"
+  assert_contains "$output" "double-fire" "warning must explain the risk"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero when legacy agents are present\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_no_legacy_warning_when_only_daemon_agent() {
+  export CEO_SCHEDULER=daemon
+  export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
+  mkdir -p "$CEO_LAUNCHD_DIR"
+  : > "$CEO_LAUNCHD_DIR/com.ceo.schedulerd.plist"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_not_contains "$output" "legacy per-playbook launchd agent" \
+    "the daemon's own keep-alive agent must not be flagged as legacy"
 }
 
 # --- ceo-schedulerd liveness (#142) ---

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -3,38 +3,44 @@
 # Sourced, not executed. Caller must have already sourced ceo-config.sh
 # (provides ceo_detect_os).
 #
+# As of #144 (Phase 2 of #136) the macOS per-playbook launchd backend is
+# retired: on macOS the Bun daemon `ceo-schedulerd` (lib/scheduler/) owns cron
+# matching and reads CEO/registry.json directly, kept alive by ONE launchd agent
+# (com.ceo.schedulerd — install template at lib/scheduler/deploy/). The OS no
+# longer holds per-playbook schedules on macOS. Linux/WSL still uses crontab.
+#
 # Public API:
-#   ceo_scheduler_backend       — prints the resolved backend name to stdout;
-#                                  returns 1 (with stderr message) on an
-#                                  unknown CEO_SCHEDULER value
-#   ceo_scheduler_list          — prints the current schedule state to stdout
-#                                  in a uniform "MIN HOUR D M W CMD  # ceo:NAME"
-#                                  format (crontab content for crontab backend;
-#                                  reconstructed lines per plist for launchd)
+#   ceo_scheduler_backend       — prints the resolved backend name to stdout
+#                                  ("crontab" | "daemon"); returns 1 (with stderr
+#                                  message) on an unknown CEO_SCHEDULER value
+#   ceo_scheduler_list          — prints the current schedule state to stdout in
+#                                  a uniform "MIN HOUR D M W CMD  # ceo:NAME"
+#                                  format (crontab content for the crontab
+#                                  backend; nothing for the daemon backend, which
+#                                  holds no per-playbook OS entries)
 #   ceo_scheduler_install <payload>
-#                                — replaces the user's schedule with <payload>;
+#                                — crontab backend: replaces the user's crontab
+#                                  with <payload>. daemon backend: no OS writes —
+#                                  prints guidance (the daemon reads the registry;
+#                                  the keep-alive agent is installed manually).
 #                                  rc=0 on success, rc=1 on backend error.
-#   ceo_scheduler_loaded_count   — prints the count of currently-loaded ceo
-#                                  jobs (launchd only — queries `launchctl
-#                                  print gui/$uid` for com.ceo.* lines). For
-#                                  the crontab backend the concept doesn't
-#                                  apply: prints "n/a" and returns 0. Lets
-#                                  `ceo doctor` flag drift between on-disk
-#                                  plist files and what launchd actually
-#                                  has loaded.
+#   ceo_scheduler_legacy_launchd_plists
+#                                — lists any retired per-playbook com.ceo.*.plist
+#                                  files (excluding com.ceo.schedulerd) so
+#                                  `ceo doctor` can warn about orphans that would
+#                                  double-fire alongside the daemon. Prints one
+#                                  absolute path per line; empty when clean.
 #
 # Backend selection priority:
-#   1. CEO_SCHEDULER env (explicit override for tests/dev); must be one of
-#      the known names — unknown values fail loud rather than fall through
-#      (per enum-config-typo-fallback)
+#   1. CEO_SCHEDULER env (explicit override for tests/dev); must be one of the
+#      known names — unknown values fail loud (per enum-config-typo-fallback)
 #   2. CEO_CRONTAB_BIN env set ⇒ crontab backend (legacy override)
-#   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ launchd
+#   3. ceo_detect_os: wsl/linux ⇒ crontab; macos ⇒ daemon
 #
-# Launchd backend env overrides (for tests):
-#   CEO_LAUNCHD_DIR     — directory holding com.ceo.*.plist (default ~/Library/LaunchAgents)
-#   CEO_LAUNCHCTL_BIN   — path to launchctl (default launchctl on PATH)
+# Env overrides (for tests):
+#   CEO_LAUNCHD_DIR  — directory holding com.ceo.*.plist (default ~/Library/LaunchAgents)
 
-_CEO_SCHEDULER_KNOWN="crontab launchd"
+_CEO_SCHEDULER_KNOWN="crontab daemon"
 
 ceo_scheduler_backend() {
   if [ -n "${CEO_SCHEDULER:-}" ]; then
@@ -70,251 +76,13 @@ ceo_scheduler_backend() {
       if [ -n "$_ct" ] && [ "${_ct#"$HOME/.bun/bin/"}" != "$_ct" ]; then
         echo "crontab"
       else
-        echo "launchd"
+        echo "daemon"
       fi
       ;;
     *)
-      echo "launchd"
+      echo "daemon"
       ;;
   esac
-}
-
-# XML-escape one string for safe interpolation into a plist body.
-# Order matters: & first so subsequent literal entities don't double-escape.
-_ceo_xml_escape() {
-  local s="$1"
-  s="${s//&/&amp;}"
-  s="${s//</&lt;}"
-  s="${s//>/&gt;}"
-  s="${s//\"/&quot;}"
-  s="${s//\'/&apos;}"
-  printf '%s' "$s"
-}
-
-# Expand one cron field to a space-separated list of concrete integers.
-# Supports: integer, list "1,3", range "1-5", step "*/N", named weekdays
-# SUN-SAT (cron 0-6, launchd 0-6).
-# Echoes "*" verbatim to signal "no constraint" (caller decides what that means).
-# Returns 1 with stderr diagnostic on: step <= 0, integer outside range,
-# reversed range (lo > hi), or any non-integer garbage.
-_ceo_cron_field_expand() {
-  local field="$1" range_start="$2" range_end="$3"
-  if [ "$field" = "*" ]; then
-    echo "*"
-    return 0
-  fi
-  # Named weekday → integer (only valid in weekday field)
-  case "$field" in
-    SUN|sun) echo 0; return 0 ;;
-    MON|mon) echo 1; return 0 ;;
-    TUE|tue) echo 2; return 0 ;;
-    WED|wed) echo 3; return 0 ;;
-    THU|thu) echo 4; return 0 ;;
-    FRI|fri) echo 5; return 0 ;;
-    SAT|sat) echo 6; return 0 ;;
-  esac
-  local out=""
-  local item
-  # List "1,3" → recurse per element
-  if [[ "$field" == *,* ]]; then
-    IFS=',' read -ra _items <<< "$field"
-    for item in "${_items[@]}"; do
-      local sub
-      sub="$(_ceo_cron_field_expand "$item" "$range_start" "$range_end")" || return 1
-      out="$out $sub"
-    done
-    echo "$out" | tr ' ' '\n' | grep -v '^$' | sort -nu | tr '\n' ' ' | sed 's/ $//'
-    return 0
-  fi
-  # Step "*/N" → range_start..range_end stepping by N
-  if [[ "$field" == */* ]]; then
-    local step="${field##*/}"
-    if ! [[ "$step" =~ ^[0-9]+$ ]] || [ "$step" -le 0 ]; then
-      echo "ERROR: invalid cron step '$step' in field '$field' (must be positive integer)" >&2
-      return 1
-    fi
-    local i="$range_start"
-    while [ "$i" -le "$range_end" ]; do
-      out="$out $i"
-      i=$((i + step))
-    done
-    echo "${out# }"
-    return 0
-  fi
-  # Range "1-5" → consecutive integers
-  if [[ "$field" == *-* ]]; then
-    local lo="${field%-*}" hi="${field#*-}"
-    if ! [[ "$lo" =~ ^[0-9]+$ ]] || ! [[ "$hi" =~ ^[0-9]+$ ]]; then
-      echo "ERROR: invalid cron range '$field' (non-integer bound)" >&2
-      return 1
-    fi
-    if [ "$lo" -gt "$hi" ]; then
-      echo "ERROR: reversed cron range '$field' ($lo > $hi)" >&2
-      return 1
-    fi
-    if [ "$lo" -lt "$range_start" ] || [ "$hi" -gt "$range_end" ]; then
-      echo "ERROR: cron range '$field' outside valid bounds [$range_start..$range_end]" >&2
-      return 1
-    fi
-    local i="$lo"
-    while [ "$i" -le "$hi" ]; do
-      out="$out $i"
-      i=$((i + 1))
-    done
-    echo "${out# }"
-    return 0
-  fi
-  # Plain integer — validate against allowed range
-  if ! [[ "$field" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: invalid cron field '$field' (not an integer)" >&2
-    return 1
-  fi
-  if [ "$field" -lt "$range_start" ] || [ "$field" -gt "$range_end" ]; then
-    echo "ERROR: cron field '$field' outside valid bounds [$range_start..$range_end]" >&2
-    return 1
-  fi
-  echo "$field"
-}
-
-# Emit one plist body for a (label, minute, hour, weekday, command) tuple.
-# weekday="*" omits the Weekday key (fires every day).
-_ceo_launchd_plist_body() {
-  local label="$1" minute="$2" hour="$3" weekday="$4" cmd="$5"
-  local label_esc cmd_esc
-  label_esc="$(_ceo_xml_escape "$label")"
-  cmd_esc="$(_ceo_xml_escape "$cmd")"
-  cat <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>${label_esc}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/bash</string>
-    <string>-lc</string>
-    <string>${cmd_esc}</string>
-  </array>
-  <key>StartCalendarInterval</key>
-  <dict>
-    <key>Minute</key>
-    <integer>${minute}</integer>
-    <key>Hour</key>
-    <integer>${hour}</integer>
-XML
-  if [ "$weekday" != "*" ]; then
-    printf '    <key>Weekday</key>\n    <integer>%s</integer>\n' "$weekday"
-  fi
-  cat <<'XML'
-  </dict>
-  <key>RunAtLoad</key>
-  <false/>
-</dict>
-</plist>
-XML
-}
-
-# Generate the set of (label, minute, hour, weekday, command, ceo_name) tuples
-# from a crontab-style payload. Emits one TSV-delimited row per tuple:
-#   label<TAB>minute<TAB>hour<TAB>weekday<TAB>cmd<TAB>ceo_name
-# Skips marker lines, blank lines, and any line that doesn't match the
-# "MIN HOUR DOM MON DOW CMD  # ceo:NAME" shape.
-_ceo_launchd_tuples_from_payload() {
-  local payload="$1"
-  printf '%s\n' "$payload" | while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// /}" ]] && continue
-    # Extract ceo:NAME tag
-    local name="${line##*# ceo:}"
-    if [ "$name" = "$line" ]; then
-      # No ceo: tag — skip
-      continue
-    fi
-    name="${name%%[[:space:]]*}"
-    local schedule_and_cmd="${line%%#*}"
-    schedule_and_cmd="${schedule_and_cmd%"${schedule_and_cmd##*[![:space:]]}"}"  # rtrim
-    local dom mon
-    read -r m h dom mon dow cmd_rest <<< "$schedule_and_cmd"
-    if [ -z "$cmd_rest" ]; then
-      echo "WARN: skipping ceo:${name} (malformed schedule line; expected 'MIN HOUR DOM MON DOW CMD')" >&2
-      continue
-    fi
-    if [ "$dom" != "*" ]; then
-      echo "WARN: skipping ceo:${name} (DOM constraints not supported on launchd backend; got '${dom}')" >&2
-      continue
-    fi
-    if [ "$mon" != "*" ]; then
-      echo "WARN: skipping ceo:${name} (Month constraints not supported on launchd backend; got '${mon}')" >&2
-      continue
-    fi
-    local minutes hours weekdays
-    if ! minutes="$(_ceo_cron_field_expand "$m" 0 59 2>/dev/null)"; then
-      echo "WARN: skipping ceo:${name} (Minute field '${m}' rejected)" >&2
-      continue
-    fi
-    if ! hours="$(_ceo_cron_field_expand "$h" 0 23 2>/dev/null)"; then
-      echo "WARN: skipping ceo:${name} (Hour field '${h}' rejected)" >&2
-      continue
-    fi
-    if ! weekdays="$(_ceo_cron_field_expand "$dow" 0 6 2>/dev/null)"; then
-      echo "WARN: skipping ceo:${name} (DOW field '${dow}' rejected)" >&2
-      continue
-    fi
-    local idx=0
-    local mi hi wi
-    # Disable filename globbing so a bare `*` from _ceo_cron_field_expand
-    # doesn't expand against the cwd. The sentinel is rendered back to `*`
-    # downstream (means "no constraint" — Weekday key omitted in the plist).
-    set -f
-    for mi in $minutes; do
-      for hi in $hours; do
-        for wi in $weekdays; do
-          local label="com.ceo.${name}-${idx}"
-          printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$label" "$mi" "$hi" "$wi" "$cmd_rest" "$name"
-          idx=$((idx + 1))
-        done
-      done
-    done
-    set +f
-  done
-}
-
-# Reconstruct an approximate crontab-style line from a plist file for use in
-# ceo_scheduler_list. Uses `plutil -extract <key> raw -o - <file>` to read
-# fields, so reformatting/whitespace-shifting the plist (Apple's xml1 ↔ binary1
-# canonical reformat) can't silently produce empty fields that get defaulted
-# to midnight. Required fields (Label, Minute, Hour, command) failing extract
-# → skip the line entirely rather than fabricating a wrong trigger time.
-# Optional Weekday → "*" when absent.
-_ceo_launchd_plist_to_cron_line() {
-  local plist="$1"
-  [ -f "$plist" ] || return 0
-  local plutil_bin="${CEO_PLUTIL_BIN:-plutil}"
-  local label minute hour weekday cmd
-  if ! label=$("$plutil_bin" -extract Label raw -o - "$plist" 2>/dev/null); then
-    echo "WARN: skipping $plist (Label extract failed)" >&2
-    return 0
-  fi
-  if ! minute=$("$plutil_bin" -extract StartCalendarInterval.Minute raw -o - "$plist" 2>/dev/null); then
-    echo "WARN: skipping $plist (Minute extract failed)" >&2
-    return 0
-  fi
-  if ! hour=$("$plutil_bin" -extract StartCalendarInterval.Hour raw -o - "$plist" 2>/dev/null); then
-    echo "WARN: skipping $plist (Hour extract failed)" >&2
-    return 0
-  fi
-  weekday=$("$plutil_bin" -extract StartCalendarInterval.Weekday raw -o - "$plist" 2>/dev/null) || weekday="*"
-  if ! cmd=$("$plutil_bin" -extract ProgramArguments.2 raw -o - "$plist" 2>/dev/null); then
-    echo "WARN: skipping $plist (ProgramArguments.2 extract failed)" >&2
-    return 0
-  fi
-  local name="${label#com.ceo.}"
-  name="${name%-*}"
-  # DOM/Month positions are hardcoded `*` because the install side
-  # (_ceo_launchd_tuples_from_payload) rejects non-`*` DOM/Month with a
-  # WARN diagnostic — no plist on disk can have encoded them. See #109.
-  printf '%s %s * * %s %s  # ceo:%s\n' "$minute" "$hour" "$weekday" "$cmd" "$name"
 }
 
 ceo_scheduler_list() {
@@ -325,14 +93,10 @@ ceo_scheduler_list() {
     crontab)
       "${CEO_CRONTAB_BIN:-crontab}" -l 2>/dev/null
       ;;
-    launchd)
-      local dir="${CEO_LAUNCHD_DIR:-$HOME/Library/LaunchAgents}"
-      [ -d "$dir" ] || return 0
-      local plist
-      for plist in "$dir"/com.ceo.*.plist; do
-        [ -f "$plist" ] || continue
-        _ceo_launchd_plist_to_cron_line "$plist"
-      done
+    daemon)
+      # The daemon holds no per-playbook OS entries — scheduling lives in
+      # registry.json, which it reads directly. Nothing to list.
+      return 0
       ;;
     *)
       echo "ERROR: unknown scheduler backend '$_backend'" >&2
@@ -358,86 +122,13 @@ ceo_scheduler_install() {
       fi
       return 0
       ;;
-    launchd)
-      local dir="${CEO_LAUNCHD_DIR:-$HOME/Library/LaunchAgents}"
-      local launchctl_bin="${CEO_LAUNCHCTL_BIN:-launchctl}"
-      mkdir -p "$dir"
-
-      # Resolve the GUI domain uid. Don't fall back to 0 on failure — that
-      # silently targets root's launchd domain (per shell-required-env-vars).
-      local uid
-      uid="$(id -u 2>/dev/null)"
-      : "${uid:?id -u failed; cannot resolve launchd GUI domain}"
-
-      # Phase 1: render every plist as $target.tmp. No launchctl calls yet.
-      # If any tuple fails to render, abort before mutating the live set.
-      local kept_labels=" "
-      local rendered=""
-      local label minute hour weekday cmd name
-      while IFS=$'\t' read -r label minute hour weekday cmd name; do
-        [ -n "$label" ] || continue
-        local target="$dir/$label.plist"
-        if ! _ceo_launchd_plist_body "$label" "$minute" "$hour" "$weekday" "$cmd" > "$target.tmp"; then
-          echo "ERROR: failed to render plist for $label" >&2
-          rm -f "$target.tmp"
-          for _r in $rendered; do rm -f "$dir/$_r.plist.tmp"; done
-          return 1
-        fi
-        rendered="$rendered $label"
-        kept_labels="$kept_labels$label "
-      done < <(_ceo_launchd_tuples_from_payload "$payload")
-
-      # Refuse to proceed if the payload named registry entries (lines tagged
-      # `# ceo:`) but every one was rejected by the parser. Otherwise the
-      # stale-plist cleanup below treats an empty desired-state as "wipe
-      # everything", silently unloading live jobs whenever a registry update
-      # ships a typo. WARN to stderr alone is not enough — cron callers
-      # routinely redirect 2>/dev/null.
-      if [ -z "$rendered" ] && printf '%s\n' "$payload" | grep -q '# ceo:'; then
-        echo "ERROR: ceo_scheduler_install: every registry entry was rejected by the launchd parser; refusing to tear down existing jobs" >&2
-        return 1
-      fi
-
-      # Phase 2: commit each rendered .tmp to its final path, then bootout +
-      # bootstrap. On bootstrap failure, roll back: bootout everything we
-      # installed in this run, restore-via-delete the newly-committed plists,
-      # leaving the prior live set untouched.
-      local installed=""
-      local _r _r_target
-      for _r in $rendered; do
-        _r_target="$dir/$_r.plist"
-        mv "$_r_target.tmp" "$_r_target"
-        # bootout-before-bootstrap is the supported reload pattern on modern
-        # macOS (12+). bootout on a not-yet-loaded label errors — suppress.
-        "$launchctl_bin" bootout "gui/$uid" "$_r_target" 2>/dev/null || true
-        if ! "$launchctl_bin" bootstrap "gui/$uid" "$_r_target" 2>/dev/null; then
-          echo "ERROR: launchctl bootstrap failed for $_r; rolling back this install" >&2
-          local _rb
-          for _rb in $installed; do
-            "$launchctl_bin" bootout "gui/$uid" "$dir/$_rb.plist" 2>/dev/null || true
-            rm -f "$dir/$_rb.plist"
-          done
-          rm -f "$_r_target"
-          for _rb in $rendered; do rm -f "$dir/$_rb.plist.tmp"; done
-          return 1
-        fi
-        installed="$installed $_r"
-      done
-
-      # Stale-plist cleanup: anything matching com.ceo.*.plist that wasn't
-      # written above is no longer in the registry — bootout + delete.
-      local existing_plist existing_label
-      for existing_plist in "$dir"/com.ceo.*.plist; do
-        [ -f "$existing_plist" ] || continue
-        existing_label="$(basename "$existing_plist" .plist)"
-        case "$kept_labels" in
-          *" $existing_label "*) ;;
-          *)
-            "$launchctl_bin" bootout "gui/$uid" "$existing_plist" 2>/dev/null || true
-            rm -f "$existing_plist"
-            ;;
-        esac
-      done
+    daemon)
+      # No per-playbook OS install on macOS: ceo-schedulerd reads the registry
+      # directly. The single keep-alive agent is installed by hand (it runs the
+      # user's vault, so it can't be a scan side effect). Surface that loudly so
+      # a macOS scan doesn't look like it silently scheduled nothing.
+      echo "macOS: scheduling is handled by the ceo-schedulerd daemon — no per-playbook OS entries are installed."
+      echo "       Ensure the keep-alive agent is running: see lib/scheduler/deploy/com.ceo.schedulerd.plist (and 'ceo doctor')."
       return 0
       ;;
     *)
@@ -447,47 +138,19 @@ ceo_scheduler_install() {
   esac
 }
 
-ceo_scheduler_loaded_count() {
-  local _backend _rc=0
-  _backend="$(ceo_scheduler_backend)" || _rc=$?
-  [ "$_rc" -eq 0 ] || return "$_rc"
-  case "$_backend" in
-    crontab)
-      # cron entries don't "load" — they run on schedule. Doctor's plist-
-      # vs-loaded drift check doesn't apply.
-      echo "n/a"
-      return 0
-      ;;
-    launchd)
-      local uid
-      uid="$(id -u 2>/dev/null)"
-      : "${uid:?id -u failed; cannot resolve launchd GUI domain}"
-      local launchctl_bin="${CEO_LAUNCHCTL_BIN:-launchctl}"
-      # Capture launchctl stdout separately so we can distinguish "ran ok,
-      # 0 com.ceo jobs loaded" from "couldn't query launchd at all". Real
-      # `launchctl print gui/$uid` references each label across multiple
-      # sections (services / endpoints / executable path), so count UNIQUE
-      # labels — not lines — to avoid double-counting.
-      local out rc
-      out="$("$launchctl_bin" print "gui/$uid" 2>/dev/null)"
-      rc=$?
-      if [ "$rc" -ne 0 ]; then
-        echo "unknown"
-        return 0
-      fi
-      # Labels are `com.ceo.<name>-<idx>`; the suffix has no internal dots.
-      # Excluding `.` from the character class avoids matching the trailing
-      # `.plist` of `executable = .../com.ceo.foo-0.plist` as part of the label.
-      printf '%s\n' "$out" \
-        | grep -oE 'com\.ceo\.[A-Za-z0-9_-]+' \
-        | sort -u \
-        | wc -l \
-        | tr -d ' '
-      return 0
-      ;;
-    *)
-      echo "ERROR: unknown scheduler backend '$_backend'" >&2
-      return 1
-      ;;
-  esac
+# List retired per-playbook launchd plists (the #98 backend wrote
+# com.ceo.<name>-<idx>.plist). These are NOT the daemon's keep-alive agent
+# (com.ceo.schedulerd) and, if still loaded, would dispatch playbooks in
+# parallel with the daemon — a double-fire. `ceo doctor` warns when any exist so
+# the operator can bootout + rm them. Prints one absolute path per line.
+ceo_scheduler_legacy_launchd_plists() {
+  local dir="${CEO_LAUNCHD_DIR:-$HOME/Library/LaunchAgents}"
+  [ -d "$dir" ] || return 0
+  local plist base
+  for plist in "$dir"/com.ceo.*.plist; do
+    [ -f "$plist" ] || continue
+    base="$(basename "$plist" .plist)"
+    [ "$base" = "com.ceo.schedulerd" ] && continue
+    printf '%s\n' "$plist"
+  done
 }

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-# Tests for the scheduler abstraction (#97) + launchd backend (#98).
+# Tests for the scheduler abstraction (#97).
 #
+# As of #144 the macOS per-playbook launchd backend is retired: macOS uses the
+# `daemon` backend (ceo-schedulerd owns scheduling; no per-playbook OS entries).
 # Covers:
 #   - Backend selection priority (CEO_SCHEDULER > CEO_CRONTAB_BIN > ceo_detect_os)
 #   - Unknown CEO_SCHEDULER fails loud (enum-config-typo-fallback)
-#   - macOS sniffer narrowed to $HOME/.bun/bin (AC #3 of #97)
+#   - macOS sniffer narrowed to $HOME/.bun/bin (else daemon)
 #   - macOS empty HOME aborts (shell-required-env-vars)
 #   - crontab backend: list/install via CEO_CRONTAB_BIN; rc=1 on failure
-#   - launchd backend: cron-field expansion, plist generation, install writes
-#     plists + bootstraps, re-install removes stale plists (AC of #98),
-#     list reconstructs cron-style lines, integration via `ceo playbook scan`.
+#   - daemon backend: install is a no-op-with-guidance; list is empty
+#   - legacy per-playbook launchd plist detection (#98 retirement / migration)
 
 set -uo pipefail
 
@@ -26,49 +27,9 @@ setup() {
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
   export CEO_LAUNCHD_DIR="$TEST_HOME/LaunchAgents"
-  export CEO_LAUNCHCTL_BIN="$TEST_HOME/stub-launchctl"
-  export CEO_PLUTIL_BIN="$TEST_HOME/stub-plutil"
   mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_LAUNCHD_DIR"
-
-  # plutil stub. Real plutil is macOS-only; CI runs on Linux. Stub uses
-  # python3's stdlib plistlib (present on both ubuntu-latest and macOS) so
-  # the test exercises the same key-extraction contract real plutil offers.
-  cat > "$CEO_PLUTIL_BIN" <<'STUB'
-#!/bin/bash
-# Honors `plutil -extract <key> raw -o - <file>` invocation shape only.
-key="$2"
-file="${!#}"
-[ -f "$file" ] || { echo "stub-plutil: file not found: $file" >&2; exit 1; }
-python3 - "$key" "$file" <<'PY'
-import plistlib, sys
-key, path = sys.argv[1], sys.argv[2]
-with open(path, "rb") as f:
-    d = plistlib.load(f)
-v = d
-for p in key.split("."):
-    if p.isdigit():
-        try:
-            v = v[int(p)]
-        except (IndexError, TypeError):
-            sys.exit(1)
-    else:
-        if not isinstance(v, dict) or p not in v:
-            sys.exit(1)
-        v = v[p]
-print(v)
-PY
-STUB
-  chmod +x "$CEO_PLUTIL_BIN"
   : > "$CEO_DIR/AGENTS.md"
   : > "$CEO_DIR/inbox.md"
-
-  # Recording launchctl stub — logs every invocation to $TEST_HOME/launchctl.log.
-  cat > "$CEO_LAUNCHCTL_BIN" <<STUB
-#!/bin/bash
-echo "\$@" >> "$TEST_HOME/launchctl.log"
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
 
   unset CEO_SCHEDULER CEO_CRONTAB_BIN
   # shellcheck source=ceo-config.sh
@@ -80,15 +41,15 @@ STUB
 teardown() {
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR CEO_LAUNCHD_DIR CEO_LAUNCHCTL_BIN CEO_PLUTIL_BIN
+  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR CEO_LAUNCHD_DIR
   rm -rf "$TEST_HOME"
 }
 
 # === Backend selection ===
 
 test_ceo_scheduler_env_overrides_os_detection() {
-  export CEO_SCHEDULER=launchd
-  assert_eq "$(ceo_scheduler_backend)" "launchd" "explicit CEO_SCHEDULER must win"
+  export CEO_SCHEDULER=daemon
+  assert_eq "$(ceo_scheduler_backend)" "daemon" "explicit CEO_SCHEDULER must win"
   export CEO_SCHEDULER=crontab
   assert_eq "$(ceo_scheduler_backend)" "crontab" "explicit CEO_SCHEDULER must win"
 }
@@ -99,11 +60,11 @@ test_ceo_crontab_bin_implies_crontab_backend() {
 }
 
 test_unknown_ceo_scheduler_fails_loud() {
-  export CEO_SCHEDULER=launhd
+  export CEO_SCHEDULER=launchd  # the retired backend value is now unknown
   local out rc=0
   out=$(ceo_scheduler_backend 2>&1) || rc=$?
   assert_eq "$rc" "1" "unknown CEO_SCHEDULER must return rc=1"
-  assert_contains "$out" "unknown CEO_SCHEDULER='launhd'" "must surface typo to user"
+  assert_contains "$out" "unknown CEO_SCHEDULER='launchd'" "must surface the retired/typo value"
   rc=0; out=$(ceo_scheduler_list 2>&1) || rc=$?
   assert_eq "$rc" "1" "ceo_scheduler_list must propagate unknown-backend rc=1"
   rc=0; out=$(ceo_scheduler_install "x" 2>&1) || rc=$?
@@ -126,8 +87,8 @@ STUB
   cp "$TEST_HOME/.bun/bin/crontab" "$TEST_HOME/bin/crontab"
   rm -f "$TEST_HOME/.bun/bin/crontab"
   assert_eq \
-    "$(PATH="$TEST_HOME/bin:$PATH" ceo_scheduler_backend)" "launchd" \
-    "macOS + crontab outside \$HOME/.bun/bin must pick launchd (narrow sniffer)"
+    "$(PATH="$TEST_HOME/bin:$PATH" ceo_scheduler_backend)" "daemon" \
+    "macOS + crontab outside \$HOME/.bun/bin must pick daemon (narrow sniffer)"
 }
 
 test_macos_empty_home_fails_loud() {
@@ -168,647 +129,73 @@ STUB
   assert_contains "$out" "crontab install failed" "error message must surface"
 }
 
-# === launchd: cron-field expansion ===
+# === daemon backend (#144) ===
 
-test_cron_field_expand_handles_all_shapes() {
-  assert_eq "$(_ceo_cron_field_expand '*' 0 59)" "*" "* must remain literal *"
-  assert_eq "$(_ceo_cron_field_expand '7' 0 59)" "7" "integer must pass through"
-  assert_eq "$(_ceo_cron_field_expand '1-5' 0 23)" "1 2 3 4 5" "range expands"
-  assert_eq "$(_ceo_cron_field_expand '1,3' 0 6)" "1 3" "list expands"
-  assert_eq "$(_ceo_cron_field_expand '*/6' 0 23)" "0 6 12 18" "step expands within range"
-  assert_eq "$(_ceo_cron_field_expand 'SUN' 0 6)" "0" "named SUN expands to 0"
-  assert_eq "$(_ceo_cron_field_expand 'MON' 0 6)" "1" "named MON expands to 1"
-}
-
-test_tuples_from_payload_parses_real_registry_lines() {
-  local payload
-  payload=$(cat <<'BLOCK'
-# CEO Agent START
-0 9 * * * /path/to/ceo-cron.sh morning  # ceo:morning
-47 17 * * 1-5 /path/to/ceo-cron.sh eod  # ceo:eod
-0 8 * * SUN /path/to/ceo-cron.sh weekly  # ceo:weekly
-# CEO Agent END
-BLOCK
-)
-  local out
-  out=$(_ceo_launchd_tuples_from_payload "$payload")
-  # morning: 1 tuple (every day at 9:00, weekday=*)
-  assert_contains "$out" "com.ceo.morning-0	0	9	*	"
-  # eod: 5 tuples (Mon-Fri at 17:47)
-  assert_contains "$out" "com.ceo.eod-0	47	17	1	"
-  assert_contains "$out" "com.ceo.eod-4	47	17	5	"
-  # weekly: 1 tuple (SUN at 08:00)
-  assert_contains "$out" "com.ceo.weekly-0	0	8	0	"
-  # Count: 1 + 5 + 1 = 7 lines
-  local lines
-  lines=$(printf '%s\n' "$out" | grep -c "^com.ceo." || true)
-  assert_eq "$lines" "7" "must emit 7 tuples for 3 triggers (1 + 5 + 1)"
-}
-
-# === launchd: DOM/Month constraints are rejected (issue #109) ===
-
-# Run a single bad DOM/Month case: stdout must be empty for the tagged name,
-# stderr must contain a WARN that names the offending field + value.
-_ceo_test_assert_rejects_dom_mon() {
-  local cron_line="$1" expect_field="$2" expect_value="$3" tag="$4"
-  local payload="${cron_line}  # ceo:${tag}"
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_not_contains "$out" "com.ceo.${tag}-" "must emit no tuples for ${tag} (${cron_line})"
-  assert_contains "$err" "WARN" "stderr must carry WARN for ${tag}"
-  assert_contains "$err" "${expect_field}" "WARN must name field ${expect_field} for ${tag}"
-  assert_contains "$err" "${expect_value}" "WARN must include offending value ${expect_value} for ${tag}"
-}
-
-test_tuples_rejects_dom_literal_value() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * 5 * * /tmp/ceo-cron.sh foo" "DOM" "5" "dom-literal"
-}
-
-test_tuples_rejects_dom_range() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * 1-7 * * /tmp/ceo-cron.sh foo" "DOM" "1-7" "dom-range"
-}
-
-test_tuples_rejects_dom_list() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * 1,15 * * /tmp/ceo-cron.sh foo" "DOM" "1,15" "dom-list"
-}
-
-test_tuples_rejects_dom_step() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * */2 * * /tmp/ceo-cron.sh foo" "DOM" "*/2" "dom-step"
-}
-
-test_tuples_rejects_dom_high_value() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * 31 * * /tmp/ceo-cron.sh foo" "DOM" "31" "dom-31"
-}
-
-test_tuples_rejects_month_literal() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * * 6 * /tmp/ceo-cron.sh foo" "Month" "6" "mon-literal"
-}
-
-test_tuples_rejects_month_range() {
-  _ceo_test_assert_rejects_dom_mon \
-    "* * * 1-3 * /tmp/ceo-cron.sh foo" "Month" "1-3" "mon-range"
-}
-
-# Mixed payload: bad DOM line is rejected while a sibling valid line still emits.
-test_tuples_rejects_bad_line_keeps_good_line() {
-  local payload
-  payload=$(cat <<'BLOCK'
-0 9 * * * /tmp/ceo-cron.sh good  # ceo:good
-15 10 5 * * /tmp/ceo-cron.sh bad  # ceo:bad
-BLOCK
-)
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_contains "$out" "com.ceo.good-0" "valid sibling must still emit a tuple"
-  assert_not_contains "$out" "com.ceo.bad-" "rejected line must not emit a tuple"
-  assert_contains "$err" "DOM" "WARN must fire for bad line"
-}
-
-# Negative control: literal `*` for both fields must NOT trigger the WARN.
-test_tuples_accepts_star_dom_and_month() {
-  local payload="0 9 * * * /tmp/ceo-cron.sh ok  # ceo:ok"
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_contains "$out" "com.ceo.ok-0" "happy-path must emit"
-  assert_not_contains "$err" "WARN" "happy-path must not WARN about DOM/Month"
-}
-
-# === launchd: symmetric WARN for non-DOM/Month skip branches (#117) ===
-
-# Helper for the four sibling skip branches in _ceo_launchd_tuples_from_payload
-# that historically `continue`d silently while DOM/Month emitted WARN. Each
-# branch must emit `WARN:` + the field name + the offending value to stderr,
-# and must NOT emit a tuple for that name.
-_ceo_test_assert_silent_skip_warns() {
-  local cron_line="$1" expect_field="$2" tag="$3"
-  local payload="${cron_line}  # ceo:${tag}"
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_not_contains "$out" "com.ceo.${tag}-" "must emit no tuples for ${tag}"
-  assert_contains "$err" "WARN" "stderr must carry WARN for ${tag}"
-  assert_contains "$err" "${expect_field}" "WARN must name field ${expect_field} for ${tag}"
-  assert_contains "$err" "ceo:${tag}" "WARN must name the offending ceo:NAME tag"
-}
-
-test_tuples_warns_on_invalid_minute() {
-  _ceo_test_assert_silent_skip_warns \
-    "99 * * * * /tmp/ceo-cron.sh foo" "Minute" "bad-min"
-}
-
-test_tuples_warns_on_invalid_hour() {
-  _ceo_test_assert_silent_skip_warns \
-    "0 25 * * * /tmp/ceo-cron.sh foo" "Hour" "bad-hour"
-}
-
-test_tuples_warns_on_invalid_dow() {
-  _ceo_test_assert_silent_skip_warns \
-    "0 9 * * 9 /tmp/ceo-cron.sh foo" "DOW" "bad-dow"
-}
-
-test_tuples_warns_on_malformed_line_missing_command() {
-  # Line tagged ceo:foo but missing command field after the 5 cron fields.
-  # The schedule_and_cmd parse yields cmd_rest="" — historically a silent
-  # continue.
-  local payload="0 9 * * *  # ceo:bad-malformed"
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_not_contains "$out" "com.ceo.bad-malformed-" "malformed line must not emit"
-  assert_contains "$err" "WARN" "malformed line must WARN"
-  assert_contains "$err" "ceo:bad-malformed" "WARN must name the offending tag"
-  assert_contains "$err" "malformed" "WARN must classify the reason as malformed"
-}
-
-# === launchd: install writes plists + bootstraps + cleans stale ===
-
-test_launchd_install_writes_one_plist_per_tuple() {
-  export CEO_SCHEDULER=launchd
-  local payload
-  payload=$(cat <<'BLOCK'
-# CEO Agent START
-0 9 * * * /path/to/ceo-cron.sh morning  # ceo:morning
-0 8 * * 1,3 /path/to/ceo-cron.sh twice  # ceo:twice
-# CEO Agent END
-BLOCK
-)
-  ceo_scheduler_install "$payload" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist" "morning plist must be written"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.twice-0.plist" "twice (Mon) plist must be written"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.twice-1.plist" "twice (Wed) plist must be written"
-  # Plist contents — Minute, Hour, command
-  local morning
-  morning=$(cat "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist")
-  assert_contains "$morning" "<integer>9</integer>" "morning plist must encode Hour=9"
-  assert_contains "$morning" "/path/to/ceo-cron.sh morning" "plist must carry command"
-}
-
-test_launchd_install_bootstraps_each_plist_via_launchctl() {
-  export CEO_SCHEDULER=launchd
+test_daemon_backend_install_is_noop_with_guidance() {
+  export CEO_SCHEDULER=daemon
   local payload="0 9 * * * /tmp/ceo-cron.sh foo  # ceo:foo"
-  ceo_scheduler_install "$payload" >/dev/null 2>&1
-  local log
-  log=$(cat "$TEST_HOME/launchctl.log" 2>/dev/null || echo "")
-  assert_contains "$log" "bootstrap gui/" "launchctl must be invoked with bootstrap"
-  assert_contains "$log" "com.ceo.foo-0.plist" "bootstrap must reference the written plist"
+  local out rc=0
+  out=$(ceo_scheduler_install "$payload" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "daemon install must succeed (no-op)"
+  assert_contains "$out" "ceo-schedulerd" "must point the operator at the daemon"
+  assert_contains "$out" "com.ceo.schedulerd.plist" "must name the keep-alive template"
+  # No per-playbook OS entries are written.
+  assert_no_match "$(ls "$CEO_LAUNCHD_DIR" 2>/dev/null || echo)" "com.ceo.foo" \
+    "daemon backend must NOT write per-playbook plists"
 }
 
-test_launchd_install_removes_stale_plists_on_rescan() {
-  export CEO_SCHEDULER=launchd
-  # First install: two playbooks.
-  local payload_v1
-  payload_v1=$(cat <<'BLOCK'
-0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper
-0 10 * * * /tmp/ceo-cron.sh stale  # ceo:stale
-BLOCK
-)
-  ceo_scheduler_install "$payload_v1" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "v1: keeper plist written"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.stale-0.plist" "v1: stale plist written"
-
-  # Second install: stale playbook removed from registry.
-  local payload_v2="0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper"
-  # Truncate the launchctl log before v2 so the bootout assertion below only
-  # observes v2 activity — otherwise the per-install bootout from v1 would
-  # satisfy a bare "bootout" assertion regardless of stale cleanup.
-  : > "$TEST_HOME/launchctl.log"
-  ceo_scheduler_install "$payload_v2" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "v2: keeper plist preserved"
-  assert_no_match "$(ls "$CEO_LAUNCHD_DIR")" "com.ceo.stale-0.plist" \
-    "v2: stale plist must be cleaned up on rescan"
-  # bootout must fire specifically against the stale plist's path.
-  local log
-  log=$(cat "$TEST_HOME/launchctl.log" 2>/dev/null || echo "")
-  assert_contains "$log" "bootout gui/" "launchctl bootout must fire during v2"
-  assert_contains "$log" "com.ceo.stale-0.plist" \
-    "bootout must reference the stale plist by name"
+test_daemon_backend_list_is_empty() {
+  export CEO_SCHEDULER=daemon
+  local out rc=0
+  out=$(ceo_scheduler_list 2>&1) || rc=$?
+  assert_eq "$rc" "0" "daemon list must succeed"
+  assert_eq "$out" "" "daemon backend holds no per-playbook OS entries — list is empty"
 }
 
-test_launchd_install_refuses_to_wipe_live_jobs_when_every_payload_line_rejected() {
-  export CEO_SCHEDULER=launchd
-  # Prior live install: a real job we'd be heartbroken to lose.
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" "seed: keeper plist present"
+# === legacy per-playbook launchd plist detection (#98 retirement) ===
 
-  # Rescan with a payload whose every entry has a DOM/Month constraint
-  # (rejected by the launchd backend). _ceo_launchd_tuples_from_payload
-  # emits zero tuples. Without the install-level gate, the cleanup pass
-  # would walk com.ceo.*.plist with kept_labels empty and wipe keeper.
-  local bad_payload
-  bad_payload=$(cat <<'BLOCK'
-15 10 5 * * /tmp/ceo-cron.sh foo  # ceo:foo
-0 9 * 6 * /tmp/ceo-cron.sh bar  # ceo:bar
-BLOCK
-)
-  local rc=0
-  ceo_scheduler_install "$bad_payload" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "1" "install must return non-zero when every registry entry is rejected"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.keeper-0.plist" \
-    "keeper plist must survive an all-rejected rescan (no silent wipe)"
-}
-
-# Counter-control: a payload mixing one rejected line with one valid line
-# still installs the valid line and leaves prior live plists alone.
-test_launchd_install_partial_reject_installs_valid_and_keeps_other_priors() {
-  export CEO_SCHEDULER=launchd
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh older  # ceo:older" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.older-0.plist" "seed: older plist present"
-
-  local mixed
-  mixed=$(cat <<'BLOCK'
-0 11 * * * /tmp/ceo-cron.sh newer  # ceo:newer
-15 10 5 * * /tmp/ceo-cron.sh bad  # ceo:bad
-BLOCK
-)
-  local rc=0
-  ceo_scheduler_install "$mixed" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "0" "partial-reject install must still succeed for valid entries"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.newer-0.plist" "valid line must install"
-  assert_no_match "$(ls "$CEO_LAUNCHD_DIR")" "com.ceo.bad-0.plist" \
-    "rejected line must not produce a plist"
-  # older was not in the new payload — stale cleanup should remove it.
-  # (Symmetric with test_launchd_install_removes_stale_plists_on_rescan.)
-}
-
-# Symmetric Month counter-control to test_tuples_rejects_bad_line_keeps_good_line.
-test_tuples_rejects_bad_month_keeps_good_line() {
-  local payload
-  payload=$(cat <<'BLOCK'
-0 9 * * * /tmp/ceo-cron.sh good  # ceo:good
-15 10 * 6 * /tmp/ceo-cron.sh bad  # ceo:bad
-BLOCK
-)
-  local stderr_file out
-  stderr_file=$(mktemp)
-  out=$(_ceo_launchd_tuples_from_payload "$payload" 2>"$stderr_file")
-  local err
-  err=$(cat "$stderr_file")
-  rm -f "$stderr_file"
-  assert_contains "$out" "com.ceo.good-0" "valid sibling must still emit a tuple"
-  assert_not_contains "$out" "com.ceo.bad-" "rejected month line must not emit a tuple"
-  assert_contains "$err" "Month" "WARN must name Month for bad line"
-}
-
-# #111: pin the destructive empty-payload semantics. The install function
-# treats an empty/marker-only payload as "desired state is nothing" — every
-# existing com.ceo.*.plist is stale and gets booted out. The #116 install-
-# level gate only fires when the payload had `# ceo:` tags that were all
-# rejected; a payload with NO tags at all is a legitimate "uninstall all"
-# request.
-test_launchd_install_empty_payload_clears_all_plists() {
-  export CEO_SCHEDULER=launchd
-  local seed
-  seed=$(cat <<'BLOCK'
-0 9 * * * /tmp/ceo-cron.sh a  # ceo:a
-0 10 * * * /tmp/ceo-cron.sh b  # ceo:b
-BLOCK
-)
-  ceo_scheduler_install "$seed" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.a-0.plist" "seed: a present"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.b-0.plist" "seed: b present"
-
-  local rc=0
-  ceo_scheduler_install "" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "0" "empty payload is a legitimate uninstall-all, must succeed"
-  assert_no_match "$(ls "$CEO_LAUNCHD_DIR" 2>/dev/null || echo)" "com.ceo.a-0.plist" \
-    "empty payload must clear a"
-  assert_no_match "$(ls "$CEO_LAUNCHD_DIR" 2>/dev/null || echo)" "com.ceo.b-0.plist" \
-    "empty payload must clear b"
-}
-
-# #111 sibling: marker-only payload (CEO Agent START/END comments, no
-# entries) is equivalent to empty.
-test_launchd_install_marker_only_payload_clears_all_plists() {
-  export CEO_SCHEDULER=launchd
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh a  # ceo:a" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.a-0.plist" "seed: a present"
-
-  local marker_only
-  marker_only=$(cat <<'BLOCK'
-# CEO Agent START
-# CEO Agent END
-BLOCK
-)
-  local rc=0
-  ceo_scheduler_install "$marker_only" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "0" "marker-only payload must succeed (no entries to reject)"
-  assert_no_match "$(ls "$CEO_LAUNCHD_DIR" 2>/dev/null || echo)" "com.ceo.a-0.plist" \
-    "marker-only payload must clear a"
-}
-
-# #112: every plist generated by ceo_scheduler_install must be well-formed
-# XML. xmllint is available on both Linux (CI) and macOS; plutil -lint is
-# the macOS-native counterpart. Grep-based assertions on tag content can
-# pass on malformed plists with mis-nested dicts or unclosed tags.
-test_launchd_install_generates_well_formed_plists() {
-  if ! command -v xmllint >/dev/null 2>&1; then
-    # CI guarantees xmllint via libxml2-utils; locally on a stripped
-    # system, skip with an assertion counter bump so the no-assertions
-    # guard doesn't abort the test.
-    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-    echo "  SKIP [test_launchd_install_generates_well_formed_plists]: xmllint not available"
-    return 0
-  fi
-  export CEO_SCHEDULER=launchd
-  local payload
-  payload=$(cat <<'BLOCK'
-0 9 * * * /path/to/ceo-cron.sh a  # ceo:a
-0 10 * * 1,3,5 /path/to/ceo-cron.sh b  # ceo:b
-30 17 * * 1-5 /path/to/ceo-cron.sh c  # ceo:c
-BLOCK
-)
-  ceo_scheduler_install "$payload" >/dev/null 2>&1
-  local plist
-  for plist in "$CEO_LAUNCHD_DIR"/com.ceo.*.plist; do
-    [ -f "$plist" ] || continue
-    local lint_out lint_rc=0
-    lint_out=$(xmllint --noout "$plist" 2>&1) || lint_rc=$?
-    assert_eq "$lint_rc" "0" "xmllint --noout must accept $(basename "$plist") ($lint_out)"
-  done
-}
-
-test_launchd_install_rolls_back_on_bootstrap_failure_mid_loop() {
-  export CEO_SCHEDULER=launchd
-  # Seed a prior live install so we can verify rollback doesn't disturb it.
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh prior  # ceo:prior" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.prior-0.plist" "prior install must seed"
-
-  # Stub that fails the second bootstrap call. Counter persisted via a file
-  # so it survives the stub's per-invocation subshell.
-  local counter="$TEST_HOME/bootstrap-counter"
-  echo 0 > "$counter"
-  cat > "$CEO_LAUNCHCTL_BIN" <<STUB
-#!/bin/bash
-echo "\$@" >> "$TEST_HOME/launchctl.log"
-if [ "\$1" = "bootstrap" ]; then
-  n=\$(cat "$counter")
-  n=\$((n + 1))
-  echo \$n > "$counter"
-  if [ "\$n" -eq 2 ]; then
-    echo "simulated bootstrap failure" >&2
-    exit 5
-  fi
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-
-  : > "$TEST_HOME/launchctl.log"
-  # 3 tuples; bootstrap #2 of this install will fail.
-  local payload
-  payload=$(cat <<'BLOCK'
-0 9 * * * /tmp/ceo-cron.sh new-a  # ceo:new-a
-0 10 * * * /tmp/ceo-cron.sh new-b  # ceo:new-b
-0 11 * * * /tmp/ceo-cron.sh new-c  # ceo:new-c
-BLOCK
-)
-  local rc=0
-  ceo_scheduler_install "$payload" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "1" "bootstrap failure mid-loop must propagate as rc=1"
-  # Rolled back: none of the new plists remain on disk.
-  for label in new-a new-b new-c; do
-    if [ -f "$CEO_LAUNCHD_DIR/com.ceo.$label-0.plist" ]; then
-      assert_eq "$label rolled back" "true" "v2: $label plist must be removed on rollback"
-    fi
-    if [ -f "$CEO_LAUNCHD_DIR/com.ceo.$label-0.plist.tmp" ]; then
-      assert_eq "$label tmp cleaned" "true" "v2: $label .tmp must be cleaned on rollback"
-    fi
-  done
-}
-
-test_launchd_install_does_not_touch_unrelated_plists() {
-  export CEO_SCHEDULER=launchd
-  # Pre-seed an unrelated plist (not com.ceo.*) — must survive install.
-  cat > "$CEO_LAUNCHD_DIR/com.example.other.plist" <<'XML'
-<?xml version="1.0"?>
-<plist><dict><key>Label</key><string>com.example.other</string></dict></plist>
-XML
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh keeper  # ceo:keeper" >/dev/null 2>&1
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.example.other.plist" "non-ceo plists must not be touched"
-}
-
-# === launchd: list reconstructs cron-style lines ===
-
-test_launchd_list_reconstructs_cron_lines_for_doctor() {
-  export CEO_SCHEDULER=launchd
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh morning  # ceo:morning" >/dev/null 2>&1
+test_legacy_launchd_plists_detected_excluding_daemon_agent() {
+  # A retired per-playbook agent plus the daemon's own keep-alive agent.
+  : > "$CEO_LAUNCHD_DIR/com.ceo.morning-0.plist"
+  : > "$CEO_LAUNCHD_DIR/com.ceo.eod-3.plist"
+  : > "$CEO_LAUNCHD_DIR/com.ceo.schedulerd.plist"
+  : > "$CEO_LAUNCHD_DIR/com.example.other.plist"
   local out
-  out=$(ceo_scheduler_list 2>&1)
-  # Full leading prefix incl. weekday `*` — pins both extraction AND the
-  # absent-Weekday fallback branch. Substring check too weak (hour 9 from
-  # fixture would let grep+sed reintroduce midnight defaults silently).
-  assert_contains "$out" "0 9 * * * /tmp/ceo-cron.sh morning  # ceo:morning" \
-    "full line must reconstruct from plutil extracts, not fabricated defaults"
+  out=$(ceo_scheduler_legacy_launchd_plists)
+  assert_contains "$out" "com.ceo.morning-0.plist" "must report a retired per-playbook agent"
+  assert_contains "$out" "com.ceo.eod-3.plist" "must report every retired per-playbook agent"
+  assert_no_match "$out" "com.ceo.schedulerd.plist" "must NOT report the daemon keep-alive agent"
+  assert_no_match "$out" "com.example.other.plist" "must NOT report unrelated agents"
 }
 
-test_launchd_list_warns_and_skips_when_plutil_missing() {
-  export CEO_SCHEDULER=launchd
-  ceo_scheduler_install "0 9 * * * /tmp/ceo-cron.sh morning  # ceo:morning" >/dev/null 2>&1
-  # Point CEO_PLUTIL_BIN at a binary that doesn't exist. The function must
-  # emit a WARN per plist to stderr and skip the line, not silently return
-  # empty (which would reproduce #108's failure mode one branch deeper).
-  export CEO_PLUTIL_BIN="$TEST_HOME/does-not-exist-plutil"
-  local out err
-  out=$(ceo_scheduler_list 2>/tmp/ceo-sched-stderr.$$)
-  err=$(cat /tmp/ceo-sched-stderr.$$); rm -f /tmp/ceo-sched-stderr.$$
-  assert_no_match "$out" "ceo-cron.sh" "stdout must be empty — no fabricated line on plutil failure"
-  assert_contains "$err" "WARN: skipping" "stderr must surface the skip with a WARN line"
-}
-
-_ceo_test_write_plist_missing_field() {
-  local label="$1" missing="$2"
-  local has_label=1 has_minute=1 has_hour=1 has_cmd=1
-  case "$missing" in
-    Label) has_label=0 ;;
-    Minute) has_minute=0 ;;
-    Hour) has_hour=0 ;;
-    ProgramArguments) has_cmd=0 ;;
-  esac
-  {
-    echo '<?xml version="1.0" encoding="UTF-8"?>'
-    echo '<plist version="1.0"><dict>'
-    [ "$has_label" -eq 1 ] && echo "  <key>Label</key><string>com.ceo.$label-0</string>"
-    if [ "$has_cmd" -eq 1 ]; then
-      echo '  <key>ProgramArguments</key><array>'
-      echo '    <string>/bin/bash</string><string>-lc</string>'
-      echo "    <string>/tmp/ceo-cron.sh $label</string>"
-      echo '  </array>'
-    fi
-    echo '  <key>StartCalendarInterval</key><dict>'
-    [ "$has_minute" -eq 1 ] && echo "    <key>Minute</key><integer>0</integer>"
-    [ "$has_hour" -eq 1 ] && echo "    <key>Hour</key><integer>9</integer>"
-    echo '  </dict></dict></plist>'
-  } > "$CEO_LAUNCHD_DIR/com.ceo.$label-0.plist"
-}
-
-test_launchd_list_skips_plist_missing_any_required_field() {
-  export CEO_SCHEDULER=launchd
-  mkdir -p "$CEO_LAUNCHD_DIR"
-  # Parameterised across the 4 required-field branches. Each writes a plist
-  # missing exactly one required key; the resulting line must NOT render and
-  # stderr must carry the field-named WARN.
-  local field expected_token
-  for field in Label Minute Hour ProgramArguments; do
-    rm -f "$CEO_LAUNCHD_DIR"/com.ceo.*.plist
-    _ceo_test_write_plist_missing_field "missing-$field" "$field"
-    local out err
-    out=$(ceo_scheduler_list 2>/tmp/ceo-sched-stderr.$$)
-    err=$(cat /tmp/ceo-sched-stderr.$$); rm -f /tmp/ceo-sched-stderr.$$
-    assert_no_match "$out" "missing-$field" "missing-$field plist must NOT render"
-    case "$field" in
-      ProgramArguments) expected_token="ProgramArguments.2 extract failed" ;;
-      *) expected_token="$field extract failed" ;;
-    esac
-    assert_contains "$err" "$expected_token" "stderr must surface the missing-$field skip"
-  done
-}
-
-test_launchd_list_reconstructs_weekday_constrained_line() {
-  export CEO_SCHEDULER=launchd
-  # eod 17:47 Mon-Fri → 5 plists with Weekday 1..5
-  ceo_scheduler_install "47 17 * * 1-5 /tmp/ceo-cron.sh eod  # ceo:eod" >/dev/null 2>&1
+test_legacy_launchd_plists_empty_when_only_daemon_agent_present() {
+  : > "$CEO_LAUNCHD_DIR/com.ceo.schedulerd.plist"
   local out
-  out=$(ceo_scheduler_list 2>&1)
-  assert_contains "$out" "47 17 * * 1" "weekday=1 reconstruction must carry hour+minute"
-  assert_contains "$out" "47 17 * * 5" "weekday=5 reconstruction must carry hour+minute"
-  assert_contains "$out" "# ceo:eod" "ceo:NAME tag survives weekday-constrained plists"
+  out=$(ceo_scheduler_legacy_launchd_plists)
+  assert_eq "$out" "" "a host with only the daemon agent has no legacy orphans"
 }
 
-test_launchd_list_skips_malformed_plist_without_fabricating_midnight() {
-  export CEO_SCHEDULER=launchd
-  # Write a plist that's missing the StartCalendarInterval block. plutil
-  # extract for Minute/Hour will fail; the function must not fabricate "0 0".
-  mkdir -p "$CEO_LAUNCHD_DIR"
-  cat > "$CEO_LAUNCHD_DIR/com.ceo.broken-0.plist" <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.ceo.broken-0</string>
-  <key>ProgramArguments</key><array>
-    <string>/bin/bash</string><string>-lc</string>
-    <string>/tmp/ceo-cron.sh broken</string>
-  </array>
-</dict></plist>
-XML
-  local out
-  out=$(ceo_scheduler_list 2>&1)
-  # No "0 0 * * *" line should appear — that's exactly the fabricated-midnight
-  # failure mode this fix exists to prevent.
-  assert_no_match "$out" "0 0 * * * /tmp/ceo-cron.sh broken" \
-    "malformed plist must NOT silently render as fabricated midnight cron line"
+test_legacy_launchd_plists_empty_when_dir_absent() {
+  rm -rf "$CEO_LAUNCHD_DIR"
+  local out rc=0
+  out=$(ceo_scheduler_legacy_launchd_plists) || rc=$?
+  assert_eq "$rc" "0" "missing LaunchAgents dir is not an error"
+  assert_eq "$out" "" "missing LaunchAgents dir yields no orphans"
 }
 
-# === launchd: loaded-job count via launchctl print (#107) ===
+# === Integration: ceo playbook scan end-to-end on the daemon backend ===
 
-test_loaded_count_parses_unique_labels_from_realistic_launchctl_print() {
-  export CEO_SCHEDULER=launchd
-  # Stub emits a realistic multi-section `launchctl print gui/$uid` output:
-  # the same label appears in `services`, `endpoints`, `enabled services`,
-  # AND as an `executable = .../com.ceo.foo.plist` path line. Counting lines
-  # naively → 9; counting unique labels → 3. Pins the unique-label fix.
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-if [ "$1" = "print" ]; then
-  cat <<OUT
-services = {
-    0  com.apple.dock.extra
-    -  com.example.unrelated
-    0  com.ceo.morning-0
-    -  com.ceo.eod-3
-    0  com.ceo.weekly-0
-    0  com.apple.other
-}
-endpoints = {
-    com.ceo.morning-0
-    com.ceo.eod-3
-    com.ceo.weekly-0
-}
-enabled services = {
-    com.ceo.morning-0 => enabled
-    com.ceo.eod-3 => enabled
-    com.ceo.weekly-0 => enabled
-}
-executable = /Users/me/Library/LaunchAgents/com.ceo.morning-0.plist
-executable = /Users/me/Library/LaunchAgents/com.ceo.eod-3.plist
-executable = /Users/me/Library/LaunchAgents/com.ceo.weekly-0.plist
-OUT
-  exit 0
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-  assert_eq "$(ceo_scheduler_loaded_count)" "3" "must count UNIQUE com.ceo.* labels across realistic multi-section launchctl output"
-}
-
-test_loaded_count_emits_unknown_when_launchctl_fails() {
-  export CEO_SCHEDULER=launchd
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-echo "launchctl: domain not found" >&2
-exit 3
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-  assert_eq "$(ceo_scheduler_loaded_count)" "unknown" "launchctl failure must surface 'unknown', not silent 0"
-}
-
-test_loaded_count_is_zero_when_no_ceo_jobs_loaded() {
-  export CEO_SCHEDULER=launchd
-  cat > "$CEO_LAUNCHCTL_BIN" <<'STUB'
-#!/bin/bash
-if [ "$1" = "print" ]; then
-  echo "services = { 0 com.apple.dock.extra }"
-fi
-exit 0
-STUB
-  chmod +x "$CEO_LAUNCHCTL_BIN"
-  assert_eq "$(ceo_scheduler_loaded_count)" "0" "no com.ceo.* lines must yield 0"
-}
-
-test_loaded_count_returns_na_on_crontab_backend() {
-  export CEO_CRONTAB_BIN="$TEST_HOME/fake-crontab"
-  echo '#!/bin/bash' > "$CEO_CRONTAB_BIN"; chmod +x "$CEO_CRONTAB_BIN"
-  assert_eq "$(ceo_scheduler_loaded_count)" "n/a" "crontab backend must surface n/a (concept doesn't apply)"
-}
-
-# === Integration: ceo playbook scan end-to-end on launchd ===
-
-test_playbook_scan_writes_plists_via_launchd_backend() {
-  export CEO_SCHEDULER=launchd
+test_playbook_scan_installs_no_plists_via_daemon_backend() {
+  export CEO_SCHEDULER=daemon
   cat > "$CEO_DIR/registry.json" <<'EOF'
 {"schema_version": 3, "generated": "1970-01-01T00:00:00Z", "playbooks": []}
 EOF
-  # Point CEO_REPO_PLAYBOOK_DIR at an empty dir so scan reads ONLY the test
-  # fixture (otherwise it discovers the real plugin's docs/playbooks/ and the
-  # test becomes order-dependent on whatever's registered there).
   export CEO_REPO_PLAYBOOK_DIR="$TEST_HOME/empty-repo-playbooks"
   mkdir -p "$CEO_REPO_PLAYBOOK_DIR"
   cat > "$CEO_DIR/playbooks/scan-target.md" <<'EOF'
 ---
 name: scan-target
-description: Integration test playbook for launchd backend
+description: Integration test playbook for the daemon backend
 trigger: cron
 schedule: "0 9 * * *"
 status: active
@@ -816,10 +203,12 @@ runner: script
 script: noop.sh
 ---
 EOF
-  local rc=0
-  bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "0" "playbook scan must succeed on launchd backend"
-  assert_file_exists "$CEO_LAUNCHD_DIR/com.ceo.scan-target-0.plist" "scan must write the plist"
+  local out rc=0
+  out=$(bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
+  assert_eq "$rc" "0" "playbook scan must succeed on the daemon backend"
+  assert_no_match "$(ls "$CEO_LAUNCHD_DIR" 2>/dev/null || echo)" "com.ceo.scan-target" \
+    "daemon backend scan must NOT write per-playbook plists"
+  assert_contains "$out" "ceo-schedulerd" "scan must surface the daemon guidance"
 }
 
 run_tests


### PR DESCRIPTION
Closes #144

## Description (Issue Fixed & New Behavior)
Phase 2 of #136 — the final epic task. macOS now runs the `ceo-schedulerd` daemon under **one** launchd keep-alive agent instead of the per-playbook plist fan-out (#98). The daemon (shipped #142/#143) owns cron matching and reads `CEO/registry.json` directly, so the OS scheduler only has to keep one process alive.

- **New keep-alive template** `lib/scheduler/deploy/com.ceo.schedulerd.plist` — a single `com.ceo.schedulerd` LaunchAgent (`KeepAlive={SuccessfulExit=false}` so a clean `bootout` exit-0 doesn't tight-loop, `ThrottleInterval=10` for the ≥10s back-off the issue asks for, `RunAtLoad`, `CEO_VAULT` via `EnvironmentVariables`). A LaunchAgent (needs a logged-in GUI session) **not** a LaunchDaemon, because it must read the user's synced vault. `plutil -lint` clean. Mirrors the #142 systemd template.
- **Retires the #98 per-plist backend.** Deletes `_ceo_cron_field_expand`, `_ceo_xml_escape`, `_ceo_launchd_plist_body`, `_ceo_launchd_tuples_from_payload`, `_ceo_launchd_plist_to_cron_line`, `ceo_scheduler_loaded_count`, and the launchd branches. The macOS backend is now `daemon` (enum-validated, `crontab|daemon|*→rc=1`); its `install` is a no-op that prints guidance (the daemon reads the registry; the keep-alive agent is installed by hand), and `list` is empty.
- **Resolves #109** by deletion: the launchd field-expander silently dropped non-`*` DOM/Month; the daemon's croner handles them correctly.
- **Migration (audit HIGH).** Deleting the backend doesn't un-bootstrap agents a host already loaded — they'd double-fire with the daemon. Added `ceo_scheduler_legacy_launchd_plists` + a `ceo doctor` check that flags retired `com.ceo.<name>-N` agents (✗, non-zero) with a `bootout`+`rm` one-liner; README migration section. doctor gates the crontab "Cron entries installed" / duplicate checks to the `crontab` backend and reports daemon scheduling on macOS; liveness stays the #142 heartbeat check.

No Linux/crontab behavior changes — the crontab backend is untouched.

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-scheduler.test.sh` → **13 pass** (backend selection incl. `launchd`-is-now-unknown, crontab, daemon no-op install, empty list, legacy-orphan detection excluding `com.ceo.schedulerd`, scan-installs-no-plists integration).
3. `bash scripts/ceo-doctor.test.sh` → **16 pass** (daemon-backend scheduling line + cron-entries line skipped; legacy-orphan flagged non-zero; daemon's own agent not flagged; the #142 heartbeat checks).
4. `bash scripts/ceo-schedule.test.sh` (13), `bash scripts/ceo-setup.test.sh` (30), `bash scripts/ceo-config.test.sh` (64) — all pass (no shared-helper breakage from the deletion).
5. `shellcheck --severity=warning scripts/ceo scripts/ceo-scheduler.sh scripts/ceo-scheduler.test.sh scripts/ceo-doctor.test.sh` — clean. `plutil -lint lib/scheduler/deploy/com.ceo.schedulerd.plist` — OK.
6. **Real-Mac smoke** (done on MacBook-Pro-190, throwaway label `com.ceo.schedulerd-smoke144` in temp paths, `trap` teardown — never touches the real label or runs `ceo playbook scan`): `launchctl bootstrap` → daemon writes a heartbeat → `kill -9` the daemon → **KeepAlive respawns it** (new pid, after the throttle) → `bootout`+`rm` → `launchctl print` confirms it's gone.

## Additional Notes
Final task of #136. After merge the epic is complete (#137–#144). Follow-ups remain open: #157 (per-playbook catch-up look-back). The retired backend's deletion is large (−1270 lines); the migration doctor-check is the safety net for hosts that still have per-playbook agents loaded.