### PR TITLE
Append prior-day full report to the morning Discord brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ Store that JSON at `~/.config/claude-ceo/secrets.json`, or set `CEO_DISCORD_REPO
 
 The full report is split across multiple Discord messages when it exceeds Discord's message limit.
 
+After posting `morning-brief`, the poster also appends the **prior day's full daily report** (the most recent `CEO/reports/<date>.md` before today, so a Monday brief surfaces Friday's) as additional Discord messages. This is Discord-only — the Obsidian report keeps its existing front matter and is untouched. Gate it with its own allowlist (defaults to `morning-brief`):
+
+```json
+{
+  "discord_prior_day_report_triggers": ["morning-brief"]
+}
+```
+
 ## Architecture
 
 ### Authority tiers

--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -47,6 +47,10 @@ Then append a Personal section sourced from the `<external-data>` `Blessings tod
 
 _Add one?_ Run `count-blessings add "your blessing"` from a terminal.
 
+## Delivery
+
+The brief is written to `CEO/reports/YYYY-MM-DD.md` (Obsidian, canonical) and, when a report webhook is configured, posted to Discord by `ceo-discord-report.sh`. On Discord only, the prior day's full daily report (most recent `CEO/reports/<date>.md` before today) is appended after the brief as additional messages. The Obsidian report is untouched — keeps its existing front matter. Disable the prior-day append by setting `discord_prior_day_report_triggers: []` in `CEO/settings.json`.
+
 ## Constraints
 
 - This is a read-only playbook. Do not execute any write actions.

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -849,7 +849,7 @@ ceo_assert_primary_host() {
     return 1
   fi
 
-  local known_keys=" primary_host cooldown_seconds branch_prefix notify_events discord_report_triggers "
+  local known_keys=" primary_host cooldown_seconds branch_prefix notify_events discord_report_triggers discord_prior_day_report_triggers "
   local k
   while IFS= read -r k; do
     [ -n "$k" ] || continue

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -976,4 +976,14 @@ test_discovery_probes_mnt_candidates_on_wsl() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_assert_primary_host_accepts_prior_day_report_triggers_key() {
+  local dir="$TEST_HOME/cdir"
+  mkdir -p "$dir"
+  printf '%s\n' '{"primary_host":"","discord_prior_day_report_triggers":["morning-brief"]}' > "$dir/settings.json"
+  local err
+  err=$(CEO_DIR="$dir" bash -c "source '$LIB'; ceo_assert_primary_host" 2>&1 >/dev/null)
+  assert_not_contains "$err" "unknown key 'discord_prior_day_report_triggers'" \
+    "discord_prior_day_report_triggers must be a registered settings key (no unknown-key warning)"
+}
+
 run_tests

--- a/scripts/ceo-discord-report.sh
+++ b/scripts/ceo-discord-report.sh
@@ -15,6 +15,10 @@ set -euo pipefail
 #   $CEO_DIR/settings.json -> .discord_report_triggers
 #     Defaults to ["morning-brief"] when unset. Set [] to disable.
 #
+# Prior-day full report append (after the brief, morning-brief only by default):
+#   $CEO_DIR/settings.json -> .discord_prior_day_report_triggers
+#     Defaults to ["morning-brief"] when unset. Set [] to disable.
+#
 # Exits 0 always after argument validation; report delivery must not break cron.
 
 TRIGGER="${1:-}"
@@ -78,6 +82,9 @@ TODAY="${TODAY:-$(date +%Y-%m-%d)}"
 _post_report() {
   local title="$1" body="$2"
   local cdir; cdir=$(mktemp -d)
+  # Guarantee cleanup even if a command between here and the tail aborts under
+  # set -e (RETURN fires on any function exit, unlike the prior bare tail rm).
+  trap 'rm -rf "$cdir"' RETURN
   printf '%s\n' "$body" | awk -v dir="$cdir" -v max=1800 '
     function flush() {
       if (chunk != "") {
@@ -121,7 +128,6 @@ $chunk"
     curl -sS -o /dev/null -X POST -H "Content-Type: application/json" \
       --max-time 10 -d "$payload" "$WEBHOOK" >/dev/null 2>&1 || true
   done
-  rm -rf "$cdir"
   printf '%s' "$sent"
 }
 
@@ -164,6 +170,8 @@ if [ "$prior_enabled" = "1" ]; then
       psent=$(_post_report "**📄 Prior-day full report — ${prior_date}**" "$prior_body")
       total=$((total + psent))
       _dlog "prior-day report posted date=$prior_date chunks=$psent"
+    else
+      _dlog "prior-day report empty after front-matter strip date=$prior_date"
     fi
   else
     _dlog "no prior-day report found to append"

--- a/scripts/ceo-discord-report.sh
+++ b/scripts/ceo-discord-report.sh
@@ -69,57 +69,106 @@ fi
   exit 0
 }
 
-tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT
-
-printf '%s\n' "$CONTENT" | awk -v dir="$tmp_dir" -v max=1800 '
-  function flush() {
-    if (chunk != "") {
-      n += 1
-      file = sprintf("%s/chunk-%04d.txt", dir, n)
-      printf "%s", chunk > file
-      close(file)
-      chunk = ""
-    }
-  }
-  {
-    line = $0 "\n"
-    if (length(chunk) + length(line) > max) {
-      flush()
-    }
-    while (length(line) > max) {
-      n += 1
-      file = sprintf("%s/chunk-%04d.txt", dir, n)
-      printf "%s", substr(line, 1, max) > file
-      close(file)
-      line = substr(line, max + 1)
-    }
-    chunk = chunk line
-  }
-  END { flush() }
-'
-
 HOSTNAME_SHORT="${CEO_HOSTNAME:-$(hostname -s 2>/dev/null || echo unknown)}"
 TODAY="${TODAY:-$(date +%Y-%m-%d)}"
-sent=0
 
-for chunk_file in "$tmp_dir"/chunk-*.txt; do
-  [ -f "$chunk_file" ] || continue
-  chunk=$(cat "$chunk_file")
-  sent=$((sent + 1))
-  if [ "$sent" -eq 1 ]; then
-    message="**CEO full report: ${TRIGGER} — ${TODAY} (${HOSTNAME_SHORT})**
+# Post a body to the report webhook, chunked to Discord's per-message limit. The
+# first message carries the bold title; continuation chunks are bare. Echoes the
+# number of messages sent.
+_post_report() {
+  local title="$1" body="$2"
+  local cdir; cdir=$(mktemp -d)
+  printf '%s\n' "$body" | awk -v dir="$cdir" -v max=1800 '
+    function flush() {
+      if (chunk != "") {
+        n += 1
+        file = sprintf("%s/chunk-%04d.txt", dir, n)
+        printf "%s", chunk > file
+        close(file)
+        chunk = ""
+      }
+    }
+    {
+      line = $0 "\n"
+      if (length(chunk) + length(line) > max) {
+        flush()
+      }
+      while (length(line) > max) {
+        n += 1
+        file = sprintf("%s/chunk-%04d.txt", dir, n)
+        printf "%s", substr(line, 1, max) > file
+        close(file)
+        line = substr(line, max + 1)
+      }
+      chunk = chunk line
+    }
+    END { flush() }
+  '
+  local sent=0 chunk_file chunk message payload
+  for chunk_file in "$cdir"/chunk-*.txt; do
+    [ -f "$chunk_file" ] || continue
+    chunk=$(cat "$chunk_file")
+    sent=$((sent + 1))
+    if [ "$sent" -eq 1 ]; then
+      message="$title
 
 $chunk"
-  else
-    message="$chunk"
+    else
+      message="$chunk"
+    fi
+    payload=$(jq -n --arg content "$message" \
+      '{username: "CEO Report", content: $content}')
+    curl -sS -o /dev/null -X POST -H "Content-Type: application/json" \
+      --max-time 10 -d "$payload" "$WEBHOOK" >/dev/null 2>&1 || true
+  done
+  rm -rf "$cdir"
+  printf '%s' "$sent"
+}
+
+total=0
+sent=$(_post_report "**CEO full report: ${TRIGGER} — ${TODAY} (${HOSTNAME_SHORT})**" "$CONTENT")
+total=$((total + sent))
+
+# Prior-day full report append (morning-brief only by default). The Obsidian
+# report keeps its existing front matter and is untouched; the complete prior-day
+# report is delivered here, on Discord only. Gate on its own allow-list so other
+# report triggers don't carry yesterday's report.
+if [ -f "$SETTINGS_FILE" ]; then
+  prior_enabled=$(jq -e --arg trig "$TRIGGER" \
+    '(.discord_prior_day_report_triggers // ["morning-brief"]) | index($trig) != null' \
+    "$SETTINGS_FILE" >/dev/null 2>&1 && echo 1 || echo 0)
+else
+  [ "$TRIGGER" = "morning-brief" ] && prior_enabled=1 || prior_enabled=0
+fi
+
+if [ "$prior_enabled" = "1" ]; then
+  report_dir="${CEO_DIR:-$HOME/Documents/Obsidian/CEO}/reports"
+  prior_base=""
+  if [ -d "$report_dir" ]; then
+    # Most recent dated report strictly before today (the glob is lexically sorted
+    # and lexical == chronological for YYYY-MM-DD), so a Monday brief surfaces
+    # Friday's report, not an empty Sunday.
+    shopt -s nullglob
+    for _rf in "$report_dir"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md; do
+      _rb=$(basename "$_rf")
+      [ "$_rb" \< "${TODAY}.md" ] && prior_base="$_rb"
+    done
+    shopt -u nullglob
   fi
+  if [ -n "$prior_base" ] && [ -s "$report_dir/$prior_base" ]; then
+    prior_date="${prior_base%.md}"
+    # Strip a leading YAML front-matter block — it is Obsidian metadata, noise on Discord.
+    prior_body=$(awk 'NR==1 && $0=="---" {fm=1; next} fm && $0=="---" {fm=0; next} !fm {print}' \
+      "$report_dir/$prior_base")
+    if [ -n "${prior_body//[[:space:]]/}" ]; then
+      psent=$(_post_report "**📄 Prior-day full report — ${prior_date}**" "$prior_body")
+      total=$((total + psent))
+      _dlog "prior-day report posted date=$prior_date chunks=$psent"
+    fi
+  else
+    _dlog "no prior-day report found to append"
+  fi
+fi
 
-  payload=$(jq -n --arg content "$message" \
-    '{username: "CEO Report", content: $content}')
-  curl -sS -o /dev/null -X POST -H "Content-Type: application/json" \
-    --max-time 10 -d "$payload" "$WEBHOOK" >/dev/null 2>&1 || true
-done
-
-_dlog "posted chunks=$sent"
+_dlog "posted chunks=$total"
 exit 0

--- a/scripts/ceo-discord-report.test.sh
+++ b/scripts/ceo-discord-report.test.sh
@@ -92,12 +92,12 @@ test_splits_large_report() {
 
   local count
   count=$(find "$CURL_CAPTURE_DIR" -type f | wc -l | tr -d ' ')
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
   if [ "$count" -lt 2 ]; then
     printf '  FAIL [%s] large report should split into multiple messages; got %s\n' \
       "$CURRENT_TEST" "$count"
-    FAILS=$((FAILS + 1))
+    _record_assertion_fail
   fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 _write_prior_report() {
@@ -126,12 +126,7 @@ test_appends_prior_day_report_for_morning_brief() {
   all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
   assert_contains "$all" "Prior-day full report — 2026-06-14" "prior-day section header must be posted"
   assert_contains "$all" "PRIOR_DAY_BODY_MARKER" "prior-day report body must be posted in full"
-  # Front matter must be stripped, not posted as Discord noise.
-  if printf '%s' "$all" | grep -q "type: ceo-daily-report"; then
-    printf '  FAIL [%s] prior-day front matter must be stripped before posting\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_not_contains "$all" "type: ceo-daily-report" "prior-day front matter must be stripped before posting"
   unset TODAY
 }
 
@@ -147,11 +142,7 @@ test_prior_day_append_gated_to_morning_brief() {
   local all
   all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json 2>/dev/null || echo "")
   assert_contains "$all" "scan body" "morning-scan's own report must still post"
-  if printf '%s' "$all" | grep -q "Prior-day full report"; then
-    printf '  FAIL [%s] prior-day append must not fire for non-morning-brief triggers\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_not_contains "$all" "Prior-day full report" "prior-day append must not fire for non-morning-brief triggers"
   unset TODAY
 }
 
@@ -165,11 +156,7 @@ test_skips_prior_day_when_none_exists() {
   local all
   all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
   assert_contains "$all" "todays brief" "brief must still post when no prior report exists"
-  if printf '%s' "$all" | grep -q "Prior-day full report"; then
-    printf '  FAIL [%s] must not post a prior-day section when no prior report exists\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_not_contains "$all" "Prior-day full report" "must not post a prior-day section when no prior report exists"
   unset TODAY
 }
 
@@ -185,15 +172,26 @@ test_picks_most_recent_prior_report_excluding_today() {
   local all
   all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
   assert_contains "$all" "MOST_RECENT_PRIOR_MARKER" "must pick the most recent report before today"
-  if printf '%s' "$all" | grep -q "OLDEST_MARKER"; then
-    printf '  FAIL [%s] must not post an older report when a more recent prior exists\n' "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  if printf '%s' "$all" | grep -q "TODAY_MARKER"; then
-    printf "  FAIL [%s] must not post today's own report as the prior day\n" "$CURRENT_TEST"
-    FAILS=$((FAILS + 1))
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_not_contains "$all" "OLDEST_MARKER" "must not post an older report when a more recent prior exists"
+  assert_not_contains "$all" "TODAY_MARKER" "must not post today's own report as the prior day"
+  unset TODAY
+}
+
+test_empty_prior_day_allowlist_disables_append() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  # An explicit empty list disables the append — the jq `// ["morning-brief"]`
+  # default only applies when the key is ABSENT, not when it is [].
+  echo '{"discord_prior_day_report_triggers":[]}' > "$CEO_DIR/settings.json"
+  export TODAY="2026-06-15"
+  _write_prior_report "2026-06-14" "PRIOR_DAY_BODY_MARKER"
+
+  printf 'todays brief' | "$REPORT" morning-brief >/dev/null 2>&1
+
+  local all
+  all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
+  assert_contains "$all" "todays brief" "the brief itself must still post when prior-day append is disabled"
+  assert_not_contains "$all" "Prior-day full report" "empty allowlist must disable the prior-day append"
+  assert_not_contains "$all" "PRIOR_DAY_BODY_MARKER" "prior-day body must not post when allowlist is empty"
   unset TODAY
 }
 

--- a/scripts/ceo-discord-report.test.sh
+++ b/scripts/ceo-discord-report.test.sh
@@ -100,4 +100,101 @@ test_splits_large_report() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+_write_prior_report() {
+  # _write_prior_report <date> <body-line>
+  mkdir -p "$CEO_DIR/reports"
+  cat > "$CEO_DIR/reports/$1.md" << EOF
+---
+date: $1
+type: ceo-daily-report
+---
+
+# CEO Daily Report — $1
+
+$2
+EOF
+}
+
+test_appends_prior_day_report_for_morning_brief() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  export TODAY="2026-06-15"
+  _write_prior_report "2026-06-14" "PRIOR_DAY_BODY_MARKER"
+
+  printf 'todays brief' | "$REPORT" morning-brief >/dev/null 2>&1
+
+  local all
+  all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
+  assert_contains "$all" "Prior-day full report — 2026-06-14" "prior-day section header must be posted"
+  assert_contains "$all" "PRIOR_DAY_BODY_MARKER" "prior-day report body must be posted in full"
+  # Front matter must be stripped, not posted as Discord noise.
+  if printf '%s' "$all" | grep -q "type: ceo-daily-report"; then
+    printf '  FAIL [%s] prior-day front matter must be stripped before posting\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  unset TODAY
+}
+
+test_prior_day_append_gated_to_morning_brief() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  # Post morning-scan's own report, but prior-day append stays morning-brief-only.
+  echo '{"discord_report_triggers":["morning-brief","morning-scan"]}' > "$CEO_DIR/settings.json"
+  export TODAY="2026-06-15"
+  _write_prior_report "2026-06-14" "PRIOR_DAY_BODY_MARKER"
+
+  printf 'scan body' | "$REPORT" morning-scan >/dev/null 2>&1
+
+  local all
+  all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json 2>/dev/null || echo "")
+  assert_contains "$all" "scan body" "morning-scan's own report must still post"
+  if printf '%s' "$all" | grep -q "Prior-day full report"; then
+    printf '  FAIL [%s] prior-day append must not fire for non-morning-brief triggers\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  unset TODAY
+}
+
+test_skips_prior_day_when_none_exists() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  export TODAY="2026-06-15"
+  mkdir -p "$CEO_DIR/reports"
+
+  printf 'todays brief' | "$REPORT" morning-brief >/dev/null 2>&1
+
+  local all
+  all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
+  assert_contains "$all" "todays brief" "brief must still post when no prior report exists"
+  if printf '%s' "$all" | grep -q "Prior-day full report"; then
+    printf '  FAIL [%s] must not post a prior-day section when no prior report exists\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  unset TODAY
+}
+
+test_picks_most_recent_prior_report_excluding_today() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  export TODAY="2026-06-15"
+  _write_prior_report "2026-06-11" "OLDEST_MARKER"
+  _write_prior_report "2026-06-12" "MOST_RECENT_PRIOR_MARKER"
+  _write_prior_report "2026-06-15" "TODAY_MARKER"
+
+  printf 'todays brief' | "$REPORT" morning-brief >/dev/null 2>&1
+
+  local all
+  all=$(cat "$CURL_CAPTURE_DIR"/payload-*.json)
+  assert_contains "$all" "MOST_RECENT_PRIOR_MARKER" "must pick the most recent report before today"
+  if printf '%s' "$all" | grep -q "OLDEST_MARKER"; then
+    printf '  FAIL [%s] must not post an older report when a more recent prior exists\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if printf '%s' "$all" | grep -q "TODAY_MARKER"; then
+    printf "  FAIL [%s] must not post today's own report as the prior day\n" "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  unset TODAY
+}
+
 run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

