### PR TITLE
fix(cron): ollama runner ingests full prompt via HTTP API + num_ctx

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -428,21 +428,26 @@ _append_pending_drip_to_inbox() {
   } >> "$inbox_file"
 }
 
-# _ollama_run — invoke `ollama run <model>`, reading the prompt from stdin,
-# bounded by a wall-clock timeout so a degenerate runaway (observed: a 12B model
-# emitting 65k tokens over ~18 min on a single prompt) cannot hang a cron slot.
-# `ollama run` (the CLI) has no num_predict flag, so a timeout — not a token cap
-# — is what bounds the operational risk. Prefer GNU `timeout` (Linux), else
-# `gtimeout` (macOS via Homebrew coreutils). When neither is present the call
-# runs unbounded (re-opening the hang risk), so log that fact rather than
-# degrade silently. Override the bound with CEO_OLLAMA_TIMEOUT (seconds; default
-# 300). On expiry the wrapper exits 124, which callers already treat as failure.
+# _ollama_run — generate a completion from <model>, reading the prompt from
+# stdin, via the ollama HTTP API (`/api/generate`) rather than `ollama run`.
+#
+# Two reasons for the API over the CLI:
+#  1. `ollama run` exposes no way to set num_ctx, so it uses the server default
+#     (~4096 tokens). Our prompts run 27–50 KB (well past that), so the CLI path
+#     silently truncated them. The API takes options.num_ctx — set it to the
+#     model's real window (gemma4:12b-it-qat holds 256K; we use 32K, override
+#     via CEO_OLLAMA_NUM_CTX) so the whole prompt is actually ingested.
+#  2. curl --max-time bounds wall-clock natively, so a degenerate runaway (a 12B
+#     model emitting 65k tokens over ~18 min) can't hang a cron slot — no
+#     separate timeout/gtimeout binary needed. Override with CEO_OLLAMA_TIMEOUT
+#     (seconds; default 300). curl --fail makes HTTP errors exit non-zero, and
+#     we also inspect the JSON .error field (a 200 can still carry one), so a
+#     failed generation routes to the caller's failure path instead of looking
+#     like empty-but-successful output.
 _ollama_run() {
-  local model="$1" tbin="" to="${CEO_OLLAMA_TIMEOUT:-300}"
-  # Validate the bound: a typo (`300s`, `abc`) makes `timeout` exit 125 without
-  # running ollama, surfacing as a misleading model failure; `0` is a legal GNU
-  # value meaning "no limit", silently re-opening the hang. Reject non-integers,
-  # warn loudly on the cap-disabling 0.
+  local model="$1" to="${CEO_OLLAMA_TIMEOUT:-300}" num_ctx="${CEO_OLLAMA_NUM_CTX:-32768}"
+  local host="${OLLAMA_HOST:-http://localhost:11434}"
+  case "$host" in http://*|https://*) ;; *) host="http://$host" ;; esac
   case "$to" in
     ''|*[!0-9]*)
       echo "$(date): WARNING — CEO_OLLAMA_TIMEOUT='$to' is not a non-negative integer; using 300" \
@@ -452,18 +457,34 @@ _ollama_run() {
       echo "$(date): WARNING — CEO_OLLAMA_TIMEOUT=0 disables the wall-clock cap (hang risk)" \
         >> "${LOG_DIR:-/tmp}/cron-stderr.log" ;;
   esac
-  if command -v timeout >/dev/null 2>&1; then
-    tbin="timeout"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    tbin="gtimeout"
-  fi
-  if [ -n "$tbin" ]; then
-    "$tbin" "$to" ollama run "$model"
-  else
-    echo "$(date): WARNING — no timeout/gtimeout on PATH; running ollama unbounded (model: $model)" \
+  case "$num_ctx" in
+    ''|*[!0-9]*|0)
+      echo "$(date): WARNING — CEO_OLLAMA_NUM_CTX='$num_ctx' is not a positive integer; using 32768" \
+        >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+      num_ctx=32768 ;;
+  esac
+
+  local req resp rc=0
+  req=$(jq -Rs --arg model "$model" --argjson num_ctx "$num_ctx" \
+    '{model:$model, prompt:., stream:false, options:{num_ctx:$num_ctx}}') || {
+    echo "$(date): WARNING — failed to encode ollama request (model: $model)" \
       >> "${LOG_DIR:-/tmp}/cron-stderr.log"
-    ollama run "$model"
+    return 1
+  }
+  resp=$(printf '%s' "$req" | curl -fsS --max-time "$to" "$host/api/generate" -d @-) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "$(date): WARNING — ollama API call failed (curl exit $rc, model: $model, host: $host)" \
+      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+    return "$rc"
   fi
+  local err
+  err=$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)
+  if [ -n "$err" ]; then
+    echo "$(date): WARNING — ollama API error (model: $model): $err" \
+      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+    return 1
+  fi
+  printf '%s' "$resp" | jq -r '.response // empty'
 }
 
 # _ollama_chunked_scan — run an ollama playbook whose scan data exceeds the
