### PR TITLE
feat(scheduler): per-schedule catch-up look-back derived from cadence (#157)

### DIFF
--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -66,13 +66,15 @@ Pipeline, all of it unit-tested behind injected side effects:
 - `heartbeat-store.ts` — durable read/write of the heartbeat
   (`~/.ceo/schedulerd/heartbeat.json`, host-local, **not** the synced vault).
   Corrupt/missing → guard starts empty, no crash.
-- `catchup.ts` — `newestMissedSlot` / `catchUpFires`: when a downtime or suspend
-  gap means slots were skipped, fire **once** for the newest missed slot per
-  playbook and skip the rest (no replay storm), bounded by `CATCHUP_LOOKBACK_MS`
-  so a stale slot isn't run late. Driven by `last_fired` in the heartbeat (#143).
+- `catchup.ts` — `newestMissedSlot` / `catchUpFires` / `lookbackForSchedule`: when
+  a downtime or suspend gap means slots were skipped, fire **once** for the newest
+  missed slot per playbook and skip the rest (no replay storm), bounded by a
+  per-schedule look-back derived from each playbook's own cadence (#157) so a stale
+  slot isn't run late. Driven by `last_fired` in the heartbeat (#143).
 - `runtime.ts` — path/host/argv helpers and the `MAX_SLEEP_MS` / `HEARTBEAT_STALE_MS`
-  / `CATCHUP_LOOKBACK_MS` constants. Dispatch spawns `ceo-cron.sh <name> --scheduled`
-  directly (no shell), with `CEO_VAULT` passed via the spawn environment.
+  / `CATCHUP_LOOKBACK_FLOOR_MS` / `CATCHUP_LOOKBACK_CAP_MS` constants. Dispatch spawns
+  `ceo-cron.sh <name> --scheduled` directly (no shell), with `CEO_VAULT` passed via
+  the spawn environment.
 
 Schedules evaluate in the **host's local timezone** (the matcher is created with no
 timezone; registry schedules carry no per-entry tz). A second host in a different
@@ -86,7 +88,8 @@ tick the daemon also computes catch-up fires: for a playbook that owes fires sin
 its `last_fired`, it dispatches **once** for the newest missed slot within the
 look-back window (default 1h) and skips the rest. A playbook already firing this
 minute is not also caught up, and a first-seen playbook (no `last_fired` baseline)
-is initialized to "now" rather than replayed.
+is initialized to "now" rather than replayed. The look-back window is per-schedule
+(see below).
 
 `last_fired` is persisted in the same pre-dispatch heartbeat write as the
 double-fire guard, so catch-up keeps #142's **at-most-once** invariant: a crash
