### PR TITLE
fix(cron): bound ollama run with a wall-clock timeout so a runaway can't hang a slot

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -428,6 +428,31 @@ _append_pending_drip_to_inbox() {
   } >> "$inbox_file"
 }
 
+# _ollama_run — invoke `ollama run <model>`, reading the prompt from stdin,
+# bounded by a wall-clock timeout so a degenerate runaway (observed: a 12B model
+# emitting 65k tokens over ~18 min on a single prompt) cannot hang a cron slot.
+# `ollama run` (the CLI) has no num_predict flag, so a timeout — not a token cap
+# — is what bounds the operational risk. Prefer GNU `timeout` (Linux), else
+# `gtimeout` (macOS via Homebrew coreutils). When neither is present the call
+# runs unbounded (re-opening the hang risk), so log that fact rather than
+# degrade silently. Override the bound with CEO_OLLAMA_TIMEOUT (seconds; default
+# 300). On expiry the wrapper exits 124, which callers already treat as failure.
+_ollama_run() {
+  local model="$1" tbin=""
+  if command -v timeout >/dev/null 2>&1; then
+    tbin="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    tbin="gtimeout"
+  fi
+  if [ -n "$tbin" ]; then
+    "$tbin" "${CEO_OLLAMA_TIMEOUT:-300}" ollama run "$model"
+  else
+    echo "$(date): WARNING — no timeout/gtimeout on PATH; running ollama unbounded (model: $model)" \
+      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+    ollama run "$model"
+  fi
+}
+
 # _ollama_chunked_scan — run an ollama playbook whose scan data exceeds the
 # context budget by splitting SCAN_BLOCK into per-chunk extraction passes then
 # synthesizing the findings into one final call that produces the LOG_ENTRY.
@@ -489,7 +514,7 @@ VAULT DATA FRAGMENT $i of $n_chunks:
 $piece"
 
     chunk_exit=0
