### PR TITLE
fix(gather): mark PR gather degraded when jq post-processing fails (#167)

### DIFF
--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -74,6 +74,30 @@ _pr_gather_mark_degraded() {
 $1"
 }
 
+# Durable channel for jq-failure reasons. The post-processing helpers below run
+# inside `$(...)` command substitution, so a `_pr_gather_mark_degraded` call from
+# there would set PR_GATHER_DEGRADED in a discarded subshell. Failures are
+# appended to this file instead and drained into PR_GATHER_DEGRADED in the parent
+# scope after gather completes (same pattern as the test harness's TEST_FAILS_TMP).
+_PR_GATHER_JQ_FAILS=$(mktemp 2>/dev/null || echo "")
+
+# _pr_gather_jq <reason> <fallback> <jq-args...> — apply a jq transform to JSON
+# read from stdin. On jq failure (malformed input, jq absent, transform error)
+# record <reason> as a degradation and emit <fallback> unchanged. Without this,
+# the bare `jq ... || echo "$prior"` idiom silently preserves the prior value (or
+# empties the set) on a transform error, so a shrunk PR set reads as a clean
+# all-clear instead of surfacing the "counts may be incomplete" marker.
+_pr_gather_jq() {
+  local _reason="$1" _fallback="$2"; shift 2
+  local _out
+  if _out=$(jq "$@" 2>/dev/null); then
+    printf '%s' "$_out"
+  else
+    [ -n "$_PR_GATHER_JQ_FAILS" ] && echo "jq-failed:$_reason" >> "$_PR_GATHER_JQ_FAILS"
+    printf '%s' "$_fallback"
+  fi
+}
+
 if command -v gh &>/dev/null; then
   while IFS= read -r ACCT; do
     [ -z "$ACCT" ] && continue
@@ -93,7 +117,7 @@ if command -v gh &>/dev/null; then
       _R="[]"
     fi
     rm -f "$_err"
-    _REVIEW_PARTS=$(printf '%s\n%s' "$_REVIEW_PARTS" "$_R" | jq -s 'add' 2>/dev/null || echo "$_REVIEW_PARTS")
+    _REVIEW_PARTS=$(printf '%s\n%s' "$_REVIEW_PARTS" "$_R" | _pr_gather_jq "merge-review:$ACCT" "$_REVIEW_PARTS" -s 'add')
 
     _err=$(mktemp)
     if ! _A=$(GH_TOKEN="$TOKEN" _CEO_TIMEOUT 30 gh search prs \
@@ -104,7 +128,7 @@ if command -v gh &>/dev/null; then
       _A="[]"
     fi
     rm -f "$_err"
-    _AUTHORED_PARTS=$(printf '%s\n%s' "$_AUTHORED_PARTS" "$_A" | jq -s 'add' 2>/dev/null || echo "$_AUTHORED_PARTS")
+    _AUTHORED_PARTS=$(printf '%s\n%s' "$_AUTHORED_PARTS" "$_A" | _pr_gather_jq "merge-authored:$ACCT" "$_AUTHORED_PARTS" -s 'add')
 
     _err=$(mktemp)
     _MQ=(--author "@me" --merged --json "number,title,closedAt,repository,url" --limit 50)
@@ -115,7 +139,7 @@ if command -v gh &>/dev/null; then
       _M="[]"
     fi
     rm -f "$_err"
-    _MERGED_PARTS=$(printf '%s\n%s' "$_MERGED_PARTS" "$_M" | jq -s 'add' 2>/dev/null || echo "$_MERGED_PARTS")
+    _MERGED_PARTS=$(printf '%s\n%s' "$_MERGED_PARTS" "$_M" | _pr_gather_jq "merge-merged:$ACCT" "$_MERGED_PARTS" -s 'add')
   done < <(ceo_pr_sources_github_accounts)
 
   # Drop excluded orgs (case-insensitive match on the owner segment).
@@ -128,12 +152,10 @@ if command -v gh &>/dev/null; then
     echo "WARN: exclude_orgs configured but parsed to empty list — check $(ceo_pr_sources_path)" >&2
   fi
   if [ "$EXCLUDE_ORGS" != "[]" ]; then
-    _REVIEW_PARTS=$(echo "$_REVIEW_PARTS" | jq --argjson ex "$EXCLUDE_ORGS" \
-      '[.[] | select(.repository.nameWithOwner != null) | select((.repository.nameWithOwner | split("/")[0] | ascii_downcase) as $o | ($ex | map(ascii_downcase) | index($o)) | not)]' 2>/dev/null || echo "$_REVIEW_PARTS")
-    _AUTHORED_PARTS=$(echo "$_AUTHORED_PARTS" | jq --argjson ex "$EXCLUDE_ORGS" \
-      '[.[] | select(.repository.nameWithOwner != null) | select((.repository.nameWithOwner | split("/")[0] | ascii_downcase) as $o | ($ex | map(ascii_downcase) | index($o)) | not)]' 2>/dev/null || echo "$_AUTHORED_PARTS")
-    _MERGED_PARTS=$(echo "$_MERGED_PARTS" | jq --argjson ex "$EXCLUDE_ORGS" \
-      '[.[] | select(.repository.nameWithOwner != null) | select((.repository.nameWithOwner | split("/")[0] | ascii_downcase) as $o | ($ex | map(ascii_downcase) | index($o)) | not)]' 2>/dev/null || echo "$_MERGED_PARTS")
+    _exclude_jq='[.[] | select(.repository.nameWithOwner != null) | select((.repository.nameWithOwner | split("/")[0] | ascii_downcase) as $o | ($ex | map(ascii_downcase) | index($o)) | not)]'
+    _REVIEW_PARTS=$(printf '%s' "$_REVIEW_PARTS" | _pr_gather_jq "exclude-review" "$_REVIEW_PARTS" --argjson ex "$EXCLUDE_ORGS" "$_exclude_jq")
+    _AUTHORED_PARTS=$(printf '%s' "$_AUTHORED_PARTS" | _pr_gather_jq "exclude-authored" "$_AUTHORED_PARTS" --argjson ex "$EXCLUDE_ORGS" "$_exclude_jq")
+    _MERGED_PARTS=$(printf '%s' "$_MERGED_PARTS" | _pr_gather_jq "exclude-merged" "$_MERGED_PARTS" --argjson ex "$EXCLUDE_ORGS" "$_exclude_jq")
   fi
 
   # Dedupe by repo+number — same PR can appear under both accounts when one
@@ -141,9 +163,10 @@ if command -v gh &>/dev/null; then
   # `select(.repository.nameWithOwner and .number)` prevents jq's null-as-"null"
   # interpolation from collapsing distinct null-key entries into a single row.
   if ceo_pr_sources_dedupe; then
-    _REVIEW_PARTS=$(echo "$_REVIEW_PARTS" | jq '[.[] | select(.repository.nameWithOwner and .number)] | unique_by("\(.repository.nameWithOwner)#\(.number)")' 2>/dev/null || echo "$_REVIEW_PARTS")
-    _AUTHORED_PARTS=$(echo "$_AUTHORED_PARTS" | jq '[.[] | select(.repository.nameWithOwner and .number)] | unique_by("\(.repository.nameWithOwner)#\(.number)")' 2>/dev/null || echo "$_AUTHORED_PARTS")
-    _MERGED_PARTS=$(echo "$_MERGED_PARTS" | jq '[.[] | select(.repository.nameWithOwner and .number)] | unique_by("\(.repository.nameWithOwner)#\(.number)")' 2>/dev/null || echo "$_MERGED_PARTS")
+    _dedupe_jq='[.[] | select(.repository.nameWithOwner and .number)] | unique_by("\(.repository.nameWithOwner)#\(.number)")'
+    _REVIEW_PARTS=$(printf '%s' "$_REVIEW_PARTS" | _pr_gather_jq "dedupe-review" "$_REVIEW_PARTS" "$_dedupe_jq")
+    _AUTHORED_PARTS=$(printf '%s' "$_AUTHORED_PARTS" | _pr_gather_jq "dedupe-authored" "$_AUTHORED_PARTS" "$_dedupe_jq")
+    _MERGED_PARTS=$(printf '%s' "$_MERGED_PARTS" | _pr_gather_jq "dedupe-merged" "$_MERGED_PARTS" "$_dedupe_jq")
   fi
 fi
 
@@ -169,15 +192,25 @@ if command -v glab &>/dev/null && glab auth status &>/dev/null 2>&1; then
     rm -f "$_err"
     # Guard `references.full` — null on rare MR shapes would throw inside sub()
     # and the outer `|| echo "[]"` would empty the entire batch.
-    _R=$(echo "$_GLR" | jq '[.[] | select(.references.full != null) | {number: .iid, title, createdAt: .created_at, repository: {nameWithOwner: (.references.full | sub("![^!]*$"; ""))}, url: .web_url}]' 2>/dev/null || echo "[]")
-    _A=$(echo "$_GLA" | jq '[.[] | select(.references.full != null) | {number: .iid, title, createdAt: .created_at, repository: {nameWithOwner: (.references.full | sub("![^!]*$"; ""))}, url: .web_url}]' 2>/dev/null || echo "[]")
-    _GL_REVIEW_PARTS=$(printf '%s\n%s' "$_GL_REVIEW_PARTS" "$_R" | jq -s 'add' 2>/dev/null || echo "$_GL_REVIEW_PARTS")
-    _GL_AUTHORED_PARTS=$(printf '%s\n%s' "$_GL_AUTHORED_PARTS" "$_A" | jq -s 'add' 2>/dev/null || echo "$_GL_AUTHORED_PARTS")
+    _gl_shape_jq='[.[] | select(.references.full != null) | {number: .iid, title, createdAt: .created_at, repository: {nameWithOwner: (.references.full | sub("![^!]*$"; ""))}, url: .web_url}]'
+    _R=$(printf '%s' "$_GLR" | _pr_gather_jq "shape-gl-review:$GL_USER" "[]" "$_gl_shape_jq")
+    _A=$(printf '%s' "$_GLA" | _pr_gather_jq "shape-gl-authored:$GL_USER" "[]" "$_gl_shape_jq")
+    _GL_REVIEW_PARTS=$(printf '%s\n%s' "$_GL_REVIEW_PARTS" "$_R" | _pr_gather_jq "merge-gl-review:$GL_USER" "$_GL_REVIEW_PARTS" -s 'add')
+    _GL_AUTHORED_PARTS=$(printf '%s\n%s' "$_GL_AUTHORED_PARTS" "$_A" | _pr_gather_jq "merge-gl-authored:$GL_USER" "$_GL_AUTHORED_PARTS" -s 'add')
   done < <(ceo_pr_sources_gitlab_usernames)
 fi
 
-_REVIEW_PARTS=$(printf '%s\n%s' "$_REVIEW_PARTS" "$_GL_REVIEW_PARTS" | jq -s 'add' 2>/dev/null || echo "$_REVIEW_PARTS")
-_AUTHORED_PARTS=$(printf '%s\n%s' "$_AUTHORED_PARTS" "$_GL_AUTHORED_PARTS" | jq -s 'add' 2>/dev/null || echo "$_AUTHORED_PARTS")
+_REVIEW_PARTS=$(printf '%s\n%s' "$_REVIEW_PARTS" "$_GL_REVIEW_PARTS" | _pr_gather_jq "merge-review-final" "$_REVIEW_PARTS" -s 'add')
+_AUTHORED_PARTS=$(printf '%s\n%s' "$_AUTHORED_PARTS" "$_GL_AUTHORED_PARTS" | _pr_gather_jq "merge-authored-final" "$_AUTHORED_PARTS" -s 'add')
+
+# Drain jq-failure reasons recorded inside the post-processing subshells into the
+# degradation state in this (parent) scope.
+if [ -n "$_PR_GATHER_JQ_FAILS" ] && [ -s "$_PR_GATHER_JQ_FAILS" ]; then
+  while IFS= read -r _r; do
+    [ -n "$_r" ] && _pr_gather_mark_degraded "$_r"
+  done < "$_PR_GATHER_JQ_FAILS"
+fi
+[ -n "$_PR_GATHER_JQ_FAILS" ] && rm -f "$_PR_GATHER_JQ_FAILS"
 
 export PR_REVIEW_REQUESTED="$_REVIEW_PARTS"
 export PR_AUTHORED="$_AUTHORED_PARTS"

--- a/scripts/ceo-gather.test.sh
+++ b/scripts/ceo-gather.test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Tests for ceo-gather.sh — PR gather degradation observability (#167).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TMP=$(mktemp -d)
+  OLD_HOME="$HOME"
+  OLD_PATH="$PATH"
+  export HOME="$TMP"
+  export CEO_VAULT="$TMP/vault"
+  mkdir -p "$CEO_VAULT/CEO/approvals" "$CEO_VAULT/CEO/log"
+
+  mkdir -p "$TMP/.ceo"
+  cat > "$TMP/.ceo/pr-sources.json" << 'JSON'
+{ "github": { "accounts": ["testacct"] }, "gitlab": { "usernames": [] } }
+JSON
+
+  mkdir -p "$TMP/bin"
+  # glab stub: report unauthenticated so the GitLab block is skipped entirely,
+  # keeping the test deterministic regardless of a real glab on the host.
+  cat > "$TMP/bin/glab" << 'STUB'
+#!/bin/bash
+[ "$1" = "auth" ] && [ "$2" = "status" ] && exit 1
+exit 1
+STUB
+  chmod +x "$TMP/bin/glab"
+  export PATH="$TMP/bin:$PATH"
+}
+
+teardown() {
+  export HOME="$OLD_HOME"
+  export PATH="$OLD_PATH"
+  unset CEO_VAULT
+  rm -rf "$TMP"
+}
+
+# argv-validating gh stub. $1 controls the merged-search body so each test can
+# inject a valid or malformed payload; exit 99 on any unexpected shape.
+_write_gh_stub() {
+  local merged_body="$1"
+  cat > "$TMP/bin/gh" << STUB
+#!/bin/bash
+case "\$1 \$2" in
+  "auth token") echo "ghs_faketoken"; exit 0 ;;
+  "auth status") exit 0 ;;
+esac
+if [ "\$1" = "search" ] && [ "\$2" = "prs" ]; then
+  case "\$*" in
+    *"--merged"*)            printf '%s' '$merged_body'; exit 0 ;;
+    *"--review-requested"*)  echo '[]'; exit 0 ;;
+    *"--state open"*"--author"*) echo '[]'; exit 0 ;;
+  esac
+fi
+echo "stub gh: unexpected argv: \$*" >&2
+exit 99
+STUB
+  chmod +x "$TMP/bin/gh"
+}
+
+_run_gather() {
+  # Source in an isolated subshell with set +eu (gather tolerates failures and
+  # is sourced by cron without nounset); echo the observability vars.
+  ( set +eu
+    source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1
+    echo "DEGRADED=${PR_GATHER_DEGRADED}|MERGED_COUNT=${PR_MERGED_COUNT}|REASONS=${PR_GATHER_DEGRADED_REASONS}" )
+}
+
+# A jq post-processing failure (malformed payload that the gh call returns with
+# exit 0, so the gh-failure branch is NOT taken) must mark the gather degraded —
+# otherwise a silently-shrunk PR set reads as a clean all-clear.
+test_jq_postprocessing_failure_marks_degraded() {
+  _write_gh_stub 'this is not valid json'
+  local out; out=$(_run_gather)
+  assert_contains "$out" "DEGRADED=1" "a jq post-processing failure must set PR_GATHER_DEGRADED (#167)"
+}
+
+# The complement: a fully-valid gather must NOT mark degraded — guards the fix
+# against falsely flagging every run.
+test_clean_gather_not_degraded() {
+  _write_gh_stub '[]'
+  local out; out=$(_run_gather)
+  assert_contains "$out" "DEGRADED=0" "a clean gather must leave PR_GATHER_DEGRADED unset"
+}
+
+run_tests