@@ -1441,12 +1462,14 @@ END_LOG_ENTRY"
     export CEO_MODEL_SOURCE="invoked"
 
     OLLAMA_PROMPT="$SINGLE_PROMPT_BODY"
-    # gemma4:12b-it-qat fits fully in 12 GB VRAM and holds a 32K+ context
-    # window. Reserve ~8K for output
-    # and overhead; the rest is the prompt budget. Override via env when a
-    # larger-context model is selected. `wc -c` measures bytes — `${#var}`
-    # would return character count under a UTF-8 locale and undercount.
-    : "${CEO_OLLAMA_MAX_PROMPT_BYTES:=24576}"
+    # Sized to the num_ctx _ollama_run requests (CEO_OLLAMA_NUM_CTX, default 32K
+    # tokens). The prompt and the generated output share that window, so reserve
+    # ~7K tokens for output: 90 KB ≈ 24K prompt tokens leaves headroom. The old
+    # 24 KB cap predated the API path — it was a proxy for `ollama run`'s ~4K
+    # default num_ctx and is no longer the real constraint. `wc -c` measures
+    # bytes — `${#var}` would return character count under a UTF-8 locale and
+    # undercount. Override via env if num_ctx is raised for a larger model.
+    : "${CEO_OLLAMA_MAX_PROMPT_BYTES:=90000}"
     OLLAMA_PROMPT_BYTES=$(printf '%s' "$OLLAMA_PROMPT" | wc -c | tr -d ' ')
     if [ "$OLLAMA_PROMPT_BYTES" -gt "$CEO_OLLAMA_MAX_PROMPT_BYTES" ]; then
       if [ -n "${SCAN_BLOCK:-}" ]; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -428,6 +428,15 @@ _append_pending_drip_to_inbox() {
   } >> "$inbox_file"
 }
 
+# _ollama_host — normalized base URL for the ollama daemon. Single source of
+# truth so the reachability probe and the generation call never target
+# different hosts. Honors OLLAMA_HOST (adding an http:// scheme if bare).
+_ollama_host() {
+  local host="${OLLAMA_HOST:-http://localhost:11434}"
+  case "$host" in http://*|https://*) ;; *) host="http://$host" ;; esac
+  printf '%s' "$host"
+}
+
 # _ollama_run — generate a completion from <model>, reading the prompt from
 # stdin, via the ollama HTTP API (`/api/generate`) rather than `ollama run`.
 #
@@ -446,8 +455,7 @@ _append_pending_drip_to_inbox() {
 #     like empty-but-successful output.
 _ollama_run() {
   local model="$1" to="${CEO_OLLAMA_TIMEOUT:-300}" num_ctx="${CEO_OLLAMA_NUM_CTX:-32768}"
-  local host="${OLLAMA_HOST:-http://localhost:11434}"
-  case "$host" in http://*|https://*) ;; *) host="http://$host" ;; esac
+  local host; host=$(_ollama_host)
   case "$to" in
     ''|*[!0-9]*)
       echo "$(date): WARNING — CEO_OLLAMA_TIMEOUT='$to' is not a non-negative integer; using 300" \
@@ -471,18 +479,28 @@ _ollama_run() {
       >> "${LOG_DIR:-/tmp}/cron-stderr.log"
     return 1
   }
-  resp=$(printf '%s' "$req" | curl -fsS --max-time "$to" "$host/api/generate" -d @-) || rc=$?
+  # --fail-with-body (not -f): HTTP 4xx/5xx still exits non-zero, but the body is
+  # retained so the daemon's JSON .error (model-not-found, OOM) can be logged.
+  resp=$(printf '%s' "$req" | curl -sS --fail-with-body --max-time "$to" "$host/api/generate" -d @-) || rc=$?
+  # Validate the body is JSON explicitly — don't let a non-JSON body (proxy HTML
+  # error, truncated stream) fall through on an ambient `set -e` trip with no
+  # diagnostic. A failed parse routes to the failure path with the body logged.
+  if ! printf '%s' "$resp" | jq -e . >/dev/null 2>&1; then
+    echo "$(date): WARNING — ollama returned non-JSON or empty body (curl exit $rc, model: $model, host: $host): $(printf '%s' "$resp" | head -c 200)" \
+      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+    return "$(( rc != 0 ? rc : 1 ))"
+  fi
+  local err
+  err=$(printf '%s' "$resp" | jq -r '.error // empty')
+  if [ -n "$err" ]; then
+    echo "$(date): WARNING — ollama API error (curl exit $rc, model: $model): $err" \
+      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
+    return "$(( rc != 0 ? rc : 1 ))"
+  fi
   if [ "$rc" -ne 0 ]; then
     echo "$(date): WARNING — ollama API call failed (curl exit $rc, model: $model, host: $host)" \
       >> "${LOG_DIR:-/tmp}/cron-stderr.log"
     return "$rc"
-  fi
-  local err
-  err=$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)
-  if [ -n "$err" ]; then
-    echo "$(date): WARNING — ollama API error (model: $model): $err" \
-      >> "${LOG_DIR:-/tmp}/cron-stderr.log"
-    return 1
   fi
   printf '%s' "$resp" | jq -r '.response // empty'
 }
