### PR TITLE
feat(notify): surface model used in Discord cron embed

### DIFF
--- a/scripts/ceo-notify.sh
+++ b/scripts/ceo-notify.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 #   1. $CEO_DISCORD_WEBHOOK env var (testing convenience)
 #   2. ~/.config/claude-ceo/secrets.json -> .discord_webhook
 #
+# Model field:
+#   $CEO_MODEL (exported by ceo-cron.sh for every runner) is surfaced as a
+#   "Model" embed field. On the rate-limit fallback path this reflects the
+#   local model actually used, not the playbook's configured Claude model.
+#   Omitted when unset (e.g. early failures before the runner is resolved).
+#
 # Event filter (controls when notifications fire):
 #   $CEO_VAULT/CEO/settings.json -> .notify_events
 #     "failures" (default) | "all" | "off"
@@ -102,6 +108,8 @@ esac
 
 HOSTNAME_SHORT="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo unknown)}"
 NOW="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+MODEL="${CEO_MODEL:-}"
+_dlog "model='${MODEL:-(unset)}'"
 
 if [ "$STATUS" = "success" ]; then
   TITLE="🟢 ${TRIGGER} completed"
@@ -118,6 +126,7 @@ PAYLOAD=$(jq -n \
   --arg desc  "$DESCRIPTION" \
   --arg trig  "$TRIGGER" \
   --arg host  "$HOSTNAME_SHORT" \
+  --arg model "$MODEL" \
   --arg ts    "$NOW" \
   --argjson color "$COLOR" \
   '{
@@ -126,11 +135,12 @@ PAYLOAD=$(jq -n \
        title: $title,
        description: $desc,
        color: $color,
-       fields: [
-         { name: "Trigger", value: $trig, inline: true },
-         { name: "Host",    value: $host, inline: true },
-         { name: "Time",    value: $ts,   inline: false }
-       ]
+       fields: (
+         [ { name: "Trigger", value: $trig, inline: true } ]
+         + (if $model != "" then [ { name: "Model", value: $model, inline: true } ] else [] end)
+         + [ { name: "Host", value: $host, inline: true },
+             { name: "Time", value: $ts,   inline: false } ]
+       )
      }]
    }')
 

--- a/scripts/ceo-notify.test.sh
+++ b/scripts/ceo-notify.test.sh
@@ -135,6 +135,63 @@ test_does_not_log_webhook_url() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+# Installs a fake `curl` on PATH that records the POSTed -d payload to
+# $CAPTURE and returns a curl-like -w line. Validates argv shape (stub-cli rule):
+# a real ceo-notify invocation always passes -d <json>; bail non-zero otherwise.
+_install_curl_capture() {
+  STUBDIR=$(mktemp -d)
+  CAPTURE="$STUBDIR/payload.json"
+  cat > "$STUBDIR/curl" <<'STUB'
+#!/bin/bash
+payload="" prev=""
+for a in "$@"; do
+  [ "$prev" = "-d" ] && payload="$a"
+  prev="$a"
+done
+[ -n "$payload" ] || { echo "stub curl: no -d payload in argv: $*" >&2; exit 99; }
+printf '%s' "$payload" > "$STUB_CAPTURE"
+echo "200 time=0.001s"
+STUB
+  chmod +x "$STUBDIR/curl"
+  export STUB_CAPTURE="$CAPTURE"
+  _SAVED_PATH="$PATH"
+  export PATH="$STUBDIR:$PATH"
+}
+_remove_curl_capture() {
+  export PATH="$_SAVED_PATH"
+  rm -rf "$STUBDIR"
+  unset STUB_CAPTURE STUBDIR CAPTURE _SAVED_PATH
+}
+
+test_model_field_present_when_ceo_model_set() {
+  setup
+  echo '{"discord_webhook":"http://127.0.0.1:1/never"}' > "$CEO_SECRETS_FILE"
+  echo '{"notify_events":"all"}' > "$CEO_DIR/settings.json"
+  _install_curl_capture
+  export CEO_MODEL="gemma4:12b-it-qat"
+  "$NOTIFY" failure morning-brief "model field check" >/dev/null 2>&1
+  model_val=$(jq -r '.embeds[0].fields[] | select(.name=="Model") | .value' "$CAPTURE" 2>/dev/null)
+  unset CEO_MODEL
+  _remove_curl_capture
+  assert_eq "$model_val" "gemma4:12b-it-qat" "embed Model field must carry the actual model used"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_model_field_omitted_when_ceo_model_unset() {
+  setup
+  echo '{"discord_webhook":"http://127.0.0.1:1/never"}' > "$CEO_SECRETS_FILE"
+  echo '{"notify_events":"all"}' > "$CEO_DIR/settings.json"
+  _install_curl_capture
+  unset CEO_MODEL
+  "$NOTIFY" failure morning-brief "no model check" >/dev/null 2>&1
+  model_count=$(jq '[.embeds[0].fields[] | select(.name=="Model")] | length' "$CAPTURE" 2>/dev/null)
+  _remove_curl_capture
+  assert_eq "$model_count" "0" "embed must omit the Model field when CEO_MODEL is unset"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_jq_argjson_color_no_injection() {
   setup
   # Reason field with shell-special and JSON-special characters. If the script
@@ -163,6 +220,8 @@ TESTS=(
   test_missing_args_no_op
   test_unknown_events_warns_and_defaults_to_failures
   test_curl_unreachable_does_not_break
+  test_model_field_present_when_ceo_model_set
+  test_model_field_omitted_when_ceo_model_unset
   test_env_var_overrides_secrets_file
   test_does_not_log_webhook_url
   test_jq_argjson_color_no_injection


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
The CEO cron Discord notification (`ceo-notify.sh`) carried only **Trigger / Host / Time** — never the model that actually ran. `CEO_MODEL` is already exported by every runner path in `ceo-cron.sh` (script `:1051`, skill `:1087`, ollama `:1428`, claude `:1479`/`:1506`), **including the rate-limit fallback** that flips a Claude playbook to a local model at runtime. So a fallback run that silently dropped to `gemma4:12b-it-qat` looked identical on Discord to a real Claude run.

This reads `$CEO_MODEL` in `ceo-notify.sh` and splices a **Model** embed field in (between Trigger and Host) when non-empty; it is omitted gracefully when unset (early failures that fail before a runner is resolved). No `ceo-cron.sh` change — the value was already in the subprocess environment, just never surfaced.

## Testing Procedure
1. Check out this branch.
2. Run `bash scripts/ceo-notify.test.sh` — expect `All tests passed. (12 tests)`.
3. The two new tests use a `curl` stub that captures the posted JSON and asserts via `jq`:
   - `test_model_field_present_when_ceo_model_set` — `CEO_MODEL=gemma4:12b-it-qat` ⇒ embed field `Model = gemma4:12b-it-qat`.
   - `test_model_field_omitted_when_ceo_model_unset` — `CEO_MODEL` unset ⇒ zero `Model` fields.
4. Mutation check: revert the conditional `fields` splice to the old static array ⇒ `test_model_field_present_when_ceo_model_set` fails.
5. `shellcheck scripts/ceo-notify.sh scripts/ceo-notify.test.sh` — clean (only pre-existing SC1091/SC2016 infos).

## Additional Notes / HelpScout Tickets
N/A