### PR TITLE
feat(doctor): flag Linux crontab + systemd daemon double-fire (#159)

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -251,6 +251,16 @@ cmd_doctor() {
     fail=$((fail + 1))
   fi
 
+  # Linux double-fire (#159): the Phase-1 per-playbook crontab block AND the
+  # ceo-schedulerd systemd daemon both active dispatch every playbook twice.
+  local _cron_daemon_conflict
+  _cron_daemon_conflict="$(ceo_scheduler_crontab_daemon_conflict 2>/dev/null || true)"
+  if [ -n "$_cron_daemon_conflict" ]; then
+    echo "  ✗ CEO crontab block ($_cron_daemon_conflict triggers) active alongside the ceo-schedulerd daemon — every playbook double-fires"
+    echo "    Remove the crontab block (the daemon reads the registry): crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent\$' | crontab -"
+    fail=$((fail + 1))
+  fi
+
   # plugin
   if claude plugin list 2>/dev/null | grep -q "ceo"; then
     echo "  ✓ CEO plugin installed in Claude Code"

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -95,7 +95,7 @@ teardown() {
   export PATH="$PATH_BACKUP"
   export HOME="$HOME_BACKUP"
   unset TEST_HOME PATH_BACKUP HOME_BACKUP CEO_VAULT CEO_DIR CEO_HOSTNAME CEO_PLUTIL_BIN
-  unset CEO_SCHEDULER CEO_LAUNCHD_DIR
+  unset CEO_SCHEDULER CEO_LAUNCHD_DIR CEO_CRONTAB_BIN CEO_SYSTEMCTL_BIN
 }
 
 _log_completed_today() {
@@ -268,6 +268,90 @@ test_doctor_no_legacy_warning_when_only_daemon_agent() {
   output=$("$CEO_BIN" doctor 2>&1 || true)
   assert_not_contains "$output" "legacy per-playbook launchd agent" \
     "the daemon's own keep-alive agent must not be flagged as legacy"
+}
+
+# --- #159: Linux crontab + systemd daemon double-fire migration ---
+#
+# The Linux sibling of the macOS orphan check above. A host carrying the
+# Phase-1 per-playbook CEO crontab block AND running the ceo-schedulerd systemd
+# daemon (#142) fires every playbook twice. doctor must flag it.
+
+# Writes a CEO_CRONTAB_BIN stub whose `-l` prints $1 (a crontab body) and
+# exits non-zero on any other argv (per stub-cli-argv-validation).
+_write_crontab_list_stub() {
+  local body="$1"
+  export CEO_CRONTAB_BIN="$TEST_HOME/stubs/crontab-159"
+  cat > "$CEO_CRONTAB_BIN" <<STUB
+#!/bin/bash
+case "\$1" in
+  -l) cat <<'CRON'
+$body
+CRON
+  ;;
+  *) echo "stub-crontab: unexpected argv: \$*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+}
+
+# Writes a CEO_SYSTEMCTL_BIN stub answering `--user is-active ceo-schedulerd`
+# with $1 ("active"/"inactive") and the matching exit code; any other argv
+# exits 99 (per stub-cli-argv-validation).
+_write_systemctl_stub() {
+  local state="$1" rc
+  [ "$state" = "active" ] && rc=0 || rc=3
+  export CEO_SYSTEMCTL_BIN="$TEST_HOME/stubs/systemctl-159"
+  cat > "$CEO_SYSTEMCTL_BIN" <<STUB
+#!/bin/bash
+case "\$*" in
+  "--user is-active ceo-schedulerd") echo "$state"; exit $rc ;;
+  *) echo "stub-systemctl: unexpected argv: \$*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_SYSTEMCTL_BIN"
+}
+
+test_doctor_flags_crontab_daemon_double_fire() {
+  export CEO_SCHEDULER=crontab
+  _write_crontab_list_stub "# CEO Agent START
+*/5 * * * * /p/ceo-cron.sh morning  # ceo:morning
+0 9 * * * /p/ceo-cron.sh standup  # ceo:standup
+# CEO Agent END"
+  _write_systemctl_stub active
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "double-fire" \
+    "doctor must warn when the crontab block and the systemd daemon both run"
+  assert_contains "$output" "crontab block" \
+    "the warning must name the crontab block as the conflicting scheduler"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on a crontab+daemon double-fire (got rc=0)\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_doctor_no_double_fire_warning_when_daemon_inactive() {
+  export CEO_SCHEDULER=crontab
+  _write_crontab_list_stub "# CEO Agent START
+*/5 * * * * /p/ceo-cron.sh morning  # ceo:morning
+# CEO Agent END"
+  _write_systemctl_stub inactive
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_not_contains "$output" "double-fire" \
+    "the crontab block alone (daemon inactive) is not a double-fire"
+}
+
+test_doctor_no_double_fire_warning_when_no_crontab_block() {
+  export CEO_SCHEDULER=crontab
+  _write_crontab_list_stub "# unrelated user cron
+0 0 * * * /usr/bin/true"
+  _write_systemctl_stub active
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_not_contains "$output" "double-fire" \
+    "an active daemon with no CEO crontab entries is not a double-fire"
 }
 
 # --- ceo-schedulerd liveness (#142) ---

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -154,3 +154,26 @@ ceo_scheduler_legacy_launchd_plists() {
     printf '%s\n' "$plist"
   done
 }
+
+# Linux sibling of ceo_scheduler_legacy_launchd_plists (#159). The Phase-1
+# per-playbook CEO crontab block and the Phase-1.5 ceo-schedulerd systemd
+# daemon each dispatch every playbook independently; running both fires
+# everything twice. Detect the conflict by combining two signals:
+#   - the CEO crontab block is live  → ceo_scheduler_list emits ceo-cron.sh lines
+#   - the systemd user unit is active → `systemctl --user is-active ceo-schedulerd`
+# Prints the conflicting cron-trigger count (a non-empty marker for the caller)
+# when BOTH hold; prints nothing (clean) otherwise — including when systemctl is
+# absent (macOS) or the unit is inactive. `ceo doctor` warns on a non-empty
+# result so the operator removes the crontab block once the daemon is adopted.
+#   CEO_SYSTEMCTL_BIN — systemctl binary (default "systemctl"); test override.
+ceo_scheduler_crontab_daemon_conflict() {
+  local systemctl_bin="${CEO_SYSTEMCTL_BIN:-systemctl}"
+  command -v "$systemctl_bin" >/dev/null 2>&1 || return 0
+  local _state
+  _state="$("$systemctl_bin" --user is-active ceo-schedulerd 2>/dev/null || true)"
+  [ "$_state" = "active" ] || return 0
+  local _count
+  _count="$(ceo_scheduler_list 2>/dev/null | grep -c 'ceo-cron\.sh' || true)"
+  [ "${_count:-0}" -gt 0 ] || return 0
+  printf '%s\n' "$_count"
+}

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -41,7 +41,7 @@ setup() {
 teardown() {
   export HOME="$HOME_BACKUP"
   export PATH="$PATH_BACKUP"
-  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR CEO_LAUNCHD_DIR
+  unset CEO_SCHEDULER CEO_CRONTAB_BIN CEO_VAULT CEO_DIR CEO_LAUNCHD_DIR CEO_SYSTEMCTL_BIN
   rm -rf "$TEST_HOME"
 }
 
@@ -181,6 +181,82 @@ test_legacy_launchd_plists_empty_when_dir_absent() {
   out=$(ceo_scheduler_legacy_launchd_plists) || rc=$?
   assert_eq "$rc" "0" "missing LaunchAgents dir is not an error"
   assert_eq "$out" "" "missing LaunchAgents dir yields no orphans"
+}
+
+# === Linux crontab + systemd daemon double-fire detection (#159) ===
+
+# Stub systemctl to answer `--user is-active ceo-schedulerd` with $1 and the
+# matching exit code; any other argv exits 99 (per stub-cli-argv-validation).
+_stub_systemctl() {
+  local state="$1" rc
+  [ "$state" = "active" ] && rc=0 || rc=3
+  export CEO_SYSTEMCTL_BIN="$TEST_HOME/systemctl-stub"
+  cat > "$CEO_SYSTEMCTL_BIN" <<STUB
+#!/bin/bash
+case "\$*" in
+  "--user is-active ceo-schedulerd") echo "$state"; exit $rc ;;
+  *) echo "stub-systemctl: unexpected argv: \$*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_SYSTEMCTL_BIN"
+}
+
+# Stub crontab -l to print a CEO block; exits 99 on unexpected argv.
+_stub_crontab_with_ceo_block() {
+  export CEO_CRONTAB_BIN="$TEST_HOME/crontab-stub"
+  cat > "$CEO_CRONTAB_BIN" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -l) printf '%s\n' "# CEO Agent START" "*/5 * * * * /p/ceo-cron.sh morning  # ceo:morning" "# CEO Agent END" ;;
+  *) echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+}
+
+test_crontab_daemon_conflict_when_block_and_daemon_active() {
+  export CEO_SCHEDULER=crontab
+  _stub_crontab_with_ceo_block
+  _stub_systemctl active
+  local out
+  out=$(ceo_scheduler_crontab_daemon_conflict)
+  assert_eq "$out" "1" "must report the conflicting cron-trigger count when both schedulers run"
+}
+
+test_no_conflict_when_daemon_inactive() {
+  export CEO_SCHEDULER=crontab
+  _stub_crontab_with_ceo_block
+  _stub_systemctl inactive
+  local out
+  out=$(ceo_scheduler_crontab_daemon_conflict)
+  assert_eq "$out" "" "crontab block alone (daemon inactive) is not a conflict"
+}
+
+test_no_conflict_when_no_ceo_crontab_block() {
+  export CEO_SCHEDULER=crontab
+  export CEO_CRONTAB_BIN="$TEST_HOME/crontab-empty"
+  cat > "$CEO_CRONTAB_BIN" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -l) printf '%s\n' "0 0 * * * /usr/bin/true" ;;
+  *) echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+  _stub_systemctl active
+  local out
+  out=$(ceo_scheduler_crontab_daemon_conflict)
+  assert_eq "$out" "" "active daemon with no CEO crontab entries is not a conflict"
+}
+
+test_no_conflict_when_systemctl_absent() {
+  export CEO_SCHEDULER=crontab
+  _stub_crontab_with_ceo_block
+  export CEO_SYSTEMCTL_BIN="$TEST_HOME/nonexistent-systemctl"
+  local out rc=0
+  out=$(ceo_scheduler_crontab_daemon_conflict) || rc=$?
+  assert_eq "$rc" "0" "absent systemctl (e.g. macOS) is not an error"
+  assert_eq "$out" "" "absent systemctl yields no conflict"
 }
 
 # === Integration: ceo playbook scan end-to-end on the daemon backend ===