@@ -1433,8 +1451,9 @@ END_LOG_ENTRY"
         _record_failure "curl not available — cannot probe ollama daemon (playbook: $TRIGGER)"
         exit 1
       fi
-      if ! curl -fsS --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>>"$LOG_DIR/cron-stderr.log"; then
-        _record_failure "ollama daemon not reachable at 127.0.0.1:11434 (playbook: $TRIGGER)"
+      _OLLAMA_HOST=$(_ollama_host)
+      if ! curl -fsS --max-time 3 "$_OLLAMA_HOST/api/tags" >/dev/null 2>>"$LOG_DIR/cron-stderr.log"; then
+        _record_failure "ollama daemon not reachable at $_OLLAMA_HOST (playbook: $TRIGGER)"
         exit 1
       fi
     else

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -61,18 +61,52 @@ STUB
 
   # Stub ollama on PATH for runner:ollama / runner:ollama-think tests. Captures
   # the model argument so tests can assert which model was dispatched.
+  # Presence stub: production checks `command -v ollama` before dispatching, but
+  # generation now goes through the HTTP API (curl), not `ollama run`. This stub
+  # only needs to exist; the curl stub below does the real emulation.
   cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
 #!/bin/bash
-if [ "${1:-}" = "run" ]; then
-  echo "$2" > "$HOME/ollama-invoked-model.txt"
-  printf '%s' "${CEO_MODEL_SOURCE:-UNSET}" > "$HOME/ollama-model-source.txt"
-  cat > "$HOME/ollama-invoked-prompt.txt"
-  echo "ollama-stub-response"
-  exit 0
-fi
 exit 0
 STUB
   chmod +x "$TEST_HOME/.bun/bin/ollama"
+
+  # _ollama_run posts to the ollama HTTP API (POST /api/generate). Emulate it:
+  # validate the request shape (model present, num_ctx a positive integer),
+  # capture model/prompt/num_ctx so tests can assert what was dispatched, record
+  # full argv (so timeout tests can check --max-time), and return a canned
+  # completion. Per stub-cli-argv-validation the stub exits non-zero on a
+  # malformed generate call. Any non-generate curl (Discord webhook, daemon
+  # probe) execs the real binary so unrelated behavior is unchanged; tests that
+  # need different curl behavior override this file.
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+args="$*"
+url="" ; data="" ; prev=""
+for a in "$@"; do
+  case "$prev" in -d|--data|--data-binary|--data-raw) data="$a" ;; esac
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  */api/generate)
+    echo "$args" >> "$HOME/curl-invoked.txt"
+    [ "$data" = "@-" ] && data="$(cat)"
+    model=$(printf '%s' "$data" | jq -r '.model // empty' 2>/dev/null)
+    numctx=$(printf '%s' "$data" | jq -r '.options.num_ctx // empty' 2>/dev/null)
+    if [ -z "$model" ]; then echo "curl stub: /api/generate body missing .model" >&2; exit 91; fi
+    case "$numctx" in ''|*[!0-9]*|0) echo "curl stub: /api/generate missing positive .options.num_ctx (got '$numctx')" >&2; exit 92 ;; esac
+    printf '%s\n' "$model" >> "$HOME/ollama-invoked-model.txt"
+    printf '%s' "$data" | jq -r '.prompt // empty' > "$HOME/ollama-invoked-prompt.txt"
+    { printf '%s' "$data" | jq -r '.prompt // empty'; printf '\n---CALL---\n'; } >> "$HOME/ollama-invoked-prompts.txt"
+    printf '%s' "$numctx" > "$HOME/ollama-invoked-numctx.txt"
+    printf '%s' "${CEO_MODEL_SOURCE:-UNSET}" > "$HOME/ollama-model-source.txt"
+    printf 'ollama-stub-response' | jq -Rs '{response:.}'
+    exit 0 ;;
+  *)
+    exec /usr/bin/curl "$@" ;;
+esac
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   # macOS lacks `timeout` from GNU coreutils; the dispatcher uses
   # `timeout N claude ...`. Stub it as a transparent passthrough.
@@ -226,16 +260,13 @@ runner: ollama
 # Body
 PB
 
-  cat > "$TEST_HOME/.bun/bin/ollama" << SH
+  cat > "$TEST_HOME/.bun/bin/curl" << SH
 #!/bin/bash