@@ -95,14 +98,20 @@ drops a fire rather than doubling it. (This is a deliberate divergence from #143
 for write-tier playbooks, and dispatch is a fire-and-forget spawn whose completion
 the daemon can't observe anyway.)
 
-The look-back is **one global value** (`CATCHUP_LOOKBACK_MS`, default 1h),
-overridable per host via the `CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS` env var (a
-non-numeric/zero/negative value falls back to the default). A single global value
-is a known limitation: it suits sub-hourly playbooks but is wrong for the
-daily-report playbooks that dominate the registry — a daily slot missed by more
-than the look-back is **not** replayed (by design, so a morning job doesn't run
-late at night). A daily-heavy host should raise the env var; per-playbook (or
-per-cadence) look-back is the fuller fix, tracked as a follow-up.
+The look-back is **per-schedule, derived from each playbook's own cadence** (#157,
+`lookbackForSchedule`): the cadence proxy is the **min gap** between the next few
+fires (cadence-intrinsic — invariant to wake time even for irregular schedules like
+`0 9,12`), clamped to `[CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS]` (1h–6h).
+So a sub-hourly playbook gets ~1h (a slot hours stale isn't replayed) while a daily
+report gets the 6h cap (an overnight-suspend miss still catches up in the morning).
+A long-cadence slot missed by more than the cap is **not** replayed — by design, so
+a morning job doesn't run late at night (a weekly slot missed >6h is likewise
+dropped).
+
+A host may still pin **one fixed window for every playbook** via the
+`CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS` env var (the #143 escape hatch); a
+non-numeric/zero/negative value is ignored and the derived per-schedule default is
+used instead.
 
 ### Run / keep-alive
 

--- a/lib/scheduler/src/catchup.ts
+++ b/lib/scheduler/src/catchup.ts
@@ -16,6 +16,61 @@ import type { Playbook } from "@/registry";
 const MINUTE_MS = 60_000;
 /** Bound on forward iteration when scanning for missed fires (defensive). */
 const MAX_SCAN = 100_000;
+/** Fires sampled forward to estimate a schedule's cadence (yields N-1 gaps). */
+const PERIOD_SAMPLES = 5;
+
+/**
+ * A per-schedule catch-up look-back derived from the schedule's own cadence
+ * (#157), so a registry with mixed cadences isn't served by one global value:
+ * a 5-minutely slot shouldn't replay hours late, but a daily slot missed by an
+ * overnight suspend should still catch up within a few hours.
+ *
+ * The cadence proxy is the MIN gap between the next {@link PERIOD_SAMPLES} fires
+ * — the tightest interval the schedule fires at. Min-of-gaps (not the single
+ * next gap) is deliberate: a forward sample anchored at `now` varies with wake
+ * time for irregular schedules (e.g. fires at 09:00 and 12:00 give a 3h-then-21h
+ * or 21h-then-3h pattern depending on `now`), whereas the min is
+ * cadence-intrinsic. The result is
+ * clamped to [floorMs, capMs]: sub-floor cadences clamp up (catch-up fires the
+ * newest slot once regardless), and long cadences (daily, weekly) clamp down to
+ * the cap — a weekly slot missed by more than the cap is deliberately not
+ * replayed (don't run a stale job late at night). Unparseable / single-fire
+ * schedules fall back to the floor and never throw.
+ *
+ * The min over a fixed sample window is an upper-bound estimate: a schedule
+ * whose tightest gap only recurs beyond the window would round *up* toward the
+ * cap. That errs conservative — a too-large look-back only ever replays the one
+ * already-newest slot once (newest-slot semantics) and is still clamped to the
+ * cap — so under-sampling can't cause a replay storm.
+ */
+export function lookbackForSchedule(
+  schedule: string,
+  now: Date,
+  matcher: CronMatcher,
+  floorMs: number,
+  capMs: number,
+): number {
+  let cursor = now;
+  let prev: Date | null = null;
+  let minGap = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < PERIOD_SAMPLES; i++) {
+    let next: Date | null;
+    try {
+      next = matcher.nextFire(schedule, cursor);
+    } catch {
+      break;
+    }
+    if (next === null) break;
+    if (prev !== null) {
+      const gap = next.getTime() - prev.getTime();
+      if (gap < minGap) minGap = gap;
+    }
+    prev = next;
+    cursor = next;
+  }
+  if (!Number.isFinite(minGap)) return floorMs;
+  return Math.min(Math.max(minGap, floorMs), capMs);
+}
 
 /**
  * The newest fire strictly after `lastFired` (clamped to `now - lookbackMs`) and
@@ -58,19 +113,23 @@ export interface CatchUpFire {
  * Catch-up fires for a set of playbooks. A playbook with no `last_fired` baseline
  * is skipped — the daemon has no basis to claim a slot was missed before it
  * started watching, so first-sight never triggers a replay.
+ *
+ * `lookbackFor` resolves each playbook's look-back from its own schedule (#157):
+ * the daemon passes a period-derived resolver ({@link lookbackForSchedule}) or a
+ * fixed `() => n` when the host pins the window via the env override.
  */
 export function catchUpFires(
   playbooks: Playbook[],
   lastFired: Record<string, number>,
   now: Date,
   matcher: CronMatcher,
-  lookbackMs: number,
+  lookbackFor: (schedule: string) => number,
 ): CatchUpFire[] {
   const fires: CatchUpFire[] = [];
   for (const p of playbooks) {
     const baseline = lastFired[p.name];
     if (baseline === undefined) continue;
-    const slot = newestMissedSlot(p.schedule, baseline, now, matcher, lookbackMs);
+    const slot = newestMissedSlot(p.schedule, baseline, now, matcher, lookbackFor(p.schedule));
     if (slot !== null) fires.push({ playbook: p, slot });
   }
   return fires;

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -51,8 +51,13 @@ export interface DaemonDeps {
   host: string;
   matcher: CronMatcher;
   maxSleepMs: number;
-  /** Look-back window for missed-slot catch-up; a missed slot older than this is too stale to replay. */
-  catchupLookbackMs: number;
+  /**
+   * Catch-up look-back resolver (#157): given a playbook's schedule and the
+   * current `now`, returns how far back a missed slot may be and still replay.
+   * Production passes a per-schedule derived resolver (or a fixed window when
+   * the host pins `CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS`).
+   */
+  resolveLookback(schedule: string, now: Date): number;
   shouldContinue(): boolean;
 }
 
@@ -91,7 +96,7 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
     // playbook if that exclusion ever changes.
     const due = dueAt(runnable, now, deps.matcher).filter((p) => guard.get(p.name) !== minute);
     const dueNames = new Set(due.map((p) => p.name));
-    const catches = catchUpFires(runnable, lastFired, now, deps.matcher, deps.catchupLookbackMs).filter(
+    const catches = catchUpFires(runnable, lastFired, now, deps.matcher, (s) => deps.resolveLookback(s, now)).filter(
       (f) => !dueNames.has(f.playbook.name),
     );
 

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -18,12 +18,15 @@ import { createMatcher } from "@/cron";
 import { type DaemonDeps, runForever } from "@/daemon";
 import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
 import { parseRegistry } from "@/registry";
+import { lookbackForSchedule } from "@/catchup";
 import {
+  CATCHUP_LOOKBACK_CAP_MS,
+  CATCHUP_LOOKBACK_FLOOR_MS,
   dispatchArgv,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
-  resolveCatchupLookbackMs,
+  resolveFixedLookbackMs,
   resolveHost,
 } from "@/runtime";
 
@@ -58,6 +61,12 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => stop("SIGINT"));
 
   const log = (msg: string) => process.stderr.write(`[${nowStamp()}] ceo-schedulerd: ${msg}\n`);
+
+  // Per-schedule derived look-back (#157), unless the host pins a fixed window.
+  const matcher = createMatcher();
+  const fixedLookback = resolveFixedLookbackMs(process.env.CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS);
+  const resolveLookback = (schedule: string, now: Date): number =>
+    fixedLookback ?? lookbackForSchedule(schedule, now, matcher, CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS);
 
   const deps: DaemonDeps = {
     now: () => new Date(),
@@ -97,9 +106,9 @@ async function main(): Promise<void> {
     writeHeartbeat: (hb) => writeHeartbeatFile(hbPath, hb),
     log,
     host,
-    matcher: createMatcher(),
+    matcher,
     maxSleepMs: MAX_SLEEP_MS,
-    catchupLookbackMs: resolveCatchupLookbackMs(process.env.CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS),
+    resolveLookback,
     shouldContinue: () => running,
   };
 

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -14,24 +14,28 @@ export const MAX_SLEEP_MS = 60_000;
 export const HEARTBEAT_STALE_MS = 600_000; // 10 minutes
 
 /**
- * Missed-slot catch-up look-back (#143). On wake after a downtime/suspend gap,
- * a missed slot older than this is too stale to replay. One hour: long enough to
- * cover a brief outage, short enough that an hours-old slot isn't run late.
+ * Bounds for the per-schedule missed-slot catch-up look-back (#157). The daemon
+ * derives each playbook's look-back from its own cadence and clamps it here: a
+ * sub-floor cadence (e.g. 5-minutely) clamps up to the floor, a long cadence
+ * (daily, weekly) clamps down to the cap. The floor covers a brief outage; the
+ * cap keeps an hours-stale slot from running late at night. See
+ * `lookbackForSchedule` in catchup.ts.
  */
-export const CATCHUP_LOOKBACK_MS = 3_600_000; // 1 hour
+export const CATCHUP_LOOKBACK_FLOOR_MS = 3_600_000; // 1 hour
+export const CATCHUP_LOOKBACK_CAP_MS = 21_600_000; // 6 hours
 
 /**
- * Resolve the catch-up look-back from an optional env override
- * (`CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS`), defaulting to {@link CATCHUP_LOOKBACK_MS}.
- * A non-numeric / zero / negative value falls back to the default rather than
- * silently installing a wrong window — a host with daily playbooks can raise it
- * (e.g. to several hours) without a registry/schema change. Per-playbook
- * look-back is the fuller fix, tracked separately.
+ * Optional per-host override (`CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS`) that pins a
+ * single fixed look-back for every playbook, bypassing the per-schedule derived
+ * default. Returns the parsed value when set to a positive integer, else `null`
+ * — absent, non-numeric, zero, and negative all fall through to the derived
+ * look-back rather than silently installing a wrong window. The env override
+ * survives from #143 as an escape hatch; the derived default is the #157 fix.
  */
-export function resolveCatchupLookbackMs(raw: string | undefined): number {
-  if (raw === undefined) return CATCHUP_LOOKBACK_MS;
+export function resolveFixedLookbackMs(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
   const n = Number(raw.trim());
-  return Number.isInteger(n) && n > 0 ? n : CATCHUP_LOOKBACK_MS;
+  return Number.isInteger(n) && n > 0 ? n : null;
 }
 
 export function registryPath(vault: string): string {

--- a/lib/scheduler/tests/catchup.test.ts
+++ b/lib/scheduler/tests/catchup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { catchUpFires, newestMissedSlot } from "@/catchup";
+import { catchUpFires, lookbackForSchedule, newestMissedSlot } from "@/catchup";
 import { createMatcher } from "@/cron";
 import type { Playbook } from "@/registry";
 
@@ -7,6 +7,8 @@ const m = createMatcher({ timezone: "UTC" });
 const d = (iso: string) => new Date(iso);
 const ms = (iso: string) => d(iso).getTime();
 const HOUR = 3_600_000;
+const FLOOR = HOUR; // 1h
+const CAP = 6 * HOUR; // 6h
 
 const pb = (over: Partial<Playbook>): Playbook => ({
   name: "p",
@@ -77,11 +79,52 @@ describe("newestMissedSlot", () => {
   });
 });
 
+describe("lookbackForSchedule", () => {
+  const now = d("2026-06-01T10:00:00Z");
+
+  test("sub-floor cadence (*/5) clamps UP to the floor", () => {
+    // 5-minute period < 1h floor → floor. (Newest-slot-only fires once anyway.)
+    expect(lookbackForSchedule("*/5 * * * *", now, m, FLOOR, CAP)).toBe(FLOOR);
+  });
+
+  test("hourly period passes through unclamped", () => {
+    expect(lookbackForSchedule("0 * * * *", now, m, FLOOR, CAP)).toBe(HOUR);
+  });
+
+  test("an in-range period (every 2h) is used as-is", () => {
+    expect(lookbackForSchedule("0 */2 * * *", now, m, FLOOR, CAP)).toBe(2 * HOUR);
+  });
+
+  test("daily period clamps DOWN to the cap", () => {
+    expect(lookbackForSchedule("0 9 * * *", now, m, FLOOR, CAP)).toBe(CAP);
+  });
+
+  test("weekly period clamps down to the cap (a >cap-stale weekly slot is not replayed)", () => {
+    expect(lookbackForSchedule("0 9 * * 1", now, m, FLOOR, CAP)).toBe(CAP);
+  });
+
+  test("irregular schedule uses the MIN gap and is invariant to `now` (the tightest cadence)", () => {
+    // 0 9,12 → gaps of 3h (09→12) and 21h (12→09 next day). The min gap is 3h,
+    // in range → 3h. A single-forward-gap proxy anchored at `now` would yield
+    // 21h→cap(6h) at 10:00 but 3h at 13:00; min-of-gaps is the same either way.
+    const at10 = lookbackForSchedule("0 9,12 * * *", d("2026-06-01T10:00:00Z"), m, FLOOR, CAP);
+    const at13 = lookbackForSchedule("0 9,12 * * *", d("2026-06-01T13:00:00Z"), m, FLOOR, CAP);
+    expect(at10).toBe(3 * HOUR);
+    expect(at13).toBe(3 * HOUR);
+  });
+
+  test("unparseable schedule falls back to the floor (never throws)", () => {
+    expect(lookbackForSchedule("not a cron", now, m, FLOOR, CAP)).toBe(FLOOR);
+  });
+});
+
 describe("catchUpFires", () => {
+  const fixedHour = () => HOUR;
+
   test("includes playbooks with a missed slot, excludes those without a last_fired baseline", () => {
     const pbs = [pb({ name: "seen" }), pb({ name: "fresh" })];
     const lastFired = { seen: ms("2026-06-01T09:00:00Z") }; // 'fresh' has no baseline yet
-    const fires = catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, HOUR);
+    const fires = catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, fixedHour);
     expect(fires.map((f) => f.playbook.name)).toEqual(["seen"]);
     expect(fires[0]!.slot).toEqual(d("2026-06-01T09:15:00Z"));
   });
@@ -89,6 +132,18 @@ describe("catchUpFires", () => {
   test("excludes a playbook with no gap", () => {
     const pbs = [pb({ name: "current" })];
     const lastFired = { current: ms("2026-06-01T09:15:00Z") };
-    expect(catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, HOUR)).toEqual([]);
+    expect(catchUpFires(pbs, lastFired, d("2026-06-01T09:17:30Z"), m, fixedHour)).toEqual([]);
+  });
+
+  test("resolver is applied per schedule: a 3h-stale daily slot catches up (derived ~6h) where a fixed 1h would skip", () => {
+    const daily = pb({ name: "daily", schedule: "0 9 * * *" });
+    const lastFired = { daily: ms("2026-05-31T09:00:00Z") }; // yesterday 09:00
+    const now = d("2026-06-01T12:00:00Z"); // 3h after today's 09:00 slot
+    const derived = (s: string) => lookbackForSchedule(s, now, m, FLOOR, CAP);
+    expect(catchUpFires([daily], lastFired, now, m, derived).map((f) => f.slot)).toEqual([
+      d("2026-06-01T09:00:00Z"),
+    ]);
+    // The same slot is 3h stale → a fixed 1h look-back drops it.
+    expect(catchUpFires([daily], lastFired, now, m, fixedHour)).toEqual([]);
   });
 });

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { lookbackForSchedule } from "@/catchup";
 import { createMatcher } from "@/cron";
 import type { Playbook } from "@/registry";
 import { type DaemonDeps, type Heartbeat, runForever } from "@/daemon";
+import { CATCHUP_LOOKBACK_CAP_MS, CATCHUP_LOOKBACK_FLOOR_MS } from "@/runtime";
 
 const m = createMatcher({ timezone: "UTC" });
 const d = (iso: string) => new Date(iso);
@@ -21,6 +23,7 @@ interface HarnessOpts {
   startHeartbeat?: Heartbeat | null;
   host?: string;
   cap?: number;
+  /** Pin a fixed look-back for all schedules (the env-override path). Omit to use the production-default derived resolver. */
   lookback?: number;
 }
 
@@ -66,7 +69,10 @@ function harness(opts: HarnessOpts) {
     host: opts.host ?? "ml-1",
     matcher: m,
     maxSleepMs: opts.cap ?? 60_000,
-    catchupLookbackMs: opts.lookback ?? 3_600_000,
+    resolveLookback:
+      opts.lookback !== undefined
+        ? () => opts.lookback as number
+        : (schedule, now) => lookbackForSchedule(schedule, now, m, CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS),
     shouldContinue: () => i < opts.nows.length,
   };
   return {
@@ -244,15 +250,38 @@ describe("missed-slot catch-up (#143)", () => {
     expect(h.heartbeats[0]!.last_fired.ev).toBe(now.getTime());
   });
 
-  test("a slot too stale for the look-back window is not replayed", async () => {
-    // daily 09:00, down since yesterday, back at 11:00 with default 1h look-back → no replay.
+  test("a slot too stale for the derived look-back window is not replayed", async () => {
+    // daily 09:00 derives a 6h look-back; back at 16:00 (7h after 09:00) → too stale → no replay.
     const h = harness({
-      nows: [d("2026-06-01T11:00:00Z")],
+      nows: [d("2026-06-01T16:00:00Z")],
       playbooks: [pb({ name: "daily", schedule: "0 9 * * *" })],
       startHeartbeat: hbWith({ daily: d("2026-05-31T09:00:00Z").getTime() }),
     });
     await runForever(h.deps);
     expect(h.dispatched).toEqual([]);
+  });
+
+  test("derived look-back (#157): a daily slot 3h stale catches up where the old global 1h would have skipped it", async () => {
+    // daily 09:00, down since yesterday, back at 12:00 (3h after the 09:00 slot).
+    // The derived daily look-back is 6h, so 09:00 today is within window → replay once.
+    const h = harness({
+      nows: [d("2026-06-01T12:00:00Z")],
+      playbooks: [pb({ name: "daily", schedule: "0 9 * * *" })],
+      startHeartbeat: hbWith({ daily: d("2026-05-31T09:00:00Z").getTime() }),
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["daily"]);
+    expect(h.heartbeats[0]!.last_fired.daily).toBe(d("2026-06-01T09:00:00Z").getTime());
+
+    // Same scenario, but the host pins a fixed 1h window (env override) → too stale → skipped.
+    const fixed = harness({
+      nows: [d("2026-06-01T12:00:00Z")],
+      playbooks: [pb({ name: "daily", schedule: "0 9 * * *" })],
+      startHeartbeat: hbWith({ daily: d("2026-05-31T09:00:00Z").getTime() }),
+      lookback: 3_600_000,
+    });
+    await runForever(fixed.deps);
+    expect(fixed.dispatched).toEqual([]);
   });
 
   test("advances last_fired to the missed slot and persists it BEFORE dispatch (at-most-once)", async () => {

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
-  CATCHUP_LOOKBACK_MS,
+  CATCHUP_LOOKBACK_CAP_MS,
+  CATCHUP_LOOKBACK_FLOOR_MS,
   dispatchArgv,
   HEARTBEAT_STALE_MS,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
-  resolveCatchupLookbackMs,
+  resolveFixedLookbackMs,
   resolveHost,
 } from "@/runtime";
 
@@ -42,17 +43,25 @@ describe("staleness threshold is comfortably larger than the wake cap", () => {
   });
 });
 
-describe("resolveCatchupLookbackMs", () => {
-  test("absent env → the default", () => {
-    expect(resolveCatchupLookbackMs(undefined)).toBe(CATCHUP_LOOKBACK_MS);
+describe("catch-up look-back bounds (#157)", () => {
+  test("the floor is sane and strictly below the cap", () => {
+    expect(CATCHUP_LOOKBACK_FLOOR_MS).toBe(3_600_000); // 1h
+    expect(CATCHUP_LOOKBACK_CAP_MS).toBe(21_600_000); // 6h
+    expect(CATCHUP_LOOKBACK_FLOOR_MS).toBeLessThan(CATCHUP_LOOKBACK_CAP_MS);
   });
-  test("a positive integer override is honored", () => {
-    expect(resolveCatchupLookbackMs("21600000")).toBe(21_600_000);
+});
+
+describe("resolveFixedLookbackMs (env override → fixed window, else derived)", () => {
+  test("absent env → null (use the per-schedule derived look-back)", () => {
+    expect(resolveFixedLookbackMs(undefined)).toBeNull();
   });
-  test("non-numeric / zero / negative falls back to the default (never a wrong window)", () => {
-    expect(resolveCatchupLookbackMs("abc")).toBe(CATCHUP_LOOKBACK_MS);
-    expect(resolveCatchupLookbackMs("0")).toBe(CATCHUP_LOOKBACK_MS);
-    expect(resolveCatchupLookbackMs("-5")).toBe(CATCHUP_LOOKBACK_MS);
-    expect(resolveCatchupLookbackMs("  ")).toBe(CATCHUP_LOOKBACK_MS);
+  test("a positive integer override pins a fixed window for all playbooks", () => {
+    expect(resolveFixedLookbackMs("21600000")).toBe(21_600_000);
+  });
+  test("non-numeric / zero / negative / blank → null (fall through to derived, never a wrong window)", () => {
+    expect(resolveFixedLookbackMs("abc")).toBeNull();
+    expect(resolveFixedLookbackMs("0")).toBeNull();
+    expect(resolveFixedLookbackMs("-5")).toBeNull();
+    expect(resolveFixedLookbackMs("  ")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #157

## Description (Issue Fixed & New Behavior)
Follow-up from #143 (PR #156). The missed-slot catch-up look-back was a single global value (`CATCHUP_LOOKBACK_MS`, 1h, env-overridable). A single value can't fit a registry with mixed cadences: a `*/5` playbook wants ~1h (don't replay a 6h-old 5-minutely slot), but the daily reports that dominate the registry want several hours so an overnight-suspend miss still catches up in the morning — the #156 panel flagged the daily-dominated registry as under-served by 1h.

This implements the issue's recommended **period-derived** option (no registry schema change):

- **`lookbackForSchedule(schedule, now, matcher, floorMs, capMs)`** (`catchup.ts`) — derives each playbook's look-back from its own cadence. The cadence proxy is the **min gap** between the next few fires, clamped to `[CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS]` (1h–6h). Sub-floor cadences (5-minutely) clamp up to 1h; daily/weekly clamp down to the 6h cap. A slot missed beyond the cap is deliberately not replayed (so a morning job doesn't run late at night).
- **Min-of-gaps, not single-forward-gap** — a forward sample anchored at `now` varies with wake time for irregular schedules (`0 9,12 * * *` → 3h-then-21h or 21h-then-3h depending on `now`); the min gap is cadence-intrinsic. This was a HIGH finding from the pre-implementation design audit; the invariance test (`at10`/`at13` both → 3h) proves the fix.
- **`catchUpFires`** now takes a per-schedule resolver `(schedule) => number`. The daemon builds a derived resolver by default; a host can still pin one fixed window for all playbooks via `CEO_SCHEDULERD_CATCHUP_LOOKBACK_MS` (the #143 escape hatch, now `resolveFixedLookbackMs` → `number | null`: unset/non-numeric/zero/negative falls through to the derived default).

Completes the #143 follow-up; no schema bump.

## Testing Procedure
1. Check out this branch; `cd lib/scheduler && bun install`.
2. `bun run typecheck` — clean.
3. `bun test` — 97 pass. New coverage:
   - `lookbackForSchedule`: sub-floor clamps up, hourly/2h pass through, daily/weekly clamp to cap, **irregular `0 9,12` invariant to `now`** (3h both at 10:00 and 13:00), unparseable → floor.
   - `catchUpFires`: resolver applied per schedule (3h-stale daily catches up under derived ~6h, skipped under fixed 1h).
   - `runForever` (#157): a daily slot 3h stale catches up under the derived default but is skipped when the host pins a fixed 1h window; a >6h-stale daily slot is not replayed.
   - `resolveFixedLookbackMs`: unset/invalid → null (derived); positive int → fixed.
4. Mutation check: replace the min-gap loop in `lookbackForSchedule` with the single next gap (`nextFire(now)`→`nextFire(that)`) — the `0 9,12` invariance test fails (at10 ≠ at13).

## Additional Notes / HelpScout Tickets
Pre-implementation design auditor reviewed the approach: confirmed period-derived answers the ask with no schema change, and raised the HIGH min-of-gaps fix (folded before coding) plus the deliberate weekly→cap consequence (documented in `lookbackForSchedule` + `lib/scheduler/README.md`). Env-override semantics changed (the var now *pins a fixed override*; unset = derived), reflected in `runtime.ts` + README.