After the `morning-brief` report posts to Discord, append the **prior day's full daily report** as additional Discord messages, so the morning recipient gets the complete prior-day context alongside the brief.

- **Discord-only.** All logic lives in `ceo-discord-report.sh` (the Discord side-channel). The canonical Obsidian report (`CEO/reports/YYYY-MM-DD.md`) is untouched and keeps its existing front matter — no inlined prior-day content there.
- **Most-recent prior report**, not literal yesterday: picks the most recent `CEO/reports/<date>.md` strictly before today (lexical == chronological for `YYYY-MM-DD`), so a Monday brief surfaces Friday's report rather than an empty Sunday.
- **Front matter stripped** before posting (Obsidian metadata is noise on Discord); reuses the existing 1800-char chunker via a refactored `_post_report` helper.
- **Gated** by its own `discord_prior_day_report_triggers` allowlist in `CEO/settings.json` (default `["morning-brief"]`); set `[]` to disable. Other report triggers never carry the prior-day append.
- Skips silently (debug-logged) when no prior report exists.

## Testing Procedure

1. Check out this branch.
2. Run `bash scripts/ceo-discord-report.test.sh` — expect `All tests passed. (9 tests)`. The 4 new tests cover: append for morning-brief, gating to morning-brief only, skip-when-none-exists, and most-recent-prior-excluding-today.
3. `shellcheck scripts/ceo-discord-report.sh` — clean.
4. Mutation check: force the prior-day gate off (`if false; then`) and re-run — the 3 positive assertions fail; restore → 9 pass.

## Additional Notes / HelpScout Tickets

Behavior documented in `docs/playbooks/morning-brief.md` (Delivery section) and `README.md` (Discord full reports). Reviewed via the `pr-review-panel` mini variant after open.