-if [ "\${1:-}" = "run" ]; then
-  printf '%s' "\${CEO_PLAYBOOK_ID:-UNSET}" > "$TEST_HOME/playbook-id-from-ollama.txt"
-  cat >/dev/null
-  echo "ollama-stub-response"
-fi
-exit 0
+printf '%s' "\${CEO_PLAYBOOK_ID:-UNSET}" > "$TEST_HOME/playbook-id-from-ollama.txt"
+cat >/dev/null
+printf 'ollama-stub-response' | jq -Rs '{response:.}'
 SH
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_VERBOSE=1 bash "$CRON" playbook-id-ollama >/dev/null 2>&1 || true
@@ -886,19 +917,9 @@ PB
 }
 
 test_ollama_run_is_bounded_by_timeout() {
-  # Recording timeout stub: capture argv, enforce the real `timeout` contract
-  # (first arg is a numeric duration), then pass the command through so the
-  # ollama stub still runs. Asserts the dispatcher wraps `ollama run` in a
-  # timeout bound by CEO_OLLAMA_TIMEOUT so a runaway can't hang a cron slot.
-  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
-#!/bin/bash
-echo "$*" >> "$HOME/timeout-invoked.txt"
-case "${1:-}" in ''|*[!0-9]*) echo "timeout stub: non-numeric duration: ${1:-}" >&2; exit 99 ;; esac
-shift
-exec "$@"
-STUB
-  chmod +x "$TEST_HOME/.bun/bin/timeout"
-
+  # _ollama_run bounds wall-clock via curl --max-time (no separate timeout
+  # binary). Assert the API call carries --max-time <CEO_OLLAMA_TIMEOUT> so a
+  # runaway generation can't hang a cron slot.
   cat > "$CEO_DIR/playbooks/ollama-timeout.md" << 'PB'
 ---
 name: ollama-timeout
@@ -916,13 +937,13 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local rc=0
   CEO_OLLAMA_TIMEOUT=123 bash "$CRON" ollama-timeout >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "0" "dispatcher must exit 0 when the timeout wrapper passes through"
+  assert_eq "$rc" "0" "dispatcher must exit 0 when the ollama API call succeeds"
 
-  assert_file_exists "$HOME/timeout-invoked.txt" "ollama run must be wrapped in a timeout"
+  assert_file_exists "$HOME/curl-invoked.txt" "ollama generation must go through curl"
   local rec
-  rec=$(cat "$HOME/timeout-invoked.txt" 2>/dev/null || echo "")
-  assert_contains "$rec" "123 ollama run gemma4:12b-it-qat" \
-    "ollama run must be bounded by CEO_OLLAMA_TIMEOUT seconds"
+  rec=$(cat "$HOME/curl-invoked.txt" 2>/dev/null || echo "")
+  assert_contains "$rec" "--max-time 123" \
+    "ollama API call must be bounded by CEO_OLLAMA_TIMEOUT seconds"
 }
 
 test_runner_ollama_think_uses_gpt_oss_default() {
@@ -993,13 +1014,15 @@ runner: ollama
 # body
 PB
 
-  # Override the default ollama stub for this test to simulate failure.
-  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+  # Override the default curl stub to simulate an ollama API failure: write a
+  # sentinel to stderr (which _ollama_run's caller redirects to cron-stderr.log)
+  # and exit non-zero so the run is recorded as a failure, not silent-empty.
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
 echo "ollama-error-sentinel" >&2
 exit 9
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_VERBOSE=1 bash "$CRON" ollama-fail >/dev/null 2>&1 || true
@@ -1026,17 +1049,14 @@ STUB
 }
 
 test_ollama_timeout_kill_propagates_as_failure() {
-  # The whole point of the timeout wrap: when it fires (exit 124), the run must
-  # be recorded as a failure, not silently skipped. Stub `timeout` to simulate a
-  # kill (124) specifically when wrapping ollama; everything else passes through.
-  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
+  # The point of curl --max-time: when it fires (curl exit 28), the run must be
+  # recorded as a failure, not silently skipped. Stub curl to simulate the
+  # timeout exit.
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
-case "${1:-}" in ''|*[!0-9]*) echo "timeout stub: bad duration: ${1:-}" >&2; exit 99 ;; esac
-shift
-if [ "${1:-}" = "ollama" ]; then exit 124; fi
-exec "$@"
+exit 28
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/timeout"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   cat > "$CEO_DIR/playbooks/ollama-killed.md" << 'PB'
 ---
