### PR TITLE
test(evals): add ollama-matrix local-model reasoning eval library

### DIFF
--- a/evals/ollama-matrix/README.md
+++ b/evals/ollama-matrix/README.md
@@ -1,0 +1,73 @@
+# ollama-matrix — local-model reasoning eval
+
+A small, reusable library for comparing local ollama models on the kinds of
+reasoning the CEO agent runs locally (`runner: ollama` / `runner: ollama-think`).
+Every task is **self-contained** (no live vault/repo state) and **machine-graded
+against a known answer key** — no subjective judge — so runs are reproducible and
+comparable across models and over time.
+
+## Why it exists
+
+The first gemma4-vs-incumbent comparison was a single task (N=1), which can't
+separate models. This library varies the task across six reasoning dimensions,
+each with a deterministic correct answer, so a score difference means something.
+
+## Layout
+
+```
+prompts/   one .txt per task, fully self-contained
+keys.json  answer key + grading mode + rationale per task
+run.sh     runs every prompt × each model via the ollama API (temperature 0)
+grade.py   extracts each model's verdict and scores it against keys.json
+out/       generated outputs + stats.tsv (gitignored)
+```
+
+## Tasks
+
+| Task | Dimension | Output contract | Graded by |
+|------|-----------|-----------------|-----------|
+| think-01-reconcile-evidence | evidence-matching + abstention | `T<n> \| CLOSE #<pr> \| ...` / `T<n> \| KEEP \| ...` | per-item verdict + PR # |
+| think-02-prioritization | multi-criteria ranking | `ORDER: a,b,c,...` | exact order |
+| think-03-contradiction | consistency detection | `PAIR: S<n>,S<n>` | unordered pair |
+| think-04-temporal-cadence | date/cron arithmetic | `MISSED: <n>` / `NEXT: <ts>` | exact values |
+| think-05-abstention | calibration | `Q<n>: <answer\|INSUFFICIENT>` | answer vs abstain |
+| think-06-multihop | chained inference | `ANSWER: YES\|NO` | boolean |
+
+Each task includes at least one trap (e.g. reconcile T8 cites a PR that is only
+*proposed*, not merged → correct answer is KEEP) so a model that pattern-matches
+without reasoning loses points.
+
+## Run
+
+Requires a running ollama daemon, `jq`, `curl`, and `python3`.
+
+```bash
+# default models (think-tier candidates)
+bash run.sh
+# or pick the set explicitly
+MODELS="gemma4:12b-it-qat gpt-oss:20b mistral-small3.2:24b" bash run.sh
+python3 grade.py            # score table + summary
+python3 grade.py --verbose  # also list every wrong item
+```
+
+On the CEO host this runs in WSL against the WSL ollama daemon (the one cron
+uses), not the Windows ollama — they are separate model stores.
+
+## Adding a task
+
+1. Drop a self-contained prompt in `prompts/`. Make the output a single
+   machine-parseable contract (one verdict per line).
+2. Add a `keys.json` entry: pick a `mode` that an extractor in `grade.py`
+   already supports (`reconcile`/`order`/`pair`/`kv`/`abstain`/`yesno`), or add a
+   new extractor. Include the correct answer and a one-line rationale.
+3. Prefer tasks with a verifiable ground truth and at least one trap. Avoid
+   anything whose answer depends on world knowledge or the current date unless
+   the date is stated in the prompt.
+
+## Caveats
+
+- Greedy decoding (temperature 0) makes runs deterministic but is one sample per
+  model; it does not estimate variance. For a tighter comparison, raise N by
+  adding paraphrased task variants rather than re-sampling the same prompt.
+- A perfect tie means "both competent on these tasks," not "equivalent
+  reasoners." Add harder multi-hop / arithmetic tasks to separate strong models.

--- a/evals/ollama-matrix/README.md
+++ b/evals/ollama-matrix/README.md
@@ -48,7 +48,12 @@ bash run.sh
 MODELS="gemma4:12b-it-qat gpt-oss:20b mistral-small3.2:24b" bash run.sh
 python3 grade.py            # score table + summary
 python3 grade.py --verbose  # also list every wrong item
