### PR TITLE
Swarm sync: multi-machine playbook selection without conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cron / interactive trigger
 ceo-cron.sh ──► ceo-config.sh        (resolve $CEO_VAULT)
             ──► ceo-gather.sh         (pre-gather context → env)
             ──► ceo-scan.sh           (vault diff)
-            ──► registry.json         (dispatch lookup)
+            ──► ~/.ceo/registry.json  (host-local dispatch lookup)
             ──► preflight_<name>()
             ──► runner:
                  • claude (default)   — read tier = single call,
@@ -27,7 +27,7 @@ Output: CEO/reports/YYYY-MM-DD.md
 State:  CEO/log/, CEO/approvals/, CEO/cache/
 ```
 
-Playbooks self-register: `ceo playbook scan` walks `CEO/playbooks/*.md`, extracts each frontmatter block via `yq`, rewrites `registry.json`, and updates the crontab between `# CEO Agent START/END` markers.
+Playbooks self-register: `ceo playbook scan` walks `CEO/playbooks/*.md`, extracts each frontmatter block via `yq`, and rewrites the host-local `~/.ceo/registry.json`. Scheduling is owned by the `ceo-schedulerd` daemon (which reads that registry) — scan does not touch the crontab.
 
 ## Subagents
 
@@ -108,14 +108,14 @@ ceo playbook info token-intake
 ## Install
 
 1. Clone somewhere persistent (e.g. `~/ML-AI/claude/ceo`).
-2. Run `scripts/ceo setup` — installs deps where it can, walks you through git/ssh/cron, creates `~/.ceo/config` with the resolved vault path.
+2. Run `scripts/ceo setup` — installs deps where it can, walks you through git/ssh and the `ceo-schedulerd` daemon, creates `~/.ceo/config` with the resolved vault path.
 3. Symlink the CLIs onto `PATH`:
    ```bash
    ln -s "$(pwd)/scripts/ceo"               ~/bin/ceo
    ln -s "$(pwd)/scripts/count-blessings.sh" ~/bin/count-blessings
    ```
-4. Run `scripts/ceo doctor` to verify everything resolves (yq, gh auth, vault, cron).
-5. Run `ceo playbook scan` to build `registry.json` and install the crontab.
+4. Run `scripts/ceo doctor` to verify everything resolves (yq, gh auth, vault, scheduler daemon).
+5. Run `ceo playbook scan` to build the host-local `~/.ceo/registry.json`. Scheduling is handled by the `ceo-schedulerd` daemon — scan does not install a crontab.
 
 ### Requirements
 
@@ -227,7 +227,7 @@ Playbook frontmatter `schedule:` is the default. Per-user overrides live in `$CE
 }
 ```
 
-Unknown playbook names and invalid cron syntax warn to stderr and are ignored — never silently coerced. `ceo playbook scan` performs collision detection before installing the crontab; a refused scan leaves the previous good state intact. Use `ceo schedule <playbook>` for an interactive reschedule.
+Unknown playbook names and invalid cron syntax warn to stderr and are ignored — never silently coerced. `ceo playbook scan` performs collision detection before writing the registry; a refused scan leaves the previous good registry intact. Use `ceo schedule <playbook>` for an interactive reschedule.
 
 ### Read-tier pre-gather
 
@@ -287,7 +287,7 @@ CEO/
 ├── TRAINING.md        — rules learned from corrections
 ├── training/          — domain-specific training rules
 ├── playbooks/         — step-by-step workflows (frontmatter drives registration)
-├── registry.json      — derived dispatch table
+├── swarm.json         — synced swarm topology + single-scope owners
 ├── settings.json      — runtime config (cooldown, branch_prefix, …)
 ├── repos.md           — registry of cloned repos
 ├── inbox.md           — shared task queue for the inbox playbook
@@ -305,9 +305,9 @@ CEO/
 `ceo`:
 
 ```
-ceo setup            First-time machine setup (deps, git, ssh, cron)
+ceo setup            First-time machine setup (deps, git, ssh, scheduler daemon)
 ceo next             Redisplay post-setup steps
-ceo doctor           Check system health (deps, vault, cron, auth)
+ceo doctor           Check system health (deps, vault, scheduler daemon, auth)
 ceo test             Smoke test: trigger morning-brief, check log
 ceo cron <name>      Manually run a cron trigger
 ceo chat [name]      Interactive playbook (no cron); empty = triage conversation; defaults to --effort medium
@@ -342,7 +342,7 @@ count-blessings show         Show today's three picks
 
 - **WSL2 cron does not auto-start at boot.** Add `[boot] command = service cron start` to `/etc/wsl.conf`, or set up a Windows Task Scheduler job that runs `wsl.exe -u <user> -- /etc/init.d/cron start` at logon.
 - **Portable timeout.** `ceo-cron.sh` uses `timeout` (Linux) or `gtimeout` (macOS via `brew install coreutils`). If neither is installed, the wrapper degrades to no wall-clock cap (`--max-turns` and API timeout still apply) and a `WARN` is logged.
-- **Schedule collisions are refused, not coerced.** Two cron-trigger playbooks on the same minute would race the global `/tmp/ceo-cron.lock`; `ceo playbook scan` refuses to install the crontab until you resolve via `ceo schedule <playbook>` or by editing `schedules.json`.
+- **Schedule collisions are refused, not coerced.** Two cron-trigger playbooks on the same minute would race the global `/tmp/ceo-cron.lock`; `ceo playbook scan` refuses to write the registry until you resolve via `ceo schedule <playbook>` or by editing `schedules.json`.
 - **Playbook frontmatter schema.** See [`docs/playbooks/SCHEMA.md`](docs/playbooks/SCHEMA.md) for the full field reference. `status:` is now an enum (`active` / `draft` / `disabled`) — drafts are runnable on-demand but never cron-installed, disabled tears down previously-installed cron lines. Unknown status values are rejected at parse time.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -135,6 +135,34 @@ ceo playbook info token-intake
 
 Open `http://localhost:8384` on each machine, add devices, share the Obsidian vault (Send & Receive everywhere), copy `syncthing/shared.stignore` to `~/Documents/Obsidian/.stignore`. See `syncthing/README.md` for write-domain rules and conflict handling.
 
+## Swarm (multi-machine)
+
+CEO runs across two or more machines from one synced Obsidian vault with no write-conflicts and no double token spend. Playbook `.md` *definitions* are synced (a shared catalog), but the generated `registry.json` is host-local at `~/.ceo/registry.json` — each host scans its own. A synced `CEO/swarm.json` (`{schema_version, hosts, owners}`) holds the topology and the owners of single-scope playbooks. Each host runs the intersection of the shared catalog, its host-local enablement, and the swarm owners — so the same scheduled work never fires twice.
+
+Per-playbook `scope` decides where it runs:
+
+| `scope` | Runs on | Select with |
+|---------|---------|-------------|
+| `each` | every host where locally enabled | `ceo playbook enable <name>` / `ceo playbook disable <name>` (host-local `~/.ceo/enabled.json`) |
+| `single` | exactly one owner host (no double spend; empty owner = nowhere) | `ceo playbook assign <name> <host>` (recorded in synced `CEO/swarm.json`) |
+
+`ceo playbook list` shows each playbook's scope, status, and current per-host state (`✓ enabled here` / `owner: <host>`).
+
+Operational commands:
+
+```bash
+ceo playbook list                 # per-host view of scope + state
+ceo playbook enable <name>        # run an each-scope playbook on THIS host
+ceo playbook disable <name>       # stop it on THIS host
+ceo playbook assign <name> <host> # set the owner of a single-scope playbook
+ceo swarm doctor [--fix]          # detect/heal swarm.json sync-conflict copies
+ceo swarm owners-health           # flag single-scope owners whose heartbeat is stale (offline)
+```
+
+Scheduling is owned by the `ceo-schedulerd` daemon (native crontab install is retired); its run predicate (`selectRunnable`) is exactly the intersection above.
+
+See [`docs/install.md`](docs/install.md) for fresh multi-machine setup, [`docs/playbooks/SCHEMA.md`](docs/playbooks/SCHEMA.md#swarm-selection-model) for the full selection model, and [`docs/migration.md`](docs/migration.md) for migrating an existing single-host install.
+
 ## Development
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,99 @@
+# Multi-Machine Install Guide
+
+Set up CEO across two or more machines from scratch, sharing one Obsidian vault with no write-conflicts and no double token spend.
+
+The swarm model in one paragraph: playbook `.md` *definitions* are synced (a shared catalog), but the generated registry is host-local (`~/.ceo/registry.json`) — each host scans its own. A synced `CEO/swarm.json` holds the topology (`hosts`) and the owners of `single`-scope playbooks. Each host runs the intersection of the shared catalog, its host-local enablement (`each` scope), and the swarm owners (`single` scope). See [`playbooks/SCHEMA.md`](playbooks/SCHEMA.md#swarm-selection-model) for the full selection predicate.
+
+Migrating an existing single-host install rather than starting fresh? See [`migration.md`](migration.md).
+
+## 1. Prerequisites
+
+`ceo setup` checks for these on each machine:
+
+- **git** and **gh** (GitHub CLI), authenticated — `gh auth login`.
+- **jq** — required for swarm bootstrapping and registration.
+- **yq** — required by `ceo playbook scan`. ([install](https://github.com/mikefarah/yq#install))
+- **Syncthing** — running on every machine to sync the Obsidian vault. ([install](https://syncthing.net/))
+- **Claude Code** with an authenticated subscription (`claude --print`).
+- **bun** (≥ 1.3.5) — runtime for the `ceo-schedulerd` scheduler daemon.
+- An **Obsidian vault** with `CEO/`, `VAULT.md`, and `Profile.md`, shared by Syncthing across all machines.
+
+`ceo setup` installs what it can on macOS/Linux and warns (without failing) on Syncthing / yq / Claude Code so you can install them yourself; missing git/gh/jq fail the run.
+
+## 2. Set a UNIQUE `CEO_HOSTNAME` per machine
+
+Host identity defaults to `hostname -s`. If two machines resolve to the same short hostname and you let it auto-resolve, the swarm-registration **collision guard refuses** the second registration — it cannot tell whether the existing `hosts[]` entry is this machine or a clone, and a silently shared id leads to double-ownership (and double token spend) of a `single`-scope playbook.
+
+An explicit `CEO_HOSTNAME` is trusted: you have asserted the id is unique, so re-registration becomes a safe no-op. Set a distinct value on **every** machine, even when `hostname -s` already differs — it makes identity explicit and stable.
+
+`~/.ceo/config` is sourced as a shell file, so add a line there:
+
+```bash
+mkdir -p ~/.ceo
+echo 'CEO_HOSTNAME=ml-1' >> ~/.ceo/config   # ml-2, mac-mini, … on the others
+```
+
+(Or export `CEO_HOSTNAME` in your shell before running `ceo`.) Do this **before** `ceo setup` so the host registers under the right id.
+
+## 3. Machine 1 — create the swarm
+
+```bash
+ceo setup
+```
+
+Setup detects/writes the vault path into `~/.ceo/config`, then bootstraps `CEO/swarm.json` and registers this host into `hosts[]`. Machine 1 is the one that *creates* `swarm.json`.
+
+Then bring up Syncthing and share the Obsidian vault to the other machines (Send & Receive everywhere) — see the [README](../README.md#syncthing). Wait for the vault (including the newly created `CEO/swarm.json`) to fully sync before touching machine 2.
+
+## 4. Machine 2 — join after the vault has synced
+
+**Order matters.** Machine 1 creates `swarm.json`; machine 2 joins it. Run `ceo setup` on machine 2 only **after** the vault has synced, so setup finds the existing `swarm.json` and registers this host into it (rather than two machines creating it concurrently and producing Syncthing conflict copies):
+
+```bash
+ceo setup                       # with CEO_HOSTNAME=ml-2 already in ~/.ceo/config
+```
+
+If the host id is ambiguous, setup prints the collision-guard message and does **not** register — set a unique `CEO_HOSTNAME` and re-run. Repeat for each additional machine.
+
+## 5. Scan playbooks on each host
+
+The generated registry is host-local, so scan on **every** machine:
+
+```bash
+ceo playbook scan
+```
+
+This reads the synced playbook definitions and writes `~/.ceo/registry.json` for that host. (`ceo setup`'s final step offers to run this for you.) Preview without writing via `ceo playbook scan --dry-run`.
+
+## 6. Select what runs where
+
+```bash
+ceo playbook list                 # per-host view: scope, status, current state
+```
+
+- **`each`-scope** playbooks (run on every host where enabled):
+
+  ```bash
+  ceo playbook enable <name>      # run on THIS host
+  ceo playbook disable <name>     # stop on THIS host
+  ```
+
+- **`single`-scope** playbooks (run on exactly one owner — guarantees no double token spend; an unowned single-scope playbook runs nowhere):
+
+  ```bash
+  ceo playbook assign <name> <host>
+  ```
+
+`enable`/`disable` are rejected for `single`-scope playbooks, and `assign` is rejected for `each`-scope — `ceo playbook list` tells you which is which.
+
+## 7. Verify
+
+On each host:
+
+```bash
+ceo doctor                # deps, vault, scheduler daemon, auth
+ceo swarm doctor          # detect swarm.json sync-conflict copies (--fix to heal)
+ceo swarm owners-health   # flag single-scope owners whose heartbeat has gone stale
+```
+
+`ceo swarm doctor` exits non-zero if any `swarm.sync-conflict-*.json` copy exists; `--fix` merges them back (`hosts` union, owners live-wins-per-key, max `schema_version`) and removes the copies. `ceo swarm owners-health` flags single-scope playbooks whose owner host's synced heartbeat is stale (host presumed offline → those playbooks run nowhere) and exits non-zero when any owner is stale.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -54,9 +54,14 @@ hosts scanning a shared copy would both rewrite it and produce Syncthing
 ## 4. Create and populate `swarm.json`
 
 Run `ceo setup` to bootstrap `CEO/swarm.json` and register each host into
-`hosts[]`. Each machine needs a **unique `CEO_HOSTNAME`** — the registration
-collision guard refuses an ambiguous id (two machines sharing one id leads to
-double ownership of a `single`-scope playbook). See
+`hosts[]`. Set an explicit **`CEO_HOSTNAME` on every machine** as the default —
+not only when hostnames collide. An explicit id makes the bash (`hostname -s`)
+and TS (`os.hostname().split('.')[0]`) host-id resolution byte-identical,
+eliminating any rare OS divergence between the two. The registration collision
+guard is the backstop: if you do let identity auto-resolve and two machines
+share a short hostname, the guard refuses the ambiguous second registration
+(two machines sharing one id leads to double ownership of a `single`-scope
+playbook). See
 [`install.md` §2–§5](install.md#2-set-a-unique-ceo_hostname-per-machine) for the
 per-host setup, ordering (machine 1 creates `swarm.json`, others join after it
 syncs), and the scan step.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,136 @@
+# Migrating an Existing Single-Host Install to the Swarm
+
+This guide migrates a CEO install that has been running on **one** machine to
+the multi-host swarm model. Setting up new machines from scratch instead? See
+[`install.md`](install.md).
+
+**Order is load-bearing.** Doing these steps out of order risks two failure
+modes the swarm model exists to prevent: a token playbook running on every host
+(double spend), or playbooks silently dropped (run nowhere). Do the steps in
+order, on the host(s) named.
+
+## 1. Upgrade `ceo` on all hosts first
+
+Pull the new code on **every** machine before changing any state. A mixed fleet
+(one host on the new binary, another on the old) will mis-handle the new
+`scope` field and the host-local registry. Upgrade everywhere, then migrate.
+
+## 2. Backfill `scope` on every playbook `.md`
+
+Each playbook definition now carries a `scope` field that replaces the old
+`hosts:` list. Convert every playbook:
+
+- `hosts: ["*"]` (ran on all hosts) → `scope: each`
+- `hosts: ["<one-host>"]` (ran on one host) → `scope: single`, and assign that
+  host as the owner in step 4 (`ceo playbook assign <name> <host>`)
+
+**An absent `scope` resolves to the SAFE default `single`** — the playbook runs
+**nowhere** until an owner is assigned. This is deliberate: `scope` must **never**
+default to `each`, because a token-spending playbook silently fanned out to
+every host is exactly the double-spend this feature prevents. A missing scope
+failing closed (runs nowhere, visible in `ceo playbook list`) is recoverable; a
+missing scope failing open (runs everywhere) is not.
+
+An **unknown** `scope` value (a typo like `evry`) is **rejected at scan time** —
+`ceo playbook scan` skips the playbook with a `SKIP` diagnostic and exits
+non-zero. Fix the typo; don't rely on a default swallowing it.
+
+## 3. Move `registry.json` out of the synced vault
+
+The generated registry is now **host-local** at `~/.ceo/registry.json`. Two
+hosts scanning a shared copy would both rewrite it and produce Syncthing
+`.sync-conflict` copies. The vault keeps only the playbook `.md` definitions
+(which scan reads).
+
+- Delete the synced copy: `rm "$CEO_VAULT/CEO/registry.json"`
+- Each host regenerates its own host-local registry via `ceo playbook scan`
+  (step 4 / 5).
+- Update `syncthing/shared.stignore` so the vault `CEO/registry.json` is no
+  longer synced (this repo already adds the ignore line — copy the updated
+  `shared.stignore` to `~/Documents/Obsidian/.stignore` on every host). See
+  [`syncthing/README.md`](../syncthing/README.md#swarm-state-what-syncs-and-what-doesnt)
+  for what syncs (`swarm.json`, `heartbeats/`) and what doesn't (`registry.json`).
+
+## 4. Create and populate `swarm.json`
+
+Run `ceo setup` to bootstrap `CEO/swarm.json` and register each host into
+`hosts[]`. Each machine needs a **unique `CEO_HOSTNAME`** — the registration
+collision guard refuses an ambiguous id (two machines sharing one id leads to
+double ownership of a `single`-scope playbook). See
+[`install.md` §2–§5](install.md#2-set-a-unique-ceo_hostname-per-machine) for the
+per-host setup, ordering (machine 1 creates `swarm.json`, others join after it
+syncs), and the scan step.
+
+Then assign an owner for every `single`-scope playbook (including the ones you
+converted from `hosts: ["<one-host>"]` in step 2):
+
+```bash
+ceo playbook assign <single-playbook> <host>
+```
+
+A `single`-scope playbook with no owner runs nowhere — `ceo playbook list`
+shows it as unowned, and `ceo swarm owners-health` will not flag it (there is no
+owner to be offline). Assign every one you intend to keep running.
+
+## 5. Retire the native crontab FIRST, then rely on the daemon
+
+`ceo-schedulerd` is now the sole scheduler — it reads the host-local registry
+and applies scope-aware per-host selection that the old `# CEO Agent` crontab
+block could not. The native crontab install path is retired.
+
+**Remove the old `# CEO Agent` crontab block BEFORE (or as) you bring up
+`ceo-schedulerd` on each host.** If both the crontab block and the daemon are
+live at once, they fire the same playbook twice — and the crontab block ignores
+`scope`, so it runs *everything* on that host (double spend). There is no
+`ceo` subcommand to remove the block; edit the crontab by hand:
+
+```bash
+crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent$' | crontab -
+```
+
+(Or `crontab -e` and delete the `# CEO Agent START` … `# CEO Agent END` block.)
+Then the daemon is the scheduler — see
+[`install.md` §7](install.md#7-verify) for the `ceo-schedulerd` keep-alive
+agent.
+
+`ceo doctor` now flags a lingering `# CEO Agent` crontab block as a migration
+leftover **regardless of whether the daemon is already running** (it is always a
+leftover now that install is retired), so run `ceo doctor` on each host after
+this step and clear anything it reports.
+
+## 6. Retire the `ceo-scan-only-on-ml1` rule — POST-MIGRATION
+
+> Do this only **after** every host is migrated and verified (step 7 passes on
+> all of them).
+
+The old operational rule "run `ceo playbook scan` only on ML-1" existed because
+scan used to install host-local schedulers **and** rewrite the *synced*
+`registry.json` — so scanning on a second host mutated shared state for the
+whole fleet. That is no longer true: scan now writes only the **host-local**
+`~/.ceo/registry.json` and installs nothing into the synced vault. Multi-host
+scan is the **intended** model — every host scans its own registry.
+
+Once migration is complete, the ML-1-only constraint is lifted: scan on every
+host as a normal operation.
+
+This rule lives **outside this repo** (in the user's global rules / `llm-tools`),
+not in `claude-ceo`. Do **not** delete or edit any repo file for it — there is
+nothing here to remove. This section documents only that the operational
+constraint no longer applies post-migration; retiring the rule itself is a
+separate change made wherever that rule is defined, after this ships.
+
+## 7. Verify
+
+On each host:
+
+```bash
+ceo doctor                # deps, vault, scheduler daemon, leftover crontab block
+ceo swarm doctor          # detect swarm.json sync-conflict copies (--fix to heal)
+ceo swarm owners-health   # flag single-scope owners whose heartbeat has gone stale
+ceo playbook list         # confirm expected scope + state per playbook
+```
+
+Confirm on every host that `~/.ceo/registry.json` exists (the host-local
+registry) and that `ceo playbook list` shows the scope and enablement/ownership
+state you expect — no playbook unintentionally running on every host, none
+silently unowned.

--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -95,6 +95,23 @@ The `hosts` field declares which machines a playbook may run on:
 
 **Enforcement depends on the scheduler backend.** The Phase-1.5 daemon (`ceo-schedulerd`, `lib/scheduler/`) enforces `hosts` — it only dispatches playbooks whose `hosts` includes `"*"` or this host's short hostname (`selectRunnable`). The Phase-1 **native-cron** install path (`_playbook_update_crontab`) still records `hosts` without enforcing it, so a host running via crontab rather than the daemon runs every playbook regardless of scope. The deferred registry `schema_version` bump (which would stop a non-enforcing peer binary from running a host-scoped playbook everywhere) is tracked separately and is **not** part of the daemon change.
 
+### Fan-out scope
+
+The `scope` field declares whether a playbook runs once or fans out per target:
+
+| `scope` value | Meaning |
+|---|---|
+| absent | `single` — run once (the safe default) |
+| `single` | run once |
+| `each` | fan out per target (consumed by the scheduler daemon) |
+| any other value | **unknown** — `ceo playbook scan` skips the entry with a `SKIP` diagnostic and a non-zero exit |
+
+`ceo playbook scan` validates `scope` at parse time and never coerces an unknown value to a default (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)). An absent `scope` defaults to `single`; a typo'd value is skipped and counts toward the scan's failure exit, the same as an unknown `status`.
+
+### Generated registry is host-local
+
+`ceo playbook scan` reads the playbook `.md` definitions from the synced vault (`$CEO_VAULT/CEO/playbooks/`) but writes the generated `registry.json` host-local to `~/.ceo/registry.json`. The vault holds only the definitions; the registry is per-host. Two machines scanning a shared vault would otherwise both rewrite the synced `registry.json` and produce Syncthing `.sync-conflict` copies. The scheduler daemon (`lib/scheduler/`) reads the same host-local path.
+
 ### Use draft for WIP playbooks
 
 `draft` exists for "exists, runnable on demand, not ready for cron." Author iteratively via `bash scripts/ceo-cron.sh <name>` (optionally `--force` to bypass the cooldown between runs) until happy with the behavior, then flip frontmatter to `status: active` and re-run `ceo playbook scan` to install.

--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -22,7 +22,8 @@ Unknown values for enum fields are **rejected at parse time** with a `SKIP` diag
 | `bin` | no | string | If set, `ceo playbook scan` installs a `~/.local/bin/<bin-without-.sh>` symlink pointing at `scripts/<bin>`. Only created for `status: active`. |
 | `inputs` | no | JSON array | Pre-gather keys the dispatcher injects into the prompt context. Empty array = no pre-gathered context. Absent = all keys (back-compat default). Unknown keys warn-and-skip at dispatch. Valid keys: `pr_data`, `pending_count`, `today_log`, `yesterday_log`, `daily_note`, `briefings_training`, `active_domains`, `pending_ask`, `scan_data`, `blessings`. |
 | `requires` | no | JSON array of env-var names | Credentials the playbook needs (e.g. `["HUBSPOT_REFRESH_TOKEN"]`). `ceo creds check <name>` reports missing values. Non-array entries are warned and dropped. |
-| `hosts` | no | JSON array of host names | Which machines the playbook runs on. Absent or `["*"]` → all hosts. **Recorded in the registry but not yet enforced** — the Phase-1.5 daemon consumes it; see [Host scoping](#host-scoping). Malformed values (scalar, empty array, blank element) warn and default to `["*"]`. |
+| `scope` | no | enum: `each`, `single` | How the playbook fans out across the swarm. Absent defaults to `single` (safe: a single-scope playbook runs nowhere until an owner is assigned). `each` runs on every host where locally enabled; `single` runs on exactly one owner host. Unknown values are **rejected at parse** with a `SKIP` and a non-zero scan exit. See [Swarm selection model](#swarm-selection-model). |
+| `hosts` | no | JSON array of host names | **DEPRECATED** — no longer consulted for scheduling. Selection is now `scope` plus host-local enablement (`each`) or `swarm.json` ownership (`single`); `selectRunnable` does not read `hosts`. `ceo playbook scan` still parses and normalizes it (malformed → `["*"]` with a `WARN`) but warns-and-ignores it for scheduling. See [Swarm selection model](#swarm-selection-model) and [Host scoping (legacy)](#host-scoping-legacy). |
 | `artifact` | recommended for `runner: script` | string template | Expected output path relative to the vault. Must start with `CEO/`. Supports `{TODAY}` (YYYY-MM-DD) and `{HOST}` (short hostname). Unknown tokens reject at parse. `ceo doctor` cross-checks declared artifact vs disk for every active script that logged "completed" today. |
 | `out_pattern` | no | string | Legacy reporting pattern (output filename hint). Kept for back-compat with older playbooks. New playbooks should use `artifact`. |
 
@@ -79,9 +80,36 @@ Unknown `--depth` values are rejected at parse (no silent default). `--depth` / 
 
 > **Note on `--model` vs the original design.** The issue proposed "unset → local Ollama default." Forcing Ollama globally would break tier:write playbooks (the three-phase pipeline requires Claude; Ollama is rejected for non-read tiers), so unset keeps each playbook's configured model. The cheap-sweep goal is met by the `preflight` default, which makes no model call at all.
 
-### Host scoping
+### Swarm selection model
 
-The `hosts` field declares which machines a playbook may run on:
+`scope` replaces `hosts` as the mechanism that decides which host runs a playbook. The daemon's run predicate (`selectRunnable`, `lib/scheduler/src/select.ts`) is:
+
+> A host runs a playbook iff it is an **active** `cron` playbook with a non-blank schedule **and** either:
+> - `scope: each` **and** the playbook is in this host's local `~/.ceo/enabled.json`, **or**
+> - `scope: single` **and** this host equals the playbook's owner in `CEO/swarm.json` (`owners[name] === host`).
+
+| `scope` value | Meaning |
+|---|---|
+| absent | `single` (the safe default — runs nowhere until an owner is assigned) |
+| `single` | runs on exactly **one** owner host; assigned via `ceo playbook assign <name> <host>`, recorded in the synced `CEO/swarm.json`. Guarantees no double token spend; an empty owner = runs nowhere. |
+| `each` | runs on **every** host where locally enabled, selected per-host via `ceo playbook enable` / `disable` (host-local `~/.ceo/enabled.json`). |
+| any other value | **unknown** — `ceo playbook scan` skips the entry with a `SKIP` diagnostic and a non-zero exit. |
+
+`ceo playbook scan` validates `scope` at parse time and never coerces an unknown value to a default (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)); a typo'd value counts toward the scan's failure exit, the same as an unknown `status`. Ownership is authoritative for `single` scope — local enablement does not gate it.
+
+Selection verbs:
+
+- `ceo playbook enable <name>` / `ceo playbook disable <name>` — toggle an `each`-scope playbook in this host's `~/.ceo/enabled.json` (rejected for `single` scope).
+- `ceo playbook assign <name> <host>` — set the owner of a `single`-scope playbook in `CEO/swarm.json` (rejected for `each` scope).
+- `ceo playbook list` — per-host view: shows each playbook's scope, status, and current state (`✓ enabled here` / `· disabled here` for `each`; `owner: <host>` / `owner: (none) ⚠` for `single`).
+
+`swarm.json` is synced across the fleet and has the shape `{schema_version, hosts: [], owners: {}}` — `owners` maps a single-scope playbook name to its owning host. Because it is synced, two hosts editing it can produce Syncthing conflict copies; `ceo swarm doctor [--fix]` self-heals by merging `swarm.sync-conflict-*.json` copies (live keys win, owners union, max `schema_version`). `ceo swarm owners-health` flags single-scope playbooks whose assigned owner is missing from the swarm's host list and files an inbox item.
+
+### Host scoping (legacy)
+
+> **Deprecated.** The `hosts` field below describes the pre-swarm selection mechanism. It is no longer consulted for scheduling — see [Swarm selection model](#swarm-selection-model). `ceo playbook scan` still parses and normalizes `hosts` for back-compat, but warns-and-ignores it; `selectRunnable` does not read it.
+
+The `hosts` field formerly declared which machines a playbook may run on:
 
 | `hosts` value | Meaning |
 |---|---|
@@ -91,22 +119,7 @@ The `hosts` field declares which machines a playbook may run on:
 | `["*", "ml-1"]` | `*` mixed with names is reserved to mean **all hosts** — the wildcard dominates |
 | scalar / `[]` / blank element | **malformed** — `ceo playbook scan` warns and records `["*"]` |
 
-`ceo playbook scan` validates the shape at parse time and never silently scopes a playbook to nowhere or to a typo'd host: any malformed value defaults to `["*"]` with a `WARN` (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)). To stop a playbook entirely, use `status: disabled`, not an empty `hosts` list.
-
-**Enforcement depends on the scheduler backend.** The Phase-1.5 daemon (`ceo-schedulerd`, `lib/scheduler/`) enforces `hosts` — it only dispatches playbooks whose `hosts` includes `"*"` or this host's short hostname (`selectRunnable`). The Phase-1 **native-cron** install path (`_playbook_update_crontab`) still records `hosts` without enforcing it, so a host running via crontab rather than the daemon runs every playbook regardless of scope. The deferred registry `schema_version` bump (which would stop a non-enforcing peer binary from running a host-scoped playbook everywhere) is tracked separately and is **not** part of the daemon change.
-
-### Fan-out scope
-
-The `scope` field declares whether a playbook runs once or fans out per target:
-
-| `scope` value | Meaning |
-|---|---|
-| absent | `single` — run once (the safe default) |
-| `single` | run once |
-| `each` | fan out per target (consumed by the scheduler daemon) |
-| any other value | **unknown** — `ceo playbook scan` skips the entry with a `SKIP` diagnostic and a non-zero exit |
-
-`ceo playbook scan` validates `scope` at parse time and never coerces an unknown value to a default (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)). An absent `scope` defaults to `single`; a typo'd value is skipped and counts toward the scan's failure exit, the same as an unknown `status`.
+`ceo playbook scan` still validates the shape at parse time and defaults any malformed value to `["*"]` with a `WARN` (per [`enum-config-typo-fallback`](../../../.claude/rules/enum-config-typo-fallback.md)), but the normalized value no longer affects whether any host runs the playbook. To scope a playbook to specific hosts, use `scope` + `assign` / `enable`; to stop it entirely, use `status: disabled`.
 
 ### Generated registry is host-local
 

--- a/docs/playbooks/SCHEMA.md
+++ b/docs/playbooks/SCHEMA.md
@@ -103,7 +103,7 @@ Selection verbs:
 - `ceo playbook assign <name> <host>` — set the owner of a `single`-scope playbook in `CEO/swarm.json` (rejected for `each` scope).
 - `ceo playbook list` — per-host view: shows each playbook's scope, status, and current state (`✓ enabled here` / `· disabled here` for `each`; `owner: <host>` / `owner: (none) ⚠` for `single`).
 
-`swarm.json` is synced across the fleet and has the shape `{schema_version, hosts: [], owners: {}}` — `owners` maps a single-scope playbook name to its owning host. Because it is synced, two hosts editing it can produce Syncthing conflict copies; `ceo swarm doctor [--fix]` self-heals by merging `swarm.sync-conflict-*.json` copies (live keys win, owners union, max `schema_version`). `ceo swarm owners-health` flags single-scope playbooks whose assigned owner is missing from the swarm's host list and files an inbox item.
+`swarm.json` is synced across the fleet and has the shape `{schema_version, hosts: [], owners: {}}` — `owners` maps a single-scope playbook name to its owning host. Because it is synced, two hosts editing it can produce Syncthing conflict copies; `ceo swarm doctor [--fix]` self-heals by merging `swarm.sync-conflict-*.json` copies: `hosts` union, `owners` live-wins-per-key (for live-absent keys the most-recent conflict wins), max `schema_version`. `ceo swarm owners-health` flags single-scope playbooks whose owner host's synced heartbeat has gone stale (presumed offline → those playbooks run nowhere), escalating to the inbox once on a fresh→stale transition.
 
 ### Host scoping (legacy)
 

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -59,6 +59,15 @@ export interface DaemonDeps {
    */
   resolveLookback(schedule: string, now: Date): number;
   shouldContinue(): boolean;