@@ -1070,15 +1090,7 @@ PB
 
 test_ollama_timeout_rejects_non_numeric_bound() {
   # A non-numeric CEO_OLLAMA_TIMEOUT must be rejected (warn + fall back to 300),
-  # not passed verbatim to `timeout` (which would exit 125 without running ollama).
-  cat > "$TEST_HOME/.bun/bin/timeout" << 'STUB'
-#!/bin/bash
-echo "$1" > "$HOME/timeout-duration.txt"
-shift
-exec "$@"
-STUB
-  chmod +x "$TEST_HOME/.bun/bin/timeout"
-
+  # not passed verbatim to curl --max-time (which would exit before connecting).
   cat > "$CEO_DIR/playbooks/ollama-badto.md" << 'PB'
 ---
 name: ollama-badto
@@ -1095,9 +1107,9 @@ PB
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_OLLAMA_TIMEOUT=abc bash "$CRON" ollama-badto >/dev/null 2>&1 || true
 
-  local dur
-  dur=$(cat "$HOME/timeout-duration.txt" 2>/dev/null || echo "missing")
-  assert_eq "$dur" "300" "non-numeric CEO_OLLAMA_TIMEOUT must fall back to 300, not reach timeout verbatim"
+  local rec
+  rec=$(cat "$HOME/curl-invoked.txt" 2>/dev/null || echo "missing")
+  assert_contains "$rec" "--max-time 300" "non-numeric CEO_OLLAMA_TIMEOUT must fall back to 300, not reach curl verbatim"
 
   local stderr_log
   stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
@@ -1208,11 +1220,14 @@ runner: ollama
 # body
 PB
 
-  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+  # API returns 200 with an empty .response — _ollama_run must surface that as
+  # empty output so the caller records a failure (not a silent success).
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
+echo '{"response":""}'
 exit 0
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_VERBOSE=1 bash "$CRON" ollama-empty >/dev/null 2>&1 || true
@@ -1379,47 +1394,39 @@ PB
 
 test_runner_ollama_chunked_scan_when_prompt_exceeds_budget() {
   # Trigger chunking by creating real vault files so ceo-scan.sh produces enough
-  # scan data to push the prompt over CEO_OLLAMA_MAX_PROMPT_BYTES=5000.
-  # The mock ollama appends to a call log so we can count invocations.
-  #
-  # jq stub: ceo-cron.sh and ceo-config.sh require jq for registry parsing
-  # (schema validation, entry lookup). Install the shared jq-stub.js which
-  # handles the jq subset used by these scripts.
-  cp "$SCRIPT_DIR/jq-stub.js" "$TEST_HOME/.bun/bin/jq.js"
-  cat > "$TEST_HOME/.bun/bin/jq" << 'SHIM'
+  # scan data to push the prompt over CEO_OLLAMA_MAX_PROMPT_BYTES=5000. Both the
+  # per-chunk extraction calls and the synthesis call go through _ollama_run →
+  # curl /api/generate; the stub appends a model line per call so the test can
+  # count invocations, and returns the LOG_ENTRY as the API .response. Real jq
+  # is used (the API request/response encoding needs the full jq, not a subset
+  # stub).
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
-exec node "$(dirname "$0")/jq.js" "$@"
-SHIM
-  chmod +x "$TEST_HOME/.bun/bin/jq"
-
-  # yq stub: prevents path-lookup noise in the controlled test PATH. ceo-cron.sh
-  # itself does not call yq (removed in PR #130); stub retained for test isolation.
-  cat > "$TEST_HOME/.bun/bin/yq" << 'STUB'
-#!/bin/bash
-exit 0
+url="" ; data="" ; prev=""
+for a in "$@"; do
+  case "$prev" in -d|--data|--data-binary|--data-raw) data="$a" ;; esac
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  */api/generate)
+    [ "$data" = "@-" ] && data="$(cat)"
+    printf '%s' "$data" | jq -r '.model' >> "$HOME/ollama-invoked-model.txt"
+    { printf '%s' "$data" | jq -r '.prompt'; printf '\n---CALL---\n'; } >> "$HOME/ollama-invoked-prompts.txt"
+    printf '%s' 'LOG_ENTRY:
+## 03:10 — morning-scan
+**Status:** completed
+**Playbook:** playbooks/morning-scan.md
+**Output:**
+- chunked-scan-sentinel
+**Errors:**
+- none
+END_LOG_ENTRY' | jq -Rs '{response:.}'
+    exit 0 ;;
+  *) exec /usr/bin/curl "$@" ;;
+esac
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/yq"
-
-  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
-#!/bin/bash
-if [ "${1:-}" = "run" ]; then
-  echo "$2" >> "$HOME/ollama-invoked-model.txt"
-  cat >> "$HOME/ollama-invoked-prompts.txt"
-  printf '\n---CALL---\n' >> "$HOME/ollama-invoked-prompts.txt"
-  echo "LOG_ENTRY:"
-  echo "## 03:10 — morning-scan"
-  echo "**Status:** completed"
-  echo "**Playbook:** playbooks/morning-scan.md"
-  echo "**Output:**"
-  echo "- chunked-scan-sentinel"
-  echo "**Errors:**"
-  echo "- none"
-  echo "END_LOG_ENTRY"
-  exit 0
-fi
-exit 0
-STUB
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   cat > "$CEO_DIR/playbooks/morning-scan.md" << 'PB'
 ---
@@ -1597,17 +1604,26 @@ runner: ollama
 # body
 PB
 