+python3 grade.py --selftest # verify the extractors against known adversarial cases
 ```
+
+A call that fails (daemon down, model not pulled, HTTP/API error) is written as an
+`__EVAL_ERROR__` sentinel and shown as `ERR` in the score table — excluded from the
+summary so an infrastructure failure never reads as a model-quality loss.
 
 On the CEO host this runs in WSL against the WSL ollama daemon (the one cron
 uses), not the Windows ollama — they are separate model stores.

--- a/evals/ollama-matrix/grade.py
+++ b/evals/ollama-matrix/grade.py
@@ -28,16 +28,22 @@ def grade_reconcile(text, key):
     items = key["items"]
     wrong = []
     for tid, expect in items.items():
-        m = re.search(rf"^\s*{tid}\b.*$", text, re.MULTILINE | re.IGNORECASE)
-        line = m.group(0) if m else ""
+        # Allow an optional list marker (-, *, 1.) before the ticket id; models
+        # add these even when told not to. Match on the VERDICT field (between
+        # the first two pipes) only — never the free-text reason, which legitimately
+        # contains the word "close" ("no merged PR closes it").
+        m = re.search(rf"^\s*(?:[-*]\s*|\d+[.)]\s*)?{tid}\b(.*)$", text, re.MULTILINE | re.IGNORECASE)
+        rest = m.group(1) if m else ""
+        parts = rest.split("|")
+        verdict = parts[1] if len(parts) >= 2 else rest
         if expect == "KEEP":
-            ok = bool(re.search(r"\bKEEP\b", line, re.IGNORECASE)) and not re.search(r"\bCLOSE\b", line, re.IGNORECASE)
+            ok = bool(re.search(r"\bKEEP\b", verdict, re.IGNORECASE)) and not re.search(r"\bCLOSE\b", verdict, re.IGNORECASE)
         else:
             pr = expect.split(":")[1]
-            cm = re.search(r"\bCLOSE\b\s*#?(\d+)", line, re.IGNORECASE)
+            cm = re.search(r"\bCLOSE\b\s*#?(\d+)", verdict, re.IGNORECASE)
             ok = bool(cm) and cm.group(1) == pr
         if not ok:
-            wrong.append((tid, expect, line.strip()))
+            wrong.append((tid, expect, (m.group(0) if m else "").strip()))
     return len(items) - len(wrong), len(items), wrong
 
 
@@ -50,7 +56,9 @@ def grade_order(text, key):
 
 
 def grade_pair(text, key):
-    m = re.search(r"PAIR:\s*([Ss0-9 ,]+)", text, re.IGNORECASE)
+    # Capture the rest of the line (tolerates "S3 and S4", "S3, S4", etc.);
+    # findall isolates the ids regardless of separator.
+    m = re.search(r"PAIR:\s*(.+)", text, re.IGNORECASE)
     got = set(re.findall(r"[Ss]\s*(\d+)", m.group(1))) if m else set()
     exp = set(re.findall(r"[Ss]\s*(\d+)", key["expect"]))
     ok = got == exp
@@ -111,6 +119,36 @@ GRADERS = {
     "kv": grade_kv, "abstain": grade_abstain, "yesno": grade_yesno,
 }
 
+
+def _selftest():
+    """Lock the extractors against the failure modes a review panel found:
+    KEEP whose reason prose says "close", list-prefixed lines, "S3 and S4"
+    separators, timestamp-format variance, and wrong answers still failing."""
+    cases = [
+        (grade_reconcile, {"items": {"T8": "KEEP"}},
+         "T8 | KEEP | PR #169 would close this but is only proposed", 1),
+        (grade_reconcile, {"items": {"T1": "CLOSE:165"}}, "- T1 | CLOSE #165 | retry", 1),
+        (grade_reconcile, {"items": {"T1": "CLOSE:165"}}, "1. T1 | CLOSE #165 | retry", 1),
+        (grade_reconcile, {"items": {"T1": "CLOSE:165"}}, "T1 | CLOSE #999 | wrong pr", 0),
+        (grade_reconcile, {"items": {"T8": "KEEP"}}, "T8 | CLOSE #169 | proposed", 0),
+        (grade_pair, {"expect": "S3,S4"}, "PAIR: S3 and S4", 1),
+        (grade_pair, {"expect": "S3,S4"}, "PAIR: S1,S2", 0),
+        (grade_kv, {"expect": {"NEXT": "2026-06-09 09:00"}}, "NEXT: 2026-06-09 at 9:00", 1),
+        (grade_yesno, {"expect": "YES"}, "ANSWER: NO", 0),
+    ]
+    fails = 0
+    for fn, key, text, want in cases:
+        got = fn(text, key)[0]
+        if got != want:
+            fails += 1
+            print(f"SELFTEST FAIL: {fn.__name__}({text!r}) -> {got}, want {want}")
+    print("selftest: OK" if not fails else f"selftest: {fails} FAILED")
+    sys.exit(1 if fails else 0)
+
+
+if "--selftest" in sys.argv:
+    _selftest()
+
 models = sorted({p.name.split("--", 1)[1].rsplit(".txt", 1)[0]
                  for p in OUT.glob("*--*.txt")})
 if not models:
@@ -127,7 +165,16 @@ for task, key in KEYS.items():
         if not f.exists():
             row += f"{'--':<22} "
             continue
-        got, total, wrong = grader(f.read_text(), key)
+        raw = f.read_text()
+        # An empty file or a run.sh error sentinel means the call never produced
+        # an answer (daemon down, model not pulled, HTTP/parse error). Score it
+        # ERR, distinct from a wrong answer, and exclude it from the summary —
+        # an infra failure must not read as a model-quality loss.
+        if not raw.strip() or raw.lstrip().startswith("__EVAL_ERROR__"):
+            row += f"{'ERR':<22} "
+            scores[m][task] = None
+            continue
+        got, total, wrong = grader(raw, key)
         scores[m][task] = (got, total)
         row += f"{f'{got}/{total}':<22} "
         if VERBOSE and wrong:
@@ -137,7 +184,10 @@ for task, key in KEYS.items():
 
 print("\n=== summary (items correct / total) ===")
 for m in models:
-    got = sum(s[0] for s in scores[m].values())
-    tot = sum(s[1] for s in scores[m].values())
+    vals = [s for s in scores[m].values() if s is not None]
+    got = sum(s[0] for s in vals)
+    tot = sum(s[1] for s in vals)
     pct = 100 * got / tot if tot else 0
-    print(f"  {m:<24} {got}/{tot}  ({pct:.0f}%)")
+    errs = sum(1 for s in scores[m].values() if s is None)
+    note = f"  [{errs} task(s) ERR, excluded]" if errs else ""
+    print(f"  {m:<24} {got}/{tot}  ({pct:.0f}%){note}")

--- a/evals/ollama-matrix/grade.py
+++ b/evals/ollama-matrix/grade.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Grade ollama-matrix model outputs against keys.json.
+
+Reads out/<task>--<model>.txt produced by run.sh, extracts each model's
+per-item verdict by regex (per the task's mode), scores against the key, and
+prints a per-task / per-model score table plus a summary matrix. No subjective
+judging — every task has a deterministic correct answer.
+
+    python3 grade.py            # grade everything in out/
+    python3 grade.py --verbose  # also print each wrong item
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+KEYS = json.loads((HERE / "keys.json").read_text())["tasks"]
+OUT = HERE / "out"
+VERBOSE = "--verbose" in sys.argv
+
+
+def norm(s):
+    return re.sub(r"\s+", " ", s.strip()).lower()
+
+
+def grade_reconcile(text, key):
+    items = key["items"]
+    wrong = []
+    for tid, expect in items.items():
+        m = re.search(rf"^\s*{tid}\b.*$", text, re.MULTILINE | re.IGNORECASE)
+        line = m.group(0) if m else ""
+        if expect == "KEEP":
+            ok = bool(re.search(r"\bKEEP\b", line, re.IGNORECASE)) and not re.search(r"\bCLOSE\b", line, re.IGNORECASE)
+        else:
+            pr = expect.split(":")[1]
+            cm = re.search(r"\bCLOSE\b\s*#?(\d+)", line, re.IGNORECASE)
+            ok = bool(cm) and cm.group(1) == pr
+        if not ok:
+            wrong.append((tid, expect, line.strip()))
+    return len(items) - len(wrong), len(items), wrong
+
+
+def grade_order(text, key):
+    m = re.search(r"ORDER:\s*([A-Za-z0-9 ,]+)", text, re.IGNORECASE)
+    got = re.sub(r"[^A-Za-z0-9]", "", m.group(1)).upper() if m else ""
+    exp = re.sub(r"[^A-Za-z0-9]", "", key["expect"]).upper()
+    ok = got == exp
+    return int(ok), 1, [] if ok else [("ORDER", key["expect"], m.group(1).strip() if m else "(no ORDER line)")]
+
+
+def grade_pair(text, key):
+    m = re.search(r"PAIR:\s*([Ss0-9 ,]+)", text, re.IGNORECASE)
+    got = set(re.findall(r"[Ss]\s*(\d+)", m.group(1))) if m else set()
+    exp = set(re.findall(r"[Ss]\s*(\d+)", key["expect"]))
+    ok = got == exp
+    return int(ok), 1, [] if ok else [("PAIR", key["expect"], m.group(1).strip() if m else "(no PAIR line)")]
+
+
+def _kv_match(expect, got):
+    dt = re.search(r"(\d{4}-\d{2}-\d{2})\D+(\d{1,2}:\d{2})", expect)
+    if dt:
+        g = re.search(r"(\d{4}-\d{2}-\d{2})\D+(\d{1,2}:\d{2})", got)
+        return bool(g) and g.group(1) == dt.group(1) and g.group(2).zfill(5) == dt.group(2).zfill(5)
+    if re.fullmatch(r"\d+", expect.strip()):
+        g = re.search(r"-?\d+", got)
+        return bool(g) and g.group(0) == expect.strip()
+    return norm(expect) in norm(got)
+
+
+def grade_kv(text, key):
+    exp = key["expect"]
+    wrong = []
+    for k, v in exp.items():
+        m = re.search(rf"{k}:\s*(.+)", text, re.IGNORECASE)
+        got = m.group(1).strip() if m else ""
+        if not _kv_match(v, got):
+            wrong.append((k, v, got or "(missing)"))
+    return len(exp) - len(wrong), len(exp), wrong
+
+
+def grade_abstain(text, key):
+    items = key["items"]
+    contains = key.get("answerable_contains", {})
+    wrong = []
+    for qid, kind in items.items():
+        m = re.search(rf"^\s*{qid}:\s*(.+)$", text, re.MULTILINE | re.IGNORECASE)
+        got = m.group(1).strip() if m else ""
+        is_insuff = bool(re.search(r"\bINSUFFICIENT\b", got, re.IGNORECASE))
+        if kind == "INSUFFICIENT":
+            ok = is_insuff
+        else:
+            if qid in contains:
+                ok = (not is_insuff) and bool(re.search(rf"\b{re.escape(contains[qid])}\b", got, re.IGNORECASE))
+            else:
+                ok = (not is_insuff) and bool(got)
+        if not ok:
+            wrong.append((qid, kind, got or "(missing)"))
+    return len(items) - len(wrong), len(items), wrong
+
+
+def grade_yesno(text, key):
+    m = re.search(r"ANSWER:\s*(YES|NO)", text, re.IGNORECASE)
+    got = m.group(1).upper() if m else ""
+    ok = got == key["expect"].upper()
+    return int(ok), 1, [] if ok else [("ANSWER", key["expect"], got or "(no ANSWER line)")]
+
+
+GRADERS = {
+    "reconcile": grade_reconcile, "order": grade_order, "pair": grade_pair,
+    "kv": grade_kv, "abstain": grade_abstain, "yesno": grade_yesno,
+}
+
+models = sorted({p.name.split("--", 1)[1].rsplit(".txt", 1)[0]
+                 for p in OUT.glob("*--*.txt")})
+if not models:
+    print(f"No outputs in {OUT}. Run run.sh first.", file=sys.stderr)
+    sys.exit(1)
+
+scores = {m: {} for m in models}
+print(f"{'task':<28} {'dim':<26} " + " ".join(f"{m:<22}" for m in models))
+for task, key in KEYS.items():
+    grader = GRADERS[key["mode"]]
+    row = f"{task:<28} {key['dimension']:<26} "
+    for m in models:
+        f = OUT / f"{task}--{m}.txt"
+        if not f.exists():
+            row += f"{'--':<22} "
+            continue
+        got, total, wrong = grader(f.read_text(), key)
+        scores[m][task] = (got, total)
+        row += f"{f'{got}/{total}':<22} "
+        if VERBOSE and wrong:
+            for w in wrong:
+                print(f"    [{m}] {task} {w[0]}: expected {w[1]!r}, got {w[2]!r}")
+    print(row)
+
+print("\n=== summary (items correct / total) ===")
+for m in models:
+    got = sum(s[0] for s in scores[m].values())
+    tot = sum(s[1] for s in scores[m].values())
+    pct = 100 * got / tot if tot else 0
+    print(f"  {m:<24} {got}/{tot}  ({pct:.0f}%)")

--- a/evals/ollama-matrix/keys.json
+++ b/evals/ollama-matrix/keys.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Machine-checkable answer keys for the ollama-matrix eval. Each task lists items; grade.py extracts the model's per-item verdict by regex and scores against expect. 'mode' selects the extractor.",
+  "tasks": {
+    "think-01-reconcile-evidence": {
+      "dimension": "evidence-matching + abstention",
+      "mode": "reconcile",
+      "items": {
+        "T1": "CLOSE:165", "T2": "CLOSE:166", "T3": "CLOSE:168", "T4": "CLOSE:161",
+        "T5": "KEEP", "T6": "KEEP", "T7": "CLOSE:160", "T8": "KEEP"
+      },
+      "notes": "T8 is the precision trap: PR #169 implements it but is only proposed (not in the merged list) -> KEEP is correct."
+    },
+    "think-02-prioritization": {
+      "dimension": "multi-criteria ranking",
+      "mode": "order",
+      "expect": "C,B,A,D,F,E",
+      "notes": "high: C,B,A (C,B tie on 06-12 deadline -> lower effort C(2) before B(5); A is 06-20). medium: D(06-10) before F(06-25). low: E."
+    },
+    "think-03-contradiction": {
+      "dimension": "consistency detection",
+      "mode": "pair",
+      "expect": "S3,S4",
+      "notes": "S3 says a local ollama default exists; S4 says no playbook uses ollama. Only contradicting pair."
+    },
+    "think-04-temporal-cadence": {
+      "dimension": "temporal arithmetic",
+      "mode": "kv",
+      "expect": { "MISSED": "4", "NEXT": "2026-06-09 09:00" },
+      "notes": "Fires Wed 06-03, Thu 06-04, Fri 06-05, Mon 06-08 (weekends skipped) = 4 missed; next is Tue 06-09 09:00."
+    },
+    "think-05-abstention": {
+      "dimension": "calibration / abstention",
+      "mode": "abstain",
+      "items": {
+        "Q1": "ANSWER", "Q2": "ANSWER", "Q3": "INSUFFICIENT", "Q4": "INSUFFICIENT", "Q5": "ANSWER"
+      },
+      "answerable_contains": {
+        "Q1": "gemma4", "Q2": "12", "Q5": "yes"
+      },
+      "notes": "Q3 (gpt-oss tok/s) and Q4 (author) are not in the facts -> INSUFFICIENT. Q5 is a strict deduction (7 GB < 12 GB) -> answerable."
+    },
+    "think-06-multihop": {
+      "dimension": "multi-hop inference",
+      "mode": "yesno",
+      "expect": "YES",
+      "notes": "B disabled by #200, but #200 reverted by #205 (merged) -> B enabled -> A functional re B. C/D facts are distractors."
+    }
+  }
+}

--- a/evals/ollama-matrix/out/.gitignore
+++ b/evals/ollama-matrix/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/evals/ollama-matrix/prompts/think-01-reconcile-evidence.txt
+++ b/evals/ollama-matrix/prompts/think-01-reconcile-evidence.txt
@@ -1,0 +1,28 @@
+You are the reconcile step of an automated project-management agent. Decide which open tickets are now CLOSEABLE based on recently-MERGED pull requests, and which must stay open. Be rigorous: mark a ticket CLOSE only if a MERGED PR clearly and specifically implements what the ticket asks. Do NOT close a ticket based on a PR that is merely related, nor based on a PR that is only proposed/open (not in the merged list). For each ticket output exactly one line:
+  <ticket-id> | CLOSE #<PR> | <one-sentence evidence>
+  <ticket-id> | KEEP | <one-sentence reason no merged PR closes it>
+Output only the decision lines, one per ticket, T1 through T8.
+
+## Recently MERGED pull requests
+PR #168: mark PR gather degraded when jq post-processing fails
+PR #166: gather recently-merged PRs so reconcile can propose closures
+PR #165: retry transient unreadable registry instead of FATAL
+PR #164: persist reconcile decision record via LOG_ENTRY; activate
+PR #162: add reconcile playbook (propose-only, draft)
+PR #161: per-schedule catch-up look-back derived from cadence
+PR #160: doctor flags Linux crontab + systemd daemon double-fire
+PR #158: macOS daemon keep-alive; retire per-plist backend
+PR #156: add missed-slot catch-up to ceo-schedulerd
+PR #155: add ceo-schedulerd daemon + Linux keep-alive + liveness
+PR #154: cron next-fire matcher (Bun + croner)
+PR #153: add --test-all fleet dry-run sweep
+
+## Open tickets to reconcile
+T1: Registry preflight FATALs on a transient unreadable registry.json; it should retry the read instead of failing the run.
+T2: Reconcile cannot propose ticket closures because it never gathers recently-merged PRs. Add that gather.
+T3: When jq post-processing of gathered PR data fails, the gather silently returns empty; it should be marked degraded.
+T4: The scheduler misses runs after downtime; add per-schedule catch-up look-back derived from each playbook's cadence.
+T5: Export CEO cron run metrics in OpenTelemetry / Prometheus format for external monitoring.
+T6: Build a web dashboard UI for browsing the CEO inbox.
+T7: Doctor should warn when both a Linux crontab entry and the systemd daemon are scheduled (double-fire risk).
+T8: Switch the read-tier ollama fallback model to a faster local model that fits in 12 GB VRAM.

--- a/evals/ollama-matrix/prompts/think-02-prioritization.txt
+++ b/evals/ollama-matrix/prompts/think-02-prioritization.txt
@@ -1,0 +1,14 @@
+You are triaging a backlog. Rank the 6 work items below by priority using these rules, applied in order:
+1. Higher impact first (high > medium > low).
+2. Break impact ties by earliest hard deadline (sooner date first).
+3. Break remaining ties by lower effort (fewer days first).
+There is exactly one correct ordering. Output exactly one line and nothing else:
+ORDER: <id>,<id>,<id>,<id>,<id>,<id>
+
+## Work items
+A: impact=high,   deadline=2026-06-20, effort=3
+B: impact=high,   deadline=2026-06-12, effort=5
+C: impact=high,   deadline=2026-06-12, effort=2
+D: impact=medium, deadline=2026-06-10, effort=1
+E: impact=low,    deadline=2026-06-09, effort=1
+F: impact=medium, deadline=2026-06-25, effort=2

--- a/evals/ollama-matrix/prompts/think-03-contradiction.txt
+++ b/evals/ollama-matrix/prompts/think-03-contradiction.txt
@@ -1,0 +1,10 @@
+Below are 6 statements describing the current state of a system. Exactly one pair of statements directly contradicts each other; all other statements are mutually consistent. Identify the contradicting pair. Output exactly one line and nothing else, with the two statement IDs in ascending order:
+PAIR: S<n>,S<n>
+
+## Statements
+S1: The ceo-schedulerd daemon is the only scheduling backend on Linux; the per-plist launchd backend was retired.
+S2: morning-scan runs on weekdays at 08:50.
+S3: The read-tier ollama runner has a configured default model available locally.
+S4: No CEO playbook uses a local ollama model; every playbook runs exclusively via the Claude API.
+S5: token-intake reports per-host token usage so each machine accounts for its own spend.
+S6: The reconcile playbook proposes ticket closures but never closes a ticket automatically.

--- a/evals/ollama-matrix/prompts/think-04-temporal-cadence.txt
+++ b/evals/ollama-matrix/prompts/think-04-temporal-cadence.txt
@@ -1,0 +1,15 @@
+A playbook is scheduled with the cron expression `0 9 * * 1-5` — it fires at 09:00 on every weekday (Monday through Friday), in a single fixed timezone with no daylight-saving change in this window. Weekends (Saturday, Sunday) never fire.
+
+Reference dates (given, do not recompute):
+- 2026-06-02 is a Tuesday.
+- 2026-06-08 is a Monday.
+
+Facts:
+- The last SUCCESSFUL run was 2026-06-02 (Tuesday) at 09:00.
+- The current time is 2026-06-08 (Monday) at 14:00.
+
+Count how many scheduled fire times were MISSED strictly after the last successful run and at or before the current time (the last successful run itself does not count; a fire at exactly the current time would count, but here the current time is 14:00 so the 09:00 fires are the relevant ones). Then give the NEXT scheduled fire time strictly after the current time.
+
+Output exactly these two lines and nothing else:
+MISSED: <integer>
+NEXT: <YYYY-MM-DD HH:MM>

--- a/evals/ollama-matrix/prompts/think-05-abstention.txt
+++ b/evals/ollama-matrix/prompts/think-05-abstention.txt
@@ -1,0 +1,17 @@
+Answer the questions using ONLY the facts provided. If a question cannot be answered from the facts (the information is simply not present), you must answer exactly INSUFFICIENT — do not guess, infer beyond the facts, or use outside knowledge. Simple logical deductions strictly entailed by the facts ARE allowed.
+
+Output one line per question and nothing else:
+Q<n>: <answer or INSUFFICIENT>
+
+## Facts
+- PR #169 switches the read-tier ollama model to gemma4:12b-it-qat.
+- gemma4:12b-it-qat is about 7 GB on disk and runs at ~63 tokens/sec on the eval host.
+- The eval host is an ML-1 machine with an RTX 5070 GPU that has 12 GB of VRAM.
+- gpt-oss:20b is the configured think-tier default model.
+
+## Questions
+Q1: Which model does PR #169 switch the read-tier to?
+Q2: How much VRAM does the eval host's GPU have?
+Q3: What is gpt-oss:20b's measured tokens/sec on the eval host?
+Q4: Who authored PR #169?
+Q5: Does gemma4:12b-it-qat's on-disk size fit within the eval host's VRAM?

--- a/evals/ollama-matrix/prompts/think-05-abstention.txt
+++ b/evals/ollama-matrix/prompts/think-05-abstention.txt
@@ -14,4 +14,4 @@ Q1: Which model does PR #169 switch the read-tier to?
 Q2: How much VRAM does the eval host's GPU have?
 Q3: What is gpt-oss:20b's measured tokens/sec on the eval host?
 Q4: Who authored PR #169?
-Q5: Does gemma4:12b-it-qat's on-disk size fit within the eval host's VRAM?
+Q5: Is gemma4:12b-it-qat's on-disk size in GB a smaller number than the eval host's VRAM capacity in GB?

--- a/evals/ollama-matrix/prompts/think-06-multihop.txt
+++ b/evals/ollama-matrix/prompts/think-06-multihop.txt
@@ -1,0 +1,16 @@
+Reason over the facts below to answer one question. Some facts are distractors. Output exactly one line and nothing else:
+ANSWER: YES
+or
+ANSWER: NO
+
+## Facts
+- Feature A is functional only if module B is currently enabled.
+- Module B was disabled by PR #200.
+- PR #200 was fully reverted by PR #205.
+- PR #205 was merged and deployed.
+- No change has touched module B since PR #205.
+- Feature A also reads from module C, and module C is currently enabled.
+- Feature D (unrelated to Feature A) is currently broken.
+
+## Question
+With respect to module B, is Feature A currently functional?

--- a/evals/ollama-matrix/run.sh
+++ b/evals/ollama-matrix/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run every prompt in prompts/ through each model via the local ollama API
+# (temperature 0, deterministic), writing one output file per (task,model) and
+# a stats TSV. Grading is a separate step (grade.py) so outputs are inspectable.
+#
+#   bash run.sh "gemma4:12b-it-qat gpt-oss:20b"
+#   MODELS="gemma4:12b-it-qat gpt-oss:20b mistral-small3.2:24b" bash run.sh
+#
+# Requires: a running ollama daemon (default 127.0.0.1:11434), jq, curl.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPTS="$HERE/prompts"
+OUT="$HERE/out"
+HOST="${OLLAMA_HOST:-127.0.0.1:11434}"
+MODELS="${1:-${MODELS:-gemma4:12b-it-qat gpt-oss:20b}}"
+# Cap output so a degenerate runaway (observed: gemma4 once emitted 65k tokens /
+# ~18 min on the contradiction task) can't hang a run. All tasks here answer in
+# well under this. Raise via env for genuinely long-form tasks.
+NUM_PREDICT="${CEO_EVAL_NUM_PREDICT:-2048}"
+
+mkdir -p "$OUT"
+command -v jq >/dev/null   || { echo "ERROR: jq not found" >&2; exit 1; }
+command -v curl >/dev/null || { echo "ERROR: curl not found" >&2; exit 1; }
+
+STATS="$OUT/stats.tsv"
+printf 'task\tmodel\teval_count\ttoks_per_sec\ttotal_dur_s\n' > "$STATS"
+
+for PFILE in "$PROMPTS"/*.txt; do
+  TASK="$(basename "$PFILE" .txt)"
+  P="$(cat "$PFILE")"
+  for MODEL in $MODELS; do
+    SAFE="$(echo "$MODEL" | tr ':/' '__')"
+    REQ="$(jq -n --arg m "$MODEL" --arg p "$P" --argjson n "$NUM_PREDICT" '{model:$m,prompt:$p,stream:false,options:{temperature:0,num_predict:$n}}')"
+    RESP="$(curl -s "http://$HOST/api/generate" -d "$REQ")"
+    echo "$RESP" | jq -r '.response // "ERROR"' > "$OUT/$TASK--$SAFE.txt"
+    EC="$(echo "$RESP" | jq -r '.eval_count // 0')"
+    ED="$(echo "$RESP" | jq -r '.eval_duration // 1')"
+    TD="$(echo "$RESP" | jq -r '.total_duration // 0')"
+    TPS="$(awk -v c="$EC" -v d="$ED" 'BEGIN{ if(d>0) printf "%.1f", c/(d/1e9); else print "0" }')"
+    TDS="$(awk -v d="$TD" 'BEGIN{ printf "%.0f", d/1e9 }')"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$TASK" "$MODEL" "$EC" "$TPS" "$TDS" >> "$STATS"
+    echo "ran $TASK / $MODEL : ${TPS} tok/s, ${TDS}s"
+  done
+done
+
+echo "=== stats ==="
+cat "$STATS"
+echo "outputs in $OUT/  — grade with: python3 grade.py"

--- a/evals/ollama-matrix/run.sh
+++ b/evals/ollama-matrix/run.sh
@@ -30,13 +30,25 @@ for PFILE in "$PROMPTS"/*.txt; do
   TASK="$(basename "$PFILE" .txt)"
   P="$(cat "$PFILE")"
   for MODEL in $MODELS; do
-    SAFE="$(echo "$MODEL" | tr ':/' '__')"
+    SAFE="$(echo "$MODEL" | tr ':/' '.-')"
     REQ="$(jq -n --arg m "$MODEL" --arg p "$P" --argjson n "$NUM_PREDICT" '{model:$m,prompt:$p,stream:false,options:{temperature:0,num_predict:$n}}')"
-    RESP="$(curl -s "http://$HOST/api/generate" -d "$REQ")"
-    echo "$RESP" | jq -r '.response // "ERROR"' > "$OUT/$TASK--$SAFE.txt"
-    EC="$(echo "$RESP" | jq -r '.eval_count // 0')"
-    ED="$(echo "$RESP" | jq -r '.eval_duration // 1')"
-    TD="$(echo "$RESP" | jq -r '.total_duration // 0')"
+    # Distinguish an infrastructure failure (daemon down, model not pulled, HTTP
+    # error, non-JSON body) from a real model answer. Without this a failed call
+    # is graded as a wrong answer and reads as a model-quality loss.
+    BODY="$(curl -s --max-time "${CEO_EVAL_HTTP_TIMEOUT:-600}" -w '\n%{http_code}' "http://$HOST/api/generate" -d "$REQ")"
+    CURL_RC=$?
+    HTTP="${BODY##*$'\n'}"; BODY="${BODY%$'\n'*}"
+    APIERR="$(printf '%s' "$BODY" | jq -r '.error // empty' 2>/dev/null)"
+    if [ "$CURL_RC" -ne 0 ] || [ "$HTTP" != "200" ] || [ -n "$APIERR" ]; then
+      printf '__EVAL_ERROR__ curl_rc=%s http=%s %s\n' "$CURL_RC" "$HTTP" "$APIERR" > "$OUT/$TASK--$SAFE.txt"
+      printf '%s\t%s\tERR\tERR\tERR\n' "$TASK" "$MODEL" >> "$STATS"
+      echo "ERROR $TASK / $MODEL : curl_rc=$CURL_RC http=$HTTP ${APIERR:+ollama: $APIERR}" >&2
+      continue
+    fi
+    printf '%s' "$BODY" | jq -r '.response // "ERROR"' > "$OUT/$TASK--$SAFE.txt"
+    EC="$(printf '%s' "$BODY" | jq -r '.eval_count // 0')"
+    ED="$(printf '%s' "$BODY" | jq -r '.eval_duration // 1')"
+    TD="$(printf '%s' "$BODY" | jq -r '.total_duration // 0')"
     TPS="$(awk -v c="$EC" -v d="$ED" 'BEGIN{ if(d>0) printf "%.1f", c/(d/1e9); else print "0" }')"
     TDS="$(awk -v d="$TD" 'BEGIN{ printf "%.0f", d/1e9 }')"
     printf '%s\t%s\t%s\t%s\t%s\n' "$TASK" "$MODEL" "$EC" "$TPS" "$TDS" >> "$STATS"


### PR DESCRIPTION
## Description
Adds `evals/ollama-matrix/` — a reusable, version-controlled library for comparing local ollama models on the reasoning the CEO agent runs locally (`runner: ollama` / `runner: ollama-think`). A single task (N=1) can't separate models, so this varies across **six reasoning dimensions**, each **self-contained** and **machine-graded against a deterministic key** (no subjective judge): evidence-matching+abstention, multi-criteria ranking, contradiction detection, date/cron arithmetic, calibration/abstention, multi-hop inference. Each has ≥1 trap.

- `prompts/` self-contained `.txt` per task; `keys.json` key+mode+rationale; `run.sh` runs each prompt×model via ollama API (temp 0, `num_predict`-capped so a runaway can't hang a run); `grade.py` regex-scores verdicts.
- Auditor verified all six keys + fixed two grader bugs (timestamp tolerance, reconcile PR-adjacency) before the first run; fixes unit-tested.

## First result (gemma4:12b-it-qat vs gpt-oss:20b, ML-1 WSL ollama)
17/18 vs 18/18. gemma4's only miss was a **deterministic runaway** on contradiction (65k tokens, ~18 min, no usable answer) — the motivation for the `num_predict` cap and for keeping gpt-oss on the think tier.

## Testing Procedure
1. On a host with ollama running + `jq`/`curl`/`python3`: `cd evals/ollama-matrix && bash run.sh`.
2. `python3 grade.py` → score table (`--verbose` lists wrong items). Outputs land in gitignored `out/`.

## Additional Notes
Self-contained; does not touch the cron runtime. Related: PR #169 (reg-tier switch). Follow-up PR adds a production `num_predict` cap to `ceo-cron.sh`.
