### PR TITLE
fix(reconcile): persist decision record via LOG_ENTRY; activate (#135)

### DIFF
--- a/docs/playbooks/reconcile.md
+++ b/docs/playbooks/reconcile.md
@@ -7,9 +7,8 @@ runner: claude
 model: sonnet
 preflight: none
 tier: high-stakes
-status: draft
+status: active
 inputs: ["pr_data", "daily_note", "pending_count", "today_log", "yesterday_log"]
-artifact: CEO/reports/reconcile/{TODAY}.md
 ---
 
 # Reconcile
@@ -57,19 +56,19 @@ ACTION: <n> | high-stakes | reconcile close: "<to-do verbatim>" — <one-line ev
 ACTION: <n> | high-stakes | reconcile amend: "<to-do verbatim>" → <rewritten line>; NOT covered: <what remains> | n/a
 ```
 
-**Decision record (low-stakes-write).** Emit one `low-stakes-write` ACTION to append
-today's full record to `CEO/reports/reconcile/<TODAY>.md` (create the file if absent),
-one line per item examined — including `keep`s, which are not proposed elsewhere:
+**Decision record.** Do NOT use the `Write`/`Edit` tools or shell out to write a file —
+the headless EXECUTE phase has no file-write permission, and a Write attempt only
+produces a spurious error. Instead, put the full record in the **Output** section of
+the `LOG_ENTRY` block below; the dispatcher persists the whole `LOG_ENTRY` to the daily
+report (`CEO/reports/<TODAY>.md`), which the morning scan reads. One line per item
+examined — including `keep`s, which are not proposed elsewhere:
 
 ```
 - <close|amend|keep> | <confidence: high|medium|low> | <to-do verbatim> | <evidence or "none">
 ```
 
-This is the only file this playbook writes directly. The record is the audit trail;
-the approvals queue holds only the actionable close/amend subset. **Always emit this
-report ACTION — even on a day when every item is `keep` and there are no proposals —
-so the record always exists for the morning scan** (otherwise, with no safe action to
-execute, the run produces nothing).
+Always include the full record in Output — even on a day when every item is `keep` and
+there are no proposals — so the audit trail always exists.
 
 ## Hard invariants (v1)
 
@@ -77,17 +76,23 @@ execute, the run produces nothing).
 - Do NOT edit any file under `Daily/` (no in-place `[x]`).
 - Do NOT write to `CEO/approvals/pending.md` directly — proposals reach it only as
   filtered high-stakes actions.
+- Do NOT use the `Write`/`Edit` tools or any file-writing command — the EXECUTE phase
+  can't write files; everything is persisted by the dispatcher from `LOG_ENTRY`.
 - Do NOT run `gh`, `git`, or any command that changes remote state.
 - Nothing is closed or archived automatically — every resolution is a proposal.
 
 ## Output
 
-End with the LOG_ENTRY block. In **Output** give the counts; in **Proposals** list the
-close/amend proposals (these are the high-stakes actions written to pending.md):
+End with the LOG_ENTRY block. In **Output**, give the counts and then the full decision
+record (one line per item examined); in **Proposals**, list the close/amend proposals
+(these are the high-stakes actions the shell routes to pending.md):
 
 ```
 **Output:**
-Reconcile: <N> close-proposed, <N> amend-proposed, <N> kept. Record: CEO/reports/reconcile/<TODAY>.md
+Reconcile: <N> close-proposed, <N> amend-proposed, <N> kept.
+
+<close|amend|keep> | <confidence> | <to-do verbatim> | <evidence or "none">
+<...one line per item examined, including keeps...>
 **Proposals:**
 - <each close/amend proposal, or 'none'>
 ```


### PR DESCRIPTION
Closes #135 (follow-on fix + activation)

## Description
A real manual run of the reconcile playbook on ML-1 (2026-06-08) surfaced two things:
1. **The decision-record write fails.** The EXECUTE phase is a headless `claude --print` with no file-write permission, and `CEO/reports/reconcile/` doesn't exist — so the `Write`/`mkdir` were blocked and the run logged a spurious `Errors:` line every time. The record content, however, already lands in the daily report (`CEO/reports/<TODAY>.md`) because the dispatcher persists the whole `LOG_ENTRY` via `ceo-report.sh`.
2. **Behavior is otherwise correct:** it read the inbox + 3 daily notes + PR data, applied the close-guard (repo-qualified MERGED only), and classified all open to-dos `keep` with **0 false closes**.

This aligns the playbook with the system's actual persistence model and activates it:
- Decision record now goes in the `LOG_ENTRY` **Output** section (shell-persisted) instead of a `Write` ACTION to a dedicated file.
- Dropped the `artifact` field (documentation-only for `runner: claude`, and the source of the failed Write).
- Invariants now forbid `Write`/`Edit` (the EXECUTE phase can't write files).
- Proposals (close/amend) still emit as **high-stakes ACTIONs** the shell routes to `approvals/pending.md` — that path was already correct and is unchanged.
- `status: draft → active` — schedules at 07:50 weekdays.

Merged-PR gather (so reconcile can actually *propose* closures rather than mostly `keep`) is tracked in **#163**.

## Testing Procedure
1. Check out this branch.
2. Validate the frontmatter parses + schedules in an isolated scan harness (temp HOME/vault, stub `crontab`, no real host changes): copy `docs/playbooks/reconcile.md` into `$CEO_DIR/playbooks/`, `ceo playbook scan`, then `jq '.playbooks[]|select(.name=="reconcile")'` — confirm `status: active`, `artifact: ""`, `inputs` array; and `crontab -l` now contains `50 7 * * 1-5 … ceo-cron.sh reconcile  # ceo:reconcile`.
3. Confirmed on ML-1: a real `ceo-cron.sh reconcile` run reads inbox + dailies + PR data, close-guard fires, 0 false closes; the LOG_ENTRY (incl. the decision-record table) is persisted to `CEO/reports/<TODAY>.md`.

## Additional Notes
Activation takes effect on ML-1 after `git pull` + `ceo playbook scan` there (the designated automation host; `ceo-scan-only-on-ml1`).