### PR TITLE
fix(cron): retry transient unreadable registry instead of FATAL

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -354,7 +354,13 @@ ceo_registry_version() {
 # ceo_registry_validate <registry_file>
 #   0 — schema_version is an integer >= CEO_REGISTRY_SCHEMA_VERSION
 #   1 — registry file does not exist
-#   2 — schema_version missing, malformed, or below current
+#   2 — schema_version is a parseable integer below current (genuine downgrade
+#       by a peer on an older binary; fail fast — retrying cannot fix it)
+#   3 — registry exists but has no parseable integer schema_version (missing
+#       field, malformed JSON, non-integer). On a synced vault this also covers
+#       a file caught mid-replace, so callers should retry once before failing.
+# Codes 2 and 3 are kept distinct so a real downgrade is never retried into
+# acceptance and a transient unreadable read is never misreported as a downgrade.
 ceo_registry_validate() {
   local registry_file="${1:-${CEO_DIR:-}/registry.json}"
   if [ ! -f "$registry_file" ]; then
@@ -362,7 +368,10 @@ ceo_registry_validate() {
   fi
   local v
   v=$(ceo_registry_version "$registry_file")
-  if ! [ "$v" -ge "$CEO_REGISTRY_SCHEMA_VERSION" ] 2>/dev/null; then
+  if [ -z "$v" ]; then
+    return 3
+  fi
+  if [ "$v" -lt "$CEO_REGISTRY_SCHEMA_VERSION" ]; then
     return 2
   fi
   return 0

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -127,31 +127,54 @@ test_registry_validate_accepts_integer_current_schema() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_registry_validate_rejects_non_integer_schema() {
-  local registry="$TEST_HOME/registry.json"
-  printf '{"schema_version":1.5,"playbooks":[]}\n' > "$registry"
-
+_validate_rc() {
+  local registry="$1"
   local rc=0
   env -i PATH="$PATH" bash -c "
     set -uo pipefail
     source '$LIB'
     ceo_registry_validate '$registry'
   " >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "2" "float schema_version must reject instead of falling through"
+  echo "$rc"
+}
+
+test_registry_validate_non_integer_schema_is_malformed() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":1.5,"playbooks":[]}\n' > "$registry"
+  assert_eq "$(_validate_rc "$registry")" "3" "float schema_version has no parseable integer -> malformed (3), not downgrade"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_registry_validate_rejects_string_schema() {
+test_registry_validate_string_schema_is_malformed() {
   local registry="$TEST_HOME/registry.json"
   printf '{"schema_version":"2","playbooks":[]}\n' > "$registry"
+  assert_eq "$(_validate_rc "$registry")" "3" "string schema_version must not coerce -> malformed (3)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
 
-  local rc=0
-  env -i PATH="$PATH" bash -c "
-    set -uo pipefail
-    source '$LIB'
-    ceo_registry_validate '$registry'
-  " >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "2" "string schema_version must reject instead of coercing"
+test_registry_validate_missing_field_is_malformed() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"playbooks":[]}\n' > "$registry"
+  assert_eq "$(_validate_rc "$registry")" "3" "absent schema_version -> malformed (3), retryable"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_registry_validate_torn_json_is_malformed() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":3,"playbo' > "$registry"
+  assert_eq "$(_validate_rc "$registry")" "3" "truncated JSON (mid-sync read) -> malformed (3), retryable"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_registry_validate_genuine_downgrade_is_code_2() {
+  local registry="$TEST_HOME/registry.json"
+  printf '{"schema_version":2,"playbooks":[]}\n' > "$registry"
+  assert_eq "$(_validate_rc "$registry")" "2" "parseable integer below current -> downgrade (2), fail fast"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_registry_validate_missing_file_is_code_1() {
+  assert_eq "$(_validate_rc "$TEST_HOME/does-not-exist.json")" "1" "absent registry file -> not-found (1)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -812,8 +812,28 @@ preflight_has_auto_review_prs() {
 
 # --- Look up trigger in registry ---
 REGISTRY_FILE="$CEO_DIR/registry.json"
+# Append the offending registry head + jq parse status to the skip log so a
+# recurrence is diagnosable from evidence instead of re-guessed.
+_registry_diag() {
+  {
+    echo "$(date): registry diagnostic — $1"
+    echo "  head -c 256 of $REGISTRY_FILE:"
+    head -c 256 "$REGISTRY_FILE" 2>&1 | sed 's/^/    /'
+    echo "  jq parse: $(jq -e . "$REGISTRY_FILE" >/dev/null 2>&1 && echo ok || echo FAILED)"
+  } >> "$LOG_DIR/cron-skips.log"
+}
+
 REGISTRY_RC=0
 ceo_registry_validate "$REGISTRY_FILE" || REGISTRY_RC=$?
+if [ "$REGISTRY_RC" -eq 3 ]; then
+  # No parseable integer schema_version. On a syncthing-synced vault this is
+  # usually a file caught mid-replace, not a real problem — settle and re-read
+  # once before treating it as fatal. A genuine downgrade is code 2, never 3,
+  # so this retry can only ever resolve to a valid current registry.
+  sleep "${CEO_REGISTRY_RETRY_SLEEP:-1}"
+  REGISTRY_RC=0
+  ceo_registry_validate "$REGISTRY_FILE" || REGISTRY_RC=$?
+fi
 case "$REGISTRY_RC" in
   0) ;;
   1)
@@ -821,9 +841,15 @@ case "$REGISTRY_RC" in
     _v "FATAL: registry.json not found. Run: ceo playbook scan"
     exit 1 ;;
   2)
-    echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
-    _record_failure "registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary?)"
+    echo "$(date): FATAL — registry.json schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _record_failure "registry schema_version below $CEO_REGISTRY_SCHEMA_VERSION (peer host on older binary)"
     _v "FATAL: registry.json schema_version too old. Run: ceo playbook scan"
+    exit 1 ;;
+  3)
+    _registry_diag "schema_version unreadable/malformed after retry"
+    echo "$(date): FATAL — registry.json schema_version unreadable/malformed after retry (corrupt registry or persistent sync issue). Run: ceo playbook scan" >> "$LOG_DIR/cron-skips.log"
+    _record_failure "registry.json schema_version unreadable/malformed after retry"
+    _v "FATAL: registry.json unreadable. Run: ceo playbook scan"
     exit 1 ;;
 esac
 

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -1736,13 +1736,17 @@ PB
   jq 'del(.schema_version)' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
   mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
 
+  # RETRY_SLEEP=0: a missing schema_version is code 3 (malformed/transient), so
+  # the preflight re-reads once before failing. A persistently-missing field
+  # survives the retry and still trips the gate.
   local rc=0
-  bash "$CRON" example >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "1" "cron must exit 1 when registry has no schema_version"
+  CEO_REGISTRY_RETRY_SLEEP=0 bash "$CRON" example >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit 1 when registry has no schema_version (after retry)"
 
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
+  assert_contains "$skips_log" "jq parse:" "code-3 path must capture a registry diagnostic for the next occurrence"
 
   local fails
   fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
The registry preflight in `ceo-cron.sh` collapsed three conditions into one FATAL via `ceo_registry_validate` return code 2: a genuine `schema_version` downgrade, a missing/malformed field, and a syncthing-synced `registry.json` caught mid-replace. On a CEO host (MBP, 2026-06-08 09:56 EDT) a transient unreadable read tripped the gate, was reported as `peer host on older binary?`, and counted as a hard failure — inflating `.fail-count` past the alert threshold — even though both hosts were on the current binary and the on-disk registry was valid before and after.

Changes:
- **`ceo_registry_validate`**: split outcomes. A **parseable integer below current** → code 2 (genuine downgrade; fail fast — retrying cannot fix it). **No parseable integer** (missing field, malformed JSON, non-integer, torn read) → new code 3. Codes stay distinct so a real downgrade is never retried into acceptance and a transient read is never mislabeled a downgrade.
- **Cron preflight**: retries code 3 once after a short settle (`CEO_REGISTRY_RETRY_SLEEP`, default 1s) before failing. On persistent failure it writes the registry head + jq parse status to `cron-skips.log` so the next occurrence is diagnosable from evidence rather than re-guessed. Messages no longer assert "older binary" for an unreadable read.

The retry-resolves path (transient → valid on second read) is covered by composition: the preflight re-invokes `ceo_registry_validate` after the sleep and falls through the `0` case; the validator's `0`-on-valid behavior is unit-tested. It is not separately integration-tested to avoid a flaky timing-based background-rewriter test.

## Testing Procedure
1. `bash scripts/ceo-config.test.sh` → 68 pass. Validator unit tests assert codes 0/1/2/3 (current integer, missing file, integer-below-current, and missing/string/float/torn-JSON).
2. Mutation check: revert the code-3 branch to `return 2` → the four code-3 tests fail (got 2, want 3); restore → pass.
3. `bash scripts/ceo-cron.test.sh` → 139 pass. `test_cron_skips_on_missing_schema_version` now exercises the retry path (`CEO_REGISTRY_RETRY_SLEEP=0`) and asserts the `jq parse:` byte-capture diagnostic; `test_cron_skips_on_old_schema_version` (integer 1) still exits 1 via code 2, unchanged.

## Additional Notes
Sibling to llm-tools PR #82 (same incident: workload-report creds path). Follow-up: reset the misattributed `.fail-count` (currently 4) and clear the false repeated-failure ALERT in `approvals/pending.md` — done as a separate explicit vault-state step, not in this code change.