### PR TITLE
chore(swarm): clear shellcheck warnings in ceo-swarm.test.sh

### DIFF
--- a/scripts/ceo-swarm.test.sh
+++ b/scripts/ceo-swarm.test.sh
@@ -242,7 +242,7 @@ JSON
 _owners_health() {
   env HOME="$TEST_HOME" CEO_VAULT="$TEST_VAULT" CEO_HOSTNAME="checker" \
     CEO_SWARM_NOW_EPOCH="${OH_NOW:-}" PATH="$PATH" \
-    bash "$CEO_CLI" swarm owners-health "$@"
+    bash "$CEO_CLI" swarm owners-health
 }
 
 # Seed swarm.json with a single-scope owner map.
@@ -264,7 +264,7 @@ OH_REF_EPOCH=1781697600
 
 _iso_at_offset() {
   # $1 = seconds to subtract from OH_REF_EPOCH, rendered as UTC ISO8601.
-  local secs="$1" epoch=$((OH_REF_EPOCH - $1))
+  local epoch=$((OH_REF_EPOCH - $1))
   date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
     || date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ
 }


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The `shellcheck` CI job (`severity: warning`, `scandir: ./scripts`) was red repo-wide on two pre-existing warnings in `ceo-swarm.test.sh`, so every PR's checks inherited a failing `shellcheck`. Surfaced during the PR #178 review panel.

- **SC2120** — `_owners_health` forwarded `"$@"` but all 23 call sites invoke it with no args. Dropped the dead passthrough.
- **SC2034** — `_iso_at_offset` declared an unused `secs` alias. Removed it, keeping the `$1` arithmetic (original behavior). (Care: rewriting it as `local secs="$1" epoch=$((... - secs))` trips SC2318 and computes `epoch` wrong — verified that breaks 6 tests — so the alias is simply removed.)

## Testing Procedure

1. Check out this branch.
2. `shellcheck --severity=warning scripts/*.sh` — exits 0 (clean), matching the CI job.
3. `bash scripts/ceo-swarm.test.sh` — `All tests passed. (21 tests)`.

## Additional Notes / HelpScout Tickets

Behavior-preserving cleanup; no production code touched. Unblocks the `shellcheck` check for all future PRs to the repo.