### PR TITLE
feat: add reconcile playbook (propose-only, draft) (#135)

### DIFF
--- a/docs/playbooks/reconcile.md
+++ b/docs/playbooks/reconcile.md
@@ -1,0 +1,93 @@
+---
+name: reconcile
+description: Propose which open inbox/daily-note to-dos can be closed or amended, from recent daily notes + PR state
+trigger: cron
+schedule: "50 7 * * 1-5"
+runner: claude
+model: sonnet
+preflight: none
+tier: high-stakes
+status: draft
+inputs: ["pr_data", "daily_note", "pending_count", "today_log", "yesterday_log"]
+artifact: CEO/reports/reconcile/{TODAY}.md
+---
+
+# Reconcile
+
+Read recent evidence of completed work and propose which open to-dos can be closed or
+amended. **Propose only — never close, archive, or edit a to-do in place.** Each
+proposal is a **high-stakes action**: the dispatcher's FILTER phase routes it to
+`CEO/approvals/pending.md` and the user approves it there. Approval is what actually
+checks an item off; this playbook never does.
+
+## What to read (cwd is the vault root)
+
+1. `CEO/inbox.md` — every unchecked `- [ ]` item. Skip `[x]`, `[done]`, `[failed]`.
+2. The 3 most recent daily notes under `Daily/` (by dated filename, newest first,
+   on or before today). Read them in full. Also collect any unchecked `- [ ]` lines
+   under a `## Tasks` heading in those notes — those are open to-dos too.
+3. PR/issue evidence comes ONLY from the pre-gathered `PR data` lines. Do NOT run
+   `gh` or any git command. If an item names a PR/issue that is not in the
+   pre-gathered sets, treat its PR state as unknown.
+
+## How to classify each open to-do
+
+Assign exactly one verb per item:
+
+- **close** — high confidence the whole item is done. The only strong signal is a
+  repo-qualified `org/repo#N` that appears in the pre-gathered PR data as MERGED, and
+  whose verb is satisfied by a merge. A *review*/*QA*/*check* task is NOT satisfied by
+  a merge. A closed-unmerged PR is NOT "done". When unsure, do not use close.
+- **amend** — partially done or a bundle of subtasks where some are done and some are
+  not (e.g. "move pcri and decon to wsl" with pcri mostly done, decon not). Propose a
+  rewrite that resolves the done portion and keeps the rest open. State explicitly
+  what is NOT covered (if the note says "mostly", say so).
+- **keep** — no sufficient evidence. Leave it untouched and do NOT propose anything.
+
+## What to propose and record
+
+**Proposals (close / amend) are high-stakes actions — do NOT write `approvals/pending.md`
+yourself.** In the PLAN phase, emit one `ACTION` line per close/amend at the
+`high-stakes` tier; the shell FILTER routes them to `CEO/approvals/pending.md` in the
+canonical format and defers them for approval. Pack the whole proposal into the
+description (the command field is `n/a` — there is no command to run):
+
+```
+ACTION: <n> | high-stakes | reconcile close: "<to-do verbatim>" — <one-line evidence, e.g. org/repo#N merged> | n/a
+ACTION: <n> | high-stakes | reconcile amend: "<to-do verbatim>" → <rewritten line>; NOT covered: <what remains> | n/a
+```
+
+**Decision record (low-stakes-write).** Emit one `low-stakes-write` ACTION to append
+today's full record to `CEO/reports/reconcile/<TODAY>.md` (create the file if absent),
+one line per item examined — including `keep`s, which are not proposed elsewhere:
+
+```
+- <close|amend|keep> | <confidence: high|medium|low> | <to-do verbatim> | <evidence or "none">
+```
+
+This is the only file this playbook writes directly. The record is the audit trail;
+the approvals queue holds only the actionable close/amend subset. **Always emit this
+report ACTION — even on a day when every item is `keep` and there are no proposals —
+so the record always exists for the morning scan** (otherwise, with no safe action to
+execute, the run produces nothing).
+
+## Hard invariants (v1)
+
+- Do NOT write to `CEO/inbox.md`.
+- Do NOT edit any file under `Daily/` (no in-place `[x]`).
+- Do NOT write to `CEO/approvals/pending.md` directly — proposals reach it only as
+  filtered high-stakes actions.
+- Do NOT run `gh`, `git`, or any command that changes remote state.
+- Nothing is closed or archived automatically — every resolution is a proposal.
+
+## Output
+
+End with the LOG_ENTRY block. In **Output** give the counts; in **Proposals** list the
+close/amend proposals (these are the high-stakes actions written to pending.md):
+
+```
+**Output:**
+Reconcile: <N> close-proposed, <N> amend-proposed, <N> kept. Record: CEO/reports/reconcile/<TODAY>.md
+**Proposals:**
+- <each close/amend proposal, or 'none'>
+```


### PR DESCRIPTION
Closes #135

## Description (Issue Fixed & New Behavior)
Introduces a new daily playbook (`docs/playbooks/reconcile.md`) that reads recent daily notes + the inbox + pre-gathered PR state and **proposes** which open to-dos can be closed or amended. Propose-only — it never closes, archives, or edits a to-do in place; approval through the normal flow is what checks an item off.

**Routing (the key design point):** proposals are emitted as **high-stakes actions**, so the dispatcher's FILTER phase routes them to `CEO/approvals/pending.md` in the canonical format and defers them for approval. The playbook does **not** hand-write the approvals queue — propose-only is enforced by the pipeline, not just by prompt instruction. `tier: high-stakes`. The full decision record (one line per `close`/`amend`/`keep`) is a `low-stakes-write` to `CEO/reports/reconcile/{TODAY}.md`, always emitted so a record exists even on an all-`keep` day.

- **close** — repo-qualified `org/repo#N` MERGED in the pre-gathered PR data, with a merge-satisfiable verb (review/QA/check are NOT satisfied by a merge); closed-unmerged ≠ done.
- **amend** — rewrite the done portion, keep the rest, state what's not covered.
- **keep** — no evidence; recorded but not proposed.
- `inputs` declares the pre-gather keys (`pr_data`, `daily_note`, `pending_count`, `today_log`, `yesterday_log`); no `gh`/`git` in the playbook.
- `status: draft` — inert (not scheduled) until promoted to `active` and scanned on ML-1.

The original `#135` blocker (dispatcher run-modes + `--dry-run`) is resolved by the shipped #137/#138.

## Testing Procedure
1. Check out this branch.
2. Validate the frontmatter parses into a correct registry entry in an isolated env (no real host changes — temp HOME/vault, stub `crontab`, empty repo-playbook dir): copy `docs/playbooks/reconcile.md` into `$CEO_DIR/playbooks/`, run `ceo playbook scan`, and `jq '.playbooks[]|select(.name=="reconcile")' registry.json`. Confirm `tier: high-stakes`, `status: draft`, `inputs` array (no unknown-key warning), clean `ADD reconcile`.
3. Confirm `bash scripts/ceo-playbook-status.test.sh` still passes (parser unaffected).
4. **Activation (on ML-1 only, per `ceo-scan-only-on-ml1`):** promote to `status: active` and run `ceo playbook scan` on ML-1, then exercise once via the dispatcher's `--dry-run` to verify proposals route to `approvals/pending.md` and the record lands in `reports/reconcile/`. Not done in this PR (this host is not ML-1).

## Additional Notes / HelpScout Tickets
Design+plan specs live in Obsidian (`Projects/Development/nhangen/claude-ceo/specs/reconcile-playbook-{design,plan}.md`), not the repo. A pre-implementation design auditor caught a HIGH (the earlier `low-stakes-write` + hand-write-to-`pending.md` shape fought the dispatcher's tier routing); the rewrite to the high-stakes-ACTION pattern resolves it, confirmed by a verification reviewer against the `ceo-cron.sh` PLAN/FILTER/EXECUTE contract. v2 (deferred): deterministic auto-close as a `runner: script` step.