### PR DESCRIPTION
Closes #167

## Description (Issue Fixed & New Behavior)
Follow-up from #163 (silent-failure review). In `scripts/ceo-gather.sh`, every per-set jq post-processing step (merge `jq -s 'add'`, exclude-orgs, dedupe, and the GitLab shape transform) used `jq … 2>/dev/null || echo "$prior"`. On a jq failure (malformed input, jq absent, transform error) this silently preserved the prior accumulator value — or emptied the set — **without** setting `PR_GATHER_DEGRADED`. A non-empty PR set could silently shrink and the morning brief would read a clean all-clear instead of the "counts may be incomplete" marker.

This is the `safety-invariant-scope` pattern fix: *a gather set never silently shrinks without a degradation marker.*

- New **`_pr_gather_jq`** helper applies the transform, records a degradation reason and returns the fallback on jq failure. Because the helper runs inside `$(…)`/pipe **subshells**, a direct `_pr_gather_mark_degraded` call there would be discarded — so reasons are appended to a temp file and **drained into `PR_GATHER_DEGRADED` in the parent scope** after gather (same durable-signal pattern as the test harness's `TEST_FAILS_TMP`).
- Every prior-preserving post-processing fallback (GitHub + GitLab; merge/exclude/dedupe/shape) is routed through the helper.
- Count fallbacks (`| jq length || echo 0`) are intentionally left as-is: a count failure over an already-validated array is redundant with the upstream marker and falls back to `0`, not a stale set.

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-gather.test.sh` — 2 tests pass (new harness). The degraded test stubs `gh` to return **malformed JSON with exit 0** (so the gh-failure branch is bypassed), forcing a jq post-processing failure, and asserts `PR_GATHER_DEGRADED=1`; the complement asserts a clean gather stays `0`.
3. Verify the fix is covered: reverting the record line (`ceo-gather.sh:96`) flips the degraded test to fail.
4. Regression: `bash scripts/ceo-config.test.sh` (68) and `bash scripts/ceo-cron.test.sh` (140, sources gather) both pass.
5. `shellcheck -S warning scripts/ceo-gather.sh scripts/ceo-gather.test.sh` — clean.

## Additional Notes / HelpScout Tickets
Environment exercised: local MacBook shell test suites (gather 2 / config 68 / cron 140) + mutation check. Independent silent-failure audit: no HIGH/MEDIUM findings; two LOW (temp-file leak only on caller SIGINT — matches pre-existing `_err=$(mktemp)` exposure; count fallbacks out of scope) both accepted.