-  # ollama stub emits a parseable LOG_ENTRY block — the helper extracts and
-  # routes through ceo-report.sh intake, which writes to REPORT_FILE and
-  # fires the Discord side-channel via curl. We capture curl to assert the
-  # side-channel fired (same shape as test_read_tier_posts_full_report).
-  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+  # curl now serves two roles: the ollama /api/generate call (returns a
+  # parseable LOG_ENTRY block routed through ceo-report.sh intake) and the
+  # Discord side-channel POST (captured to assert it fired, same shape as
+  # test_read_tier_posts_full_report).
+  mkdir -p "$TEST_HOME/curl"
+  export CURL_CAPTURE_DIR="$TEST_HOME/curl"
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
-if [ "${1:-}" = "run" ]; then
-  echo "$2" > "$HOME/ollama-invoked-model.txt"
-  cat > "$HOME/ollama-invoked-prompt.txt"
-  cat << 'OUT'
-LOG_ENTRY:
+url="" ; data="" ; prev=""
+for a in "$@"; do
+  case "$prev" in -d|--data|--data-binary|--data-raw) data="$a" ;; esac
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  */api/generate)
+    [ "$data" = "@-" ] && data="$(cat)"
+    printf '%s' "$data" | jq -r '.model'  > "$HOME/ollama-invoked-model.txt"
+    printf '%s' "$data" | jq -r '.prompt' > "$HOME/ollama-invoked-prompt.txt"
+    printf '%s' 'LOG_ENTRY:
 ## 09:00 — ollama-intake
 **Status:** completed
 **Playbook:** playbooks/ollama-intake.md
@@ -1615,26 +1631,13 @@ LOG_ENTRY:
 Hello from ollama-intake-sentinel.
 **Errors:**
 - none
-END_LOG_ENTRY
-OUT
-  exit 0
-fi
-exit 0
-STUB
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
-
-  mkdir -p "$TEST_HOME/curl"
-  export CURL_CAPTURE_DIR="$TEST_HOME/curl"
-  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
-#!/bin/bash
-out="$CURL_CAPTURE_DIR/payload.json"
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -d) shift; printf '%s' "$1" > "$out" ;;
-  esac
-  shift || true
-done
-exit 0
+END_LOG_ENTRY' | jq -Rs '{response:.}'
+    exit 0 ;;
+  *)
+    [ "$data" = "@-" ] && data="$(cat)"
+    printf '%s' "$data" > "$CURL_CAPTURE_DIR/payload.json"
+    exit 0 ;;
+esac
 STUB
   chmod +x "$TEST_HOME/.bun/bin/curl"
 
@@ -1686,11 +1689,18 @@ runner: ollama
 # body
 PB
 
-  cat > "$TEST_HOME/.bun/bin/ollama" << 'STUB'
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
 #!/bin/bash
-if [ "${1:-}" = "run" ]; then
-  cat << 'OUT'
-LOG_ENTRY:
+url="" ; data="" ; prev=""
+for a in "$@"; do
+  case "$prev" in -d|--data|--data-binary|--data-raw) data="$a" ;; esac
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  */api/generate)
+    [ "$data" = "@-" ] && data="$(cat)"
+    printf '%s' 'LOG_ENTRY:
 ## 09:00 — ollama-selffail
 **Status:** failed
 **Playbook:** playbooks/ollama-selffail.md
@@ -1698,13 +1708,12 @@ LOG_ENTRY:
 Simulated playbook failure.
 **Errors:**
 - something broke during synthesis
-END_LOG_ENTRY
-OUT
-  exit 0
-fi
-exit 0
+END_LOG_ENTRY' | jq -Rs '{response:.}'
+    exit 0 ;;
+  *) exec /usr/bin/curl "$@" ;;
+esac
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/ollama"
+  chmod +x "$TEST_HOME/.bun/bin/curl"
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   CEO_VERBOSE=1 bash "$CRON" ollama-selffail >/dev/null 2>&1 || true

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -908,11 +908,15 @@ PB
     FAILS=$((FAILS + 1))
   fi
 
-  local model got_source
+  local model got_source numctx
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
   assert_eq "$model" "gemma4:12b-it-qat" "runner:ollama default must be gemma4:12b-it-qat"
   got_source=$(cat "$HOME/ollama-model-source.txt" 2>/dev/null || echo "MISSING")
   assert_eq "$got_source" "invoked" "ollama runner must export CEO_MODEL_SOURCE=invoked (harness drove the model)"
