### PR TITLE
perf(ollama): switch read-tier local model to gemma4:12b-it-qat

### DIFF
--- a/docs/ollama-setup.md
+++ b/docs/ollama-setup.md
@@ -5,10 +5,10 @@ The CEO agent supports local inference via the `runner: ollama` and `runner: oll
 ## Default Models
 
 If a playbook uses an ollama runner but does not specify a `model:`, the system defaults to:
-- `runner: ollama`: `mistral-small3.2:24b`
+- `runner: ollama`: `gemma4:12b-it-qat`
 - `runner: ollama-think`: `gpt-oss:20b`
 
-These models were chosen as the optimal balance between capability and speed for a local 16GB-24GB VRAM environment.
+These models were chosen as the optimal balance between capability and speed for a local VRAM-constrained environment. `gemma4:12b-it-qat` (~7 GB) fits fully in 12 GB VRAM, avoiding the CPU spill that throttles larger 24B-class models to single-digit tokens/sec.
 
 ## Bootstrap Script
 
@@ -24,7 +24,7 @@ If you prefer to pull the models manually, or if you want to use custom models:
 
 ```bash
 # Pull the standard playbook runner (fast, capable)
-ollama pull mistral-small3.2:24b
+ollama pull gemma4:12b-it-qat
 
 # Pull the thinking/reasoning runner (slower, methodical)
 ollama pull gpt-oss:20b

--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -4,7 +4,7 @@ description: Generate a prioritized overview of the day's work
 trigger: cron
 schedule: "57 8 * * 1-5"
 runner: ollama
-model: mistral-small3.2:24b
+model: gemma4:12b-it-qat
 preflight: none
 tier: read
 status: active

--- a/docs/playbooks/morning-scan.md
+++ b/docs/playbooks/morning-scan.md
@@ -4,7 +4,7 @@ description: Scan vault for overnight changes, new notes, unresolved items, carr
 trigger: cron
 schedule: "50 8 * * 1-5"
 runner: ollama
-model: mistral-small3.2:24b
+model: gemma4:12b-it-qat
 preflight: none
 tier: read
 status: active

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1361,7 +1361,7 @@ END_LOG_ENTRY"
     # playbooks still honor `model:` for explicit ollama-model overrides.
     if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
       case "$RUNNER" in
-        ollama)       OLLAMA_MODEL="mistral-small3.2:24b" ;;
+        ollama)       OLLAMA_MODEL="gemma4:12b-it-qat" ;;
         ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
       esac
     else
@@ -1373,7 +1373,8 @@ END_LOG_ENTRY"
     export CEO_MODEL="$OLLAMA_MODEL"
 
     OLLAMA_PROMPT="$SINGLE_PROMPT_BODY"
-    # mistral-small3.2:24b has a 32K context window. Reserve ~8K for output
+    # gemma4:12b-it-qat fits fully in 12 GB VRAM and holds a 32K+ context
+    # window. Reserve ~8K for output
     # and overhead; the rest is the prompt budget. Override via env when a
     # larger-context model is selected. `wc -c` measures bytes — `${#var}`
     # would return character count under a UTF-8 locale and undercount.

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -784,7 +784,7 @@ PB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "mistral-small3.2:24b" "runner:ollama default must be mistral-small3.2:24b"
+  assert_eq "$model" "gemma4:12b-it-qat" "runner:ollama default must be gemma4:12b-it-qat"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -937,7 +937,7 @@ PB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to mistral default)"
+  assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to gemma4 default)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -1211,7 +1211,7 @@ description: chunked scan test
 trigger: cron
 schedule: "50 8 * * 1-5"
 runner: ollama
-model: mistral-small3.2:24b
+model: gemma4:12b-it-qat
 preflight: none
 tier: read
 status: active
@@ -1228,7 +1228,7 @@ PB
     "description": "chunked scan test",
     "trigger": "cron",
     "schedule": "50 8 * * 1-5",
-    "model": "mistral-small3.2:24b",
+    "model": "gemma4:12b-it-qat",
     "preflight": "none",
     "tier": "read",
     "status": "active",