+  /**
+   * Scope gating for {@link selectRunnable}: the each-scope playbooks enabled on
+   * this host, and the name→owner map for single-scope playbooks. Optional only
+   * as a B3→B4 stopgap — production currently leaves both unset, so the daemon is
+   * a safe no-op (selects nothing). B4 wires `enabled.json` + `swarm.json` and
+   * should make these required.
+   */
+  enabled?: Set<string>;
+  owners?: Record<string, string>;
 }
 
 function epochMinute(when: Date): number {
@@ -86,7 +95,11 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
       deps.log(`registry load failed, reusing last-good: ${err instanceof Error ? err.message : String(err)}`);
     }
 
-    const runnable = selectRunnable(playbooks, deps.host);
+    // TODO(B4): load enabled.json (each-scope enablement) + swarm.json owners
+    // in main.ts and make these DaemonDeps fields required. Until then an
+    // unwired production daemon selects nothing for each-scope and nothing for
+    // unowned single-scope — a safe no-op.
+    const runnable = selectRunnable(playbooks, deps.host, deps.enabled ?? new Set<string>(), deps.owners ?? {});
     const minuteStart = minute * MINUTE_MS;
 
     // Current-minute fires (live path), then catch-up fires for slots missed

--- a/lib/scheduler/src/daemon.ts
+++ b/lib/scheduler/src/daemon.ts
@@ -16,6 +16,7 @@ import { catchUpFires } from "@/catchup";
 import type { CronMatcher } from "@/cron";
 import { dueAt, nextWake, selectRunnable } from "@/select";
 import type { Playbook } from "@/registry";
+import type { Swarm } from "@/swarm";
 
 const MINUTE_MS = 60_000;
 /** How many recent dispatches to retain in the heartbeat for observability. */
@@ -42,6 +43,18 @@ export interface DaemonDeps {
   now(): Date;
   sleep(ms: number): Promise<void>;
   loadRegistry(): { playbooks: Playbook[]; warnings: string[] };
+  /**
+   * Per-tick read of this host's enabled each-scope playbooks (`~/.ceo/enabled.json`).
+   * Returns an empty set on a torn/missing read — fail-safe, so an unreadable
+   * host-local selection means "nothing enabled here", never "run everything".
+   */
+  loadEnabled(): Set<string>;
+  /**
+   * Per-tick read of the synced swarm topology + single-scope owners
+   * (`<vault>/CEO/swarm.json`). Returns `null` on a torn/missing read so the loop
+   * can reuse its last-good owners instead of acting on a half-written file.
+   */
+  loadSwarm(): Swarm | null;
   /** Fire-and-forget spawn of the dispatch command; must not block the loop. */
   dispatch(name: string): void;
   /** Prior heartbeat (if any) used to restore the guard across restarts. */
@@ -59,15 +72,6 @@ export interface DaemonDeps {
    */
   resolveLookback(schedule: string, now: Date): number;
   shouldContinue(): boolean;
-  /**
-   * Scope gating for {@link selectRunnable}: the each-scope playbooks enabled on
-   * this host, and the name→owner map for single-scope playbooks. Optional only
-   * as a B3→B4 stopgap — production currently leaves both unset, so the daemon is
-   * a safe no-op (selects nothing). B4 wires `enabled.json` + `swarm.json` and
-   * should make these required.
-   */
-  enabled?: Set<string>;
-  owners?: Record<string, string>;
 }
 
 function epochMinute(when: Date): number {
@@ -80,6 +84,12 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
   const recent: DispatchRecord[] = prior ? [...prior.last_dispatch] : [];
   let lastFired: Record<string, number> = prior ? { ...prior.last_fired } : {};
   let lastGood: Playbook[] = [];
+  // Last-good swarm owners. Unlike enabled (safe-empty on a torn read), swarm
+  // owners are authoritative cross-host state: transiently losing them would
+  // de-own a single-scope playbook and skip a token-spending run that minute.
+  // So a torn swarm read reuses the previous tick's owners; enabled does not get
+  // last-good because an empty enabled set is the safe (nothing-runs) default.
+  let lastGoodOwners: Record<string, string> = {};
 
   while (deps.shouldContinue()) {
     const now = deps.now();
@@ -95,11 +105,10 @@ export async function runForever(deps: DaemonDeps): Promise<void> {
       deps.log(`registry load failed, reusing last-good: ${err instanceof Error ? err.message : String(err)}`);
     }
 
-    // TODO(B4): load enabled.json (each-scope enablement) + swarm.json owners
-    // in main.ts and make these DaemonDeps fields required. Until then an
-    // unwired production daemon selects nothing for each-scope and nothing for
-    // unowned single-scope — a safe no-op.
-    const runnable = selectRunnable(playbooks, deps.host, deps.enabled ?? new Set<string>(), deps.owners ?? {});
+    const enabled = deps.loadEnabled();
+    const swarm = deps.loadSwarm();
+    if (swarm !== null) lastGoodOwners = swarm.owners;
+    const runnable = selectRunnable(playbooks, deps.host, enabled, lastGoodOwners);
     const minuteStart = minute * MINUTE_MS;
 
     // Current-minute fires (live path), then catch-up fires for slots missed

--- a/lib/scheduler/src/enabled.ts
+++ b/lib/scheduler/src/enabled.ts
@@ -1,0 +1,23 @@
+/**
+ * Host-local enabled-playbook reader for the ceo-schedulerd daemon.
+ *
+ * `~/.ceo/enabled.json` is a plain JSON array of playbook names — the per-host
+ * selection of which `scope: each` playbooks THIS machine runs (the analogue of
+ * Claude's enabled-plugins list). It is host-local, not synced. This is a pure
+ * parser (mirroring `parseSwarm` / `parseRegistry`): on any malformed or absent
+ * input it returns an empty Set rather than throwing. The fail-safe direction is
+ * deliberate — an unreadable host-local selection means "nothing enabled here",
+ * never "run everything", so a torn or missing file can't accidentally promote
+ * playbooks this host wasn't selected for.
+ */
+
+export function parseEnabled(text: string): Set<string> {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(text);
+  } catch {
+    return new Set();
+  }
+  if (!Array.isArray(doc)) return new Set();
+  return new Set(doc.filter((x): x is string => typeof x === "string" && x.trim() !== ""));
+}

--- a/lib/scheduler/src/heartbeat-store.ts
+++ b/lib/scheduler/src/heartbeat-store.ts
@@ -58,3 +58,38 @@ export function writeHeartbeatFile(path: string, hb: Heartbeat): void {
   writeFileSync(tmp, JSON.stringify(hb, null, 2));
   renameSync(tmp, path);
 }
+
+/**
+ * Atomically write the synced per-host heartbeat (E2 offline-owner alert). The
+ * filename is the host id, so two hosts never write the same file — no sync
+ * conflict. The timestamp is taken here at the I/O edge.
+ */
+export function writeSyncedHeartbeat(path: string, host: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ host, ts: new Date().toISOString() }, null, 2));
+  renameSync(tmp, path);
+}
+
+/**
+ * Persist the heartbeat host-local first, then best-effort the synced per-host
+ * copy. Invariant: a synced-vault write failure must not crash the daemon or
+ * skip the host-local heartbeat (the double-fire guard's backing store). The
+ * host-local write happens before the try so it cannot be skipped; a synced
+ * failure is swallowed and logged.
+ */
+export function writeHeartbeatWithSync(
+  hb: Heartbeat,
+  deps: {
+    writeLocal: (hb: Heartbeat) => void;
+    writeSynced: () => void;
+    log: (msg: string) => void;
+  },
+): void {
+  deps.writeLocal(hb);
+  try {
+    deps.writeSynced();
+  } catch (err) {
+    deps.log(`synced heartbeat write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -12,12 +12,16 @@
  * Schedules evaluate in the host's local timezone (the matcher is created with
  * no timezone, matching `new Date()`); registry schedules carry no per-entry tz.
  */
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { createMatcher } from "@/cron";
 import { type DaemonDeps, runForever } from "@/daemon";
-import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
+import {
+  readHeartbeatFile,
+  writeHeartbeatFile,
+  writeHeartbeatWithSync,
+  writeSyncedHeartbeat,
+} from "@/heartbeat-store";
 import { parseRegistry } from "@/registry";
 import { parseEnabled } from "@/enabled";
 import { parseSwarm } from "@/swarm";
@@ -56,17 +60,6 @@ function nowStamp(): string {
  */
 function readIfExists(path: string): string {
   return existsSync(path) ? readFileSync(path, "utf8") : "";
-}
-
-/**
- * Atomically write the synced per-host heartbeat. The timestamp is taken here
- * at the I/O edge (not in a pure helper) so unit-tested code stays deterministic.
- */
-function writeSyncedHeartbeat(path: string, host: string): void {
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
-  writeFileSync(tmp, JSON.stringify({ host, ts: new Date().toISOString() }, null, 2));
-  renameSync(tmp, path);
 }
 
 async function main(): Promise<void> {
@@ -135,18 +128,12 @@ async function main(): Promise<void> {
       }
     },
     readHeartbeat: () => readHeartbeatFile(hbPath),
-    writeHeartbeat: (hb) => {
-      writeHeartbeatFile(hbPath, hb);
-      // Synced per-host liveness for the offline-owner alert (E2). Filename is
-      // the host id, so two hosts never write the same file — no sync conflict.
-      // Best-effort: a synced-vault write failure must not crash the daemon or
-      // skip the host-local heartbeat above.
-      try {
-        writeSyncedHeartbeat(syncedHbPath, host);
-      } catch (err) {
-        log(`synced heartbeat write failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    },
+    writeHeartbeat: (hb) =>
+      writeHeartbeatWithSync(hb, {
+        writeLocal: (h) => writeHeartbeatFile(hbPath, h),
+        writeSynced: () => writeSyncedHeartbeat(syncedHbPath, host),
+        log,
+      }),
     log,
     host,
     matcher,

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
   const home = requireEnv("HOME");
   const cronBin = process.env.CEO_CRON_BIN?.trim() || "ceo-cron.sh";
   const host = resolveHost({ CEO_HOSTNAME: process.env.CEO_HOSTNAME }, hostname().split(".")[0] ?? "unknown");
-  const regPath = registryPath(vault);
+  const regPath = registryPath(home);
   const hbPath = heartbeatPath(home);
 
   let running = true;

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -12,22 +12,28 @@
  * Schedules evaluate in the host's local timezone (the matcher is created with
  * no timezone, matching `new Date()`); registry schedules carry no per-entry tz.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { hostname } from "node:os";
 import { createMatcher } from "@/cron";
 import { type DaemonDeps, runForever } from "@/daemon";
 import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
 import { parseRegistry } from "@/registry";
+import { parseEnabled } from "@/enabled";
+import { parseSwarm } from "@/swarm";
 import { lookbackForSchedule } from "@/catchup";
 import {
   CATCHUP_LOOKBACK_CAP_MS,
   CATCHUP_LOOKBACK_FLOOR_MS,
   dispatchArgv,
+  enabledPath,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
   resolveFixedLookbackMs,
   resolveHost,
+  swarmPath,
+  syncedHeartbeatPath,
 } from "@/runtime";
 
 function requireEnv(name: string): string {
@@ -42,6 +48,27 @@ function nowStamp(): string {
   return new Date().toISOString();
 }
 
+/**
+ * Read a file, or return "" if it is absent. A missing enabled.json/swarm.json
+ * must be treated as a torn/empty read (the parsers fail safe on "") — never a
+ * crash. The registry uses readFileSync directly because a missing registry is
+ * a fatal misconfiguration the loop's last-good logic surfaces via its catch.
+ */
+function readIfExists(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+/**
+ * Atomically write the synced per-host heartbeat. The timestamp is taken here
+ * at the I/O edge (not in a pure helper) so unit-tested code stays deterministic.
+ */
+function writeSyncedHeartbeat(path: string, host: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ host, ts: new Date().toISOString() }, null, 2));
+  renameSync(tmp, path);
+}
+
 async function main(): Promise<void> {
   const vault = requireEnv("CEO_VAULT");
   const home = requireEnv("HOME");
@@ -49,6 +76,9 @@ async function main(): Promise<void> {
   const host = resolveHost({ CEO_HOSTNAME: process.env.CEO_HOSTNAME }, hostname().split(".")[0] ?? "unknown");
   const regPath = registryPath(home);
   const hbPath = heartbeatPath(home);
+  const enPath = enabledPath(home);
+  const swPath = swarmPath(vault);
+  const syncedHbPath = syncedHeartbeatPath(vault, host);
 
   let running = true;
   let wakeEarly: (() => void) | null = null;
@@ -84,6 +114,8 @@ async function main(): Promise<void> {
         };
       }),
     loadRegistry: () => parseRegistry(readFileSync(regPath, "utf8")),
+    loadEnabled: () => parseEnabled(readIfExists(enPath)),
+    loadSwarm: () => parseSwarm(readIfExists(swPath)),
     dispatch: (name) => {
       // Bun.spawn throws synchronously on e.g. ENOENT (cronBin not on PATH).
       // Swallow + log so one bad dispatch can't crash-loop the daemon; the
@@ -103,7 +135,18 @@ async function main(): Promise<void> {
       }
     },
     readHeartbeat: () => readHeartbeatFile(hbPath),