+  # The headline fix: the request must carry the model's real context window, not
+  # ollama's ~4K CLI default. Fails if options.num_ctx is dropped or shrunk.
+  numctx=$(cat "$HOME/ollama-invoked-numctx.txt" 2>/dev/null || echo "MISSING")
+  assert_eq "$numctx" "32768" "request must set options.num_ctx to the model's real window (default 32768)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -1241,6 +1245,211 @@ STUB
   if [[ "$runs_log" == *"ollama-empty completed"* ]]; then
     printf '  FAIL [%s] empty ollama output must NOT log completed\n    runs_log: %q\n' \
       "$CURRENT_TEST" "$runs_log"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_runner_ollama_error_in_200_body_records_failure() {
+  # non-throwing-client-success-check: a 200 response can still carry an .error
+  # (model not found, OOM). _ollama_run must inspect it and route to failure,
+  # not treat the (empty .response) as success — and must log the error text.
+  cat > "$CEO_DIR/playbooks/ollama-apierror.md" << 'PB'
+---
+name: ollama-apierror
+description: ollama 200 body carries an .error
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+echo '{"error":"model not found"}'
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-apierror >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "a 200 body carrying .error must increment FAIL_COUNT_FILE"
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "ollama API error" "the API .error text must be logged, not swallowed"
+  assert_contains "$stderr_log" "model not found" "the daemon's error message must reach cron-stderr.log"
+
+  local runs_log
+  runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
+  if [[ "$runs_log" == *"ollama-apierror completed"* ]]; then
+    printf '  FAIL [%s] a .error response must NOT log completed\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_runner_ollama_non_json_body_records_failure() {
+  # A non-JSON body (proxy HTML error, truncated stream) must route to failure
+  # via explicit validation with a logged diagnostic — not an ambient set -e
+  # trip that leaves cron-stderr.log silent.
+  cat > "$CEO_DIR/playbooks/ollama-nonjson.md" << 'PB'
+---
+name: ollama-nonjson
+description: ollama returns a non-JSON body
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+echo '<html>502 Bad Gateway</html>'
+exit 0
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_VERBOSE=1 bash "$CRON" ollama-nonjson >/dev/null 2>&1 || true
+
+  local fails
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  assert_eq "$fails" "1" "a non-JSON ollama body must increment FAIL_COUNT_FILE"
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "non-JSON or empty body" "a non-JSON body must log a diagnostic, not fail silently"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_ollama_num_ctx_rejects_non_integer() {
+  # Sibling of test_ollama_timeout_rejects_non_numeric_bound: a typo'd
+  # CEO_OLLAMA_NUM_CTX must warn and fall back to 32768, not reach the request
+  # verbatim.
+  cat > "$CEO_DIR/playbooks/ollama-badctx.md" << 'PB'
+---
+name: ollama-badctx
+description: bad num_ctx value
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+runner: ollama
+---
+# body
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  CEO_OLLAMA_NUM_CTX=abc bash "$CRON" ollama-badctx >/dev/null 2>&1 || true
+
+  local numctx
+  numctx=$(cat "$HOME/ollama-invoked-numctx.txt" 2>/dev/null || echo "missing")
+  assert_eq "$numctx" "32768" "non-integer CEO_OLLAMA_NUM_CTX must fall back to 32768, not reach the request verbatim"
+
+  local stderr_log
+  stderr_log=$(cat "$CEO_DIR/log/cron-stderr.log" 2>/dev/null || echo "")
+  assert_contains "$stderr_log" "CEO_OLLAMA_NUM_CTX='abc'" "a rejected num_ctx value must be warned about"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_runner_ollama_default_budget_admits_real_prompt() {
+  # Pins the budget raise (24576 -> 90000). The production failures were 27-51 KB
+  # prompts rejected/chunked at the old 24 KB cap. This fixture's scan prompt
+  # lands ~25-32 KB — above the old cap, below the new one — so at the default
+  # (90000) it dispatches as a SINGLE call; revert the default to 24576 and the
+  # same prompt is over budget and routes to the chunker (>= 2 calls). The
+  # curl stub records the prompt size so the test self-validates its premise.
+  cat > "$TEST_HOME/.bun/bin/curl" << 'STUB'
+#!/bin/bash
+url="" ; data="" ; prev=""
+for a in "$@"; do
+  case "$prev" in -d|--data|--data-binary|--data-raw) data="$a" ;; esac
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  */api/generate)
+    [ "$data" = "@-" ] && data="$(cat)"
+    echo x >> "$HOME/ollama-call-count.txt"
+    printf '%s' "$data" | jq -r '.prompt' | wc -c | tr -d ' ' > "$HOME/ollama-prompt-bytes.txt"
+    printf '%s' 'LOG_ENTRY:
+## 03:10 — morning-scan
+**Status:** completed
+**Playbook:** playbooks/morning-scan.md
+**Output:**
+- budget-ok-sentinel
+**Errors:**
+- none
+END_LOG_ENTRY' | jq -Rs '{response:.}'
+    exit 0 ;;
+  *) exec /usr/bin/curl "$@" ;;
+esac
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/curl"
+
+  cat > "$CEO_DIR/playbooks/morning-scan.md" << 'PB'
+---
+name: morning-scan
+description: default-budget admits real prompt
+trigger: cron
+schedule: "50 8 * * 1-5"
+runner: ollama
+model: gemma4:12b-it-qat
+preflight: none
+tier: read
+status: active
+---
+# morning-scan body
+PB
+
+  touch -t 202501010000 "$CEO_DIR/log/.last-scan" 2>/dev/null || touch "$CEO_DIR/log/.last-scan"
+  mkdir -p "$CEO_VAULT/Projects" "$CEO_VAULT/Areas" "$CEO_VAULT/Daily"
+  for i in $(seq 1 8); do echo "project note content $i" > "$CEO_VAULT/Projects/note-$i.md"; done
+  echo "area work content" > "$CEO_VAULT/Areas/work.md"
+  local _y _t
+  _y=$(date -d yesterday +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d)
+  _t=$(date +%Y-%m-%d)
+  { echo "# Yesterday"; for _ in $(seq 1 280); do echo "yesterday content line for the default-budget scan test padding"; done; } > "$CEO_VAULT/Daily/$_y.md"
+  { echo "# Today"; for _ in $(seq 1 140); do echo "today content line for the default-budget scan test padding"; done; } > "$CEO_VAULT/Daily/$_t.md"
+  { echo "# Report"; for _ in $(seq 1 140); do echo "yesterday report line for the default-budget scan test padding"; done; } > "$CEO_DIR/reports/$_y.md"
+
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  CEO_VERBOSE=1 bash "$CRON" morning-scan >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "the scan prompt must dispatch at the default budget, not fail"
+
+  # Premise guard: the prompt must sit strictly between the old and new caps,
+  # else the mutation (default -> 24576) wouldn't change behavior.
+  local pbytes
+  pbytes=$(cat "$HOME/ollama-prompt-bytes.txt" 2>/dev/null || echo 0)
+  if [ "$pbytes" -le 24576 ] || [ "$pbytes" -ge 90000 ]; then
+    printf '  FAIL [%s] fixture prompt %s bytes must be in (24576, 90000) for this test to bite\n' \
+      "$CURRENT_TEST" "$pbytes"
+    FAILS=$((FAILS + 1))
+  fi
+
+  # At the default budget this prompt is under budget -> exactly one API call.
+  # Reverting the default to 24576 forces the chunker (>= 2 calls).
+  local calls
+  calls=$(wc -l < "$HOME/ollama-call-count.txt" 2>/dev/null | tr -d ' ')
+  assert_eq "${calls:-0}" "1" "a ~25-32 KB prompt must be a single call at the default budget (90000), not chunked"
+
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  if echo "$skips_log" | grep -q "exceeds budget"; then
+    printf '  FAIL [%s] the scan prompt must NOT hit the budget-exceeded path at the default (90000)\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The weekday ollama fallback failed on every run for `morning-scan`, `morning-brief`, and `pending-drip`. After the Claude rate-limit fallback flipped these read-tier playbooks to ollama, the dispatcher rejected them:

- `morning-brief` / `pending-drip` — `ollama prompt exceeds budget (27015 > 24576 bytes)`
- `morning-scan` — `chunked scan: base prompt alone is 27215 bytes, no room to chunk`

Recurred Jun 2, 8, 10, 14, 16 (see ML-1 `CEO/log/cron-skips.log`).

**Root cause:** `CEO_OLLAMA_MAX_PROMPT_BYTES=24576` (24 KB) rejected the real 27–51 KB prompts, and the scan chunker computed a negative `chunk_budget` because the base prompt alone exceeded the whole budget. The 24 KB cap was a stale proxy for `ollama run`'s default `num_ctx` (~4K tokens) — `_ollama_run` never set `num_ctx`, so prompts that did fit the byte budget were silently truncated at the runtime context window. `gemma4:12b-it-qat` actually exposes a 262144-token window.

**Fix (`scripts/ceo-cron.sh`):**
- `_ollama_run` now POSTs to the ollama HTTP API (`/api/generate`) with `options.num_ctx` (default 32768, override `CEO_OLLAMA_NUM_CTX`) instead of `ollama run`, so the model's real window is used.
- `curl --max-time` bounds wall-clock natively (drops the `timeout`/`gtimeout` binary dance). `curl --fail` + JSON `.error` inspection route HTTP/API errors to the failure path instead of recording empty-but-successful output.
- Raised `CEO_OLLAMA_MAX_PROMPT_BYTES` to 90000 (≈ a 32K-token window with output headroom); corrected the stale comment.

Test stubs moved from the `ollama run` binary to a `curl /api/generate` emulator with argv validation; timeout assertions now check `curl --max-time`.

## Testing Procedure

1. Check out this branch.
2. Run the suite: `bash scripts/ceo-cron.sh` is not it — run `bash scripts/ceo-cron.test.sh`. Confirm `All tests passed. (145 tests)`, exit 0.
3. (Optional, on ML-1 with the ollama daemon up) Confirm a large prompt is fully ingested at the new context size:
   ```bash
   { for i in $(seq 1 1500); do echo "Filler line $i."; done; echo; echo "Reply with exactly one word: PINEAPPLE"; } > /tmp/bp.txt
   jq -Rs --arg m gemma4:12b-it-qat --argjson n 32768 '{model:$m,prompt:.,stream:false,options:{num_ctx:$n}}' < /tmp/bp.txt \
     | curl -fsS --max-time 180 http://localhost:11434/api/generate -d @- | jq -r '.response, (.prompt_eval_count|tostring)'
   ```
   Expect `PINEAPPLE` and a token count in the ~29K range (the tail instruction is only reachable if `num_ctx` is honored).

## Additional Notes / HelpScout Tickets

Verified on ML-1: a 105 KB prompt ingested 28,923 tokens at `num_ctx=32768` and the model obeyed an instruction at the prompt tail (unreachable under the old ~4K default). The host checkout was not modified during verification. No linked issue; surfaced while reviewing recent ollama cron-skip errors.