@@ -1571,7 +1571,7 @@ test_production_morning_brief_registers_with_ollama_runner() {
   model=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-brief.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-brief.md must declare tier: read"
-  assert_eq "$model" "mistral-small3.2:24b" "production morning-brief.md must declare model: mistral-small3.2:24b"
+  assert_eq "$model" "gemma4:12b-it-qat" "production morning-brief.md must declare model: gemma4:12b-it-qat"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -1593,7 +1593,7 @@ test_production_morning_scan_registers_with_ollama_runner() {
   model=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-scan.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-scan.md must declare tier: read"
-  assert_eq "$model" "mistral-small3.2:24b" "production morning-scan.md must declare model: mistral-small3.2:24b"
+  assert_eq "$model" "gemma4:12b-it-qat" "production morning-scan.md must declare model: gemma4:12b-it-qat"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2672,7 +2672,7 @@ STUB
   
   local ollama_invoked
   ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_contains "$ollama_invoked" "mistral-small" "ollama must be invoked with default model during fallback"
+  assert_contains "$ollama_invoked" "gemma4" "ollama must be invoked with default model during fallback"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2710,7 +2710,7 @@ STUB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "mistral-small3.2:24b" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
+  assert_eq "$model" "gemma4:12b-it-qat" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/debug-chunked-test.sh
+++ b/scripts/debug-chunked-test.sh
@@ -181,7 +181,7 @@ cat > "$CEO_DIR/registry.json" << 'JSON'
     "description": "chunked scan test",
     "trigger": "cron",
     "schedule": "50 8 * * 1-5",
-    "model": "mistral-small3.2:24b",
+    "model": "gemma4:12b-it-qat",
     "preflight": "none",
     "tier": "read",
     "status": "active",
@@ -204,7 +204,7 @@ description: chunked scan test
 trigger: cron
 schedule: "50 8 * * 1-5"
 runner: ollama
-model: mistral-small3.2:24b
+model: gemma4:12b-it-qat
 preflight: none
 tier: read
 status: active
@@ -246,7 +246,7 @@ echo "direct node test:"
 node "$TEST_HOME/.bun/bin/jq.js" -r "$QUERY" "$CEO_DIR/registry.json"
 
 echo "=== jq self-test ==="
-echo '{"playbooks":[{"name":"morning-scan","file":"playbooks/morning-scan.md","runner":"ollama","tier":"read","model":"mistral-small3.2:24b","status":"active","trigger":"cron","preflight":"none","script":"","inputs":null,"requires":null}]}' \
+echo '{"playbooks":[{"name":"morning-scan","file":"playbooks/morning-scan.md","runner":"ollama","tier":"read","model":"gemma4:12b-it-qat","status":"active","trigger":"cron","preflight":"none","script":"","inputs":null,"requires":null}]}' \
   | jq -r --arg t morning-scan '.playbooks[] | select(.name == $t)'
 
 echo "=== Running ceo-cron.sh morning-scan ==="

--- a/scripts/ollama-setup.sh
+++ b/scripts/ollama-setup.sh
@@ -11,8 +11,8 @@ fi
 
 echo "Pulling default models for CEO agent runners..."
 
-echo "1/2: Pulling mistral-small3.2:24b (default for 'runner: ollama')..."
-ollama pull mistral-small3.2:24b
+echo "1/2: Pulling gemma4:12b-it-qat (default for 'runner: ollama')..."
+ollama pull gemma4:12b-it-qat
 echo "1/2: OK"
 
 echo "2/2: Pulling gpt-oss:20b (default for 'runner: ollama-think')..."


### PR DESCRIPTION
## Description

The read-tier ollama model was pinned in **three independent places**, all on `mistral-small3.2:24b`. A blinded eval on ML-1 (RTX 5070, 12 GB VRAM) showed the 24B model (~15 GB) spills to CPU and crawls at **~2.3 tok/s**, while `gemma4:12b-it-qat` (~7 GB) fits fully in VRAM at **~62 tok/s (~25× faster)** with comparable structured-output quality. This PR switches all three:

1. **`ceo-cron.sh:1364`** — runner-default for `runner: ollama` (used when no frontmatter `model:` *or* on the Claude-rate-limit fallback path).
2. **`docs/playbooks/morning-scan.md` + `morning-brief.md`** — native `runner: ollama` read-tier playbooks that pin the model in frontmatter and run **daily**. Switching only the fallback default would have left these on the slow model.
3. **`ollama-setup.sh` + `docs/ollama-setup.md`** — the bootstrap path that `ollama pull`s the default, so a fresh host pulls the model the runtime actually uses.

`gpt-oss:20b` (the `runner: ollama-think` default) is intentionally untouched.

## Testing Procedure
1. Check out this branch.
2. Run `bash scripts/ceo-cron.test.sh` → **All tests passed. (140 tests)**.
3. Run `bash scripts/ceo-config.test.sh` → **All tests passed. (68 tests)**.
4. Mutation check: revert any single `gemma4:12b-it-qat` → `mistral-small3.2:24b` in `ceo-cron.sh` or a production playbook and re-run — the matching assertion (787 / 1574 / 1596 / 2675 / 2713) fails. Assertions drive off the production frontmatter via `ceo playbook scan` and the dispatcher case, not a hand-built expected.
5. Confirm no `mistral` references remain: `grep -rn mistral scripts/ docs/` → empty.

## Deploy note (required, ML-1 only)
The merge does **not** repoint ML-1's synced `registry.json`. Before the switch takes effect on ML-1:
1. `ollama pull gemma4:12b-it-qat` (else the first scheduled run fails with `pull model manifest: file does not exist`).
2. `ceo playbook scan` **on ML-1 only** (per the `ceo-scan-only-on-ml1` rule) to regenerate `registry.json` from the new frontmatter.

## Additional Notes
Independent auditor pass: faithful to the ask, complete (zero `mistral` refs remain), real (non-tautological) tests, no regressions. Eval write-up: Obsidian `2026-06-08-gemma4-fallback-eval.md`.