-    writeHeartbeat: (hb) => writeHeartbeatFile(hbPath, hb),
+    writeHeartbeat: (hb) => {
+      writeHeartbeatFile(hbPath, hb);
+      // Synced per-host liveness for the offline-owner alert (E2). Filename is
+      // the host id, so two hosts never write the same file — no sync conflict.
+      // Best-effort: a synced-vault write failure must not crash the daemon or
+      // skip the host-local heartbeat above.
+      try {
+        writeSyncedHeartbeat(syncedHbPath, host);
+      } catch (err) {
+        log(`synced heartbeat write failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
     log,
     host,
     matcher,

--- a/lib/scheduler/src/registry.ts
+++ b/lib/scheduler/src/registry.ts
@@ -16,6 +16,7 @@ export interface Playbook {
   status: string;
   trigger: string;
   hosts: string[];
+  scope: "each" | "single";
 }
 
 export interface ParsedRegistry {
@@ -42,6 +43,13 @@ function normalizeHosts(raw: unknown, name: string, warnings: string[]): string[
     return ["*"];
   }
   return raw as string[];
+}
+
+function normalizeScope(raw: unknown, name: string, warnings: string[]): "each" | "single" | null {
+  if (raw === undefined || raw === null) return "single";
+  if (raw === "each" || raw === "single") return raw;
+  warnings.push(`${name}: 'scope' must be 'each' or 'single' — entry skipped`);
+  return null;
 }
 
 export function parseRegistry(text: string): ParsedRegistry {
@@ -79,12 +87,15 @@ export function parseRegistry(text: string): ParsedRegistry {
       warnings.push(`${label}: missing a required field (name/schedule/status/trigger) — skipped`);
       continue;
     }
+    const scope = normalizeScope(e.scope, name, warnings);
+    if (scope === null) continue;
     playbooks.push({
       name,
       schedule: e.schedule,
       status: e.status,
       trigger: e.trigger,
       hosts: normalizeHosts(e.hosts, name, warnings),
+      scope,
     });
   }
   return { playbooks, warnings };

--- a/lib/scheduler/src/registry.ts
+++ b/lib/scheduler/src/registry.ts
@@ -1,7 +1,7 @@
 /**
  * Registry reader for the ceo-schedulerd daemon (#136 Phase 1.5).
  *
- * The on-disk registry (`$CEO_VAULT/CEO/registry.json`, schema v3) is written by
+ * The on-disk registry (host-local `~/.ceo/registry.json`, schema v3) is written by
  * `ceo playbook scan`. This module projects each entry down to the fields the
  * daemon needs and normalizes `hosts` the same way the bash scanner does
  * (absent / null / malformed → `["*"]`). Entries missing a required field are

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -55,6 +55,16 @@ export function heartbeatPath(home: string): string {
   return `${home}/.ceo/schedulerd/heartbeat.json`;
 }
 
+/**
+ * Synced per-host liveness heartbeat in the shared vault, namespaced by host so
+ * two hosts never write the same file (no Syncthing conflict). Consumed by the
+ * offline-owner alert (E2): a host whose synced heartbeat goes stale is
+ * presumed offline and its single-scope playbooks unowned.
+ */
+export function syncedHeartbeatPath(vault: string, host: string): string {
+  return `${vault}/CEO/heartbeats/${host}.json`;
+}
+
 export function resolveHost(env: { CEO_HOSTNAME?: string }, osHost: string): string {
   const override = env.CEO_HOSTNAME?.trim();
   return override ? override : osHost;

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -38,8 +38,17 @@ export function resolveFixedLookbackMs(raw: string | undefined): number | null {
   return Number.isInteger(n) && n > 0 ? n : null;
 }
 
-export function registryPath(vault: string): string {
-  return `${vault}/CEO/registry.json`;
+/** Host-local — the registry is now generated per host under `~/.ceo`, not synced via the vault, so concurrent hosts no longer write-conflict on it. */
+export function registryPath(home: string): string {
+  return `${home}/.ceo/registry.json`;
+}
+
+export function swarmPath(vault: string): string {
+  return `${vault}/CEO/swarm.json`;
+}
+
+export function enabledPath(home: string): string {
+  return `${home}/.ceo/enabled.json`;
 }
 
 export function heartbeatPath(home: string): string {

--- a/lib/scheduler/src/select.ts
+++ b/lib/scheduler/src/select.ts
@@ -8,23 +8,23 @@
 import type { CronMatcher } from "@/cron";
 import type { Playbook } from "@/registry";
 
-function hostMatches(hosts: string[], host: string): boolean {
-  return hosts.includes("*") || hosts.includes(host);
-}
-
 /**
  * The playbooks this host may run on a schedule: cron-triggered, active, with a
- * non-blank schedule, whose `hosts` includes `"*"` or this host. This is where
- * `hosts:` is enforced (Phase 1 only recorded it).
+ * non-blank schedule, gated by scope. A `scope: "each"` playbook runs iff it is
+ * in this host's local `enabled` set; a `scope: "single"` playbook runs iff this
+ * host is its owner (`owners[name] === host`). Ownership is authoritative —
+ * local enablement does not gate single-scope playbooks.
  */
-export function selectRunnable(playbooks: Playbook[], host: string): Playbook[] {
-  return playbooks.filter(
-    (p) =>
-      p.trigger === "cron" &&
-      p.status === "active" &&
-      p.schedule.trim() !== "" &&
-      hostMatches(p.hosts, host),
-  );
+export function selectRunnable(
+  playbooks: Playbook[],
+  host: string,
+  enabled: Set<string>,
+  owners: Record<string, string>,
+): Playbook[] {
+  return playbooks.filter((p) => {
+    if (p.trigger !== "cron" || p.status !== "active" || p.schedule.trim() === "") return false;
+    return p.scope === "single" ? owners[p.name] === host : enabled.has(p.name);
+  });
 }
 
 /** Playbooks firing during the minute containing `when`. Invalid schedules are skipped. */

--- a/lib/scheduler/src/swarm.ts
+++ b/lib/scheduler/src/swarm.ts
@@ -1,0 +1,38 @@
+/**
+ * Swarm reader for the ceo-schedulerd daemon.
+ *
+ * `$CEO_VAULT/CEO/swarm.json` holds the swarm topology (`hosts`) and per-playbook
+ * owners for `scope: single` playbooks (`owners`). The file lives in a
+ * Syncthing-synced vault, so a read can land on a half-written/partial file. This
+ * is a pure parser (mirroring `parseRegistry`): it returns `null` on any malformed
+ * input — never throws, never returns a half-parsed object — so the caller can fall
+ * back to its last-good copy instead of acting on a torn read.
+ */
+
+export interface Swarm {
+  hosts: string[];
+  owners: Record<string, string>;
+}
+
+export function parseSwarm(text: string): Swarm | null {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) return null;
+  const d = doc as Record<string, unknown>;
+  const hosts = Array.isArray(d.hosts)
+    ? d.hosts.filter((h): h is string => typeof h === "string" && h.trim() !== "")
+    : [];
+  const ownersRaw =
+    typeof d.owners === "object" && d.owners !== null && !Array.isArray(d.owners)
+      ? (d.owners as Record<string, unknown>)
+      : {};
+  const owners: Record<string, string> = {};
+  for (const [k, v] of Object.entries(ownersRaw)) {
+    if (typeof v === "string" && v.trim() !== "") owners[k] = v;
+  }
+  return { hosts, owners };
+}

--- a/lib/scheduler/tests/catchup.test.ts
+++ b/lib/scheduler/tests/catchup.test.ts
@@ -16,6 +16,7 @@ const pb = (over: Partial<Playbook>): Playbook => ({
   status: "active",
   trigger: "cron",
   hosts: ["*"],
+  scope: "each",
   ...over,
 });
 

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -3,6 +3,7 @@ import { lookbackForSchedule } from "@/catchup";
 import { createMatcher } from "@/cron";
 import type { Playbook } from "@/registry";
 import { type DaemonDeps, type Heartbeat, runForever } from "@/daemon";
+import type { Swarm } from "@/swarm";
 import { CATCHUP_LOOKBACK_CAP_MS, CATCHUP_LOOKBACK_FLOOR_MS } from "@/runtime";
 
 const m = createMatcher({ timezone: "UTC" });
@@ -26,6 +27,19 @@ interface HarnessOpts {
   cap?: number;
   /** Pin a fixed look-back for all schedules (the env-override path). Omit to use the production-default derived resolver. */
   lookback?: number;
+  /**
+   * Per-tick swarm reads (mirrors `loadSwarm`). `null` simulates a torn read.
+   * Default: a single static swarm with the given `owners`, returned every tick.
+   */
+  swarms?: (Swarm | null)[];
+  /** Owners for the default static swarm (when `swarms` is not supplied). */
+  owners?: Record<string, string>;
+  /**
+   * Per-tick enabled reads (mirrors `loadEnabled`). When supplied, REPLACES the
+   * default accumulate-every-loaded-name behavior. A `null` entry simulates a
+   * torn read → empty set that tick.
+   */
+  enabledByTick?: (Set<string> | null)[];
 }
 
 function harness(opts: HarnessOpts) {
@@ -47,15 +61,32 @@ function harness(opts: HarnessOpts) {
     typeof opts.playbooks === "function"
       ? opts.playbooks
       : () => ({ playbooks: opts.playbooks as Playbook[], warnings: [] });
-  // B3 made selection scope-aware; these tests predate per-host enablement and
-  // assert each-scope playbooks dispatch. Enable every name each load yields by
-  // accumulating into `enabled` as the loop loads — wrapping (not pre-calling)
-  // the loader so its call counter / throw-on-Nth-call behavior is preserved.
+  // B3 made selection scope-aware; the legacy dispatch tests predate per-host
+  // enablement and assert each-scope playbooks dispatch. Default behavior:
+  // accumulate every loaded name into `enabled` as the loop loads — wrapping
+  // (not pre-calling) the loader so its call counter / throw-on-Nth-call
+  // behavior is preserved. The accumulated set is returned each tick by
+  // `loadEnabled` unless a per-tick `enabledByTick` override is supplied.
   const enabled = new Set<string>();
   const loader = () => {
     const loaded = rawLoader();
     for (const p of loaded.playbooks) enabled.add(p.name);
     return loaded;
+  };
+  let enabledTick = 0;
+  const loadEnabled = (): Set<string> => {
+    if (opts.enabledByTick) {
+      return opts.enabledByTick[enabledTick++] ?? new Set<string>();
+    }
+    return new Set(enabled);
+  };
+  let swarmTick = 0;
+  const defaultSwarm: Swarm = { hosts: [], owners: opts.owners ?? {} };
+  const loadSwarm = (): Swarm | null => {
+    if (opts.swarms) {
+      return opts.swarms[swarmTick++] ?? null;
+    }
+    return defaultSwarm;
   };
 
   const deps: DaemonDeps = {
@@ -64,6 +95,8 @@ function harness(opts: HarnessOpts) {
       sleeps.push(ms);
     },
     loadRegistry: loader,
+    loadEnabled,
+    loadSwarm,
     dispatch: (name) => {
       guardAtDispatch[name] = lastHb?.dispatched_minute[name];
       lastFiredAtDispatch[name] = lastHb?.last_fired[name];
@@ -85,8 +118,6 @@ function harness(opts: HarnessOpts) {
         ? () => opts.lookback as number
         : (schedule, now) => lookbackForSchedule(schedule, now, m, CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS),
     shouldContinue: () => i < opts.nows.length,
-    enabled,
-    owners: {},
   };
   return {
     deps,
@@ -319,5 +350,52 @@ describe("missed-slot catch-up (#143)", () => {
     });
     await runForever(h.deps);
     expect(Object.keys(h.heartbeats[0]!.last_fired)).toEqual(["stillhere"]);
+  });
+});
+
+describe("scope gating wired from loaders (B4)", () => {
+  test("dispatches enabled each-scope playbooks and single-scope playbooks owned by this host", async () => {
+    const h = harness({
+      nows: [d("2026-06-01T09:00:00Z")],
+      host: "ml-1",
+      playbooks: [
+        pb({ name: "each-on", schedule: "0 9 * * *", scope: "each" }),
+        pb({ name: "single-mine", schedule: "0 9 * * *", scope: "single" }),
+        pb({ name: "single-theirs", schedule: "0 9 * * *", scope: "single" }),
+      ],
+      enabledByTick: [new Set(["each-on"])],
+      owners: { "single-mine": "ml-1", "single-theirs": "mac" },
+    });
+    await runForever(h.deps);
+    expect(h.dispatched.sort()).toEqual(["each-on", "single-mine"]);
+  });
+
+  test("last-good swarm: a torn swarm read keeps the prior tick's owners so an owned single-scope playbook still fires", async () => {
+    // Tick 1: swarm names ml-1 as owner → single-scope fires. Tick 2 (next
+    // minute): swarm read is torn (null) → owners reused from tick 1 → it still
+    // fires. Without last-good, owners would empty and the playbook be dropped.
+    const swarm: Swarm = { hosts: ["ml-1"], owners: { mine: "ml-1" } };
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:01:05Z")],
+      host: "ml-1",
+      playbooks: [pb({ name: "mine", schedule: "* * * * *", scope: "single" })],
+      enabledByTick: [new Set<string>(), new Set<string>()],
+      swarms: [swarm, null],
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["mine", "mine"]);
+  });
+
+  test("torn enabled read (empty set) disables each-scope dispatch that tick, safe and without crashing", async () => {
+    // Tick 1 enabled has the playbook → fires. Tick 2 (next minute) torn read
+    // (null → empty set) → not enabled → does NOT fire. No last-good for enabled.
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:01:05Z")],
+      playbooks: [pb({ name: "ev", schedule: "* * * * *", scope: "each" })],
+      enabledByTick: [new Set(["ev"]), null],
+      owners: {},
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["ev"]);
   });
 });

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -14,6 +14,7 @@ const pb = (over: Partial<Playbook>): Playbook => ({
   status: "active",
   trigger: "cron",
   hosts: ["*"],
+  scope: "each",
   ...over,
 });
 
@@ -42,10 +43,20 @@ function harness(opts: HarnessOpts) {
   // dispatch is called. Proves catch-up keeps at-most-once even if the two
   // fields are ever split into separate heartbeat writes.
   const lastFiredAtDispatch: Record<string, number | undefined> = {};
-  const loader =
+  const rawLoader =
     typeof opts.playbooks === "function"
       ? opts.playbooks
       : () => ({ playbooks: opts.playbooks as Playbook[], warnings: [] });
+  // B3 made selection scope-aware; these tests predate per-host enablement and
+  // assert each-scope playbooks dispatch. Enable every name each load yields by
+  // accumulating into `enabled` as the loop loads — wrapping (not pre-calling)
+  // the loader so its call counter / throw-on-Nth-call behavior is preserved.
+  const enabled = new Set<string>();
+  const loader = () => {
+    const loaded = rawLoader();
+    for (const p of loaded.playbooks) enabled.add(p.name);
+    return loaded;
+  };
 
   const deps: DaemonDeps = {
     now: () => opts.nows[i++]!,
@@ -74,6 +85,8 @@ function harness(opts: HarnessOpts) {
         ? () => opts.lookback as number
         : (schedule, now) => lookbackForSchedule(schedule, now, m, CATCHUP_LOOKBACK_FLOOR_MS, CATCHUP_LOOKBACK_CAP_MS),
     shouldContinue: () => i < opts.nows.length,
+    enabled,
+    owners: {},
   };
   return {
     deps,

--- a/lib/scheduler/tests/daemon.test.ts
+++ b/lib/scheduler/tests/daemon.test.ts
@@ -386,6 +386,23 @@ describe("scope gating wired from loaders (B4)", () => {
     expect(h.dispatched).toEqual(["mine", "mine"]);
   });
 
+  test("a fresh good swarm read overwrites last-good owners (reassignment is not stuck)", async () => {
+    // Tick 1: ml-1 owns `mine` → fires here. Tick 2: a fresh good read reassigns
+    // ownership to mac → ml-1 must DROP it. If last-good owners were only ever
+    // set (never overwritten), ml-1 would keep firing — a stuck-owners bug.
+    const tick1: Swarm = { hosts: ["ml-1", "mac"], owners: { mine: "ml-1" } };
+    const tick2: Swarm = { hosts: ["ml-1", "mac"], owners: { mine: "mac" } };
+    const h = harness({
+      nows: [d("2026-06-01T09:00:05Z"), d("2026-06-01T09:01:05Z")],
+      host: "ml-1",
+      playbooks: [pb({ name: "mine", schedule: "* * * * *", scope: "single" })],
+      enabledByTick: [new Set<string>(), new Set<string>()],
+      swarms: [tick1, tick2],
+    });
+    await runForever(h.deps);
+    expect(h.dispatched).toEqual(["mine"]);
+  });
+
   test("torn enabled read (empty set) disables each-scope dispatch that tick, safe and without crashing", async () => {
     // Tick 1 enabled has the playbook → fires. Tick 2 (next minute) torn read
     // (null → empty set) → not enabled → does NOT fire. No last-good for enabled.

--- a/lib/scheduler/tests/enabled.test.ts
+++ b/lib/scheduler/tests/enabled.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { parseEnabled } from "@/enabled";
+
+test("parses a string array into a Set", () => {
+  const s = parseEnabled(JSON.stringify(["a", "b"]));
+  expect(s).toEqual(new Set(["a", "b"]));
+});
+
+test("malformed or empty input yields an empty set (fail-safe: nothing enabled)", () => {
+  expect(parseEnabled("{ partial")).toEqual(new Set());
+  expect(parseEnabled("")).toEqual(new Set());
+});
+
+test("a non-array top-level yields an empty set", () => {
+  expect(parseEnabled(JSON.stringify({ a: 1 }))).toEqual(new Set());
+  expect(parseEnabled("42")).toEqual(new Set());
+});
+
+test("non-string and blank elements are dropped", () => {
+  expect(parseEnabled(JSON.stringify(["ok", 3, "", null]))).toEqual(new Set(["ok"]));
+});

--- a/lib/scheduler/tests/heartbeat-store.test.ts
+++ b/lib/scheduler/tests/heartbeat-store.test.ts
@@ -1,9 +1,14 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Heartbeat } from "@/daemon";
-import { readHeartbeatFile, writeHeartbeatFile } from "@/heartbeat-store";
+import {
+  readHeartbeatFile,
+  writeHeartbeatFile,
+  writeHeartbeatWithSync,
+  writeSyncedHeartbeat,
+} from "@/heartbeat-store";
 
 const dir = mkdtempSync(join(tmpdir(), "ceo-hb-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -63,5 +68,53 @@ describe("heartbeat round-trip", () => {
       JSON.stringify({ ts: 1, host: "x", dispatched_minute: {}, last_fired: { good: 99, bad: "x" } }),
     );
     expect(readHeartbeatFile(path)!.last_fired).toEqual({ good: 99 });
+  });
+});
+
+describe("synced heartbeat", () => {
+  test("writes {host, ts} atomically and leaves no .tmp on success", () => {
+    const path = join(dir, "heartbeats", "ml-1.json");
+    writeSyncedHeartbeat(path, "ml-1");
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+    const written = JSON.parse(readFileSync(path, "utf8"));
+    expect(written.host).toBe("ml-1");
+    expect(typeof written.ts).toBe("string");
+  });
+});
+
+describe("writeHeartbeatWithSync", () => {
+  test("a synced-write failure does not skip the host-local heartbeat and is logged, not thrown", () => {
+    const localWrites: Heartbeat[] = [];
+    const logs: string[] = [];
+    expect(() =>
+      writeHeartbeatWithSync(hb, {
+        writeLocal: (h) => localWrites.push(h),
+        writeSynced: () => {
+          throw new Error("EROFS: read-only synced vault");
+        },
+        log: (m) => logs.push(m),
+      }),
+    ).not.toThrow();
+    // Invariant: host-local write happened even though the synced write failed.
+    expect(localWrites).toEqual([hb]);
+    expect(logs.some((m) => m.includes("synced heartbeat write failed"))).toBe(true);
+  });
+
+  test("on success both writes run and nothing is logged", () => {
+    let local = false;
+    let synced = false;
+    const logs: string[] = [];
+    writeHeartbeatWithSync(hb, {
+      writeLocal: () => {
+        local = true;
+      },
+      writeSynced: () => {
+        synced = true;
+      },
+      log: (m) => logs.push(m),
+    });
+    expect(local).toBe(true);
+    expect(synced).toBe(true);
+    expect(logs).toEqual([]);
   });
 });

--- a/lib/scheduler/tests/registry.test.ts
+++ b/lib/scheduler/tests/registry.test.ts
@@ -22,8 +22,27 @@ describe("parseRegistry", () => {
     const { playbooks, warnings } = parseRegistry(registry(ENTRY));
     expect(warnings).toEqual([]);
     expect(playbooks).toEqual([
-      { name: "morning-scan", schedule: "50 8 * * 1-5", status: "active", trigger: "cron", hosts: ["ml-1"] },
+      { name: "morning-scan", schedule: "50 8 * * 1-5", status: "active", trigger: "cron", hosts: ["ml-1"], scope: "single" },
     ]);
+  });
+
+  test("projects scope, defaulting absent scope to 'single' (safe: off until owned)", () => {
+    const { playbooks, warnings } = parseRegistry(JSON.stringify({
+      playbooks: [
+        { name: "a", schedule: "0 9 * * *", status: "active", trigger: "cron", scope: "each" },
+        { name: "b", schedule: "0 9 * * *", status: "active", trigger: "cron" },
+      ],
+    }));
+    expect(playbooks.map((p) => [p.name, p.scope])).toEqual([["a", "each"], ["b", "single"]]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("an unknown scope value skips the entry (no silent default)", () => {
+    const { playbooks, warnings } = parseRegistry(JSON.stringify({
+      playbooks: [{ name: "bad", schedule: "0 9 * * *", status: "active", trigger: "cron", scope: "all" }],
+    }));
+    expect(playbooks).toHaveLength(0);
+    expect(warnings[0]).toContain("scope");
   });
 
   test("tolerates unknown extra fields", () => {

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -3,17 +3,27 @@ import {
   CATCHUP_LOOKBACK_CAP_MS,
   CATCHUP_LOOKBACK_FLOOR_MS,
   dispatchArgv,
+  enabledPath,
   HEARTBEAT_STALE_MS,
   heartbeatPath,
   MAX_SLEEP_MS,
   registryPath,
   resolveFixedLookbackMs,
   resolveHost,
+  swarmPath,
 } from "@/runtime";
 
 describe("path resolution", () => {
-  test("registry lives under <vault>/CEO/registry.json", () => {
-    expect(registryPath("/Users/x/Obsidian")).toBe("/Users/x/Obsidian/CEO/registry.json");
+  test("registryPath is host-local under ~/.ceo, not the synced vault", () => {
+    expect(registryPath("/home/me")).toBe("/home/me/.ceo/registry.json");
+  });
+
+  test("swarmPath is in the synced vault", () => {
+    expect(swarmPath("/vault")).toBe("/vault/CEO/swarm.json");
+  });
+
+  test("enabledPath is host-local", () => {
+    expect(enabledPath("/home/me")).toBe("/home/me/.ceo/enabled.json");
   });
 
   test("heartbeat is host-local under ~/.ceo, never the synced vault", () => {

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -11,6 +11,7 @@ import {
   resolveFixedLookbackMs,
   resolveHost,
   swarmPath,
+  syncedHeartbeatPath,
 } from "@/runtime";
 
 describe("path resolution", () => {
@@ -28,6 +29,10 @@ describe("path resolution", () => {
 
   test("heartbeat is host-local under ~/.ceo, never the synced vault", () => {
     expect(heartbeatPath("/home/nhang")).toBe("/home/nhang/.ceo/schedulerd/heartbeat.json");
+  });
+
+  test("syncedHeartbeatPath is in the synced vault, namespaced by host", () => {
+    expect(syncedHeartbeatPath("/vault", "ml-1")).toBe("/vault/CEO/heartbeats/ml-1.json");
   });
 });
 

--- a/lib/scheduler/tests/select.test.ts
+++ b/lib/scheduler/tests/select.test.ts
@@ -12,36 +12,56 @@ const pb = (over: Partial<Playbook>): Playbook => ({
   status: "active",
   trigger: "cron",
   hosts: ["*"],
+  scope: "each",
   ...over,
 });
 
-describe("selectRunnable — host + status + trigger gating", () => {
-  test("keeps active cron playbooks whose hosts include this host", () => {
-    const pbs = [
-      pb({ name: "wild", hosts: ["*"] }),
-      pb({ name: "mine", hosts: ["ml-1"] }),
-      pb({ name: "theirs", hosts: ["mac-mini"] }),
-    ];
-    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["wild", "mine"]);
-  });
+describe("selectRunnable — status + trigger + schedule gating", () => {
+  const enabled = new Set(["a", "b", "c", "p"]);
 
   test("drops non-active status", () => {
     const pbs = [pb({ name: "a", status: "draft" }), pb({ name: "b", status: "disabled" }), pb({ name: "c", status: "active" })];
-    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["c"]);
+    expect(selectRunnable(pbs, "ml-1", enabled, {}).map((p) => p.name)).toEqual(["c"]);
   });
 
   test("drops non-cron triggers", () => {
     const pbs = [pb({ name: "a", trigger: "manual" }), pb({ name: "b", trigger: "cron" })];
-    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["b"]);
+    expect(selectRunnable(pbs, "ml-1", enabled, {}).map((p) => p.name)).toEqual(["b"]);
   });
 
   test("drops entries with a blank schedule", () => {
     const pbs = [pb({ name: "a", schedule: "   " }), pb({ name: "b", schedule: "0 9 * * *" })];
-    expect(selectRunnable(pbs, "ml-1").map((p) => p.name)).toEqual(["b"]);
+    expect(selectRunnable(pbs, "ml-1", enabled, {}).map((p) => p.name)).toEqual(["b"]);
   });
+});
 
-  test("wildcard host matches any host id", () => {
-    expect(selectRunnable([pb({ hosts: ["*"] })], "whatever").map((p) => p.name)).toEqual(["p"]);
+describe("selectRunnable — scope gating", () => {
+  const owners = { soloA: "ml-1", soloB: "mac" };
+  const enabled = new Set(["eachOn"]);
+  test("each runs only when locally enabled", () => {
+    const pbs = [pb({ name: "eachOn", scope: "each" }), pb({ name: "eachOff", scope: "each" })];
+    expect(selectRunnable(pbs, "ml-1", enabled, owners).map((p) => p.name)).toEqual(["eachOn"]);
+  });
+  test("single runs only on its owner, ignoring local enable state", () => {
+    const pbs = [pb({ name: "soloA", scope: "single" }), pb({ name: "soloB", scope: "single" })];
+    expect(selectRunnable(pbs, "ml-1", enabled, owners).map((p) => p.name)).toEqual(["soloA"]);
+  });
+  test("single with no owner runs nowhere", () => {
+    const pbs = [pb({ name: "orphan", scope: "single" })];
+    expect(selectRunnable(pbs, "ml-1", new Set(), {})).toEqual([]);
+  });
+  test("a single playbook NOT owned by this host is excluded even if enabled", () => {
+    const pbs = [pb({ name: "soloB", scope: "single" })];
+    expect(selectRunnable(pbs, "ml-1", new Set(["soloB"]), owners)).toEqual([]);
+  });
+  test("status/trigger/blank-schedule gating still applies to each", () => {
+    const pbs = [
+      pb({ name: "draft", scope: "each", status: "draft" }),
+      pb({ name: "manual", scope: "each", trigger: "manual" }),
+      pb({ name: "blank", scope: "each", schedule: "  " }),
+      pb({ name: "ok", scope: "each" }),
+    ];
+    expect(selectRunnable(pbs, "ml-1", new Set(["draft","manual","blank","ok"]), {}).map((p) => p.name)).toEqual(["ok"]);
   });
 });
 

--- a/lib/scheduler/tests/swarm.test.ts
+++ b/lib/scheduler/tests/swarm.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseSwarm } from "@/swarm";
+
+test("parses hosts and owners", () => {
+  const s = parseSwarm(JSON.stringify({ schema_version: 1, hosts: ["ml-1","mac"], owners: { "morning-brief": "ml-1" } }))!;
+  expect(s.owners["morning-brief"]).toBe("ml-1");
+  expect(s.hosts).toEqual(["ml-1","mac"]);
+});
+
+test("a malformed/half-synced read yields null (caller keeps last-good)", () => {
+  expect(parseSwarm("{ partial")).toBeNull();
+  expect(parseSwarm("")).toBeNull();
+});
+
+test("a non-object top-level yields null", () => {
+  expect(parseSwarm("[]")).toBeNull();
+  expect(parseSwarm("42")).toBeNull();
+});
+
+test("missing owners/hosts normalize to empty", () => {
+  const s = parseSwarm(JSON.stringify({ schema_version: 1 }))!;
+  expect(s.owners).toEqual({});
+  expect(s.hosts).toEqual([]);
+});
+
+test("non-string hosts and blank/non-string owner values are dropped", () => {
+  const s = parseSwarm(JSON.stringify({ hosts: ["ok", 3, ""], owners: { a: "ml-1", b: "", c: 5 } }))!;
+  expect(s.hosts).toEqual(["ok"]);
+  expect(s.owners).toEqual({ a: "ml-1" });
+});

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -239,12 +239,14 @@ cmd_doctor() {
 
   # Migration leftover (D1, #159): the native crontab install path is retired —
   # ceo-schedulerd reads the registry and is the sole scheduler. A host still
-  # carrying the Phase-1 per-playbook `# CEO Agent` crontab block alongside the
-  # running daemon is a migration leftover that double-fires every playbook.
+  # carrying the Phase-1 per-playbook `# CEO Agent` crontab block is a migration
+  # leftover regardless of daemon state: once the daemon is up it double-fires
+  # every playbook, and before the daemon is up it fires playbooks the swarm no
+  # longer expects on this host. Flag it either way.
   local _cron_daemon_conflict
   _cron_daemon_conflict="$(ceo_scheduler_crontab_daemon_conflict 2>/dev/null || true)"
   if [ -n "$_cron_daemon_conflict" ]; then
-    echo "  ✗ Migration leftover: CEO crontab block ($_cron_daemon_conflict triggers) lingering alongside the ceo-schedulerd daemon — it double-fires what the daemon already dispatches"
+    echo "  ✗ Migration leftover: CEO crontab block ($_cron_daemon_conflict triggers) still installed — ceo-schedulerd is the sole scheduler; this block double-fires (or mis-fires) playbooks"
     echo "    Remove the leftover crontab block (the daemon reads the registry): crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent\$' | crontab -"
     fail=$((fail + 1))
   fi
@@ -585,7 +587,7 @@ cmd_playbook() {
       echo "Usage: ceo playbook <scan|list|info|diff|enable|disable|assign>"
       echo ""
       echo "  scan [--dry-run]   Discover playbooks, update host-local registry"
-      echo "                     (--dry-run prints would-be cron block, no writes)"
+      echo "                     (--dry-run prints the registry diff summary, no writes)"
       echo "  list               Show all registered playbooks with scope + state"
       echo "  info <name>        Show details for one playbook"
       echo "  diff [--quiet]     Detect drift between vault and repo playbooks"
@@ -1609,9 +1611,14 @@ _remove_crontab_block() {
   local existing
   existing=$(ceo_scheduler_list 2>/dev/null || true)
 
+  # Strip the wrapped block, then any stray CEO-installed lines that escaped it.
+  # A CEO cron line always carries the trailing `# ceo:<name>` marker that
+  # ceo_scheduler_list emits ("MIN HOUR D M W CMD  # ceo:NAME"); anchor on that
+  # marker (anchored-regex-for-identifier-allowlists) so a user line that merely
+  # mentions ceo-cron.sh in a comment or path is preserved, not clobbered.
   local cleaned
   cleaned=$(echo "$existing" | sed "/$marker_start/,/$marker_end/d")
-  cleaned=$(echo "$cleaned" | grep -v "ceo-cron\.sh" || true)
+  cleaned=$(echo "$cleaned" | grep -vE 'ceo-cron\.sh.*#[[:space:]]*ceo:[^[:space:]]+[[:space:]]*$' || true)
   cleaned=$(echo "$cleaned" | grep -v "^# CEO Agent$" || true)
 
   if [ "$cleaned" = "$existing" ]; then

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -81,7 +81,7 @@ Examples:
   CEO_CHAT_EFFORT=high ceo chat # Override chat effort (default: medium)
   ceo chat morning-scan        # Morning triage conversation
   ceo cron pr-triage           # Autonomous cron trigger (no conversation)
-  ceo playbook scan            # Discover playbooks, update registry + crontab
+  ceo playbook scan            # Discover playbooks, update host-local registry
   ceo schedule                 # List effective schedules + collisions
   ceo schedule morning-scan    # Reschedule one playbook (interactive)
 USAGE
@@ -212,27 +212,12 @@ cmd_doctor() {
   local _backend
   _backend="$(ceo_scheduler_backend 2>/dev/null || echo unknown)"
   if [ "$_backend" = "crontab" ]; then
-    local _sched_state
-    _sched_state="$(ceo_scheduler_list 2>/dev/null || true)"
-    if printf '%s\n' "$_sched_state" | grep -q "ceo-cron.sh"; then
-      local count
-      count=$(printf '%s\n' "$_sched_state" | grep -c "ceo-cron.sh")
-      echo "  ✓ Cron entries installed ($count triggers)"
-      ok=$((ok + 1))
-    else
-      echo "  ! No ceo-cron entries in crontab — run: ceo setup"
-      warn=$((warn + 1))
-    fi
-    # duplicate cron triggers
-    local dup_count
-    dup_count=$(printf '%s\n' "$_sched_state" | grep "ceo-cron\.sh" | sed 's/.*ceo-cron\.sh //' | sort | uniq -d | wc -l | xargs || true)
-    if [ "${dup_count:-0}" -gt 0 ]; then
-      echo "  ✗ Duplicate cron triggers detected — run: ceo playbook scan"
-      fail=$((fail + 1))
-    else
-      echo "  ✓ No duplicate cron triggers"
-      ok=$((ok + 1))
-    fi
+    # The native crontab install path is retired (D1). On a crontab-backend
+    # host the healthy scheduler signal is the ceo-schedulerd heartbeat (checked
+    # below); any lingering ceo-cron.sh entries are a migration leftover flagged
+    # by the migration-leftover check further down. Nothing to install here.
+    echo "  ✓ Scheduling owned by ceo-schedulerd (native crontab install retired)"
+    ok=$((ok + 1))
   elif [ "$_backend" = "daemon" ]; then
     # macOS: scheduling is owned by ceo-schedulerd; the OS holds no per-playbook
     # entries. Liveness is the heartbeat check below (added in #142).
@@ -251,13 +236,15 @@ cmd_doctor() {
     fail=$((fail + 1))
   fi
 
-  # Linux double-fire (#159): the Phase-1 per-playbook crontab block AND the
-  # ceo-schedulerd systemd daemon both active dispatch every playbook twice.
+  # Migration leftover (D1, #159): the native crontab install path is retired —
+  # ceo-schedulerd reads the registry and is the sole scheduler. A host still
+  # carrying the Phase-1 per-playbook `# CEO Agent` crontab block alongside the
+  # running daemon is a migration leftover that double-fires every playbook.
   local _cron_daemon_conflict
   _cron_daemon_conflict="$(ceo_scheduler_crontab_daemon_conflict 2>/dev/null || true)"
   if [ -n "$_cron_daemon_conflict" ]; then
-    echo "  ✗ CEO crontab block ($_cron_daemon_conflict triggers) active alongside the ceo-schedulerd daemon — every playbook double-fires"
-    echo "    Remove the crontab block (the daemon reads the registry): crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent\$' | crontab -"
+    echo "  ✗ Migration leftover: CEO crontab block ($_cron_daemon_conflict triggers) lingering alongside the ceo-schedulerd daemon — it double-fires what the daemon already dispatches"
+    echo "    Remove the leftover crontab block (the daemon reads the registry): crontab -l | sed '/# CEO Agent START/,/# CEO Agent END/d' | grep -v '^# CEO Agent\$' | crontab -"
     fail=$((fail + 1))
   fi
 
@@ -418,10 +405,10 @@ cmd_doctor() {
     drafts=$(jq -r '.playbooks[] | select(.status == "draft") | .name' "$registry_file" 2>/dev/null)
     if [ -n "$drafts" ]; then
       echo ""
-      echo "  Drafts (not installed in cron; runnable on-demand):"
+      echo "  Drafts (not scheduled by the daemon; runnable on-demand):"
       while IFS= read -r d; do
         [ -z "$d" ] && continue
-        echo "    - $d  (flip frontmatter to 'status: active' then re-run 'ceo playbook scan' to install)"
+        echo "    - $d  (flip frontmatter to 'status: active' then re-run 'ceo playbook scan' to schedule)"
       done <<< "$drafts"
     fi
   fi
@@ -596,7 +583,7 @@ cmd_playbook() {
     help|--help|-h)
       echo "Usage: ceo playbook <scan|list|info|diff|enable|disable|assign>"
       echo ""
-      echo "  scan [--dry-run]   Discover playbooks, update registry + crontab"
+      echo "  scan [--dry-run]   Discover playbooks, update host-local registry"
       echo "                     (--dry-run prints would-be cron block, no writes)"
       echo "  list               Show all registered playbooks with scope + state"
       echo "  info <name>        Show details for one playbook"
@@ -1103,9 +1090,6 @@ cmd_playbook_scan() {
 
   if [ "$dry_run" -eq 1 ]; then
     echo ""
-    echo "=== DRY-RUN: would-be crontab block (no changes applied) ==="
-    _playbook_print_cron_block "$new_registry"
-    echo ""
     echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed) — NOT written"
     if [ "$invalid_status" -gt 0 ] || [ "$invalid_scope" -gt 0 ]; then
       [ "$invalid_status" -gt 0 ] && echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
@@ -1115,18 +1099,11 @@ cmd_playbook_scan() {
     return 0
   fi
 
-  # Update crontab FIRST. If collision detection refuses, abort before
-  # touching the registry on disk — otherwise a refused scan would persist
-  # the conflicting state into registry.json and confuse later `ceo schedule`
-  # listings. Propagate the scheduler's rc so callers / cron / CI can see
-  # transient failures (rc=1) distinctly from a clean abort.
-  local _scan_install_rc=0
-  _playbook_update_crontab "$new_registry" || _scan_install_rc=$?
-  if [ "$_scan_install_rc" -ne 0 ]; then
-    echo "Aborted: registry not updated. See error above and re-run." >&2
-    return "$_scan_install_rc"
-  fi
-
+  # The native crontab install path is retired (D1). ceo-schedulerd reads the
+  # host-local registry directly and is the sole scheduler — it applies
+  # scope-aware per-host selection that the old "install everything on every
+  # host" crontab block could not. Scan now only writes the registry; it never
+  # touches the user's crontab.
   mkdir -p "$(dirname "$registry_file")"
   local registry_tmp="$registry_file.tmp"
   echo "$new_registry" | jq '.' > "$registry_tmp"
@@ -1135,6 +1112,7 @@ cmd_playbook_scan() {
   echo ""
   echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed)"
   echo "Wrote: $registry_file"
+  echo "Scheduling: ceo-schedulerd reads this registry and dispatches scope-selected playbooks (native crontab install retired)."
 
   _playbook_sync_bins "$new_registry"
 
@@ -1262,85 +1240,30 @@ _playbook_apply_schedule_overrides() {
   echo "$registry"
 }
 
-# _playbook_print_cron_block <registry-json>
-#   Prints the CEO Agent crontab block that would be installed for <registry>
-#   to stdout, without touching the user's crontab. Skips collision detection
-#   (dry-run only — collisions are caught by _playbook_update_crontab on the
-#   real install path).
-_playbook_print_cron_block() {
-  local registry="$1"
+# _remove_crontab_block
+#   Strips the retired Phase-1 `# CEO Agent START`…`# CEO Agent END` block (and
+#   any stray ceo-cron.sh / `# CEO Agent` lines) from the user's crontab and
+#   reinstalls the remainder. The native install path is retired (D1) — this
+#   removal capability survives for the migration (F3) that purges leftover
+#   blocks from hosts that ran an older CEO. Returns the scheduler's rc; a clean
+#   crontab with no CEO block is a no-op success.
+_remove_crontab_block() {
   local marker_start="# CEO Agent START"
   local marker_end="# CEO Agent END"
-  echo "$marker_start"
-  while IFS= read -r row; do
-    local p_name p_trigger p_schedule p_status
-    p_name=$(echo "$row" | jq -r '.name')
-    p_trigger=$(echo "$row" | jq -r '.trigger')
-    p_schedule=$(echo "$row" | jq -r '.schedule')
-    p_status=$(echo "$row" | jq -r '.status')
-    if [ "$p_trigger" = "cron" ] && [ "$p_status" = "active" ] && [ -n "$p_schedule" ]; then
-      echo "$p_schedule $CEO_CRON $p_name  # ceo:$p_name"
-    fi
-  done < <(echo "$registry" | jq -c '.playbooks[]')
-  echo "$marker_end"
-}
-
-_playbook_update_crontab() {
-  local registry="$1"
-  local marker_start="# CEO Agent START"
-  local marker_end="# CEO Agent END"
-
-  # Collision detection — refuse to install duplicate schedules.
-  # Two playbooks at the same minute fight for the global lock; one always
-  # loses silently. Better to fail loud at scan time than skip-with-reason
-  # at run time.
-  local collisions
-  collisions=$(echo "$registry" | jq -r '
-    [.playbooks[] | select(.trigger == "cron" and .status == "active" and .schedule != "")]
-    | group_by(.schedule)
-    | map(select(length > 1))
-    | .[] | "  \(.[0].schedule)  →  \([.[].name] | join(", "))"
-  ')
-
-  if [ -n "$collisions" ]; then
-    echo "ERROR: schedule collision(s) detected — refusing to install crontab" >&2
-    echo "$collisions" >&2
-    echo "" >&2
-    echo "Resolve via 'ceo schedule <playbook>' or by editing \$CEO_DIR/schedules.json." >&2
-    return 1
-  fi
-
-  # Share the emission body with _playbook_print_cron_block so dry-run and
-  # real install can't drift on the active+cron+scheduled filter.
-  local cron_block cron_count
-  cron_block=$(_playbook_print_cron_block "$registry")
-  cron_count=$(printf '%s\n' "$cron_block" | grep -c '# ceo:' || true)
 
   local existing
   existing=$(ceo_scheduler_list 2>/dev/null || true)
 
-  local new_crontab
-  new_crontab=$(echo "$existing" | sed "/$marker_start/,/$marker_end/d")
-  new_crontab=$(echo "$new_crontab" | grep -v "ceo-cron\.sh" || true)
-  new_crontab=$(echo "$new_crontab" | grep -v "^# CEO Agent$" || true)
+  local cleaned
+  cleaned=$(echo "$existing" | sed "/$marker_start/,/$marker_end/d")
+  cleaned=$(echo "$cleaned" | grep -v "ceo-cron\.sh" || true)
+  cleaned=$(echo "$cleaned" | grep -v "^# CEO Agent$" || true)
 
-  # Scheduler can fail for non-collision reasons (locked spool, quota, RO fs,
-  # missing crontab binary, unimplemented backend on Mac). The scheduler
-  # abstraction emits its own ERROR line to stderr; we propagate the rc.
-  local crontab_payload
-  if [ -n "$new_crontab" ]; then
-    crontab_payload=$(printf '%s\n%s\n' "$new_crontab" "$cron_block")
-  else
-    crontab_payload="$cron_block"
+  if [ "$cleaned" = "$existing" ]; then
+    return 0
   fi
 
-  local _install_rc=0
-  ceo_scheduler_install "$crontab_payload" || _install_rc=$?
-  if [ "$_install_rc" -ne 0 ]; then
-    return "$_install_rc"
-  fi
-
-  echo "Crontab: $cron_count entries installed"
+  ceo_scheduler_install "$cleaned"
 }
 
 # Validate a 5-field cron expression. Lightweight syntax check — verifies

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -794,16 +794,25 @@ CEO_OWNER_CLOCK_SKEW_S=300   # 5 minutes
 
 # _parse_iso8601_to_epoch <iso>
 #   Portable ISO8601 → epoch seconds for both GNU date (Linux) and BSD date
-#   (macOS). Mirrors the disk-monitor parse: GNU `date -d` first, then BSD
-#   `date -j -f`. Prints the epoch on success; prints nothing and returns 1 on
-#   an unparseable value so the caller routes it to the stale path rather than
-#   silently treating a parse failure as "now".
+#   (macOS). GNU `date -d` first (it accepts fractional seconds and colon
+#   offsets natively), then BSD `date -j -f`. The daemon writes its heartbeat
+#   ts with JS `new Date().toISOString()` → always fractional millis + "Z"
+#   (e.g. 2026-06-14T12:34:56.789Z); BSD `%S%z` rejects both the ".789" and a
+#   colon offset, so before the BSD branch we strip the fractional component and
+#   normalize the zone to a numeric offset BSD's %z understands. Second
+#   granularity is sufficient for an hours-wide staleness window. Prints the
+#   epoch on success; prints nothing and returns 1 on an unparseable value so
+#   the caller routes it to the stale path rather than treating a parse failure
+#   as "now".
 _parse_iso8601_to_epoch() {
-  local iso="$1" epoch=""
+  local iso="$1" epoch="" norm
   epoch=$(date -d "$iso" +%s 2>/dev/null) && { printf '%s\n' "$epoch"; return 0; }
-  # BSD date needs an explicit format; the daemon writes either a "Z" suffix or
-  # a numeric offset, so try both shapes.
-  epoch=$(date -j -f '%Y-%m-%dT%H:%M:%S%z' "${iso/Z/+0000}" +%s 2>/dev/null) \
+  # BSD date needs an explicit format and chokes on fractional seconds and
+  # colon offsets. Drop a ".NNN" fractional-seconds component (preserving any
+  # trailing zone), map "Z" to "+0000", and de-colon a "+HH:MM"/"-HH:MM" offset.
+  norm="$iso"
+  norm=$(printf '%s' "$norm" | sed -E 's/\.[0-9]+//; s/Z$/+0000/; s/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+  epoch=$(date -j -f '%Y-%m-%dT%H:%M:%S%z' "$norm" +%s 2>/dev/null) \
     && { printf '%s\n' "$epoch"; return 0; }
   return 1
 }
@@ -909,7 +918,17 @@ cmd_swarm_owners_health() {
         local marker="<!-- owner-staleness:$host -->"
         local hours=$(( CEO_OWNER_STALE_S / 3600 ))
         local task="- [ ] owner $host heartbeat stale >${hours}h — single playbooks ${owned:-<none>} not running $marker"
-        if ! printf '%s\n' "$task" >> "$inbox_file"; then
+        # Defense-in-depth on top of the transition gate: the state file is
+        # host-local but inbox/<host>.md is synced, so a wiped ~/.ceo or a fresh
+        # checker host would lose the transition memory and duplicate a still-
+        # present synced alert. Mirror disk-monitor's marker dedupe: skip the
+        # append when an UNCHECKED line bearing this marker already exists. A
+        # checked-off / [done] line does NOT match, so a legitimate re-alert
+        # after the user resolves the old one still fires.
+        if [ -f "$inbox_file" ] && \
+          awk -v m="$marker" '/^- \[ \]/ && index($0, m) { found=1; exit } END { exit !found }' "$inbox_file"; then
+          :
+        elif ! printf '%s\n' "$task" >> "$inbox_file"; then
           echo "ERROR: swarm owners-health: failed to append to $inbox_file" >&2
           return 1
         fi

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -590,14 +590,20 @@ cmd_playbook() {
     list) cmd_playbook_list ;;
     info) cmd_playbook_info "$@" ;;
     diff) cmd_playbook_diff "$@" ;;
+    enable) cmd_playbook_enable "$@" ;;
+    disable) cmd_playbook_disable "$@" ;;
+    assign) cmd_playbook_assign "$@" ;;
     help|--help|-h)
-      echo "Usage: ceo playbook <scan|list|info|diff>"
+      echo "Usage: ceo playbook <scan|list|info|diff|enable|disable|assign>"
       echo ""
       echo "  scan [--dry-run]   Discover playbooks, update registry + crontab"
       echo "                     (--dry-run prints would-be cron block, no writes)"
-      echo "  list               Show all registered playbooks"
+      echo "  list               Show all registered playbooks with scope + state"
       echo "  info <name>        Show details for one playbook"
       echo "  diff [--quiet]     Detect drift between vault and repo playbooks"
+      echo "  enable <name>      Run this each-scope playbook on THIS host"
+      echo "  disable <name>     Stop running this each-scope playbook on THIS host"
+      echo "  assign <name> <host>  Assign a single-scope playbook to an owner host"
       ;;
     *)
       echo "Unknown playbook command: $subcmd"
@@ -1496,24 +1502,169 @@ _schedule_one() {
   cmd_playbook_scan
 }
 
+# _playbook_registry_scope <registry_file> <name>
+#   Print the playbook's scope (each|single) on stdout, exit 0 if found.
+#   Exit 1 with nothing on stdout if the name isn't in the registry.
+#   enum-config-typo-fallback: a scope that isn't in CEO_VALID_SCOPES is
+#   treated as the safe `single` default (scan already rejects typos at parse).
+_playbook_registry_scope() {
+  local registry_file="$1" name="$2"
+  local entry
+  entry=$(jq -r --arg n "$name" '.playbooks[] | select(.name==$n) | .name' "$registry_file" 2>/dev/null)
+  [ -z "$entry" ] && return 1
+  local scope
+  scope=$(jq -r --arg n "$name" '.playbooks[] | select(.name==$n) | .scope // "single"' "$registry_file" 2>/dev/null)
+  case "$scope" in
+    each|single) printf '%s\n' "$scope" ;;
+    *) printf '%s\n' "single" ;;
+  esac
+  return 0
+}
+
+# _playbook_rows
+#   Render one line per registered playbook combining registry scope/status
+#   with this host's enabled.json and the swarm owners map:
+#     <name>  [scope]  <state>  <description>
+#   where state is enable-status for `each` and owner-status for `single`.
+#   Pure-ish: reads files, prints rows, no mutation. Tested directly.
+_playbook_rows() {
+  local registry_file; registry_file=$(_ceo_registry_path)
+  local enabled_file; enabled_file=$(_ceo_enabled_path)
+  local swarm_file; swarm_file=$(_swarm_path)
+
+  local enabled_json='[]'
+  [ -f "$enabled_file" ] && enabled_json=$(cat "$enabled_file")
+  local owners_json='{}'
+  [ -f "$swarm_file" ] && owners_json=$(jq -c '.owners // {}' "$swarm_file" 2>/dev/null)
+
+  while IFS= read -r row; do
+    local p_name p_scope p_desc p_status state
+    p_name=$(echo "$row" | jq -r '.name')
+    p_scope=$(echo "$row" | jq -r '.scope // "single"')
+    p_desc=$(echo "$row" | jq -r '.description // ""')
+    p_status=$(echo "$row" | jq -r '.status // "-"')
+    [ -z "$p_status" ] && p_status="-"
+    case "$p_scope" in each|single) ;; *) p_scope="single" ;; esac
+
+    if [ "$p_scope" = "each" ]; then
+      local is_on
+      is_on=$(echo "$enabled_json" | jq -r --arg n "$p_name" 'index($n) != null' 2>/dev/null)
+      if [ "$is_on" = "true" ]; then
+        state="✓ enabled here"
+      else
+        state="· disabled here"
+      fi
+    else
+      local owner
+      owner=$(echo "$owners_json" | jq -r --arg n "$p_name" '.[$n] // ""' 2>/dev/null)
+      if [ -n "$owner" ]; then
+        state="owner: $owner"
+      else
+        state="owner: (none) ⚠"
+      fi
+    fi
+
+    printf "%-16s %-8s %-9s %-18s %s\n" "$p_name" "[$p_scope]" "$p_status" "$state" "$p_desc"
+  done < <(jq -c '.playbooks[]' "$registry_file")
+}
+
 cmd_playbook_list() {
   local registry_file; registry_file=$(_ceo_registry_path)
   _require_registry_current "$registry_file"
 
-  printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
-  printf "%-16s %-10s %-20s %-10s %-8s\n" "----" "-------" "--------" "-----" "------"
+  printf "%-16s %-8s %-9s %-18s %s\n" "NAME" "SCOPE" "STATUS" "STATE" "DESCRIPTION"
+  printf "%-16s %-8s %-9s %-18s %s\n" "----" "-----" "------" "-----" "-----------"
+  _playbook_rows
+}
 
-  while IFS= read -r row; do
-    local p_name p_trigger p_schedule p_model p_status
-    p_name=$(echo "$row" | jq -r '.name')
-    p_trigger=$(echo "$row" | jq -r '.trigger')
-    p_schedule=$(echo "$row" | jq -r '.schedule // "-"')
-    p_model=$(echo "$row" | jq -r '.model // "-"')
-    p_status=$(echo "$row" | jq -r '.status // "-"')
-    [ "$p_schedule" = "" ] && p_schedule="-"
-    [ "$p_model" = "" ] && p_model="-"
-    printf "%-16s %-10s %-20s %-10s %-8s\n" "$p_name" "$p_trigger" "$p_schedule" "$p_model" "$p_status"
-  done < <(jq -c '.playbooks[]' "$registry_file")
+cmd_playbook_enable() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    echo "Usage: ceo playbook enable <name>" >&2
+    exit 1
+  fi
+  local registry_file; registry_file=$(_ceo_registry_path)
+  _require_registry_current "$registry_file"
+
+  local scope
+  if ! scope=$(_playbook_registry_scope "$registry_file" "$name"); then
+    echo "ERROR: playbook '$name' is not in the registry. Run: ceo playbook list" >&2
+    exit 1
+  fi
+  if [ "$scope" = "single" ]; then
+    echo "ERROR: '$name' is a single-scope playbook — it is not enabled per-host." >&2
+    echo "  Assign it to an owner host instead: ceo playbook assign $name <host>" >&2
+    exit 1
+  fi
+
+  local enabled_file; enabled_file=$(_ceo_enabled_path)
+  mkdir -p "$(dirname "$enabled_file")"
+  [ -f "$enabled_file" ] || echo '[]' > "$enabled_file"
+
+  local tmp
+  tmp=$(mktemp "$enabled_file.XXXXXX") || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  if ! jq --arg n "$name" '. + [$n] | unique' "$enabled_file" > "$tmp" \
+     || ! mv -f "$tmp" "$enabled_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to enable '$name' in $enabled_file" >&2
+    exit 1
+  fi
+  echo "Enabled '$name' on this host."
+}
+
+cmd_playbook_disable() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    echo "Usage: ceo playbook disable <name>" >&2
+    exit 1
+  fi
+  local registry_file; registry_file=$(_ceo_registry_path)
+  _require_registry_current "$registry_file"
+
+  if ! _playbook_registry_scope "$registry_file" "$name" >/dev/null; then
+    echo "ERROR: playbook '$name' is not in the registry. Run: ceo playbook list" >&2
+    exit 1
+  fi
+
+  local enabled_file; enabled_file=$(_ceo_enabled_path)
+  # Absent enabled.json means nothing is enabled — disabling is a no-op success.
+  [ -f "$enabled_file" ] || { echo "Disabled '$name' on this host."; return 0; }
+
+  local tmp
+  tmp=$(mktemp "$enabled_file.XXXXXX") || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  if ! jq --arg n "$name" 'map(select(. != $n))' "$enabled_file" > "$tmp" \
+     || ! mv -f "$tmp" "$enabled_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to disable '$name' in $enabled_file" >&2
+    exit 1
+  fi
+  echo "Disabled '$name' on this host."
+}
+
+cmd_playbook_assign() {
+  local name="${1:-}" host="${2:-}"
+  if [ -z "$name" ] || [ -z "$host" ]; then
+    echo "Usage: ceo playbook assign <name> <host>" >&2
+    exit 1
+  fi
+  local registry_file; registry_file=$(_ceo_registry_path)
+  _require_registry_current "$registry_file"
+
+  local scope
+  if ! scope=$(_playbook_registry_scope "$registry_file" "$name"); then
+    echo "ERROR: playbook '$name' is not in the registry. Run: ceo playbook list" >&2
+    exit 1
+  fi
+  if [ "$scope" = "each" ]; then
+    echo "ERROR: '$name' is an each-scope playbook — it runs where enabled, not by owner." >&2
+    echo "  Enable it on this host instead: ceo playbook enable $name" >&2
+    exit 1
+  fi
+
+  if ! _swarm_set_owner "$name" "$host"; then
+    exit 1
+  fi
+  echo "Assigned '$name' to '$host'."
 }
 
 cmd_playbook_info() {

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1284,9 +1284,9 @@ cmd_playbook_scan() {
         ;;
     esac
 
-    # `hosts` scopes which machines a playbook runs on. Absent → ["*"] (all
-    # hosts). Recorded in the registry but NOT enforced in Phase 1 — the daemon
-    # (Phase 1.5) consumes it. Validate shape at parse and default malformed
+    # `hosts` is deprecated: selectRunnable no longer reads it, so it is not
+    # consumed for scheduling. Scan still normalizes it (kept for back-compat
+    # with older registries; selection is scope-based). Validate shape at parse and default malformed
     # values to ["*"] rather than silently scoping to nowhere or a typo'd host
     # (per enum-config-typo-fallback). An empty array means "runs nowhere",
     # which is a likely mistake — use status:disabled to stop a playbook.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -716,7 +716,7 @@ cmd_swarm_doctor() {
         contested+="    $ck: '$prev' (earlier conflict) -> '$cv' (later conflict $(basename "$f")) — later wins"$'\n'
       fi
       merged_owners=$(jq -c --arg k "$ck" --arg v "$cv" '.[$k] = $v' <<<"$merged_owners")
-    done < <(jq -r '(.owners // {}) | to_entries[] | "\(.key)\t\(.value)"' "$f")
+    done < <(jq -r '(.owners // {}) | to_entries[] | select(.value | type == "string") | "\(.key)\t\(.value)"' "$f")
   done
 
   # schema_version: max across live + conflicts; warn on disagreement.

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1533,7 +1533,7 @@ _playbook_rows() {
   local swarm_file; swarm_file=$(_swarm_path)
 
   local enabled_json='[]'
-  [ -f "$enabled_file" ] && enabled_json=$(cat "$enabled_file")
+  [ -f "$enabled_file" ] && enabled_json=$(jq -c '. // []' "$enabled_file" 2>/dev/null || echo '[]')
   local owners_json='{}'
   [ -f "$swarm_file" ] && owners_json=$(jq -c '.owners // {}' "$swarm_file" 2>/dev/null)
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -66,6 +66,7 @@ Commands:
   playbook    Manage playbooks (scan, list, info)
   trace       Show claude-mem observations tagged by a playbook run (ceo trace <name>)
   schedule    List/edit per-user playbook schedules (overrides frontmatter)
+  swarm       Inspect/heal the synced swarm.json (swarm doctor [--fix])
   creds       Manage CEO credentials (list, check, path)
   help        Show this message
 
@@ -598,6 +599,176 @@ cmd_playbook() {
       exit 1
       ;;
   esac
+}
+
+cmd_swarm() {
+  local subcmd="${1:-help}"
+  shift 2>/dev/null || true
+  case "$subcmd" in
+    doctor) cmd_swarm_doctor "$@" ;;
+    help|--help|-h)
+      echo "Usage: ceo swarm <doctor> [--fix]"
+      echo ""
+      echo "  doctor          Detect Syncthing swarm.json sync-conflict copies."
+      echo "                  Read-only: prints the proposed merge and exits"
+      echo "                  non-zero if any conflict copy exists (health gate)."
+      echo "  doctor --fix    Apply the merge atomically, then remove the"
+      echo "                  conflict copies."
+      ;;
+    *)
+      echo "Unknown swarm command: $subcmd"
+      echo "Run: ceo swarm help"
+      exit 1
+      ;;
+  esac
+}
+
+# cmd_swarm_doctor [--fix]
+#   swarm.json is the one synced mutable file. Near-simultaneous writes on two
+#   hosts make Syncthing drop a `swarm.sync-conflict-YYYYMMDD-HHMMSS-XXXXXXX.json`
+#   copy next to it. This detects those copies and merges them back into the
+#   live file with a deterministic rule so topology self-heals:
+#
+#     hosts[]  — UNION of live + every parseable conflict copy, de-duped.
+#     owners{} — per key: live's value wins when the key exists in live. A key
+#                present only in conflict copies is taken; if multiple conflict
+#                copies disagree on a live-absent key, the value from the
+#                lexicographically-GREATEST conflict FILENAME wins (filenames
+#                embed a timestamp, so "most recent conflict wins") and the
+#                contested key is logged.
+#     schema_version — keep the max; warn if they differ.
+#
+#   A malformed live file or conflict copy is skipped with a diagnostic — never
+#   crashes, never wins the merge.
+#
+#   Read-only (no --fix): prints the proposed merge and exits non-zero when any
+#   conflict copy exists (usable as a health gate). --fix writes the merge
+#   atomically (tmp+mv) and removes the conflict copies only after the write.
+cmd_swarm_doctor() {
+  : "${CEO_VAULT:?CEO_VAULT must be set before ceo swarm doctor}"
+  local fix=0
+  case "${1:-}" in
+    --fix) fix=1 ;;
+    "") ;;
+    *) echo "Unknown swarm doctor option: $1" >&2; echo "Usage: ceo swarm doctor [--fix]" >&2; exit 1 ;;
+  esac
+
+  local swarm_file; swarm_file=$(_swarm_path) || return 1
+  local swarm_dir; swarm_dir=$(dirname "$swarm_file")
+
+  # Anchored glob: only Syncthing conflict copies of swarm.json, never an
+  # unrelated *.json (anchored-regex-for-identifier-allowlists).
+  local conflicts=()
+  local f
+  for f in "$swarm_dir"/swarm.sync-conflict-*.json; do
+    [ -e "$f" ] && conflicts+=("$f")
+  done
+
+  if [ "${#conflicts[@]}" -eq 0 ]; then
+    echo "swarm doctor: no conflicts (no swarm.sync-conflict-*.json next to swarm.json)."
+    return 0
+  fi
+
+  if [ ! -f "$swarm_file" ]; then
+    echo "ERROR: $swarm_file is missing but conflict copies exist; refusing to merge." >&2
+    return 1
+  fi
+  if ! jq -e . "$swarm_file" >/dev/null 2>&1; then
+    echo "ERROR: live $swarm_file is malformed JSON; fix or remove it before merging." >&2
+    return 1
+  fi
+
+  # Sort conflict files so the lexicographically-greatest filename is processed
+  # last → its owner value overwrites earlier conflicts for live-absent keys.
+  local sorted=()
+  while IFS= read -r f; do sorted+=("$f"); done < <(printf '%s\n' "${conflicts[@]}" | sort)
+
+  local parseable=()
+  for f in "${sorted[@]}"; do
+    if jq -e . "$f" >/dev/null 2>&1; then
+      parseable+=("$f")
+    else
+      echo "swarm doctor: skipping malformed conflict copy $(basename "$f")" >&2
+    fi
+  done
+
+  # Host union across live + parseable conflicts.
+  local merged_hosts
+  merged_hosts=$(jq -s '[.[].hosts[]?] | unique' "$swarm_file" "${parseable[@]}")
+
+  # owners: start from live (live keys win). Walk conflicts in sorted order,
+  # adding only keys not yet present — so an earlier (smaller-filename) conflict
+  # seeds a live-absent key and a later (greater-filename) one overwrites it,
+  # because we re-add when the existing source was a conflict, not live.
+  local live_owners; live_owners=$(jq -c '.owners // {}' "$swarm_file")
+  local merged_owners="$live_owners"
+  local contested=""
+  for f in "${parseable[@]}"; do
+    local ck cv prev
+    while IFS=$'\t' read -r ck cv; do
+      [ -z "$ck" ] && continue
+      # Live wins: never overwrite a key the live file owns.
+      if jq -e --arg k "$ck" 'has($k)' <<<"$live_owners" >/dev/null 2>&1; then
+        continue
+      fi
+      prev=$(jq -r --arg k "$ck" '.[$k] // empty' <<<"$merged_owners")
+      if [ -n "$prev" ] && [ "$prev" != "$cv" ]; then
+        contested+="    $ck: '$prev' (earlier conflict) -> '$cv' (later conflict $(basename "$f")) — later wins"$'\n'
+      fi
+      merged_owners=$(jq -c --arg k "$ck" --arg v "$cv" '.[$k] = $v' <<<"$merged_owners")
+    done < <(jq -r '(.owners // {}) | to_entries[] | "\(.key)\t\(.value)"' "$f")
+  done
+
+  # schema_version: max across live + conflicts; warn on disagreement.
+  local versions max_version
+  versions=$(jq -s '[.[].schema_version // 0]' "$swarm_file" "${parseable[@]}")
+  max_version=$(jq 'max' <<<"$versions")
+  if [ "$(jq 'unique | length' <<<"$versions")" != "1" ]; then
+    echo "swarm doctor: WARNING schema_version differs across files ($(jq -c . <<<"$versions")); keeping max=$max_version" >&2
+  fi
+
+  local merged
+  merged=$(jq -n \
+    --argjson v "$max_version" \
+    --argjson hosts "$merged_hosts" \
+    --argjson owners "$merged_owners" \
+    '{schema_version: $v, hosts: $hosts, owners: $owners}')
+
+  echo "swarm doctor: ${#parseable[@]} conflict cop$([ "${#parseable[@]}" -eq 1 ] && echo y || echo ies) detected."
+  echo "Proposed merge:"
+  echo "  hosts (union): $(jq -c '.hosts' <<<"$merged")"
+  echo "  owners:        $(jq -c '.owners' <<<"$merged")"
+  if [ -n "$contested" ]; then
+    echo "  contested owner keys (live-absent, resolved by greatest conflict filename):"
+    printf '%s' "$contested"
+  fi
+
+  if [ "$fix" -eq 0 ]; then
+    echo ""
+    echo "Read-only. Re-run with --fix to apply the merge and remove conflict copies."
+    return 1
+  fi
+
+  local tmp
+  tmp=$(mktemp "$swarm_file.XXXXXX") || {
+    echo "ERROR: mktemp failed for $swarm_file" >&2
+    return 1
+  }
+  if ! printf '%s\n' "$merged" > "$tmp" || ! mv -f "$tmp" "$swarm_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to write merged $swarm_file" >&2
+    return 1
+  fi
+
+  # Remove conflict copies only after the merged write landed. Includes the
+  # malformed ones (their content is preserved in syncthing history if needed,
+  # and a malformed copy contributes nothing to the merge).
+  for f in "${conflicts[@]}"; do
+    rm -f "$f"
+  done
+  echo ""
+  echo "swarm doctor: merged and removed ${#conflicts[@]} conflict cop$([ "${#conflicts[@]}" -eq 1 ] && echo y || echo ies)."
+  return 0
 }
 
 cmd_playbook_diff() {
@@ -1966,6 +2137,7 @@ case "${1:-help}" in
   playbook) ceo_require_vault; _bind_vault; shift; cmd_playbook "$@" ;;
   trace)    ceo_require_vault; _bind_vault; shift; cmd_trace "$@" ;;
   schedule) ceo_require_vault; _bind_vault; shift; cmd_schedule "$@" ;;