-    chunk_out=$(printf '%s' "$chunk_prompt" | ollama run "$model" \
+    chunk_out=$(printf '%s' "$chunk_prompt" | _ollama_run "$model" \
       2>>"$LOG_DIR/cron-stderr.log") || chunk_exit=$?
     if [ "$chunk_exit" -ne 0 ] || [ -z "$(printf '%s' "$chunk_out" | tr -d '[:space:]')" ]; then
       _v "  WARNING: chunk $i/$n_chunks failed (exit $chunk_exit) — skipping"
@@ -525,7 +550,7 @@ ${partial_findings}"
   fi
 
   synth_exit=0
-  synth_out=$(printf '%s' "$synth_prompt" | ollama run "$model" \
+  synth_out=$(printf '%s' "$synth_prompt" | _ollama_run "$model" \
     2>>"$LOG_DIR/cron-stderr.log") || synth_exit=$?
   if [ "$synth_exit" -ne 0 ] || [ -z "$(printf '%s' "$synth_out" | tr -d '[:space:]')" ]; then
     printf '%s [%s] chunked scan synthesis failed (exit %s)\n' \
@@ -1401,7 +1426,7 @@ END_LOG_ENTRY"
     fi
 
     OLLAMA_EXIT=0
-    OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | ollama run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
+    OLLAMA_OUT=$(printf '%s' "$OLLAMA_PROMPT" | _ollama_run "$OLLAMA_MODEL" 2>>"$LOG_DIR/cron-stderr.log") || OLLAMA_EXIT=$?
     if [ "$OLLAMA_EXIT" -ne 0 ]; then
       _v "FAILED (exit: $OLLAMA_EXIT)"
       printf '%s [%s] ollama non-zero exit %s (model: %s):\n%s\n---\n' \

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -438,14 +438,27 @@ _append_pending_drip_to_inbox() {
 # degrade silently. Override the bound with CEO_OLLAMA_TIMEOUT (seconds; default
 # 300). On expiry the wrapper exits 124, which callers already treat as failure.
 _ollama_run() {
-  local model="$1" tbin=""
+  local model="$1" tbin="" to="${CEO_OLLAMA_TIMEOUT:-300}"
+  # Validate the bound: a typo (`300s`, `abc`) makes `timeout` exit 125 without
+  # running ollama, surfacing as a misleading model failure; `0` is a legal GNU
+  # value meaning "no limit", silently re-opening the hang. Reject non-integers,
+  # warn loudly on the cap-disabling 0.
+  case "$to" in
+    ''|*[!0-9]*)
+      echo "$(date): WARNING — CEO_OLLAMA_TIMEOUT='$to' is not a non-negative integer; using 300" \
+        >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+      to=300 ;;
+    0)
+      echo "$(date): WARNING — CEO_OLLAMA_TIMEOUT=0 disables the wall-clock cap (hang risk)" \
+        >> "${LOG_DIR:-/tmp}/cron-stderr.log" ;;
+  esac
   if command -v timeout >/dev/null 2>&1; then
     tbin="timeout"
   elif command -v gtimeout >/dev/null 2>&1; then
     tbin="gtimeout"
   fi
   if [ -n "$tbin" ]; then
-    "$tbin" "${CEO_OLLAMA_TIMEOUT:-300}" ollama run "$model"
+    "$tbin" "$to" ollama run "$model"
   else
     echo "$(date): WARNING — no timeout/gtimeout on PATH; running ollama unbounded (model: $model)" \
       >> "${LOG_DIR:-/tmp}/cron-stderr.log"
@@ -503,6 +516,7 @@ END_LOG_ENTRY"
   _v "  Chunked scan: $total_bytes bytes → $n_chunks chunk(s) (~$chunk_budget bytes each)"
 
   local partial_findings="" i offset piece chunk_prompt chunk_out chunk_exit
+  local failed_chunks=0
   for i in $(seq 1 "$n_chunks"); do
     offset=$(( (i - 1) * chunk_budget ))
     piece=$(printf '%s' "$SCAN_BLOCK" | tail -c "+$((offset + 1))" | head -c "$chunk_budget")
@@ -520,6 +534,7 @@ $piece"
       _v "  WARNING: chunk $i/$n_chunks failed (exit $chunk_exit) — skipping"
       printf '%s [%s] chunked scan: chunk %s/%s failed (exit %s)\n' \
         "$(date)" "$trigger" "$i" "$n_chunks" "$chunk_exit" >> "$LOG_DIR/cron-raw.log"
+      failed_chunks=$(( failed_chunks + 1 ))
       continue
     fi
     partial_findings="${partial_findings}
@@ -531,6 +546,21 @@ ${chunk_out}"
     printf '%s [%s] chunked scan: all %s chunks failed or empty\n' \
       "$(date)" "$trigger" "$n_chunks" >> "$LOG_DIR/cron-raw.log"
     return 1
+  fi
+
+  # A dropped chunk means the synthesis sees only part of the vault. Don't let a
+  # partial scan report "completed" silently: past a drop budget, fail the run so
+  # the caller records it; below the budget, mark the findings partial so the
+  # synthesized LOG_ENTRY surfaces the gap in its Errors section.
+  if [ "$failed_chunks" -gt 0 ]; then
+    local drop_pct=$(( failed_chunks * 100 / n_chunks ))
+    printf '%s [%s] chunked scan: %s/%s fragments dropped (%s%%)\n' \
+      "$(date)" "$trigger" "$failed_chunks" "$n_chunks" "$drop_pct" >> "$LOG_DIR/cron-raw.log"
+    if [ "$drop_pct" -gt "${CEO_SCAN_MAX_DROP_PCT:-25}" ]; then
+      return 1
+    fi
+    partial_findings="${partial_findings}
+=== SCAN INCOMPLETE: ${failed_chunks} of ${n_chunks} vault fragments were dropped (timeout or error); the findings above are partial. Note this in the Errors section. ==="
   fi
 
   # Synthesis: base prompt + condensed findings → final LOG_ENTRY

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -788,6 +788,46 @@ PB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_ollama_run_is_bounded_by_timeout() {
+  # Recording timeout stub: capture argv, enforce the real `timeout` contract
+  # (first arg is a numeric duration), then pass the command through so the
+  # ollama stub still runs. Asserts the dispatcher wraps `ollama run` in a
+  # timeout bound by CEO_OLLAMA_TIMEOUT so a runaway can't hang a cron slot.
+  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
+#!/bin/bash
+echo "$*" >> "$HOME/timeout-invoked.txt"
+case "${1:-}" in ''|*[!0-9]*) echo "timeout stub: non-numeric duration: ${1:-}" >&2; exit 99 ;; esac
+shift
+exec "$@"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/timeout"
+
+  cat > "$CEO_DIR/playbooks/ollama-timeout.md" << 'PB'
+---
+name: ollama-timeout
+description: Routes to ollama
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_OLLAMA_TIMEOUT=123 bash "$CRON" ollama-timeout >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "dispatcher must exit 0 when the timeout wrapper passes through"
+
+  assert_file_exists "$HOME/timeout-invoked.txt" "ollama run must be wrapped in a timeout"
+  local rec
+  rec=$(cat "$HOME/timeout-invoked.txt" 2>/dev/null || echo "")
+  assert_contains "$rec" "123 ollama run gemma4:12b-it-qat" \
+    "ollama run must be bounded by CEO_OLLAMA_TIMEOUT seconds"
+}
+
 test_runner_ollama_think_uses_gpt_oss_default() {
   cat > "$CEO_DIR/playbooks/ollama-think-dispatch.md" << 'PB'
 ---

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -928,6 +928,86 @@ STUB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_ollama_timeout_kill_propagates_as_failure() {
+  # The whole point of the timeout wrap: when it fires (exit 124), the run must
+  # be recorded as a failure, not silently skipped. Stub `timeout` to simulate a
+  # kill (124) specifically when wrapping ollama; everything else passes through.
+  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
+#!/bin/bash
+case "${1:-}" in ''|*[!0-9]*) echo "timeout stub: bad duration: ${1:-}" >&2; exit 99 ;; esac
+shift
+if [ "${1:-}" = "ollama" ]; then exit 124; fi
+exec "$@"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/timeout"
+
+  cat > "$CEO_DIR/playbooks/ollama-killed.md" << 'PB'
+---
+name: ollama-killed
+description: ollama wrapped call is timeout-killed
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-killed >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "a timeout-killed (exit 124) ollama call must increment the fail count"
+
+  local runs_log
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  if [[ "$runs_log" == *"ollama-killed completed"* ]]; then
+    printf '  FAIL [%s] a timeout-killed run must NOT log completed\n    runs_log: %q\n' \
+      "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_ollama_timeout_rejects_non_numeric_bound() {
+  # A non-numeric CEO_OLLAMA_TIMEOUT must be rejected (warn + fall back to 300),
+  # not passed verbatim to `timeout` (which would exit 125 without running ollama).
+  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
+#!/bin/bash
+echo "$1" > "$HOME/timeout-duration.txt"
+shift
+exec "$@"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/timeout"
+
+  cat > "$CEO_DIR/playbooks/ollama-badto.md" << 'PB'
+---
+name: ollama-badto
+description: bad timeout value
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_OLLAMA_TIMEOUT=abc bash "$CRON" ollama-badto >/dev/null 2>&1 || true
+
+  local dur
+  dur=$(cat "$HOME/timeout-duration.txt" 2>/dev/null || echo "missing")
+  assert_eq "$dur" "300" "non-numeric CEO_OLLAMA_TIMEOUT must fall back to 300, not reach timeout verbatim"
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "CEO_OLLAMA_TIMEOUT='abc'" "a rejected timeout value must be warned about"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_runner_ollama_think_accepted_at_scan() {
   cat > "$CEO_DIR/playbooks/ollama-think-ok.md" << 'PB'
 ---


### PR DESCRIPTION
## Description

A local model can degenerate into a runaway generation — the ollama-matrix eval (PR #170) caught **gemma4:12b emitting 65k tokens over ~18 min on a single prompt** at temperature 0, producing no usable output. On a cron slot that hangs the run.

**Mechanism note (important):** the follow-up was scoped as a "num_predict cap," but `ollama run` (the CLI this dispatcher uses) has **no num_predict flag** — that option is API-only. Rather than rewrite the dispatcher onto the HTTP API, this bounds the **actual operational risk the runaway poses — a hung slot — with a wall-clock `timeout`**, consistent with how the dispatcher already wraps `claude`. Note this caps *wall-clock, not tokens*: a runaway can still burn GPU for up to the timeout before it's killed.

- New `_ollama_run` helper wraps `ollama run` in `timeout` (GNU on Linux, `gtimeout` on macOS/Homebrew). All three `ollama run` sites (main single-shot + the two chunked-scan calls) route through it.
- Bound is `CEO_OLLAMA_TIMEOUT` seconds, **default 300**. On expiry `timeout` exits 124, which callers already treat as an ollama failure.
- When neither `timeout` nor `gtimeout` exists, the call runs unbounded but **logs a warning** to `cron-stderr.log` (no silent re-opening of the hang risk). Production (Linux ML-1) always has `timeout`; this path is macOS-dev only.

## Testing Procedure
1. Check out this branch: `bash scripts/ceo-cron.test.sh` → **All tests passed. (141 tests)**.
2. New test `test_ollama_run_is_bounded_by_timeout` stubs `timeout` (validating the numeric-duration argv contract), runs an ollama-runner playbook, and asserts the call is wrapped as `<CEO_OLLAMA_TIMEOUT> ollama run <model>`.
3. Mutation check: revert `_ollama_run` to a bare `ollama run` and re-run — the new test fails (timeout never invoked). Verified.
4. `shellcheck -S warning scripts/ceo-cron.sh scripts/ceo-cron.test.sh` → clean.

## Open questions for the reviewer (your call)
- **300s default** is a margin over the slowest *legitimate* run observed (mistral full morning-scan ~175s; gemma4 ~56s), but it's not validated against a dense-model p99 — too low kills good work mid-stream (the chunk is then skipped), too high lets a runaway burn longer. Tunable via `CEO_OLLAMA_TIMEOUT`. Adjust the default if you have better data.
- The no-`timeout`-binary degradation branch logs but is **not** covered by an automated test (simulating absence fights the harness's PATH); the positive wrap + mutation check are tested.

## Additional Notes
Follow-up to PR #169 (reg→gemma4 switch) and PR #170 (eval library that surfaced the runaway). Independent auditor reviewed this diff (no HIGH findings; disclosure + warn-log folded in from its MEDIUM findings).