### PR DESCRIPTION
Closes #159

## Description (Issue Fixed & New Behavior)
The macOS sibling (#144) added a `ceo doctor` check that warns about orphan per-playbook `com.ceo.<name>-N` launchd agents which would double-fire alongside the `ceo-schedulerd` daemon. The **Linux equivalent was unaddressed**: a host carrying the Phase-1 per-playbook CEO crontab block AND running the Phase-1.5 `ceo-schedulerd` systemd daemon dispatches **every playbook twice** — once from cron, once from the daemon — with no detector.

This adds the Linux half, mirroring #144 structurally:

- **`ceo_scheduler_crontab_daemon_conflict`** (`scripts/ceo-scheduler.sh`) — reports the conflicting cron-trigger count only when BOTH signals hold:
  - the CEO crontab block is live (`ceo_scheduler_list` emits `ceo-cron.sh` lines), AND
  - `systemctl --user is-active ceo-schedulerd` returns `active`.

  Clean (prints nothing) otherwise — including when `systemctl` is absent (macOS), the unit is inactive, or there are no CEO cron entries.
- **`ceo doctor`** warns non-zero on a conflict with a crontab-block removal one-liner (`crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent$' | crontab -`), matching `_playbook_update_crontab`'s own block-removal logic.

This completes #136's cross-platform end-state: the OS keeps one agent alive, no per-playbook OS entries fire alongside the daemon on either platform.

**Migration guidance** lives in the doctor output (the removal one-liner), consistent with #144's precedent — #144 put its launchd-removal guidance in doctor output rather than a standalone docs/README section. No separate migration doc is added; flag if you'd prefer one.

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-scheduler.test.sh` — 17 tests pass (4 new: both-active conflict, daemon-inactive, no-CEO-block, systemctl-absent).
3. `bash scripts/ceo-doctor.test.sh` — 19 tests pass (3 new: doctor warns + returns non-zero on a crontab+daemon double-fire; no warning when the daemon is inactive; no warning when there is no CEO crontab block).
4. Mutation check: revert the `printf "%s\n" "$_count"` in `ceo_scheduler_crontab_daemon_conflict` to `return 0` — `test_crontab_daemon_conflict_when_block_and_daemon_active` and the doctor double-fire test fail.
5. `shellcheck -S warning scripts/ceo scripts/ceo-scheduler.sh` — clean.
6. Full shell suite (all 19 files) passes locally.

## Additional Notes / HelpScout Tickets
Follow-up from #144 (PR #158, panel-flagged). CLI stubs pattern-match argv and `exit 99` on unexpected shape (per the repo's stub-cli-argv-validation convention); test env (`CEO_CRONTAB_BIN`/`CEO_SYSTEMCTL_BIN`) is unset in teardown. Independent auditor pass: no HIGH/MEDIUM-correctness findings; one LOW (bare-marker parity in the removal one-liner) applied.