+  swarm)    ceo_require_vault; _bind_vault; shift; cmd_swarm "$@" ;;
   creds)    shift; cmd_creds "$@" ;;
   help|-h|--help) cmd_help ;;
   *)

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -606,14 +606,20 @@ cmd_swarm() {
   shift 2>/dev/null || true
   case "$subcmd" in
     doctor) cmd_swarm_doctor "$@" ;;
+    owners-health) cmd_swarm_owners_health "$@" ;;
     help|--help|-h)
-      echo "Usage: ceo swarm <doctor> [--fix]"
+      echo "Usage: ceo swarm <doctor|owners-health> [--fix]"
       echo ""
       echo "  doctor          Detect Syncthing swarm.json sync-conflict copies."
       echo "                  Read-only: prints the proposed merge and exits"
       echo "                  non-zero if any conflict copy exists (health gate)."
       echo "  doctor --fix    Apply the merge atomically, then remove the"
       echo "                  conflict copies."
+      echo "  owners-health   Detect single-scope playbook owners whose synced"
+      echo "                  heartbeat has gone stale (host presumed offline →"
+      echo "                  those playbooks run nowhere). Escalates to the inbox"
+      echo "                  on a fresh→stale transition; exits non-zero if any"
+      echo "                  owner is stale."
       ;;
     *)
       echo "Unknown swarm command: $subcmd"
@@ -768,6 +774,165 @@ cmd_swarm_doctor() {
   done
   echo ""
   echo "swarm doctor: merged and removed ${#conflicts[@]} conflict cop$([ "${#conflicts[@]}" -eq 1 ] && echo y || echo ies)."
+  return 0
+}
+
+# How long a single-scope owner's synced heartbeat may go without an update
+# before the host is presumed offline. The daemon re-beats at least every
+# MAX_SLEEP_MS (60s) and `ceo doctor` calls a host-local heartbeat stale at 10
+# minutes; an *owner* being "offline" is a more consequential claim, so this
+# window is deliberately hours, not minutes — a brief daemon restart, a laptop
+# sleep, or a Syncthing propagation lag must not flip a live owner to "offline".
+CEO_OWNER_STALE_S=10800   # 3 hours
+
+# Hosts' clocks disagree. A heartbeat ts slightly AHEAD of this host's clock is
+# the producing host being a little fast, not a time-travelling failure — treat
+# a future-dated ts within this tolerance as fresh (age clamped to 0). Beyond
+# the tolerance the ts is nonsensical and we fall through to the stale path
+# rather than trust a wildly-future timestamp.
+CEO_OWNER_CLOCK_SKEW_S=300   # 5 minutes
+
+# _parse_iso8601_to_epoch <iso>
+#   Portable ISO8601 → epoch seconds for both GNU date (Linux) and BSD date
+#   (macOS). Mirrors the disk-monitor parse: GNU `date -d` first, then BSD
+#   `date -j -f`. Prints the epoch on success; prints nothing and returns 1 on
+#   an unparseable value so the caller routes it to the stale path rather than
+#   silently treating a parse failure as "now".
+_parse_iso8601_to_epoch() {
+  local iso="$1" epoch=""
+  epoch=$(date -d "$iso" +%s 2>/dev/null) && { printf '%s\n' "$epoch"; return 0; }
+  # BSD date needs an explicit format; the daemon writes either a "Z" suffix or
+  # a numeric offset, so try both shapes.
+  epoch=$(date -j -f '%Y-%m-%dT%H:%M:%S%z' "${iso/Z/+0000}" +%s 2>/dev/null) \
+    && { printf '%s\n' "$epoch"; return 0; }
+  return 1
+}
+
+# cmd_swarm_owners_health
+#   A scope:single playbook runs only on its owner host (swarm.json owners{});
+#   there is intentionally no failover. If an owner host goes offline its
+#   single-scope playbooks run NOWHERE and fail silently. This reads each
+#   owner's SYNCED heartbeat (CEO/heartbeats/<host>.json, {host, ts:ISO8601})
+#   and, when an owner is stale (or has never beat), escalates ON TRANSITION to
+#   the inbox. State machine, not signal generator: a host-local state file at
+#   ~/.ceo/owner-staleness-state.json records the currently-stale set so a
+#   sustained outage produces one task, not one per run (the disk-monitor
+#   incident). Exit non-zero when any owner is stale (health gate).
+cmd_swarm_owners_health() {
+  : "${CEO_VAULT:?CEO_VAULT must be set before ceo swarm owners-health}"
+  : "${HOME:?HOME must be set before ceo swarm owners-health}"
+
+  local swarm_file; swarm_file=$(_swarm_path) || return 1
+  if [ ! -f "$swarm_file" ]; then
+    echo "swarm owners-health: no swarm.json at $swarm_file (nothing to check)."
+    return 0
+  fi
+  if ! jq -e . "$swarm_file" >/dev/null 2>&1; then
+    echo "ERROR: $swarm_file is malformed JSON; cannot read owners." >&2
+    return 1
+  fi
+
+  # Testing seam: CEO_SWARM_NOW_EPOCH pins "now" for deterministic staleness.
+  # An empty/non-numeric value falls through to the real clock.
+  local now_epoch="${CEO_SWARM_NOW_EPOCH:-}"
+  case "$now_epoch" in
+    ''|*[!0-9]*) now_epoch=$(date +%s) ;;
+  esac
+
+  local hb_dir="$CEO_VAULT/CEO/heartbeats"
+  local state_file="$HOME/.ceo/owner-staleness-state.json"
+  local self_host="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null)}"
+  : "${self_host:?cannot determine this host for the owners-health inbox}"
+  local inbox_dir="$CEO_VAULT/CEO/inbox"
+  local inbox_file="$inbox_dir/$self_host.md"
+
+  mkdir -p "$(dirname "$state_file")"
+  local prior_state="{}"
+  if [ -f "$state_file" ] && jq -e . "$state_file" >/dev/null 2>&1; then
+    prior_state=$(jq -c . "$state_file")
+  fi
+
+  # Distinct owner hosts and, for each, the sorted list of playbooks it owns.
+  local owner_hosts
+  owner_hosts=$(jq -r '(.owners // {}) | to_entries[] | select(.value | type == "string") | .value' \
+    "$swarm_file" | sort -u)
+
+  if [ -z "$owner_hosts" ]; then
+    echo "swarm owners-health: no single-scope owners assigned (nothing to check)."
+    return 0
+  fi
+
+  local new_state="{}"
+  local any_stale=0
+  local host
+  while IFS= read -r host; do
+    [ -z "$host" ] && continue
+    local owned
+    owned=$(jq -r --arg h "$host" \
+      '(.owners // {}) | to_entries[] | select(.value == $h) | .key' "$swarm_file" \
+      | sort | paste -sd, -)
+
+    local hb_file="$hb_dir/$host.json"
+    local stale=0 reason=""
+    if [ ! -f "$hb_file" ]; then
+      stale=1; reason="no heartbeat file (never beat / long offline)"
+    else
+      local ts; ts=$(jq -r '.ts // empty' "$hb_file" 2>/dev/null)
+      local hb_epoch
+      if [ -z "$ts" ] || ! hb_epoch=$(_parse_iso8601_to_epoch "$ts"); then
+        stale=1; reason="unparseable heartbeat ts"
+      else
+        local age=$(( now_epoch - hb_epoch ))
+        if [ "$age" -lt $(( -CEO_OWNER_CLOCK_SKEW_S )) ]; then
+          # A ts beyond the skew tolerance into the future means the producing
+          # host's clock is badly wrong — an untrustworthy heartbeat is no
+          # liveness signal, so treat it as stale rather than "very fresh".
+          stale=1; reason="heartbeat ${age}s in the future (> ${CEO_OWNER_CLOCK_SKEW_S}s skew) — clock untrustworthy"
+        elif [ "$age" -lt 0 ]; then
+          # Slightly future within tolerance: the producing host is a little
+          # fast. Clamp to 0 so it reads as fresh, not negative-age.
+          age=0
+        fi
+        if [ "$stale" -eq 0 ] && [ "$age" -gt "$CEO_OWNER_STALE_S" ]; then
+          stale=1; reason="heartbeat ${age}s old (> ${CEO_OWNER_STALE_S}s)"
+        fi
+      fi
+    fi
+
+    if [ "$stale" -eq 1 ]; then
+      any_stale=1
+      new_state=$(jq -c --arg h "$host" '.[$h] = "stale"' <<<"$new_state")
+      local was_stale; was_stale=$(jq -r --arg h "$host" '.[$h] // "fresh"' <<<"$prior_state")
+      echo "  ✗ owner $host stale — $reason — single playbooks not running: ${owned:-<none>}"
+      if [ "$was_stale" != "stale" ]; then
+        mkdir -p "$inbox_dir"
+        local marker="<!-- owner-staleness:$host -->"
+        local hours=$(( CEO_OWNER_STALE_S / 3600 ))
+        local task="- [ ] owner $host heartbeat stale >${hours}h — single playbooks ${owned:-<none>} not running $marker"
+        if ! printf '%s\n' "$task" >> "$inbox_file"; then
+          echo "ERROR: swarm owners-health: failed to append to $inbox_file" >&2
+          return 1
+        fi
+      fi
+    else
+      echo "  ✓ owner $host fresh — single playbooks running: ${owned:-<none>}"
+    fi
+  done <<<"$owner_hosts"
+
+  # Atomic state write: only the currently-stale set survives, so a recovered
+  # host drops out of state and a later re-stale re-alerts as a fresh transition.
+  local state_tmp
+  state_tmp=$(mktemp "$state_file.XXXXXX") || {
+    echo "ERROR: swarm owners-health: mktemp failed for $state_file" >&2
+    return 1
+  }
+  if ! printf '%s\n' "$new_state" > "$state_tmp" || ! mv -f "$state_tmp" "$state_file"; then
+    rm -f "$state_tmp"
+    echo "ERROR: swarm owners-health: failed to write $state_file" >&2
+    return 1
+  fi
+
+  [ "$any_stale" -eq 1 ] && return 1
   return 0
 }
 

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -279,7 +279,7 @@ cmd_doctor() {
   fi
 
   # bin symlinks for playbooks
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   if [ ! -f "$registry_file" ]; then
     echo "  ⚠ bin-symlink check skipped: registry.json not found (run: ceo playbook scan)"
     warn=$((warn + 1))
@@ -546,7 +546,7 @@ cmd_preflight() {
     return 1
   }
 
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   _require_registry_current "$registry_file"
 
   local would_run=0
@@ -760,7 +760,7 @@ cmd_playbook_scan() {
 
   local playbook_dir="$CEO_DIR/playbooks"
   local repo_playbook_dir="${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}"
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
 
   if [ ! -d "$playbook_dir" ]; then
     echo "ERROR: Playbooks directory not found at $playbook_dir"
@@ -801,6 +801,10 @@ cmd_playbook_scan() {
   # cmd_playbook_scan's exit code per ~/.claude/rules/enum-config-typo-fallback.md
   # ("failed dispatch counts toward failure observability").
   local invalid_status=0
+  # Tracked separately so a typo'd scope propagates to the exit code the same
+  # way an invalid status does (enum-config-typo-fallback: failed dispatch
+  # counts toward failure observability).
+  local invalid_scope=0
 
   local seen_names_vault=""
   local seen_names_repo=""
@@ -817,7 +821,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual scope
     name=$(_fm_scalar name "$f")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -964,6 +968,26 @@ cmd_playbook_scan() {
       continue
     fi
 
+    # `scope` selects single-run vs per-target fan-out (consumed by the
+    # scheduler daemon). Absent → the safe default `single`. An unknown value
+    # is a typo, not a default — skip the entry and count it toward the failure
+    # exit, per enum-config-typo-fallback.
+    scope=$(_fm_scalar scope "$f")
+    if [ -z "$scope" ]; then
+      scope="single"
+    else
+      local scope_valid=0
+      for s in "${CEO_VALID_SCOPES[@]}"; do
+        [ "$scope" = "$s" ] && { scope_valid=1; break; }
+      done
+      if [ "$scope_valid" -eq 0 ]; then
+        echo "  SKIP  $basename (unknown scope: '$scope', expected: ${CEO_VALID_SCOPES[*]})" >&2
+        skipped=$((skipped + 1))
+        invalid_scope=$((invalid_scope + 1))
+        continue
+      fi
+    fi
+
     if [ "$runner" = "ollama" ] || [ "$runner" = "ollama-think" ]; then
       local effective_model="$model"
       if [ "$runner" = "ollama" ]; then
@@ -1024,11 +1048,12 @@ cmd_playbook_scan() {
       --arg skill "$skill" \
       --arg out_pattern "$out_pattern" \
       --arg artifact "$artifact" \
+      --arg scope "$scope" \
       --argjson inputs "$inputs" \
       --argjson requires "$requires" \
       --argjson hosts "$hosts" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, scope:$scope, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))
@@ -1076,8 +1101,9 @@ cmd_playbook_scan() {
     _playbook_print_cron_block "$new_registry"
     echo ""
     echo "Registry: $found playbooks ($added added, $updated updated, $removed removed, $unchanged unchanged, $skipped skipped, $shadowed shadowed) — NOT written"
-    if [ "$invalid_status" -gt 0 ]; then
-      echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+    if [ "$invalid_status" -gt 0 ] || [ "$invalid_scope" -gt 0 ]; then
+      [ "$invalid_status" -gt 0 ] && echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+      [ "$invalid_scope" -gt 0 ] && echo "ERROR: $invalid_scope playbook(s) skipped due to invalid scope — see SKIP lines above" >&2
       return 1
     fi
     return 0
@@ -1095,6 +1121,7 @@ cmd_playbook_scan() {
     return "$_scan_install_rc"
   fi
 
+  mkdir -p "$(dirname "$registry_file")"
   local registry_tmp="$registry_file.tmp"
   echo "$new_registry" | jq '.' > "$registry_tmp"
   mv "$registry_tmp" "$registry_file"
@@ -1105,8 +1132,9 @@ cmd_playbook_scan() {
 
   _playbook_sync_bins "$new_registry"
 
-  if [ "$invalid_status" -gt 0 ]; then
-    echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+  if [ "$invalid_status" -gt 0 ] || [ "$invalid_scope" -gt 0 ]; then
+    [ "$invalid_status" -gt 0 ] && echo "ERROR: $invalid_status playbook(s) skipped due to invalid status — see SKIP lines above" >&2
+    [ "$invalid_scope" -gt 0 ] && echo "ERROR: $invalid_scope playbook(s) skipped due to invalid scope — see SKIP lines above" >&2
     return 1
   fi
 }
@@ -1349,7 +1377,7 @@ _schedule_source() {
 }
 
 cmd_schedule() {
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   local overrides_file="$CEO_DIR/schedules.json"
 
   if [ ! -f "$registry_file" ]; then
@@ -1469,7 +1497,7 @@ _schedule_one() {
 }
 
 cmd_playbook_list() {
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   _require_registry_current "$registry_file"
 
   printf "%-16s %-10s %-20s %-10s %-8s\n" "NAME" "TRIGGER" "SCHEDULE" "MODEL" "STATUS"
@@ -1495,7 +1523,7 @@ cmd_playbook_info() {
     exit 1
   fi
 
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   _require_registry_current "$registry_file"
 
   local entry
@@ -1558,7 +1586,7 @@ cmd_creds() {
         exit 1
       fi
       ceo_require_vault
-      local registry_file="$CEO_VAULT/CEO/registry.json"
+      local registry_file; registry_file=$(_ceo_registry_path)
       _require_registry_current "$registry_file"
       local entry
       entry=$(jq -r --arg n "$playbook" '.playbooks[] | select(.name==$n)' "$registry_file")
@@ -1656,7 +1684,7 @@ cmd_cron() {
 cmd_chat() {
   local name="${1:-triage}"
   ceo_validate_vault || exit 1
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
 
   _require_registry_current "$registry_file"
 
@@ -1806,7 +1834,7 @@ cmd_trace() {
   done
 
   ceo_validate_vault || exit 1
-  local registry_file="$CEO_DIR/registry.json"
+  local registry_file; registry_file=$(_ceo_registry_path)
   if [ -f "$registry_file" ]; then
     if ! jq empty "$registry_file" 2>/dev/null; then
       echo "ERROR: $registry_file is not valid JSON. Run 'ceo playbook scan' to regenerate." >&2

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1801,7 +1801,7 @@ _playbook_registry_scope() {
   scope=$(jq -r --arg n "$name" '.playbooks[] | select(.name==$n) | .scope // "single"' "$registry_file" 2>/dev/null)
   case "$scope" in
     each|single) printf '%s\n' "$scope" ;;
-    *) printf '%s\n' "single" ;;
+    *) echo "WARN: registry entry '$name' has out-of-set scope '$scope'; treating as single" >&2; printf '%s\n' "single" ;;
   esac
   return 0
 }
@@ -1829,7 +1829,10 @@ _playbook_rows() {
     p_desc=$(echo "$row" | jq -r '.description // ""')
     p_status=$(echo "$row" | jq -r '.status // "-"')
     [ -z "$p_status" ] && p_status="-"
-    case "$p_scope" in each|single) ;; *) p_scope="single" ;; esac
+    case "$p_scope" in
+      each|single) ;;
+      *) echo "WARN: registry entry '$p_name' has out-of-set scope '$p_scope'; treating as single" >&2; p_scope="single" ;;
+    esac
 
     if [ "$p_scope" = "each" ]; then
       local is_on

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -319,10 +319,24 @@ ceo_pin_home_or_warn() {
 #   1 — implicit (pre-runner-script registry; missing field treated as <2)
 # ---------------------------------------------------------------------------
 CEO_REGISTRY_SCHEMA_VERSION=3
+
+# The generated registry.json lives host-local, not in the synced vault: two
+# hosts scanning would otherwise both rewrite the synced file and produce
+# Syncthing .sync-conflict copies. The vault keeps only the playbook .md
+# definitions (which scan reads). The scheduler daemon reads the same path.
+_ceo_registry_path() {
+  : "${HOME:?HOME must be set to resolve the host-local registry path}"
+  printf '%s\n' "$HOME/.ceo/registry.json"
+}
 # shellcheck disable=SC2034
 CEO_VALID_RUNNERS=(claude script ollama ollama-think skill)
 # shellcheck disable=SC2034
 CEO_VALID_STATUSES=(active draft disabled)
+# Per-playbook fan-out scope. `single` runs the playbook once; `each` fans it
+# out per target (consumed by the scheduler daemon). Absent defaults to the
+# safe `single` — never coerce an unknown value to `each`.
+# shellcheck disable=SC2034
+CEO_VALID_SCOPES=(each single)
 
 # ceo_status_valid <value>
 #   Returns 0 if <value> is one of the supported statuses, 1 otherwise.
@@ -340,7 +354,7 @@ ceo_status_valid() {
 # ceo_registry_version <registry_file>
 #   Prints the integer schema_version, or nothing if missing/malformed.
 ceo_registry_version() {
-  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  local registry_file="${1:-$(_ceo_registry_path)}"
   jq -r '
     if has("schema_version")
       and (.schema_version | type) == "number"
@@ -362,7 +376,7 @@ ceo_registry_version() {
 # Codes 2 and 3 are kept distinct so a real downgrade is never retried into
 # acceptance and a transient unreadable read is never misreported as a downgrade.
 ceo_registry_validate() {
-  local registry_file="${1:-${CEO_DIR:-}/registry.json}"
+  local registry_file="${1:-$(_ceo_registry_path)}"
   if [ ! -f "$registry_file" ]; then
     return 1
   fi

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -329,6 +329,15 @@ _ceo_registry_path() {
   printf '%s\n' "$HOME/.ceo/registry.json"
 }
 
+# enabled.json is host-local like the registry: it lists the `each`-scope
+# playbook names THIS machine runs. The scheduler daemon reads the same path.
+# (`single`-scope playbooks are not gated here — they run on their assigned
+# owner host, recorded in the synced swarm.json owners map.)
+_ceo_enabled_path() {
+  : "${HOME:?HOME must be set to resolve the host-local enabled path}"
+  printf '%s\n' "$HOME/.ceo/enabled.json"
+}
+
 # Unlike registry.json (host-local), swarm.json IS synced: it describes the
 # swarm itself (which hosts participate, who owns each single-scope playbook),
 # so every host must read the same file. The scheduler daemon reads this path
@@ -413,6 +422,43 @@ _swarm_register_host() {
      || ! mv -f "$tmp" "$swarm_file"; then
     rm -f "$tmp"
     echo "ERROR: failed to register host '$host' in $swarm_file" >&2
+    return 1
+  fi
+  return 0
+}
+
+# _swarm_set_owner <name> <host>
+#   Assign single-scope playbook <name> to <host> in swarm.json owners{}.
+#   <host> must already be a registered member of hosts[] — refuse otherwise
+#   so ownership can't point at a machine the swarm doesn't know. The jq
+#   assignment `.owners[$n] = $h` REPLACES any prior owner: ownership is
+#   single-host, so re-assigning overwrites rather than accumulating. Scope
+#   validation (refusing `each` playbooks) is the caller's responsibility —
+#   it owns the registry; this helper only knows the swarm.
+_swarm_set_owner() {
+  local name="${1:?_swarm_set_owner requires a playbook name}"
+  local host="${2:?_swarm_set_owner requires a host}"
+  _swarm_bootstrap || return 1
+  local swarm_file; swarm_file=$(_swarm_path) || return 1
+
+  local known
+  known=$(jq -r --arg h "$host" '.hosts | index($h) != null' "$swarm_file" 2>/dev/null)
+  if [ "$known" != "true" ]; then
+    echo "ERROR: host '$host' is not registered in swarm.json hosts[]." >&2
+    echo "  Known hosts: $(jq -r '.hosts | join(", ")' "$swarm_file" 2>/dev/null)" >&2
+    echo "  Register it from that machine first (ceo setup), then assign." >&2
+    return 1
+  fi
+
+  local tmp
+  tmp=$(mktemp "$swarm_file.XXXXXX") || {
+    echo "ERROR: mktemp failed for $swarm_file" >&2
+    return 1
+  }
+  if ! jq --arg n "$name" --arg h "$host" '.owners[$n] = $h' "$swarm_file" > "$tmp" \
+     || ! mv -f "$tmp" "$swarm_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to set owner '$host' for '$name' in $swarm_file" >&2
     return 1
   fi
   return 0

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -328,6 +328,95 @@ _ceo_registry_path() {
   : "${HOME:?HOME must be set to resolve the host-local registry path}"
   printf '%s\n' "$HOME/.ceo/registry.json"
 }
+
+# Unlike registry.json (host-local), swarm.json IS synced: it describes the
+# swarm itself (which hosts participate, who owns each single-scope playbook),
+# so every host must read the same file. The scheduler daemon reads this path
+# and tolerates the file being absent (treats as empty / no-op).
+_swarm_path() {
+  : "${CEO_VAULT:?CEO_VAULT must be set to resolve the swarm path}"
+  printf '%s\n' "$CEO_VAULT/CEO/swarm.json"
+}
+CEO_SWARM_SCHEMA_VERSION=1
+
+# _swarm_resolve_host
+#   Prints this host's swarm id on stdout. Prefers an explicit CEO_HOSTNAME;
+#   falls back to `hostname -s`. Empty result is a fatal misconfiguration
+#   (shell-required-env-vars: an empty id silently corrupts the swarm).
+_swarm_resolve_host() {
+  local host="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null)}"
+  : "${host:?cannot determine this host (CEO_HOSTNAME unset and 'hostname -s' returned empty)}"
+  printf '%s\n' "$host"
+}
+
+# _swarm_bootstrap
+#   Create swarm.json if absent: {"schema_version":1,"hosts":[],"owners":{}}.
+#   Idempotent — an existing file (with its hosts[]/owners{}) is left untouched
+#   so a re-run never clobbers peer-registered hosts or assigned owners.
+_swarm_bootstrap() {
+  local swarm_file; swarm_file=$(_swarm_path) || return 1
+  [ -f "$swarm_file" ] && return 0
+  mkdir -p "$(dirname "$swarm_file")"
+  local tmp
+  tmp=$(mktemp "$swarm_file.XXXXXX") || {
+    echo "ERROR: mktemp failed for $swarm_file" >&2
+    return 1
+  }
+  if ! jq -n --argjson v "$CEO_SWARM_SCHEMA_VERSION" \
+        '{schema_version: $v, hosts: [], owners: {}}' > "$tmp" \
+     || ! mv -f "$tmp" "$swarm_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to write $swarm_file" >&2
+    return 1
+  fi
+  return 0
+}
+
+# _swarm_register_host
+#   Register this host into swarm.json hosts[]. Bootstraps the file first if
+#   absent. Idempotent for an explicit CEO_HOSTNAME: re-registering an
+#   already-present id is a safe no-op.
+#
+#   Collision guard (the safety invariant): a host can't know whether an
+#   existing hosts[] entry is itself or a clone. When CEO_HOSTNAME is NOT
+#   explicitly set and the bare `hostname -s` value already appears in
+#   hosts[], the id is ambiguous — two machines could silently share it and
+#   end up with double ownership of a single-scope playbook. Refuse with a
+#   non-zero exit and instruct the user to set a unique CEO_HOSTNAME. An
+#   explicit CEO_HOSTNAME is trusted: the user has asserted the id is unique,
+#   so re-registering it is the safe no-op above, never a refusal.
+_swarm_register_host() {
+  _swarm_bootstrap || return 1
+  local swarm_file; swarm_file=$(_swarm_path) || return 1
+  local host; host=$(_swarm_resolve_host) || return 1
+
+  local already_present
+  already_present=$(jq -r --arg h "$host" '.hosts | index($h) != null' "$swarm_file" 2>/dev/null)
+
+  if [ "$already_present" = "true" ]; then
+    if [ -z "${CEO_HOSTNAME:-}" ]; then
+      echo "ERROR: host id '$host' (from 'hostname -s') is already in swarm.json hosts[]." >&2
+      echo "  Cannot tell whether that entry is this machine or a different one." >&2
+      echo "  Set a unique CEO_HOSTNAME for this machine and re-run, e.g.:" >&2
+      echo "    echo 'CEO_HOSTNAME=$host-2' >> ~/.ceo/config" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "$swarm_file.XXXXXX") || {
+    echo "ERROR: mktemp failed for $swarm_file" >&2
+    return 1
+  }
+  if ! jq --arg h "$host" '.hosts += [$h]' "$swarm_file" > "$tmp" \
+     || ! mv -f "$tmp" "$swarm_file"; then
+    rm -f "$tmp"
+    echo "ERROR: failed to register host '$host' in $swarm_file" >&2
+    return 1
+  fi
+  return 0
+}
 # shellcheck disable=SC2034
 CEO_VALID_RUNNERS=(claude script ollama ollama-think skill)
 # shellcheck disable=SC2034

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -610,7 +610,7 @@ mkdir -p "$REPORT_DIR"
 # acquire it sequentially (no parent-vs-child contention). Model override and
 # CEO_DRY_RUN_DEPTH already exported above are inherited by the children.
 _run_test_all() {
-  local registry="$CEO_DIR/registry.json"
+  local registry; registry=$(_ceo_registry_path)
   local rc=0
   ceo_registry_validate "$registry" || rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -866,7 +866,7 @@ preflight_has_auto_review_prs() {
 }
 
 # --- Look up trigger in registry ---
-REGISTRY_FILE="$CEO_DIR/registry.json"
+REGISTRY_FILE="$(_ceo_registry_path)"
 # Append the offending registry head + jq parse status to the skip log so a
 # recurrence is diagnosable from evidence instead of re-guessed.
 _registry_diag() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -17,6 +17,10 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
+  # The generated registry is host-local now ($HOME/.ceo/registry.json), not in
+  # the synced vault. Both `ceo playbook scan` (write) and `ceo cron` (read)
+  # resolve this path; tests seed/inspect it here, not under $CEO_DIR.
+  REGISTRY_FILE="$HOME/.ceo/registry.json"
   # Bypass the ollama daemon HTTP probe in tests (the stubbed ollama binary
   # has no daemon backing it). Production runs leave this unset.
   export CEO_OLLAMA_SKIP_PROBE=1
@@ -24,7 +28,7 @@ setup() {
   # Isolate cron lock to this test invocation
   export CEO_LOCK_FILE="$TEST_HOME/ceo-cron.lock"
 
-  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports"
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$CEO_DIR/approvals" "$CEO_DIR/reports" "$HOME/.ceo"
   : > "$CEO_DIR/AGENTS.md"
   : > "$CEO_DIR/IDENTITY.md"
   : > "$CEO_DIR/TRAINING.md"
@@ -783,7 +787,7 @@ PB
   assert_contains "$scan_out" "unknown runner: 'scrpt'" "scan must skip unknown runner with diagnostic"
 
   local entry
-  entry=$(jq -r '.playbooks[] | select(.name=="typo-runner")' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  entry=$(jq -r '.playbooks[] | select(.name=="typo-runner")' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$entry" "" "skipped playbook must not appear in registry.json"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -805,8 +809,8 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
   jq '(.playbooks[] | select(.name=="forced-typo") | .runner) |= "scrpt"' \
-    "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+    "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   CEO_VERBOSE=1 bash "$CRON" forced-typo >/dev/null 2>&1 || rc=$?
@@ -841,7 +845,7 @@ PB
   fi
 
   local entry
-  entry=$(jq -r '.playbooks[] | select(.name=="ollama-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  entry=$(jq -r '.playbooks[] | select(.name=="ollama-ok") | .runner' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$entry" "ollama" "ollama playbook must be registered with runner:ollama"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -1124,7 +1128,7 @@ PB
   fi
 
   local entry
-  entry=$(jq -r '.playbooks[] | select(.name=="ollama-think-ok") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  entry=$(jq -r '.playbooks[] | select(.name=="ollama-think-ok") | .runner' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$entry" "ollama-think" "ollama-think playbook must be registered with runner:ollama-think"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -1432,7 +1436,7 @@ status: active
 # morning-scan body
 PB
 
-  cat > "$CEO_DIR/registry.json" << JSON
+  cat > "$REGISTRY_FILE" << JSON
 {
   "schema_version": 3,
   "generated": "2026-06-02T00:00:00Z",
@@ -1779,9 +1783,9 @@ test_production_morning_brief_registers_with_ollama_runner() {
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
   local runner tier model
-  runner=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
-  tier=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .tier' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
-  model=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  runner=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .runner' "$REGISTRY_FILE" 2>/dev/null || echo "")
+  tier=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .tier' "$REGISTRY_FILE" 2>/dev/null || echo "")
+  model=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .model' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-brief.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-brief.md must declare tier: read"
   assert_eq "$model" "gemma4:12b-it-qat" "production morning-brief.md must declare model: gemma4:12b-it-qat"
@@ -1801,9 +1805,9 @@ test_production_morning_scan_registers_with_ollama_runner() {
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
   local runner tier model
-  runner=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .runner' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
-  tier=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .tier' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
-  model=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .model' "$CEO_DIR/registry.json" 2>/dev/null || echo "")
+  runner=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .runner' "$REGISTRY_FILE" 2>/dev/null || echo "")
+  tier=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .tier' "$REGISTRY_FILE" 2>/dev/null || echo "")
+  model=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .model' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-scan.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-scan.md must declare tier: read"
   assert_eq "$model" "gemma4:12b-it-qat" "production morning-scan.md must declare model: gemma4:12b-it-qat"
@@ -1898,7 +1902,7 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
   local v
-  v=$(jq -r '.schema_version // "missing"' "$CEO_DIR/registry.json")
+  v=$(jq -r '.schema_version // "missing"' "$REGISTRY_FILE")
   assert_eq "$v" "3" "playbook scan must write schema_version=3 into registry.json"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -1917,16 +1921,16 @@ status: active
 # noop
 PB
   printf '{"schema_version":99,"future_field":"must-stay","playbooks":[]}\n' \
-    > "$CEO_DIR/registry.json"
+    > "$REGISTRY_FILE"
   local before
-  before=$(cat "$CEO_DIR/registry.json")
+  before=$(cat "$REGISTRY_FILE")
 
   local rc=0
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "1" "playbook scan must refuse to overwrite newer registry schema"
 
   local after
-  after=$(cat "$CEO_DIR/registry.json")
+  after=$(cat "$REGISTRY_FILE")
   assert_eq "$after" "$before" "newer registry content must remain unchanged"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -1946,8 +1950,8 @@ status: active
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
-  jq 'del(.schema_version)' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq 'del(.schema_version)' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   # RETRY_SLEEP=0: a missing schema_version is code 3 (malformed/transient), so
   # the preflight re-reads once before failing. A persistently-missing field
@@ -1987,8 +1991,8 @@ status: active
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
 
-  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq '.schema_version = 1' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   bash "$CRON" example >/dev/null 2>&1 || rc=$?
@@ -2023,8 +2027,8 @@ status: active
 # noop
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq '.schema_version = 1' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   bash "$CEO_CLI" playbook list >/dev/null 2>&1 || rc=$?
@@ -2046,8 +2050,8 @@ status: active
 # noop
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq '.schema_version = 1' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   bash "$CEO_CLI" playbook info example >/dev/null 2>&1 || rc=$?
@@ -2069,8 +2073,8 @@ status: active
 # noop
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq '.schema_version = 1' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   bash "$CEO_CLI" chat example >/dev/null 2>&1 || rc=$?
@@ -2092,8 +2096,8 @@ status: active
 # noop
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  jq '.schema_version = 1' "$CEO_DIR/registry.json" > "$CEO_DIR/registry.json.tmp"
-  mv "$CEO_DIR/registry.json.tmp" "$CEO_DIR/registry.json"
+  jq '.schema_version = 1' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp"
+  mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
 
   local rc=0
   bash "$CEO_CLI" preflight >/dev/null 2>&1 || rc=$?
@@ -2140,13 +2144,13 @@ status: active
 ---
 PB
   printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0 out
   out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
   assert_eq "$rc" "1" "non-primary host must be refused"
   assert_contains "$out" "primary host" "error must mention primary host gating"
-  if [ -f "$CEO_DIR/registry.json" ]; then
+  if [ -f "$REGISTRY_FILE" ]; then
     printf '  FAIL [%s] non-primary host wrote registry.json (must not)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
@@ -2166,12 +2170,12 @@ status: active
 ---
 PB
   printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0
   CEO_HOSTNAME=alpha bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "primary host must be allowed to scan"
-  assert_file_exists "$CEO_DIR/registry.json" "registry must be written by primary host"
+  assert_file_exists "$REGISTRY_FILE" "registry must be written by primary host"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2188,12 +2192,12 @@ status: active
 ---
 PB
   printf '{}\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0
   CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "no primary_host setting → backward-compatible (any host can scan)"
-  assert_file_exists "$CEO_DIR/registry.json" "registry must be written when no gate is configured"
+  assert_file_exists "$REGISTRY_FILE" "registry must be written when no gate is configured"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2210,13 +2214,13 @@ status: active
 ---
 PB
   printf '{"promary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0 out
   out=$(CEO_HOSTNAME=beta bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
   assert_eq "$rc" "0" "typo'd key falls through to no-gate (backward-compat) but must warn"
   assert_contains "$out" "unknown key 'promary_host'" "typo'd key must surface a warning so operator notices"
-  assert_file_exists "$CEO_DIR/registry.json" "scan continues despite typo (gate is not configured from parser's view)"
+  assert_file_exists "$REGISTRY_FILE" "scan continues despite typo (gate is not configured from parser's view)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2233,13 +2237,13 @@ status: active
 ---
 PB
   printf 'not valid json\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0 out
   out=$(CEO_HOSTNAME=anyhost bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
   assert_eq "$rc" "1" "malformed settings.json must fail loud, not silently fall through"
   assert_contains "$out" "not valid JSON" "error must name the JSON parse failure"
-  if [ -f "$CEO_DIR/registry.json" ]; then
+  if [ -f "$REGISTRY_FILE" ]; then
     printf '  FAIL [%s] registry written despite malformed settings.json\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
@@ -2259,14 +2263,14 @@ status: active
 ---
 PB
   printf '{"primary_host":"alpha"}\n' > "$CEO_DIR/settings.json"
-  rm -f "$CEO_DIR/registry.json"
+  rm -f "$REGISTRY_FILE"
 
   local rc=0 out
   out=$(CEO_JQ_BIN=jq-deliberately-missing-for-test CEO_HOSTNAME=anyhost \
         bash "$CEO_CLI" playbook scan 2>&1) || rc=$?
   assert_eq "$rc" "1" "missing jq with settings.json must fail loud"
   assert_contains "$out" "jq is not installed" "error must name the missing dependency"
-  if [ -f "$CEO_DIR/registry.json" ]; then
+  if [ -f "$REGISTRY_FILE" ]; then
     printf '  FAIL [%s] registry written despite missing-jq error\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
@@ -2405,7 +2409,7 @@ tier: read
 status: active
 ---
 PB
-  cat > "$CEO_DIR/registry.json" << JSON
+  cat > "$REGISTRY_FILE" << JSON
 {"schema_version":3,"playbooks":[{"name":"pending-drip","file":"$CEO_DIR/playbooks/pending-drip.md","model":"haiku","preflight":"has_pending_items","trigger":"cron","tier":"read","status":"active"}]}
 JSON
   printf -- '- [ ] pending approval sentinel\n' > "$CEO_DIR/approvals/pending.md"
@@ -2767,7 +2771,7 @@ PB
   assert_contains "$out" "ADD   _test-repo-pb" "repo playbook must be picked up by scan"
 
   local file_field
-  file_field=$(jq -r '.playbooks[] | select(.name=="_test-repo-pb") | .file' "$CEO_DIR/registry.json")
+  file_field=$(jq -r '.playbooks[] | select(.name=="_test-repo-pb") | .file' "$REGISTRY_FILE")
   assert_eq "${file_field:0:1}" "/" "repo playbook .file must be absolute"
   assert_contains "$file_field" "_test-repo-pb.md" "repo playbook .file must point at repo path"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
@@ -2807,8 +2811,8 @@ PB
   assert_contains "$out" "SHADOW" "scan must report shadowing"
 
   local desc status
-  desc=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .description' "$CEO_DIR/registry.json")
-  status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$CEO_DIR/registry.json")
+  desc=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .description' "$REGISTRY_FILE")
+  status=$(jq -r '.playbooks[] | select(.name=="_test-shadow") | .status' "$REGISTRY_FILE")
   assert_eq "$desc" "Vault override" "vault entry must win on collision"
   assert_eq "$status" "disabled" "vault status must override repo status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
@@ -3180,9 +3184,9 @@ PB
   local rc=0
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1 || rc=$?
   assert_eq "$rc" "0" "ceo playbook scan must succeed even when yq is not on PATH"
-  assert_file_exists "$CEO_DIR/registry.json" "registry.json must be written without yq"
+  assert_file_exists "$REGISTRY_FILE" "registry.json must be written without yq"
   local reg_name
-  reg_name=$(jq -r '.playbooks[] | select(.name=="no-yq-test") | .name' "$CEO_DIR/registry.json" 2>/dev/null)
+  reg_name=$(jq -r '.playbooks[] | select(.name=="no-yq-test") | .name' "$REGISTRY_FILE" 2>/dev/null)
   assert_eq "$reg_name" "no-yq-test" "playbook must be registered without yq"
 
   # Restore yq stub for subsequent tests.
@@ -3268,7 +3272,7 @@ tier: read
 ---
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  assert_contains "$(jq -r '.playbooks[].name' "$CEO_DIR/registry.json" 2>/dev/null)" "rm-nostatus" "missing-status playbook must be registered (so the gate, not a missing entry, is what skips it)"
+  assert_contains "$(jq -r '.playbooks[].name' "$REGISTRY_FILE" 2>/dev/null)" "rm-nostatus" "missing-status playbook must be registered (so the gate, not a missing entry, is what skips it)"
   bash "$CRON" rm-nostatus --scheduled >/dev/null 2>&1 || true
   assert_fails "scheduled run of a missing-status playbook must NOT dispatch (SCHEMA: missing = not active)" test -f "$HOME/claude-invoked.txt"
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "not runnable in scheduled mode" "skip must come from the run-mode gate, not a missing registry entry"
@@ -3337,7 +3341,7 @@ test_cron_force_flag_bypasses_cooldown() {
 # the old gate (that would be a tautology passing on pre-change code).
 test_cron_catchall_skips_unknown_status() {
   _register_status_playbook rm-weird active
-  local reg="$CEO_DIR/registry.json"
+  local reg="$REGISTRY_FILE"
   jq '(.playbooks[] | select(.name=="rm-weird") | .status) = "bogus"' "$reg" > "$reg.tmp" && mv "$reg.tmp" "$reg"
   bash "$CRON" rm-weird --manual >/dev/null 2>&1 || true
   assert_fails "out-of-set status must never dispatch (defense-in-depth catch-all)" test -f "$HOME/claude-invoked.txt"
@@ -3657,7 +3661,7 @@ SH
 
 # --- #139: hosts: frontmatter (host-scoped scheduling, recorded not enforced) ---
 _hosts_in_registry() {
-  jq -r --arg n "$1" '.playbooks[] | select(.name==$n) | .hosts | tojson' "$CEO_DIR/registry.json" 2>/dev/null
+  jq -r --arg n "$1" '.playbooks[] | select(.name==$n) | .hosts | tojson' "$REGISTRY_FILE" 2>/dev/null
 }
 
 # Absent hosts → recorded as ["*"] (all hosts), the backward-compatible default.

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -19,7 +19,10 @@ setup() {
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
   export CEO_HOSTNAME="testhost"
-  mkdir -p "$CEO_DIR/log" "$CEO_DIR/reports/value-tracker" "$CEO_DIR/reports/token"
+  # The generated registry is host-local now ($HOME/.ceo/registry.json), not in
+  # the synced vault — doctor reads it from there.
+  REGISTRY_FILE="$HOME/.ceo/registry.json"
+  mkdir -p "$CEO_DIR/log" "$CEO_DIR/reports/value-tracker" "$CEO_DIR/reports/token" "$HOME/.ceo"
   : > "$CEO_DIR/AGENTS.md"
 
   # Stub the binaries cmd_doctor probes so the surrounding checks don't
@@ -74,7 +77,7 @@ STUB
   chmod +x "$CEO_PLUTIL_BIN"
 
   # Minimal registry with one runner:script playbook + artifact template.
-  cat > "$CEO_DIR/registry.json" << EOF
+  cat > "$REGISTRY_FILE" << EOF
 {
   "schema_version": 3,
   "generated": "2026-05-28T00:00:00Z",
@@ -151,7 +154,7 @@ test_doctor_flags_malformed_artifact_template() {
   # coverage before this test. Seed a registry with a {BOGUS} token + a
   # completed log line and assert doctor surfaces the error and returns
   # non-zero.
-  cat > "$CEO_DIR/registry.json" << EOF
+  cat > "$REGISTRY_FILE" << EOF
 {
   "schema_version": 3,
   "generated": "2026-05-28T00:00:00Z",
@@ -192,7 +195,7 @@ test_doctor_warns_when_cron_log_missing() {
 
 test_doctor_skips_empty_artifact_field() {
   # Playbook with no artifact declared must not be checked.
-  cat > "$CEO_DIR/registry.json" << EOF
+  cat > "$REGISTRY_FILE" << EOF
 {
   "schema_version": 3,
   "generated": "2026-05-28T00:00:00Z",

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -338,16 +338,21 @@ test_doctor_flags_crontab_block_as_migration_leftover() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_doctor_no_leftover_warning_when_daemon_inactive() {
+test_doctor_flags_crontab_leftover_even_when_daemon_inactive() {
   export CEO_SCHEDULER=crontab
   _write_crontab_list_stub "# CEO Agent START
 */5 * * * * /p/ceo-cron.sh morning  # ceo:morning
 # CEO Agent END"
   _write_systemctl_stub inactive
-  local output
-  output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_not_contains "$output" "Migration leftover" \
-    "the crontab block alone (daemon inactive) is not flagged as a leftover by this check"
+  local output rc=0
+  output=$("$CEO_BIN" doctor 2>&1) || rc=$?
+  assert_contains "$output" "Migration leftover" \
+    "a lingering CEO crontab block is a migration leftover regardless of daemon state (blind-spot fix)"
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] doctor must return non-zero on a lingering crontab block even with the daemon inactive (got rc=0)\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_doctor_no_leftover_warning_when_no_crontab_block() {

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -273,11 +273,13 @@ test_doctor_no_legacy_warning_when_only_daemon_agent() {
     "the daemon's own keep-alive agent must not be flagged as legacy"
 }
 
-# --- #159: Linux crontab + systemd daemon double-fire migration ---
+# --- #159 / D1: Linux crontab block is a migration leftover ---
 #
-# The Linux sibling of the macOS orphan check above. A host carrying the
-# Phase-1 per-playbook CEO crontab block AND running the ceo-schedulerd systemd
-# daemon (#142) fires every playbook twice. doctor must flag it.
+# The Linux sibling of the macOS orphan check above. The native crontab install
+# path is retired (D1) — ceo-schedulerd is the sole scheduler. A host still
+# carrying the Phase-1 per-playbook CEO crontab block alongside the running
+# daemon is a MIGRATION LEFTOVER (the block double-fires what the daemon already
+# dispatches). doctor must flag the leftover and recommend removing it.
 
 # Writes a CEO_CRONTAB_BIN stub whose `-l` prints $1 (a crontab body) and
 # exits non-zero on any other argv (per stub-cli-argv-validation).
@@ -314,7 +316,7 @@ STUB
   chmod +x "$CEO_SYSTEMCTL_BIN"
 }
 
-test_doctor_flags_crontab_daemon_double_fire() {
+test_doctor_flags_crontab_block_as_migration_leftover() {
   export CEO_SCHEDULER=crontab
   _write_crontab_list_stub "# CEO Agent START
 */5 * * * * /p/ceo-cron.sh morning  # ceo:morning
@@ -323,18 +325,20 @@ test_doctor_flags_crontab_daemon_double_fire() {
   _write_systemctl_stub active
   local output rc=0
   output=$("$CEO_BIN" doctor 2>&1) || rc=$?
-  assert_contains "$output" "double-fire" \
-    "doctor must warn when the crontab block and the systemd daemon both run"
+  assert_contains "$output" "Migration leftover" \
+    "doctor must flag a lingering CEO crontab block as a migration leftover"
   assert_contains "$output" "crontab block" \
-    "the warning must name the crontab block as the conflicting scheduler"
+    "the warning must name the crontab block as the thing to remove"
+  assert_contains "$output" "Remove" \
+    "the warning must recommend removing the leftover crontab block"
   if [ "$rc" = "0" ]; then
-    printf '  FAIL [%s] doctor must return non-zero on a crontab+daemon double-fire (got rc=0)\n' "$CURRENT_TEST"
+    printf '  FAIL [%s] doctor must return non-zero on a lingering crontab block (got rc=0)\n' "$CURRENT_TEST"
     _record_assertion_fail
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_doctor_no_double_fire_warning_when_daemon_inactive() {
+test_doctor_no_leftover_warning_when_daemon_inactive() {
   export CEO_SCHEDULER=crontab
   _write_crontab_list_stub "# CEO Agent START
 */5 * * * * /p/ceo-cron.sh morning  # ceo:morning
@@ -342,19 +346,19 @@ test_doctor_no_double_fire_warning_when_daemon_inactive() {
   _write_systemctl_stub inactive
   local output
   output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_not_contains "$output" "double-fire" \
-    "the crontab block alone (daemon inactive) is not a double-fire"
+  assert_not_contains "$output" "Migration leftover" \
+    "the crontab block alone (daemon inactive) is not flagged as a leftover by this check"
 }
 
-test_doctor_no_double_fire_warning_when_no_crontab_block() {
+test_doctor_no_leftover_warning_when_no_crontab_block() {
   export CEO_SCHEDULER=crontab
   _write_crontab_list_stub "# unrelated user cron
 0 0 * * * /usr/bin/true"
   _write_systemctl_stub active
   local output
   output=$("$CEO_BIN" doctor 2>&1 || true)
-  assert_not_contains "$output" "double-fire" \
-    "an active daemon with no CEO crontab entries is not a double-fire"
+  assert_not_contains "$output" "Migration leftover" \
+    "an active daemon with no CEO crontab entries has no leftover to flag"
 }
 
 # --- ceo-schedulerd liveness (#142) ---

--- a/scripts/ceo-list.test.sh
+++ b/scripts/ceo-list.test.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Tests for the playbook selection UX (task C2): enable/disable for `each`-scope
+# playbooks (host-local enabled.json), single-owner assignment for `single`-scope
+# playbooks (synced swarm.json owners), and the row renderer.
+#
+# Invariants under test:
+#   - enable/disable mutate only THIS host's enabled.json, idempotently.
+#   - enable refuses `single`-scope playbooks (those are owner-assigned, not enabled).
+#   - assign refuses `each`-scope playbooks and unregistered hosts.
+#   - assign REPLACES the prior owner (single-owner invariant), never appends.
+#   - the renderer shows enable-state for `each` and owner-state for `single`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="ml-1"
+  REGISTRY_FILE="$HOME/.ceo/registry.json"
+  ENABLED_FILE="$HOME/.ceo/enabled.json"
+  SWARM_FILE="$CEO_DIR/swarm.json"
+
+  mkdir -p "$HOME/.ceo" "$CEO_DIR"
+
+  cat > "$REGISTRY_FILE" << 'JSON'
+{
+  "schema_version": 3,
+  "playbooks": [
+    { "name": "morning-brief", "description": "daily brief", "status": "active", "trigger": "cron", "scope": "each" },
+    { "name": "git-monitor",   "description": "watch repos",  "status": "active", "trigger": "cron", "scope": "each" },
+    { "name": "pr-triage",     "description": "triage PRs",   "status": "active", "trigger": "cron", "scope": "single" },
+    { "name": "value-tracker", "description": "track value",  "status": "active", "trigger": "cron", "scope": "single" }
+  ]
+}
+JSON
+
+  cat > "$ENABLED_FILE" << 'JSON'
+["morning-brief"]
+JSON
+
+  cat > "$SWARM_FILE" << 'JSON'
+{ "schema_version": 1, "hosts": ["ml-1", "mac"], "owners": { "pr-triage": "ml-1" } }
+JSON
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP REGISTRY_FILE ENABLED_FILE SWARM_FILE
+}
+
+_enabled_has() {
+  jq -e --arg n "$1" 'index($n) != null' "$ENABLED_FILE" >/dev/null 2>&1 && echo yes || echo no
+}
+
+_enabled_count() {
+  jq --arg n "$1" '[.[] | select(. == $n)] | length' "$ENABLED_FILE"
+}
+
+test_enable_each_adds_to_enabled() {
+  bash "$CEO_CLI" playbook enable git-monitor >/dev/null 2>&1
+  assert_eq "$(_enabled_has git-monitor)" "yes" "enable must add the each playbook to enabled.json"
+}
+
+test_enable_is_idempotent() {
+  bash "$CEO_CLI" playbook enable git-monitor >/dev/null 2>&1
+  bash "$CEO_CLI" playbook enable git-monitor >/dev/null 2>&1
+  assert_eq "$(_enabled_count git-monitor)" "1" "enabling twice must leave exactly one entry"
+}
+
+test_disable_each_removes_from_enabled() {
+  bash "$CEO_CLI" playbook disable morning-brief >/dev/null 2>&1
+  assert_eq "$(_enabled_has morning-brief)" "no" "disable must remove the playbook from enabled.json"
+}
+
+test_disable_absent_is_noop_success() {
+  local rc=0
+  bash "$CEO_CLI" playbook disable git-monitor >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "disabling an absent (but registered) playbook must succeed as a no-op"
+  assert_eq "$(_enabled_has git-monitor)" "no" "absent playbook stays absent"
+}
+
+test_enable_single_refuses() {
+  local rc=0 out
+  out=$(bash "$CEO_CLI" playbook enable pr-triage 2>&1) || rc=$?
+  assert_eq "$rc" "1" "enabling a single-scope playbook must exit non-zero"
+  assert_contains "$out" "assign" "refusal must direct the user to owner assignment"
+  assert_eq "$(_enabled_has pr-triage)" "no" "single playbook must not land in enabled.json"
+}
+
+test_enable_unknown_name_refuses() {
+  local rc=0 out
+  out=$(bash "$CEO_CLI" playbook enable not-a-playbook 2>&1) || rc=$?
+  assert_eq "$rc" "1" "enabling an unregistered name must exit non-zero"
+  assert_contains "$out" "not-a-playbook" "error must name the missing playbook"
+}
+
+test_disable_unknown_name_refuses() {
+  local rc=0 out
+  out=$(bash "$CEO_CLI" playbook disable not-a-playbook 2>&1) || rc=$?
+  assert_eq "$rc" "1" "disabling an unregistered name must exit non-zero"
+  assert_contains "$out" "not-a-playbook" "error must name the missing playbook"
+}
+
+test_assign_single_sets_owner() {
+  bash "$CEO_CLI" playbook assign value-tracker mac >/dev/null 2>&1
+  assert_eq "$(jq -r '.owners["value-tracker"]' "$SWARM_FILE")" "mac" "assign must set owners[name]=host"
+}
+
+test_assign_replaces_prior_owner() {
+  # pr-triage starts owned by ml-1; re-assign to mac must REPLACE, not append.
+  bash "$CEO_CLI" playbook assign pr-triage mac >/dev/null 2>&1
+  assert_eq "$(jq -r '.owners["pr-triage"]' "$SWARM_FILE")" "mac" "owner must be the new host"
+  assert_eq "$(jq -r '.owners["pr-triage"] | type' "$SWARM_FILE")" "string" "owner stays a single string, not a list"
+}
+
+test_assign_unregistered_host_refuses() {
+  local rc=0 out
+  out=$(bash "$CEO_CLI" playbook assign value-tracker ghost-host 2>&1) || rc=$?
+  assert_eq "$rc" "1" "assigning to an unregistered host must exit non-zero"
+  assert_contains "$out" "ghost-host" "error must name the unregistered host"
+  assert_eq "$(jq -r '.owners["value-tracker"] // "none"' "$SWARM_FILE")" "none" "owners unchanged after refusal"
+}
+
+test_assign_each_playbook_refuses() {
+  local rc=0 out
+  out=$(bash "$CEO_CLI" playbook assign morning-brief mac 2>&1) || rc=$?
+  assert_eq "$rc" "1" "assigning an each-scope playbook an owner must exit non-zero"
+  assert_eq "$(jq -r '.owners["morning-brief"] // "none"' "$SWARM_FILE")" "none" "each playbook must not get an owner"
+}
+
+test_renderer_each_enabled_row() {
+  local out
+  out=$(bash "$CEO_CLI" playbook list 2>&1)
+  # morning-brief is each + enabled here
+  assert_contains "$out" "morning-brief" "list must include the each playbook"
+  assert_contains "$out" "enabled here" "an enabled each playbook must render its enabled state"
+}
+
+test_renderer_each_disabled_row() {
+  local out
+  out=$(bash "$CEO_CLI" playbook list 2>&1)
+  # git-monitor is each + NOT in enabled.json
+  assert_contains "$out" "git-monitor" "list must include the disabled each playbook"
+  assert_contains "$out" "disabled here" "a disabled each playbook must render its disabled state"
+}
+
+test_renderer_single_owned_row() {
+  local out
+  out=$(bash "$CEO_CLI" playbook list 2>&1)
+  # pr-triage is single + owned by ml-1
+  assert_contains "$out" "owner: ml-1" "an owned single playbook must render its owner host"
+}
+
+test_renderer_single_unowned_row() {
+  local out
+  out=$(bash "$CEO_CLI" playbook list 2>&1)
+  # value-tracker is single + no owner
+  assert_contains "$out" "owner: (none)" "an unowned single playbook must render (none)"
+}
+
+run_tests

--- a/scripts/ceo-list.test.sh
+++ b/scripts/ceo-list.test.sh
@@ -167,6 +167,24 @@ test_renderer_single_unowned_row() {
   assert_contains "$out" "owner: (none)" "an unowned single playbook must render (none)"
 }
 
+test_renderer_warns_on_out_of_set_scope() {
+  cat > "$REGISTRY_FILE" << 'JSON'
+{
+  "schema_version": 3,
+  "playbooks": [
+    { "name": "typo-scope", "description": "bad scope", "status": "active", "trigger": "cron", "scope": "signle" }
+  ]
+}
+JSON
+  local err
+  err=$(bash "$CEO_CLI" playbook list 2>&1 >/dev/null)
+  assert_contains "$err" "typo-scope" "a corrupt scope must warn and name the playbook on stderr"
+  assert_contains "$err" "out-of-set scope" "the warning must explain the scope was out of set"
+  local out
+  out=$(bash "$CEO_CLI" playbook list 2>/dev/null)
+  assert_contains "$out" "owner: (none)" "a corrupt-scope row must still render, treated as single"
+}
+
 test_enable_does_not_clobber_malformed_enabled() {
   printf '%s' '{bad json' > "$ENABLED_FILE"
   local rc=0

--- a/scripts/ceo-list.test.sh
+++ b/scripts/ceo-list.test.sh
@@ -167,4 +167,20 @@ test_renderer_single_unowned_row() {
   assert_contains "$out" "owner: (none)" "an unowned single playbook must render (none)"
 }
 
+test_enable_does_not_clobber_malformed_enabled() {
+  printf '%s' '{bad json' > "$ENABLED_FILE"
+  local rc=0
+  bash "$CEO_CLI" playbook enable git-monitor >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "enable must exit non-zero when jq cannot parse enabled.json"
+  assert_eq "$(cat "$ENABLED_FILE")" '{bad json' "malformed enabled.json must be preserved, not clobbered"
+}
+
+test_assign_does_not_clobber_malformed_swarm() {
+  printf '%s' '{bad json' > "$SWARM_FILE"
+  local rc=0
+  bash "$CEO_CLI" playbook assign value-tracker mac >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "assign must exit non-zero when swarm.json cannot be parsed"
+  assert_eq "$(cat "$SWARM_FILE")" '{bad json' "malformed swarm.json must be preserved, not clobbered"
+}
+
 run_tests

--- a/scripts/ceo-playbook-status.test.sh
+++ b/scripts/ceo-playbook-status.test.sh
@@ -27,6 +27,10 @@ setup() {
   : > "$CEO_DIR/TRAINING.md"
   : > "$CEO_DIR/inbox.md"
 
+  # The native crontab install path is retired (D1) — scan never touches the
+  # crontab now. This stub records any invocation to $HOME/.fake-crontab so the
+  # tests can assert scan does NOT install, and the status enum gates *registry
+  # inclusion* (ceo-schedulerd reads the registry) rather than cron lines.
   mkdir -p "$TEST_HOME/.bun/bin"
   cat > "$TEST_HOME/.bun/bin/crontab" << 'STUB'
 #!/bin/bash
@@ -40,6 +44,13 @@ STUB
   : > "$HOME/.fake-crontab"
 
   export PATH="$TEST_HOME/.bun/bin:$PATH"
+}
+
+# A playbook's effective schedule status in the registry: "active" means the
+# daemon will dispatch it; anything else (draft/disabled/absent) means it won't.
+_registry_status() {
+  jq -r --arg n "$1" '.playbooks[] | select(.name==$n) | .status // "none"' \
+    "$REGISTRY_FILE" 2>/dev/null
 }
 
 teardown() {
@@ -65,48 +76,42 @@ status: $status
 PB
 }
 
-test_status_active_installs_cron_line() {
+test_status_active_recorded_active_in_registry() {
   _write_playbook "p-active" "active"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  assert_eq "$(_registry_status p-active)" "active" \
+    "active playbook must be recorded active in the registry (daemon schedules it)"
   local crontab
   crontab=$(cat "$HOME/.fake-crontab")
-  assert_contains "$crontab" "ceo:p-active" "active playbook must appear in installed crontab"
+  assert_not_contains "$crontab" "ceo:p-active" "scan must NOT install a cron line for an active playbook"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_status_draft_does_not_install_cron_line() {
+test_status_draft_recorded_draft_in_registry() {
   _write_playbook "p-draft" "draft"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local crontab
-  crontab=$(cat "$HOME/.fake-crontab")
-  assert_not_contains "$crontab" "ceo:p-draft" "draft playbook must NOT appear in crontab"
+  assert_eq "$(_registry_status p-draft)" "draft" \
+    "draft playbook must be recorded draft (daemon must not dispatch a non-active status)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_status_disabled_does_not_install_cron_line() {
+test_status_disabled_recorded_disabled_in_registry() {
   _write_playbook "p-disabled" "disabled"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local crontab
-  crontab=$(cat "$HOME/.fake-crontab")
-  assert_not_contains "$crontab" "ceo:p-disabled" "disabled playbook must NOT appear in crontab"
+  assert_eq "$(_registry_status p-disabled)" "disabled" \
+    "disabled playbook must be recorded disabled (daemon must not dispatch it)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_status_disabled_removes_previously_installed_line() {
+test_status_toggle_active_to_disabled_updates_registry() {
   _write_playbook "p-toggle" "active"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local crontab_before
-  crontab_before=$(cat "$HOME/.fake-crontab")
-  assert_contains "$crontab_before" "ceo:p-toggle" "precondition: active install must have placed a line"
+  assert_eq "$(_registry_status p-toggle)" "active" "precondition: active scan records active"
 
   _write_playbook "p-toggle" "disabled"
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local crontab_after
-  crontab_after=$(cat "$HOME/.fake-crontab")
-  assert_not_contains "$crontab_after" "ceo:p-toggle" "disabled rescan must drop the previously-installed line"
-  local registry_status
-  registry_status=$(jq -r '.playbooks[] | select(.name=="p-toggle") | .status' "$REGISTRY_FILE" 2>/dev/null)
-  assert_eq "$registry_status" "disabled" "registry must reflect the new disabled status"
+  assert_eq "$(_registry_status p-toggle)" "disabled" \
+    "disabled rescan must flip the registry status so the daemon stops dispatching it"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -159,9 +164,6 @@ tier: read
 # noop
 PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local crontab
-  crontab=$(cat "$HOME/.fake-crontab")
-  assert_not_contains "$crontab" "ceo:p-empty" "missing status must not install cron line"
   local registry_has
   registry_has=$(jq -r '[.playbooks[] | select(.name=="p-empty")] | length' "$REGISTRY_FILE" 2>/dev/null)
   assert_eq "$registry_has" "1" "missing-status playbook must still land in registry (back-compat)"
@@ -188,47 +190,12 @@ test_dry_run_does_not_write_registry() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_dry_run_prints_would_install_block() {
+test_dry_run_reports_summary_without_writing() {
   _write_playbook "p-dry-print" "active"
   local output
   output=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1)
-  assert_contains "$output" "DRY-RUN" "dry-run output must declare itself"
-  assert_contains "$output" "ceo:p-dry-print" "dry-run output must show the would-be cron line"
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-}
-
-test_dry_run_output_matches_installed_block() {
-  # Locks in the invariant that the dry-run preview emits the SAME cron
-  # block the real install would write — protects against drift between
-  # _playbook_print_cron_block and _playbook_update_crontab.
-  _write_playbook "p-parity-a" "active"
-  _write_playbook "p-parity-b" "draft"
-  _write_playbook "p-parity-c" "active"
-  # Use unique schedules so collision detection on the real path passes.
-  sed -i.bak 's|0 9 \* \* \*|0 11 * * *|' "$CEO_DIR/playbooks/p-parity-c.md"
-  rm -f "$CEO_DIR/playbooks/p-parity-c.md.bak"
-
-  local dry_out
-  dry_out=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1 \
-    | awk '/CEO Agent START/,/CEO Agent END/')
-
-  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  local installed
-  installed=$(awk '/CEO Agent START/,/CEO Agent END/' "$HOME/.fake-crontab")
-
-  assert_eq "$dry_out" "$installed" "dry-run cron block must byte-equal the installed cron block"
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-}
-
-test_dry_run_omits_draft_and_disabled() {
-  _write_playbook "p-dry-a" "active"
-  _write_playbook "p-dry-d" "draft"
-  _write_playbook "p-dry-x" "disabled"
-  local output
-  output=$(bash "$CEO_CLI" playbook scan --dry-run 2>&1)
-  assert_contains "$output" "ceo:p-dry-a" "dry-run must include active playbooks"
-  assert_not_contains "$output" "ceo:p-dry-d" "dry-run must omit draft playbooks from the cron block"
-  assert_not_contains "$output" "ceo:p-dry-x" "dry-run must omit disabled playbooks from the cron block"
+  assert_contains "$output" "NOT written" "dry-run must declare that nothing was written"
+  assert_contains "$output" "Registry:" "dry-run must report the registry summary"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -261,7 +228,7 @@ test_doctor_surfaces_drafts() {
   output=$(bash "$CEO_CLI" doctor 2>&1 || true)
   # Anchor on the section header literal so a regression that deletes the
   # Drafts block but leaves the standard playbook enumeration intact fails.
-  assert_contains "$output" "Drafts (not installed in cron" "doctor must emit the Drafts section header"
+  assert_contains "$output" "Drafts (not scheduled by the daemon" "doctor must emit the Drafts section header"
   assert_contains "$output" "p-doctor-wip" "doctor must list the draft playbook by name"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }

--- a/scripts/ceo-playbook-status.test.sh
+++ b/scripts/ceo-playbook-status.test.sh
@@ -16,8 +16,11 @@ setup() {
   export HOME="$TEST_HOME"
   export CEO_VAULT="$TEST_HOME/vault"
   export CEO_DIR="$CEO_VAULT/CEO"
+  # The generated registry is host-local now ($HOME/.ceo/registry.json), not in
+  # the synced vault — `ceo playbook scan` writes it there.
+  REGISTRY_FILE="$HOME/.ceo/registry.json"
 
-  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$TEST_HOME/empty-repo-playbooks"
+  mkdir -p "$CEO_DIR/playbooks" "$CEO_DIR/log" "$TEST_HOME/empty-repo-playbooks" "$HOME/.ceo"
   export CEO_REPO_PLAYBOOK_DIR="$TEST_HOME/empty-repo-playbooks"
   : > "$CEO_DIR/AGENTS.md"
   : > "$CEO_DIR/IDENTITY.md"
@@ -102,7 +105,7 @@ test_status_disabled_removes_previously_installed_line() {
   crontab_after=$(cat "$HOME/.fake-crontab")
   assert_not_contains "$crontab_after" "ceo:p-toggle" "disabled rescan must drop the previously-installed line"
   local registry_status
-  registry_status=$(jq -r '.playbooks[] | select(.name=="p-toggle") | .status' "$CEO_DIR/registry.json" 2>/dev/null)
+  registry_status=$(jq -r '.playbooks[] | select(.name=="p-toggle") | .status' "$REGISTRY_FILE" 2>/dev/null)
   assert_eq "$registry_status" "disabled" "registry must reflect the new disabled status"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -115,7 +118,7 @@ test_status_invalid_rejects_at_parse() {
   assert_contains "$output" "p-typo" "scan must mention the offending playbook"
   assert_contains "$output" "scrpt" "scan must echo the rejected value"
   local registry_has
-  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-typo")] | length' "$CEO_DIR/registry.json" 2>/dev/null)
+  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-typo")] | length' "$REGISTRY_FILE" 2>/dev/null)
   assert_eq "$registry_has" "0" "rejected playbook must not land in the registry"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -160,7 +163,7 @@ PB
   crontab=$(cat "$HOME/.fake-crontab")
   assert_not_contains "$crontab" "ceo:p-empty" "missing status must not install cron line"
   local registry_has
-  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-empty")] | length' "$CEO_DIR/registry.json" 2>/dev/null)
+  registry_has=$(jq -r '[.playbooks[] | select(.name=="p-empty")] | length' "$REGISTRY_FILE" 2>/dev/null)
   assert_eq "$registry_has" "1" "missing-status playbook must still land in registry (back-compat)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -177,10 +180,10 @@ test_dry_run_does_not_modify_crontab() {
 
 test_dry_run_does_not_write_registry() {
   _write_playbook "p-dry-reg" "active"
-  [ -f "$CEO_DIR/registry.json" ] && rm -f "$CEO_DIR/registry.json"
+  [ -f "$REGISTRY_FILE" ] && rm -f "$REGISTRY_FILE"
   bash "$CEO_CLI" playbook scan --dry-run >/dev/null 2>&1
   local exists="missing"
-  [ -f "$CEO_DIR/registry.json" ] && exists="present"
+  [ -f "$REGISTRY_FILE" ] && exists="present"
   assert_eq "$exists" "missing" "scan --dry-run must not create registry.json"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }

--- a/scripts/ceo-remove-crontab-block.test.sh
+++ b/scripts/ceo-remove-crontab-block.test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Tests for _remove_crontab_block in scripts/ceo.
+#
+# Verifies the migration-leftover removal strips the CEO-installed block and any
+# stray CEO cron lines (anchored on the `# ceo:<name>` marker the installer
+# emits) while PRESERVING unrelated user lines that merely mention ceo-cron.sh.
+# Regression guard for the unanchored `grep -v ceo-cron.sh` that clobbered any
+# user line containing that substring (anchored-regex-for-identifier-allowlists).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+_load_ceo_helpers() {
+  export CEO_LIB_ONLY=1
+  set +u
+  # shellcheck disable=SC1090,SC1091
+  source "$CEO_CLI"
+  set +e +u
+  unset CEO_LIB_ONLY
+}
+
+# crontab stub: `-l` prints $CRONTAB_BODY; a write (stdin/`-`) records the
+# installed payload to $INSTALLED so a test can assert the resulting crontab.
+# Any other argv shape exits non-zero per stub-cli-argv-validation.
+_write_crontab_stub() {
+  export CEO_CRONTAB_BIN="$TMP/stub-crontab"
+  export INSTALLED="$TMP/installed.txt"
+  : > "$INSTALLED"
+  cat > "$CEO_CRONTAB_BIN" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -l) printf '%s\n' "$CRONTAB_BODY" ;;
+  -|"") cat > "$INSTALLED" ;;
+  *) echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+}
+
+setup() {
+  TMP=$(mktemp -d)
+  export CEO_SCHEDULER=crontab
+  _write_crontab_stub
+  _load_ceo_helpers
+}
+
+teardown() {
+  rm -rf "$TMP"
+  unset CRONTAB_BODY
+}
+
+test_removes_block_and_preserves_user_line_mentioning_ceo_cron() {
+  export CRONTAB_BODY="# my own wrapper around ceo-cron.sh — keep this
+0 3 * * * /home/me/run-backup.sh
+# CEO Agent START
+*/5 * * * * /p/ceo-cron.sh morning  # ceo:morning
+0 9 * * * /p/ceo-cron.sh standup  # ceo:standup
+# CEO Agent END"
+
+  _remove_crontab_block
+
+  local result; result=$(cat "$INSTALLED")
+  assert_contains "$result" "wrapper around ceo-cron.sh" \
+    "a user comment mentioning ceo-cron.sh must be PRESERVED, not clobbered"
+  assert_contains "$result" "/home/me/run-backup.sh" \
+    "the user's own cron line must be preserved"
+  assert_not_contains "$result" "# ceo:morning" \
+    "the CEO-installed morning line must be removed"
+  assert_not_contains "$result" "CEO Agent START" \
+    "the CEO block markers must be removed"
+}
+
+# A stray CEO line outside the START/END block (carrying the `# ceo:` marker) is
+# still a CEO-installed line and must be stripped.
+test_removes_stray_ceo_line_outside_block() {
+  export CRONTAB_BODY="0 0 * * * /usr/bin/true
+*/10 * * * * /p/ceo-cron.sh orphan  # ceo:orphan"
+
+  _remove_crontab_block
+
+  local result; result=$(cat "$INSTALLED")
+  assert_not_contains "$result" "# ceo:orphan" \
+    "a stray CEO-installed line (with the # ceo: marker) must be removed"
+  assert_contains "$result" "/usr/bin/true" \
+    "the unrelated user line must be preserved"
+}
+
+# No CEO content at all → no install attempt (no-op success).
+test_noop_when_no_ceo_content() {
+  export CRONTAB_BODY="0 0 * * * /usr/bin/true
+0 6 * * * /home/me/ceo-cron.sh-lookalike.sh run"
+
+  _remove_crontab_block
+  local rc=$?
+
+  assert_eq "$rc" "0" "a crontab with no CEO block is a no-op success"
+  # No write should have happened (INSTALLED stays empty).
+  local result; result=$(cat "$INSTALLED")
+  assert_eq "$result" "" "no crontab write when there is no CEO content to remove"
+}
+
+run_tests

--- a/scripts/ceo-scan.test.sh
+++ b/scripts/ceo-scan.test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Tests for `ceo playbook scan` (cmd_playbook_scan):
+#   - the generated registry.json is written HOST-LOCAL ($HOME/.ceo/registry.json),
+#     NOT into the synced vault ($CEO_VAULT/CEO/registry.json)
+#   - per-playbook `scope` frontmatter: passthrough, safe default (single),
+#     and rejection of an unknown value through the existing skip/fail path
+#
+# Drives cmd_playbook_scan end-to-end against a temp vault + temp HOME, with a
+# stub crontab so no real crontab is touched.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+_load_ceo_helpers() {
+  export CEO_LIB_ONLY=1
+  set +u
+  # shellcheck disable=SC1090,SC1091
+  source "$CEO_CLI"
+  set +e +u
+  unset CEO_LIB_ONLY
+}
+
+# A crontab stub: `-l` prints nothing (empty existing crontab), a write
+# invocation (file arg or stdin) succeeds. Any other argv shape fails non-zero
+# per stub-cli-argv-validation.
+_write_crontab_stub() {
+  export CEO_CRONTAB_BIN="$TMP/stub-crontab"
+  cat > "$CEO_CRONTAB_BIN" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -l) exit 0 ;;
+  -r) exit 0 ;;
+  -|"") cat >/dev/null; exit 0 ;;
+  *)
+    if [ -f "$1" ]; then exit 0; fi
+    echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+}
+
+# Minimal valid frontmatter the scanner accepts. chat trigger + empty schedule
+# keeps the crontab path a no-op (no collision detection on these entries).
+_write_playbook() {
+  local file="$1" name="$2" scope_line="$3"
+  {
+    echo "---"
+    echo "name: $name"
+    echo "description: $name desc"
+    echo "trigger: chat"
+    echo "schedule: \"\""
+    echo "status: active"
+    echo "runner: claude"
+    [ -n "$scope_line" ] && echo "$scope_line"
+    echo "---"
+    echo ""
+    echo "# $name"
+  } > "$file"
+}
+
+setup() {
+  TMP=$(mktemp -d)
+  export HOME="$TMP/home"
+  mkdir -p "$HOME"
+
+  export CEO_VAULT="$TMP/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  mkdir -p "$CEO_DIR/playbooks"
+  # ceo_validate_vault requires CEO/inbox.md to exist.
+  : > "$CEO_DIR/inbox.md"
+
+  # No repo playbooks should leak in.
+  export CEO_REPO_PLAYBOOK_DIR="$TMP/no-such-repo-playbooks"
+
+  # Resolve hostname deterministically so the primary-host gate (absent
+  # settings.json → pass) and any host lookups don't depend on the runner.
+  export CEO_HOSTNAME="testhost"
+
+  _write_crontab_stub
+  _write_playbook "$CEO_DIR/playbooks/scope-each.md"   "scope-each"   "scope: each"
+  _write_playbook "$CEO_DIR/playbooks/scope-absent.md" "scope-absent" ""
+  _write_playbook "$CEO_DIR/playbooks/scope-bogus.md"  "scope-bogus"  "scope: bogus"
+}
+
+teardown() {
+  rm -rf "$TMP"
+  unset HOME CEO_VAULT CEO_DIR CEO_REPO_PLAYBOOK_DIR CEO_HOSTNAME CEO_CRONTAB_BIN
+}
+
+_run_scan() {
+  # Capture combined output; cmd_playbook_scan returns non-zero when an entry
+  # is skipped for an invalid enum (same path as unknown status).
+  SCAN_OUT=$(cmd_playbook_scan 2>&1)
+  SCAN_RC=$?
+}
+
+test_registry_written_host_local_not_vault() {
+  _run_scan
+  assert_file_exists "$HOME/.ceo/registry.json" "registry must be written host-local under \$HOME/.ceo"
+  assert_no_match "$(ls "$CEO_DIR" 2>/dev/null)" "registry.json" \
+    "registry.json must NOT be written into the synced vault CEO dir"
+}
+
+test_scope_each_passthrough() {
+  _run_scan
+  local scope
+  scope=$(jq -r '.playbooks[] | select(.name=="scope-each") | .scope' "$HOME/.ceo/registry.json")
+  assert_eq "$scope" "each" "scope: each must pass through to the registry"
+}
+
+test_scope_absent_defaults_to_single() {
+  _run_scan
+  local scope
+  scope=$(jq -r '.playbooks[] | select(.name=="scope-absent") | .scope' "$HOME/.ceo/registry.json")
+  assert_eq "$scope" "single" "absent scope must default to the safe value 'single'"
+}
+
+test_unknown_scope_skipped_diagnostic_and_failure_exit() {
+  _run_scan
+  # Absent from the registry.
+  local present
+  present=$(jq -r '[.playbooks[] | select(.name=="scope-bogus")] | length' "$HOME/.ceo/registry.json")
+  assert_eq "$present" "0" "playbook with unknown scope must be absent from the registry"
+  # Diagnostic mentions scope.
+  assert_contains "$SCAN_OUT" "scope" "skip diagnostic must mention scope"
+  assert_contains "$SCAN_OUT" "scope-bogus" "skip diagnostic must name the offending playbook"
+  # Counts toward the failure exit, same observable signal as unknown status.
+  assert_eq "$SCAN_RC" "1" "unknown scope must produce a non-zero scan exit (failure observability)"
+}
+
+_load_ceo_helpers
+
+run_tests

--- a/scripts/ceo-scan.test.sh
+++ b/scripts/ceo-scan.test.sh
@@ -26,21 +26,50 @@ _load_ceo_helpers() {
 
 # A crontab stub: `-l` prints nothing (empty existing crontab), a write
 # invocation (file arg or stdin) succeeds. Any other argv shape fails non-zero
-# per stub-cli-argv-validation.
+# per stub-cli-argv-validation. Every invocation is recorded (argv + stdin) to
+# $CRONTAB_LOG so a test can assert whether scan ever tried to install a block.
 _write_crontab_stub() {
   export CEO_CRONTAB_BIN="$TMP/stub-crontab"
+  export CRONTAB_LOG="$TMP/crontab-invocations.log"
+  : > "$CRONTAB_LOG"
   cat > "$CEO_CRONTAB_BIN" <<'STUB'
 #!/bin/bash
+{
+  printf 'argv:%s\n' "$*"
+  case "$1" in
+    -|"") sed 's/^/stdin:/' ;;
+    *) [ -f "$1" ] && sed 's/^/file:/' < "$1" ;;
+  esac
+} >> "$CRONTAB_LOG"
 case "$1" in
   -l) exit 0 ;;
   -r) exit 0 ;;
-  -|"") cat >/dev/null; exit 0 ;;
+  -|"") exit 0 ;;
   *)
     if [ -f "$1" ]; then exit 0; fi
     echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
 esac
 STUB
   chmod +x "$CEO_CRONTAB_BIN"
+}
+
+# A cron-triggered playbook with a concrete schedule. Under the retired Phase-1
+# behavior, scan would emit a `# CEO Agent` block containing this line and write
+# it to the crontab. The daemon now owns scheduling, so scan must NOT install.
+_write_cron_playbook() {
+  local file="$1" name="$2" schedule="$3"
+  {
+    echo "---"
+    echo "name: $name"
+    echo "description: $name desc"
+    echo "trigger: cron"
+    echo "schedule: \"$schedule\""
+    echo "status: active"
+    echo "runner: claude"
+    echo "---"
+    echo ""
+    echo "# $name"
+  } > "$file"
 }
 
 # Minimal valid frontmatter the scanner accepts. chat trigger + empty schedule
@@ -84,6 +113,7 @@ setup() {
   _write_playbook "$CEO_DIR/playbooks/scope-each.md"   "scope-each"   "scope: each"
   _write_playbook "$CEO_DIR/playbooks/scope-absent.md" "scope-absent" ""
   _write_playbook "$CEO_DIR/playbooks/scope-bogus.md"  "scope-bogus"  "scope: bogus"
+  _write_cron_playbook "$CEO_DIR/playbooks/cron-job.md" "cron-job" "0 9 * * *"
 }
 
 teardown() {
@@ -130,6 +160,28 @@ test_unknown_scope_skipped_diagnostic_and_failure_exit() {
   assert_contains "$SCAN_OUT" "scope-bogus" "skip diagnostic must name the offending playbook"
   # Counts toward the failure exit, same observable signal as unknown status.
   assert_eq "$SCAN_RC" "1" "unknown scope must produce a non-zero scan exit (failure observability)"
+}
+
+test_scan_does_not_install_crontab_block() {
+  _run_scan
+  # The cron playbook is in the registry — scan parsed it.
+  local present
+  present=$(jq -r '[.playbooks[] | select(.name=="cron-job")] | length' "$HOME/.ceo/registry.json")
+  assert_eq "$present" "1" "precondition: cron playbook must be parsed into the registry"
+  # …but scan must NOT have written a `# CEO Agent` block to the crontab. The
+  # ceo-schedulerd daemon owns scheduling now; scan only writes the registry.
+  local log
+  log=$(cat "$CRONTAB_LOG" 2>/dev/null || true)
+  assert_not_contains "$log" "# CEO Agent" \
+    "scan must NOT install a # CEO Agent crontab block (daemon is the sole scheduler)"
+  assert_not_contains "$log" "ceo:cron-job" \
+    "scan must NOT write any playbook cron line to the crontab"
+}
+
+test_scan_output_omits_crontab_install_message() {
+  _run_scan
+  assert_not_contains "$SCAN_OUT" "entries installed" \
+    "scan must not claim to install crontab entries"
 }
 
 _load_ceo_helpers

--- a/scripts/ceo-schedule.test.sh
+++ b/scripts/ceo-schedule.test.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-# Tests for the schedule override + collision detection layer added in 0.9.0.
+# Tests for the schedule override layer.
 # Exercises:
 #   - _playbook_apply_schedule_overrides (frontmatter default vs schedules.json override)
-#   - collision detection in _playbook_update_crontab
 #   - _validate_cron_expr
 #   - _schedule_source resolution
 # Does NOT exercise the interactive prompt branch of _schedule_one (read -r).
+#
+# The native crontab install path was retired in D1 (ceo-schedulerd is the sole
+# scheduler), so the former _playbook_update_crontab install/collision tests are
+# gone — that function no longer exists. Collision *detection* now surfaces only
+# in the `ceo schedule` list view (_schedule_list), not at a crontab write.
 
 set -uo pipefail
 
@@ -110,58 +114,6 @@ test_validate_cron_expr_rejects_bad_forms() {
   done
 }
 
-test_collision_detection_blocks_crontab_write() {
-  # Default REGISTRY has morning-scan and morning-brief at the same schedule.
-  # _playbook_update_crontab should refuse to write.
-  # shellcheck disable=SC2034
-  CEO_CRON="/tmp/fake-cron.sh"
-  out=$(_playbook_update_crontab "$REGISTRY" 2>&1)
-  rc=$?
-  assert_eq "$rc" "1" "collision must produce non-zero rc"
-  assert_contains "$out" "collision" "must mention collision in error"
-  assert_contains "$out" "morning-scan" "must name first colliding playbook"
-  assert_contains "$out" "morning-brief" "must name second colliding playbook"
-}
-
-test_collision_resolved_after_override() {
-  # shellcheck disable=SC2034
-  CEO_CRON="/tmp/fake-cron.sh"
-  echo '{"morning-scan": "50 8 * * 1-5"}' > "$CEO_DIR/schedules.json"
-  merged=$(_playbook_apply_schedule_overrides "$REGISTRY")
-  # Use a fake crontab binary via CEO_CRONTAB_BIN so we exercise the real
-  # write path. Function-overrides in subshells aren't reliable (functions
-  # don't auto-export across $() boundaries).
-  local capture="$TMP/crontab-capture.out"
-  cat > "$TMP/fake-crontab" <<EOF
-#!/bin/bash
-cat > "$capture"
-EOF
-  chmod +x "$TMP/fake-crontab"
-  out=$(CEO_CRONTAB_BIN="$TMP/fake-crontab" _playbook_update_crontab "$merged" 2>&1)
-  rc=$?
-  assert_eq "$rc" "0" "no collision → rc 0"
-  assert_no_match "$out" "collision" "no collision message after override"
-  assert_contains "$out" "Crontab:" "must reach 'installed' message"
-  assert_contains "$(cat "$capture" 2>/dev/null)" "ceo:morning-scan" "fake crontab received the install"
-}
-
-test_crontab_install_failure_returns_nonzero() {
-  # Fake crontab that simulates a real failure (locked spool, quota, etc).
-  cat > "$TMP/failing-crontab" <<'EOF'
-#!/bin/bash
-echo "crontab: install failed (simulated)" >&2
-exit 1
-EOF
-  chmod +x "$TMP/failing-crontab"
-  echo '{"morning-scan": "50 8 * * 1-5"}' > "$CEO_DIR/schedules.json"
-  merged=$(_playbook_apply_schedule_overrides "$REGISTRY")
-  out=$(CEO_CRONTAB_BIN="$TMP/failing-crontab" _playbook_update_crontab "$merged" 2>&1)
-  rc=$?
-  assert_eq "$rc" "1" "crontab failure must propagate as rc=1"
-  assert_contains "$out" "crontab install failed" "must surface failure to caller"
-  assert_no_match "$out" "Crontab:.*installed" "must NOT print success message on failure"
-}
-
 test_validate_cron_inside_schedule_one_blocks_bad_input() {
   # Build a real registry so _schedule_one sees a known playbook.
   echo "$REGISTRY" | jq '.' > "$CEO_DIR/registry.json"
@@ -175,6 +127,16 @@ test_validate_cron_inside_schedule_one_blocks_bad_input() {
     written=$(jq -r '."morning-scan" // ""' "$CEO_DIR/schedules.json")
     assert_eq "$written" "" "schedules.json must not contain rejected value"
   fi
+}
+
+test_schedule_list_flags_collisions() {
+  # Default REGISTRY has morning-scan and morning-brief at the same schedule.
+  # The list view (the surviving collision surface after the crontab install
+  # path was retired) must mark them as colliding.
+  echo "$REGISTRY" | jq '.' > "$CEO_DIR/registry.json"
+  out=$(_schedule_list "$CEO_DIR/registry.json" 2>&1)
+  assert_contains "$out" "collides" "list view must flag the duplicate schedule as a collision"
+  assert_contains "$out" "morning-scan" "list view must include the colliding playbook"
 }
 
 test_schedule_source_returns_frontmatter_when_no_overrides() {

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -5,7 +5,7 @@
 #
 # As of #144 (Phase 2 of #136) the macOS per-playbook launchd backend is
 # retired: on macOS the Bun daemon `ceo-schedulerd` (lib/scheduler/) owns cron
-# matching and reads CEO/registry.json directly, kept alive by ONE launchd agent
+# matching and reads the host-local $HOME/.ceo/registry.json directly, kept alive by ONE launchd agent
 # (com.ceo.schedulerd — install template at lib/scheduler/deploy/). The OS no
 # longer holds per-playbook schedules on macOS. Linux/WSL still uses crontab.
 #
@@ -95,7 +95,7 @@ ceo_scheduler_list() {
       ;;
     daemon)
       # The daemon holds no per-playbook OS entries — scheduling lives in
-      # registry.json, which it reads directly. Nothing to list.
+      # the host-local $HOME/.ceo/registry.json, which it reads directly. Nothing to list.
       return 0
       ;;
     *)

--- a/scripts/ceo-scheduler.sh
+++ b/scripts/ceo-scheduler.sh
@@ -155,25 +155,21 @@ ceo_scheduler_legacy_launchd_plists() {
   done
 }
 
-# Linux sibling of ceo_scheduler_legacy_launchd_plists (#159). The Phase-1
-# per-playbook CEO crontab block and the Phase-1.5 ceo-schedulerd systemd
-# daemon each dispatch every playbook independently; running both fires
-# everything twice. Detect the conflict by combining two signals:
-#   - the CEO crontab block is live  → ceo_scheduler_list emits ceo-cron.sh lines
-#   - the systemd user unit is active → `systemctl --user is-active ceo-schedulerd`
-# Prints the conflicting cron-trigger count (a non-empty marker for the caller)
-# when BOTH hold; prints nothing (clean) otherwise — including when systemctl is
-# absent (macOS) or the unit is inactive. `ceo doctor` warns on a non-empty
-# result so the operator removes the crontab block once the daemon is adopted.
-#   CEO_SYSTEMCTL_BIN — systemctl binary (default "systemctl"); test override.
+# Linux sibling of ceo_scheduler_legacy_launchd_plists (#159). The native
+# crontab install path is retired (D1): ceo-schedulerd reads the registry and is
+# the sole scheduler, so a CEO crontab block is ALWAYS a migration leftover —
+# never a sanctioned state. It is detected regardless of whether the daemon is
+# already running: gating on an active daemon was a blind spot, since a host
+# part-way through migration (block removed last, daemon not yet up) carries the
+# leftover with no daemon to "conflict" with. A CEO cron line always carries the
+# trailing `# ceo:<name>` marker ceo_scheduler_list emits; count those (anchored
+# per anchored-regex-for-identifier-allowlists) rather than any bare ceo-cron.sh
+# mention so a user comment isn't miscounted. Prints the leftover cron-trigger
+# count (non-empty marker) when any exist; prints nothing (clean) otherwise.
+# `ceo doctor` warns on a non-empty result so the operator removes the block.
 ceo_scheduler_crontab_daemon_conflict() {
-  local systemctl_bin="${CEO_SYSTEMCTL_BIN:-systemctl}"
-  command -v "$systemctl_bin" >/dev/null 2>&1 || return 0
-  local _state
-  _state="$("$systemctl_bin" --user is-active ceo-schedulerd 2>/dev/null || true)"
-  [ "$_state" = "active" ] || return 0
   local _count
-  _count="$(ceo_scheduler_list 2>/dev/null | grep -c 'ceo-cron\.sh' || true)"
+  _count="$(ceo_scheduler_list 2>/dev/null | grep -cE 'ceo-cron\.sh.*#[[:space:]]*ceo:[^[:space:]]+[[:space:]]*$' || true)"
   [ "${_count:-0}" -gt 0 ] || return 0
   printf '%s\n' "$_count"
 }

--- a/scripts/ceo-scheduler.test.sh
+++ b/scripts/ceo-scheduler.test.sh
@@ -214,25 +214,26 @@ STUB
   chmod +x "$CEO_CRONTAB_BIN"
 }
 
-test_crontab_daemon_conflict_when_block_and_daemon_active() {
+# The native crontab install is retired (D1): a CEO block is ALWAYS a migration
+# leftover, flagged regardless of daemon/systemctl state.
+test_crontab_leftover_flagged_when_block_present() {
   export CEO_SCHEDULER=crontab
   _stub_crontab_with_ceo_block
-  _stub_systemctl active
   local out
   out=$(ceo_scheduler_crontab_daemon_conflict)
-  assert_eq "$out" "1" "must report the conflicting cron-trigger count when both schedulers run"
+  assert_eq "$out" "1" "must report the leftover cron-trigger count when a CEO block is present"
 }
 
-test_no_conflict_when_daemon_inactive() {
+test_crontab_leftover_flagged_even_when_daemon_inactive() {
   export CEO_SCHEDULER=crontab
   _stub_crontab_with_ceo_block
   _stub_systemctl inactive
   local out
   out=$(ceo_scheduler_crontab_daemon_conflict)
-  assert_eq "$out" "" "crontab block alone (daemon inactive) is not a conflict"
+  assert_eq "$out" "1" "a CEO crontab block is a leftover even with the daemon inactive (the blind-spot fix)"
 }
 
-test_no_conflict_when_no_ceo_crontab_block() {
+test_no_leftover_when_no_ceo_crontab_block() {
   export CEO_SCHEDULER=crontab
   export CEO_CRONTAB_BIN="$TEST_HOME/crontab-empty"
   cat > "$CEO_CRONTAB_BIN" <<'STUB'
@@ -243,20 +244,27 @@ case "$1" in
 esac
 STUB
   chmod +x "$CEO_CRONTAB_BIN"
-  _stub_systemctl active
   local out
   out=$(ceo_scheduler_crontab_daemon_conflict)
-  assert_eq "$out" "" "active daemon with no CEO crontab entries is not a conflict"
+  assert_eq "$out" "" "no CEO crontab entries is not a leftover"
 }
 
-test_no_conflict_when_systemctl_absent() {
+# A user cron line that merely MENTIONS ceo-cron.sh (no `# ceo:` install marker)
+# is not a CEO-installed line and must not be counted as a leftover.
+test_no_leftover_for_user_line_mentioning_ceo_cron() {
   export CEO_SCHEDULER=crontab
-  _stub_crontab_with_ceo_block
-  export CEO_SYSTEMCTL_BIN="$TEST_HOME/nonexistent-systemctl"
-  local out rc=0
-  out=$(ceo_scheduler_crontab_daemon_conflict) || rc=$?
-  assert_eq "$rc" "0" "absent systemctl (e.g. macOS) is not an error"
-  assert_eq "$out" "" "absent systemctl yields no conflict"
+  export CEO_CRONTAB_BIN="$TEST_HOME/crontab-user-mention"
+  cat > "$CEO_CRONTAB_BIN" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -l) printf '%s\n' "# my own wrapper around ceo-cron.sh, do not touch" "0 3 * * * /home/me/run-ceo-cron.sh backup" ;;
+  *) echo "stub-crontab: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$CEO_CRONTAB_BIN"
+  local out
+  out=$(ceo_scheduler_crontab_daemon_conflict)
+  assert_eq "$out" "" "a user line mentioning ceo-cron.sh without the # ceo: marker is not a leftover"
 }
 
 # === Integration: ceo playbook scan end-to-end on the daemon backend ===

--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Self-contained tests for swarm.json bootstrap + host self-registration
+# (task C1). Drives the callable _swarm_bootstrap / _swarm_register_host
+# functions directly against a temp CEO_VAULT so the full `ceo setup` pass
+# (and its many other side effects) is never invoked.
+#
+# Invariant under test: never silently let two machines share a host id.
+# An explicit CEO_HOSTNAME is trusted and registers idempotently; an unset
+# id whose `hostname -s` value already appears in hosts[] is ambiguous and
+# must refuse.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/ceo-config.sh"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  TEST_VAULT=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TEST_VAULT"
+  unset TEST_HOME TEST_VAULT
+}
+
+# Run a snippet with the ceo library loaded (CEO_LIB_ONLY=1 skips dispatch),
+# CEO_VAULT bound to the temp vault, HOME isolated, and an optional PATH
+# prefix carrying stub binaries. $1 = explicit CEO_HOSTNAME (or "" to unset),
+# $2 = extra PATH prefix dir (or ""), $3 = bash snippet.
+_run_swarm() {
+  local host="$1" path_prefix="$2" snippet="$3"
+  local path_env="$PATH"
+  [ -n "$path_prefix" ] && path_env="$path_prefix:$PATH"
+  if [ -n "$host" ]; then
+    env -i HOME="$TEST_HOME" PATH="$path_env" CEO_VAULT="$TEST_VAULT" \
+      CEO_HOSTNAME="$host" bash -c "
+        set -uo pipefail
+        source '$LIB'
+        $snippet
+      "
+  else
+    env -i HOME="$TEST_HOME" PATH="$path_env" CEO_VAULT="$TEST_VAULT" \
+      bash -c "
+        set -uo pipefail
+        source '$LIB'
+        $snippet
+      "
+  fi
+}
+
+# Stub `hostname` per stub-cli-argv-validation: validate argv shape, exit
+# non-zero on anything but the `-s` invocation the production code uses.
+_make_hostname_stub() {
+  local dir="$1" value="$2"
+  mkdir -p "$dir"
+  cat > "$dir/hostname" << STUB
+#!/bin/bash
+case "\$*" in
+  -s) echo "$value" ;;
+  *) echo "hostname stub: unexpected argv: \$*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$dir/hostname"
+}
+
+test_bootstrap_creates_swarm_json_with_first_host() {
+  _run_swarm "ml-1" "" '_swarm_bootstrap && _swarm_register_host'
+  assert_file_exists "$TEST_VAULT/CEO/swarm.json" "bootstrap must create swarm.json"
+  assert_eq "$(jq -r '.schema_version' "$TEST_VAULT/CEO/swarm.json")" "1" "schema_version"
+  assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1"]' "hosts seeded with this host"
+  assert_eq "$(jq -c '.owners' "$TEST_VAULT/CEO/swarm.json")" '{}' "owners empty on fresh bootstrap"
+}
+
+test_register_is_idempotent_for_same_host() {
+  _run_swarm "ml-1" "" '_swarm_bootstrap && _swarm_register_host'
+  _run_swarm "ml-1" "" '_swarm_register_host'
+  assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1"]' "re-register same host must not duplicate"
+}
+
+test_second_host_appends() {
+  _run_swarm "ml-1" "" '_swarm_bootstrap && _swarm_register_host'
+  _run_swarm "mac" "" '_swarm_register_host'
+  assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1","mac"]' "second host appends"
+}
+
+test_existing_swarm_json_not_clobbered() {
+  mkdir -p "$TEST_VAULT/CEO"
+  cat > "$TEST_VAULT/CEO/swarm.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "morning-brief": "ml-1" } }
+JSON
+  _run_swarm "mac" "" '_swarm_bootstrap && _swarm_register_host'
+  assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1","mac"]' "host appended, existing preserved"
+  assert_eq "$(jq -r '.owners["morning-brief"]' "$TEST_VAULT/CEO/swarm.json")" "ml-1" "owners preserved"
+}
+
+test_unset_hostname_collision_refuses() {
+  local stubdir="$TEST_HOME/stubs"
+  _make_hostname_stub "$stubdir" "ml-1"
+  # Seed swarm.json with the value `hostname -s` will return, then register
+  # with CEO_HOSTNAME UNSET → ambiguous → must refuse.
+  mkdir -p "$TEST_VAULT/CEO"
+  cat > "$TEST_VAULT/CEO/swarm.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["ml-1"], "owners": {} }
+JSON
+  local rc=0 out
+  out=$(_run_swarm "" "$stubdir" '_swarm_register_host' 2>&1) || rc=$?
+  assert_eq "$rc" "1" "unset-id collision must refuse with non-zero"
+  assert_contains "$out" "CEO_HOSTNAME" "refusal must instruct setting CEO_HOSTNAME"
+  assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1"]' "hosts unchanged after refusal"
+}
+
+run_tests

--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -226,4 +226,130 @@ JSON
     "valid conflict-only owner key still merges alongside a dropped null"
 }
 
+# --- ceo swarm owners-health: alert when a single-playbook owner host is stale -
+#
+# A scope:single playbook runs ONLY on its owner host (swarm.json owners{}).
+# There is no failover, so an owner going offline silently stops that playbook
+# everywhere. owners-health reads the SYNCED per-host heartbeat
+# (CEO/heartbeats/<host>.json, written by the daemon with {host, ts:ISO8601})
+# and escalates to the inbox ON TRANSITION fresh->stale only — transition-gated
+# via a host-local state file under ~/.ceo (no append-on-every-fire).
+#
+# Tests inject "now" via CEO_SWARM_NOW_EPOCH so staleness is deterministic
+# without stubbing date(1). The stale threshold is hours; heartbeats are written
+# in ISO8601 with whatever offset the producing host used.
+
+_owners_health() {
+  env HOME="$TEST_HOME" CEO_VAULT="$TEST_VAULT" CEO_HOSTNAME="checker" \
+    CEO_SWARM_NOW_EPOCH="${OH_NOW:-}" PATH="$PATH" \
+    bash "$CEO_CLI" swarm owners-health "$@"
+}
+
+# Seed swarm.json with a single-scope owner map.
+_seed_owners() {
+  mkdir -p "$TEST_VAULT/CEO"
+  printf '%s\n' "$1" > "$TEST_VAULT/CEO/swarm.json"
+}
+
+# Write a synced heartbeat for <host> with an ISO8601 ts <secs> before/after
+# a fixed reference epoch. Positive secs = older (in the past).
+_write_heartbeat_iso() {
+  local host="$1" iso="$2"
+  mkdir -p "$TEST_VAULT/CEO/heartbeats"
+  printf '{ "host": "%s", "ts": "%s" }\n' "$host" "$iso" > "$TEST_VAULT/CEO/heartbeats/$host.json"
+}
+
+# A fixed reference "now": 2026-06-13T12:00:00Z == epoch 1781697600.
+OH_REF_EPOCH=1781697600
+
+_iso_at_offset() {
+  # $1 = seconds to subtract from OH_REF_EPOCH, rendered as UTC ISO8601.
+  local secs="$1" epoch=$((OH_REF_EPOCH - $1))
+  date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ
+}
+
+_inbox_count() {
+  local marker="$1" file="$TEST_VAULT/CEO/inbox/checker.md"
+  [ -f "$file" ] || { echo 0; return; }
+  grep -c -F "$marker" "$file"
+}
+
+test_owners_health_fresh_owner_healthy_no_inbox() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 60)"   # 1 minute old → fresh
+  local rc=0 out
+  out=$(OH_NOW="$OH_REF_EPOCH" _owners_health 2>&1) || rc=$?
+  assert_eq "$rc" "0" "fresh owner must exit 0"
+  assert_contains "$out" "ml-1" "must report the owner host"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "0" "fresh owner must NOT write an inbox line"
+}
+
+test_owners_health_stale_owner_transition_alerts() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1", "pb2": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 36000)"  # 10h old → stale
+  local rc=0 out
+  out=$(OH_NOW="$OH_REF_EPOCH" _owners_health 2>&1) || rc=$?
+  assert_eq "$rc" "1" "stale owner must exit non-zero (issues found)"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "fresh->stale must append exactly one inbox line"
+  local line; line=$(grep -F 'owner-staleness:ml-1' "$TEST_VAULT/CEO/inbox/checker.md")
+  assert_contains "$line" "ml-1" "alert names the stale host"
+  assert_contains "$line" "pb1" "alert names an owned playbook"
+  assert_contains "$line" "pb2" "alert names the second owned playbook"
+  assert_eq "$(jq -r '.["ml-1"]' "$TEST_HOME/.ceo/owner-staleness-state.json")" "stale" \
+    "state file records the host as stale"
+}
+
+test_owners_health_no_realert_while_still_stale() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 36000)"
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || true
+  local before; before=$(cat "$TEST_HOME/.ceo/owner-staleness-state.json")
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || true
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "second stale run must NOT re-append"
+  assert_eq "$(cat "$TEST_HOME/.ceo/owner-staleness-state.json")" "$before" \
+    "state unchanged on a no-transition stale run"
+}
+
+test_owners_health_recovery_clears_state() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 36000)"   # stale first
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || true
+  assert_eq "$(jq -r '.["ml-1"] // "absent"' "$TEST_HOME/.ceo/owner-staleness-state.json")" "stale" \
+    "precondition: host flagged stale"
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 60)"      # recovered
+  local rc=0
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "recovered owner must exit 0"
+  assert_eq "$(jq -r '.["ml-1"] // "absent"' "$TEST_HOME/.ceo/owner-staleness-state.json")" "absent" \
+    "recovery clears the host from state"
+}
+
+test_owners_health_missing_heartbeat_is_stale() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  # No heartbeat file written at all → owner has never beat / long gone.
+  local rc=0
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "missing heartbeat must be treated as stale (non-zero)"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "missing heartbeat alerts on transition"
+}
+
+test_owners_health_future_ts_within_skew_is_fresh() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset -120)"  # 2 minutes in the FUTURE
+  local rc=0
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "a slightly-future ts within clock-skew tolerance is fresh, not stale"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "0" "future-within-tolerance must NOT alert"
+}
+
+test_owners_health_far_future_ts_beyond_skew_is_stale() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset -7200)"  # 2 hours in the FUTURE
+  local rc=0
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "a wildly-future ts beyond skew tolerance is untrustworthy → stale"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "beyond-skew future alerts on transition"
+}
+
 run_tests

--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -13,6 +13,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="$SCRIPT_DIR/ceo-config.sh"
+CEO_CLI="$SCRIPT_DIR/ceo"
 
 source "$SCRIPT_DIR/test-harness.sh"
 
@@ -110,6 +111,105 @@ JSON
   assert_eq "$rc" "1" "unset-id collision must refuse with non-zero"
   assert_contains "$out" "CEO_HOSTNAME" "refusal must instruct setting CEO_HOSTNAME"
   assert_eq "$(jq -c '.hosts' "$TEST_VAULT/CEO/swarm.json")" '["ml-1"]' "hosts unchanged after refusal"
+}
+
+# --- ceo swarm doctor: detect/merge Syncthing .sync-conflict copies ---------
+#
+# These drive the full `ceo` binary (dispatcher → cmd_swarm → cmd_swarm_doctor)
+# with CEO_VAULT bound to the temp vault. The conflict copies use the real
+# Syncthing naming `swarm.sync-conflict-YYYYMMDD-HHMMSS-XXXXXXX.json` — the
+# filename's embedded timestamp is the tiebreak key (lexicographically-greatest
+# filename = most recent conflict wins) for owner keys absent from the live file.
+
+_doctor() {
+  env HOME="$TEST_HOME" CEO_VAULT="$TEST_VAULT" CEO_HOSTNAME="ml-1" \
+    PATH="$PATH" bash "$CEO_CLI" swarm doctor "$@"
+}
+
+_seed_live_swarm() {
+  mkdir -p "$TEST_VAULT/CEO"
+  cat > "$TEST_VAULT/CEO/swarm.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }
+JSON
+}
+
+test_doctor_no_conflicts_exits_zero() {
+  _seed_live_swarm
+  local rc=0 out
+  out=$(_doctor 2>&1) || rc=$?
+  assert_eq "$rc" "0" "doctor with no conflicts must exit 0"
+  assert_contains "$out" "no conflicts" "must report no conflicts"
+}
+
+test_doctor_detect_readonly_exits_nonzero_no_mutation() {
+  _seed_live_swarm
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-120000-ABCDEFG.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["mac"], "owners": { "pb1": "mac", "pb2": "mac" } }
+JSON
+  local before; before=$(cat "$TEST_VAULT/CEO/swarm.json")
+  local rc=0 out
+  out=$(_doctor 2>&1) || rc=$?
+  assert_eq "$rc" "1" "doctor (read-only) with a conflict must exit non-zero"
+  assert_contains "$out" "ml-1" "proposed merge must show host union"
+  assert_contains "$out" "mac" "proposed merge must show host union"
+  assert_contains "$out" "pb1" "must call out the contested owner key"
+  assert_eq "$(cat "$TEST_VAULT/CEO/swarm.json")" "$before" "read-only must NOT modify swarm.json"
+  assert_file_exists "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-120000-ABCDEFG.json" \
+    "read-only must NOT delete the conflict copy"
+}
+
+test_doctor_fix_merges_host_union_and_removes_conflict() {
+  _seed_live_swarm
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-120000-ABCDEFG.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["mac"], "owners": { "pb1": "mac", "pb2": "mac" } }
+JSON
+  local rc=0
+  _doctor --fix >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "--fix must exit 0 on success"
+  assert_eq "$(jq -c '.hosts | sort' "$TEST_VAULT/CEO/swarm.json")" '["mac","ml-1"]' \
+    "--fix must produce the host union"
+  assert_eq "$(jq -r '.owners.pb1' "$TEST_VAULT/CEO/swarm.json")" "ml-1" \
+    "live wins for a key present in both"
+  assert_eq "$(jq -r '.owners.pb2' "$TEST_VAULT/CEO/swarm.json")" "mac" \
+    "conflict-only key is brought in"
+  assert_eq "$(ls "$TEST_VAULT/CEO/"swarm.sync-conflict-*.json 2>/dev/null | wc -l | tr -d ' ')" "0" \
+    "--fix must remove conflict copies after a successful write"
+}
+
+test_doctor_owner_tiebreak_greatest_filename_wins() {
+  _seed_live_swarm
+  # pb3 is absent from live; two conflicts disagree. The lexicographically
+  # greatest FILENAME (later timestamp) must win → 130000 over 120000.
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-120000-AAAAAAA.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["mac"], "owners": { "pb3": "mac" } }
+JSON
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-130000-BBBBBBB.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["box"], "owners": { "pb3": "box" } }
+JSON
+  local rc=0
+  _doctor --fix >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "--fix must exit 0"
+  assert_eq "$(jq -r '.owners.pb3' "$TEST_VAULT/CEO/swarm.json")" "box" \
+    "live-absent contested key: greatest conflict filename wins"
+  assert_eq "$(jq -r '.owners.pb1' "$TEST_VAULT/CEO/swarm.json")" "ml-1" \
+    "live still wins for keys it owns"
+}
+
+test_doctor_tolerates_malformed_conflict_copy() {
+  _seed_live_swarm
+  printf '%s\n' '{bad json' > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-140000-CCCCCCC.json"
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-120000-DDDDDDD.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["mac"], "owners": { "pb2": "mac" } }
+JSON
+  local rc=0 out
+  out=$(_doctor --fix 2>&1) || rc=$?
+  assert_eq "$rc" "0" "doctor must not crash on a malformed conflict copy"
+  assert_contains "$out" "swarm.sync-conflict-20260613-140000-CCCCCCC.json" \
+    "must name the skipped malformed file in a diagnostic"
+  assert_eq "$(jq -r '.owners.pb2' "$TEST_VAULT/CEO/swarm.json")" "mac" \
+    "valid conflict still processed despite a malformed sibling"
+  assert_eq "$(jq -c '.hosts | sort' "$TEST_VAULT/CEO/swarm.json")" '["mac","ml-1"]' \
+    "malformed file contributes no hosts and does not win"
 }
 
 run_tests

--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -352,4 +352,49 @@ test_owners_health_far_future_ts_beyond_skew_is_stale() {
   assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "beyond-skew future alerts on transition"
 }
 
+# A recent heartbeat in the REAL daemon (B4) shape — JS new Date().toISOString()
+# always emits fractional millis + "Z" (e.g. 2026-06-14T12:34:56.789Z). On a
+# BSD/macOS checker host the parser must accept it; before the parser fix the
+# fractional ".789" failed `date -j -f %S%z`, routing a healthy owner to the
+# stale path → false outage alert.
+test_owners_health_fractional_second_heartbeat_is_fresh() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  local epoch=$((OH_REF_EPOCH - 60))   # 1 minute old → fresh
+  local base
+  base=$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%S 2>/dev/null \
+    || date -u -r "$epoch" +%Y-%m-%dT%H:%M:%S)
+  _write_heartbeat_iso "ml-1" "${base}.789Z"   # real B4 fractional-millis shape
+  local rc=0 out
+  out=$(OH_NOW="$OH_REF_EPOCH" _owners_health 2>&1) || rc=$?
+  assert_eq "$rc" "0" "a recent fractional-second (B4) heartbeat must parse → fresh, exit 0"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "0" \
+    "recent fractional-second heartbeat must NOT alert (no parse-failure false outage)"
+}
+
+# Genuinely malformed ts must STILL route to stale — the parser fix must not
+# broaden into accepting garbage as a valid epoch.
+test_owners_health_malformed_ts_still_stale() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "not-a-date"
+  local rc=0
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "an unparseable heartbeat ts must be treated as stale (non-zero)"
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "malformed ts alerts on transition"
+}
+
+# Defense-in-depth: the synced inbox marker dedupes even when the host-local
+# state file is wiped (fresh checker host / cleared ~/.ceo). Without the marker
+# grep, the lost transition memory re-appends a duplicate of a still-present
+# synced alert line.
+test_owners_health_marker_dedupe_survives_state_wipe() {
+  _seed_owners '{ "schema_version": 1, "hosts": ["ml-1"], "owners": { "pb1": "ml-1" } }'
+  _write_heartbeat_iso "ml-1" "$(_iso_at_offset 36000)"   # 10h old → stale
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || true
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" "first transition writes one line"
+  rm -f "$TEST_HOME/.ceo/owner-staleness-state.json"      # simulate wiped host-local state
+  OH_NOW="$OH_REF_EPOCH" _owners_health >/dev/null 2>&1 || true
+  assert_eq "$(_inbox_count 'owner-staleness:ml-1')" "1" \
+    "marker grep prevents a duplicate after the state file is wiped"
+}
+
 run_tests

--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -212,4 +212,18 @@ JSON
     "malformed file contributes no hosts and does not win"
 }
 
+test_doctor_drops_non_string_owner_value() {
+  _seed_live_swarm
+  cat > "$TEST_VAULT/CEO/swarm.sync-conflict-20260613-150000-EEEEEEE.json" << 'JSON'
+{ "schema_version": 1, "hosts": ["mac"], "owners": { "pbNull": null, "pbValid": "mac" } }
+JSON
+  local rc=0
+  _doctor --fix >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "--fix must exit 0"
+  assert_eq "$(jq -r '.owners | has("pbNull")' "$TEST_VAULT/CEO/swarm.json")" "false" \
+    "null owner value must be dropped, not written as the string \"null\""
+  assert_eq "$(jq -r '.owners.pbValid' "$TEST_VAULT/CEO/swarm.json")" "mac" \
+    "valid conflict-only owner key still merges alongside a dropped null"
+}
+
 run_tests

--- a/scripts/ceo-trace.test.sh
+++ b/scripts/ceo-trace.test.sh
@@ -16,7 +16,10 @@ setup() {
   HOME_BACKUP="$HOME"
   PATH_BACKUP="$PATH"
   export HOME="$TEST_HOME"
-  mkdir -p "$TEST_HOME/bin" "$TEST_HOME/vault/CEO"
+  mkdir -p "$TEST_HOME/bin" "$TEST_HOME/vault/CEO" "$TEST_HOME/.ceo"
+  # The generated registry is host-local now ($HOME/.ceo/registry.json), not in
+  # the synced vault — `ceo trace` reads it from there.
+  REGISTRY_FILE="$HOME/.ceo/registry.json"
 
   export VAULT="$TEST_HOME/vault"
   export CEO_VAULT="$VAULT"
@@ -52,12 +55,13 @@ _run_cmd_trace() {
   body=$(sed -n '/^cmd_trace()/,/^}$/p' "$CEO_BIN")
   bash -c '
     set -uo pipefail
-    VAULT="$1"; CEO_VAULT="$2"; CEO_DIR="$3"
-    shift 3
+    VAULT="$1"; CEO_VAULT="$2"; CEO_DIR="$3"; REGISTRY_FILE="$4"
+    shift 4
     ceo_validate_vault() { return 0; }
+    _ceo_registry_path() { printf "%s\n" "$REGISTRY_FILE"; }
     '"$body"'
     cmd_trace "$@"
-  ' -- "$VAULT" "$CEO_VAULT" "$CEO_DIR" "$@" 2>"$TEST_HOME/err" 1>"$TEST_HOME/out"
+  ' -- "$VAULT" "$CEO_VAULT" "$CEO_DIR" "$REGISTRY_FILE" "$@" 2>"$TEST_HOME/err" 1>"$TEST_HOME/out"
 }
 
 test_cmd_trace_missing_name_prints_usage_and_exits_1() {
@@ -114,7 +118,7 @@ test_cmd_trace_missing_claude_binary_exits_with_diagnostic() {
 }
 
 test_cmd_trace_warns_when_playbook_not_registered() {
-  cat > "$CEO_DIR/registry.json" << 'JSON'
+  cat > "$REGISTRY_FILE" << 'JSON'
 { "playbooks": [ { "name": "other-playbook" } ] }
 JSON
   _run_cmd_trace morning-scan
@@ -123,7 +127,7 @@ JSON
 }
 
 test_cmd_trace_aborts_on_malformed_registry() {
-  echo "this is not json {{{" > "$CEO_DIR/registry.json"
+  echo "this is not json {{{" > "$REGISTRY_FILE"
   local rc=0
   _run_cmd_trace morning-scan || rc=$?
   assert_eq "$rc" "1" "malformed registry.json must abort, not be reported as 'not registered'"

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -326,17 +326,17 @@ ceo_setup_cron() {
   local ceo_cli="$SCRIPT_DIR/ceo"
   if [ -f "$ceo_cli" ] && command -v yq &>/dev/null; then
     echo ""
-    echo "[10/10] Cron Setup"
+    echo "[10/10] Playbook Scan"
     local install_cron
-    read -p "  Scan playbooks and install cron entries? (y/n) " install_cron
+    read -p "  Scan playbooks and generate the host-local registry? (y/n) " install_cron
     if _ceo_is_yes "$install_cron"; then
       bash "$ceo_cli" playbook scan
     else
-      echo "  Skipped ('${install_cron}' interpreted as no). Run 'ceo playbook scan' later to install cron entries."
+      echo "  Skipped ('${install_cron}' interpreted as no). Run 'ceo playbook scan' later to generate the registry."
     fi
   else
     echo ""
-    echo "[10/10] Skipping cron setup (ceo CLI or yq not available)."
+    echo "[10/10] Skipping playbook scan (ceo CLI or yq not available)."
     echo "  Run 'ceo playbook scan' after installing yq."
   fi
 }

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -290,6 +290,31 @@ CEOCONF
   export VAULT CEO_OS
 }
 
+ceo_setup_swarm() {
+  echo ""
+  echo "[9a] Swarm registration"
+  # ceo_setup_vault may have pushed CEO_VAULT onto MISSING_CONFIG and left
+  # VAULT empty; without a vault there is nowhere to write swarm.json. Skip
+  # rather than fail — the missing-config surface already flags the real issue.
+  if [ -z "${VAULT:-}" ]; then
+    echo "  Skipped (no vault configured yet)."
+    return 0
+  fi
+  if ! command -v jq &>/dev/null; then
+    echo "  Skipped (jq not installed). Re-run 'ceo setup' after installing jq."
+    return 0
+  fi
+  CEO_VAULT="$VAULT" _swarm_bootstrap || {
+    echo "  WARNING: could not bootstrap swarm.json."
+    return 0
+  }
+  if CEO_VAULT="$VAULT" _swarm_register_host; then
+    echo "  Registered this host in $VAULT/CEO/swarm.json"
+  else
+    echo "  Host NOT registered — set a unique CEO_HOSTNAME (see message above) and re-run 'ceo setup'."
+  fi
+}
+
 ceo_setup_pr_sources() {
   echo ""
   echo "[9b] PR sources configuration"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -74,6 +74,7 @@ ceo_setup_check_yq "$_yq_hint"
 ceo_setup_repos_dir
 ceo_setup_check_claude
 ceo_setup_vault
+ceo_setup_swarm
 ceo_setup_pr_sources
 ceo_setup_cron
 ceo_setup_path_symlink

--- a/scripts/setup-mac.sh
+++ b/scripts/setup-mac.sh
@@ -61,6 +61,7 @@ ceo_setup_check_yq "brew install yq"
 ceo_setup_repos_dir
 ceo_setup_check_claude
 ceo_setup_vault
+ceo_setup_swarm
 ceo_setup_pr_sources
 ceo_setup_cron
 ceo_setup_path_symlink

--- a/scripts/setup-wsl.sh
+++ b/scripts/setup-wsl.sh
@@ -75,6 +75,7 @@ ceo_setup_check_yq "sudo snap install yq  (or: brew install yq on Mac)"
 ceo_setup_repos_dir
 ceo_setup_check_claude
 ceo_setup_vault
+ceo_setup_swarm
 ceo_setup_pr_sources
 ceo_setup_cron
 ceo_setup_path_symlink

--- a/syncthing/README.md
+++ b/syncthing/README.md
@@ -28,6 +28,21 @@ Write domains are enforced by the CEO's scripts and documented in VAULT.md, not 
 | CEO/delegations/ | Yes (CEO Review) | Yes (create + results) |
 | Profile.md, Pending.md, People/, etc. | Yes | No |
 
+## Swarm State: What Syncs and What Doesn't
+
+The swarm model (multiple hosts) splits CEO state into synced (shared topology)
+and host-local (per-machine) files:
+
+| Path | Synced? | Why |
+|------|---------|-----|
+| `CEO/registry.json` | **No — host-local** | Generated per host at `~/.ceo/registry.json` by `ceo playbook scan`. Syncing it would let two hosts rewrite the same file and produce `.sync-conflict` copies. Ignored in `shared.stignore`. |
+| `CEO/swarm.json` | **Yes — shared topology** | Describes the swarm itself: which hosts participate (`hosts[]`) and which host owns each `single`-scope playbook (`owners{}`). Every host must read the same file. |
+| `CEO/heartbeats/<host>.json` | **Yes — per-host liveness** | One file per host (host-namespaced), so two hosts never write the same path. The offline-owner alert reads these to detect a host whose heartbeat has gone stale. |
+
+A stale `CEO/registry.json` may linger in the vault on first migration from a
+single-host install; the `shared.stignore` entry stops it from syncing going
+forward (delete the vault copy during migration — see `docs/migration.md`).
+
 ## Conflict Detection
 
 If both machines write to the same file within a sync window, Syncthing creates `.sync-conflict-*` files. The CEO's cleanup playbook scans for these and logs them as errors.

--- a/syncthing/shared.stignore
+++ b/syncthing/shared.stignore
@@ -32,3 +32,9 @@ CEO/log/.config-hash
 CEO/log/.fail-count
 // --dry-run preview output is host-local scratch (see ceo-cron.sh --dry-run)
 CEO/log/preview/
+// registry.json is host-local — it now lives at ~/.ceo/registry.json (each host
+// regenerates its own via `ceo playbook scan`). Two hosts scanning a synced copy
+// would both rewrite it and produce .sync-conflict files. Ignore any stale copy
+// lingering in the vault from before the swarm migration; nothing should sync it.
+// (CEO/swarm.json and CEO/heartbeats/ DO sync — they describe the swarm, not one host.)
+CEO/registry.json


### PR DESCRIPTION
Closes #175

## Description (Issue Fixed & New Behavior)

Lets CEO run on 2+ machines (a "swarm") from one Syncthing-synced vault without conflict, with per-machine playbook selection — the plugin-enable/disable analogy made literal.

**Model:**
- Playbook `.md` definitions stay **synced** (shared catalog); each definition declares `scope: each | single`.
- `registry.json` **moves out** of the synced vault to host-local `~/.ceo/registry.json` (each host scans + generates its own catalog). No more two-hosts-scanning write-conflict.
- `CEO/swarm.json` (`{schema_version, hosts[], owners{}}`) is the only synced-mutable file: swarm topology + the owner host for each `single` playbook. Written rarely.
- `~/.ceo/enabled.json` is host-local per-host selection for `each`-scope playbooks.

**Run predicate:** a host runs playbook P iff P is an active cron playbook in its local catalog AND ((`scope: each` AND P ∈ enabled.json) OR (`scope: single` AND host == owners[P])).

**No double token spend:** `scope: single` runs on exactly one owner host; empty owner ⇒ runs nowhere (safe default). Absent scope resolves to `single`, never `each`.

**Scheduler:** all hosts run the `ceo-schedulerd` daemon (selection-aware); native crontab install (installs everything, ignores selection) is retired.

**Hardening:** scan rejects unknown/absent scope per `enum-config-typo-fallback`; daemon tolerates half-synced `swarm.json` (keeps last-good owners); `ceo swarm doctor` detects + merges `.sync-conflict-*` files (hosts union, owners live-wins-per-key); `ceo swarm owners-health` flags stale owner heartbeats (transition-gated inbox alert, clock-skew tolerant, fractional-second parse).

Also includes `docs/install.md` (fresh multi-machine install), `docs/migration.md` (single-host → swarm, crontab-removal-first ordering), `docs/playbooks/SCHEMA.md` scope field + `hosts` deprecation, README swarm section, and `syncthing/shared.stignore` ignoring the now-host-local `registry.json`.

## Testing Procedure

1. Check out this branch.
2. Scheduler unit tests: `cd lib/scheduler && bun test` — expect all pass (117); `bunx tsc --noEmit` exits 0.
3. Bash suites: `bash tests/ceo-scan.test.sh`, `ceo-swarm.test.sh`, `ceo-list.test.sh`, `ceo-doctor.test.sh`, `ceo-scheduler.test.sh`, `ceo-remove-crontab-block.test.sh` — all pass.
4. Bootstrap: with `CEO_VAULT` set and unique `CEO_HOSTNAME`, run `ceo setup` and confirm `CEO/swarm.json` is created and the host is in `hosts[]`.
5. Selection: `ceo playbook scan` (writes `~/.ceo/registry.json`, no crontab); `ceo playbook list` shows `[each]`/`[single]` + owner/enabled state; `ceo playbook enable <name>` / `assign <name> <host>`.
6. Conflict merge: create a `CEO/swarm.json.sync-conflict-*` file and run `ceo swarm doctor`; confirm hosts union + owners merged.

## Additional Notes / HelpScout Tickets

Post-merge follow-up (documented in `docs/migration.md`, not done here): retire the `ceo-scan-only-on-ml1` global rule once all hosts migrate. Design spec + plan live in Obsidian (not committed per repo convention).