### PR TITLE
Add CEO morning flow: one orchestrated briefing ranked by real signals + learning ledger

### DIFF
--- a/docs/cutover-morning-flow.md
+++ b/docs/cutover-morning-flow.md
@@ -1,0 +1,96 @@
+# Morning Flow Cutover (ML-1 only)
+
+This runbook documents the runtime steps needed to activate the `morning` playbook
+and retire the four legacy playbooks. All file/frontmatter changes are already
+committed in `nh/feat/ceo-morning-flow`. The steps below are deferred runtime
+actions that must run on ML-1.
+
+## Prerequisites
+
+- Branch `nh/feat/ceo-morning-flow` is merged to master.
+- You are on ML-1 (check: `hostname` must be ML-1).
+- Per `ceo-scan-only-on-ml1`: `ceo playbook scan` installs host-local launchd
+  agents and rewrites the synced `CEO/registry.json`. Never run it on the
+  MacBook or any other host.
+
+## Step 1: Run `ceo playbook scan` on ML-1
+
+```bash
+ceo playbook scan
+```
+
+This regenerates `~/.ceo/registry.json` from frontmatter and registers the
+`morning` schedule via ceo-schedulerd. The four legacy playbooks
+(`morning-scan`, `morning-brief`, `pending-drip`, `pr-triage`) have
+`status: disabled` in their frontmatter and will be de-scheduled automatically.
+
+## Step 2: Add `morning` to `discord_report_triggers` (vault CEO/settings.json)
+
+Edit the synced vault file `CEO/settings.json`. Add `"morning"` to the
+`discord_report_triggers` array. **Keep `"morning-brief"` in the array for
+ONE cycle** while you diff the outputs (see Step 3).
+
+Example delta:
+```json
+"discord_report_triggers": ["morning-brief", "morning"]
+```
+
+This is a vault edit — do it directly in Obsidian or via a terminal on ML-1.
+Do NOT commit `CEO/settings.json` to this repo; it lives in the synced vault.
+
+## Step 3: One-cycle diff (1-2 days)
+
+For the first 1-2 weekday mornings after cutover, compare:
+
+- New `morning` briefing (written to `CEO/reports/YYYY-MM-DD.md`)
+- Legacy `morning-brief` output (check Discord second message)
+
+Confirm the new briefing has parity or improvement on:
+- Priority ranking (sprint membership as primary key)
+- Overnight digest coverage
+- Predicted-priorities block presence
+
+## Step 4: Remove `morning-brief` from `discord_report_triggers`
+
+Once parity/superiority is confirmed, edit `CEO/settings.json` again:
+
+```json
+"discord_report_triggers": ["morning"]
+```
+
+Leave legacy playbooks in their `status: disabled` state — disabled, not deleted,
+so they can be re-enabled for comparison if needed.
+
+## Step 5: Register `morning` as an automated writer
+
+Per `ceo-automated-writers-are-playbooks`: `morning` writes to `CEO/model/YYYY-MM.md`
+(the learning ledger). Ensure the registry entry in `CEO/registry.json` declares
+this output under `outputs`. If the scan did not auto-populate it, add manually:
+
+```json
+{
+  "name": "morning",
+  "outputs": ["CEO/reports/", "CEO/model/"]
+}
+```
+
+The `CEO/model/` path is write-append (one dated entry per run); `CEO/reports/`
+is the daily briefing. Both are sanctioned output locations per
+`CEO/rules/output-locations.md`.
+
+## Summary of status changes (committed)
+
+| Playbook | Before | After |
+|---|---|---|
+| `morning` | draft | **active** |
+| `morning-scan` | active | **disabled** |
+| `morning-brief` | active | **disabled** |
+| `pending-drip` | active | **disabled** |
+| `pr-triage` | active | **disabled** |
+
+## What was NOT done in this commit
+
+- `ceo playbook scan` was NOT run (ML-1 runtime action).
+- Vault `CEO/settings.json` was NOT edited (outside this repo; deferred runtime step).
+- No launchd agents were installed.
+- No crontab entries were modified.

--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -7,7 +7,7 @@ runner: ollama
 model: gemma4:12b-it-qat
 preflight: none
 tier: read
-status: active
+status: disabled
 ---
 
 # Morning Brief

--- a/docs/playbooks/morning-scan.md
+++ b/docs/playbooks/morning-scan.md
@@ -7,7 +7,7 @@ runner: ollama
 model: gemma4:12b-it-qat
 preflight: none
 tier: read
-status: active
+status: disabled
 ---
 
 # Morning Scan

--- a/docs/playbooks/morning.md
+++ b/docs/playbooks/morning.md
@@ -21,7 +21,7 @@ You are the CEO arriving at the office. Produce ONE briefing from the pre-gather
 2. **Priorities (ranked by REAL signal).** Rank today's work. **Sprint membership is the primary key: an item in `CURRENT_SPRINT_ITEMS` outranks an older non-sprint PR.** Never rank by age alone. For Personal, use `Daily note Top 3`. Show the top 3-5 with a one-clause justification each ("in current sprint", "Top 3 today").
 3. **Day plan.** Translate the priorities into a short ordered plan.
 4. **Goals/todos.** Surface relevant items from `Active Domains` + `Daily note Tasks` + 1-2 `Pending [ask] questions`.
-5. **Predicted-priorities block.** End the output with this exact machine-readable block (consumed by the learning ledger), listing the top priorities you chose in step 2:
+5. **Predicted-priorities block.** Place this block as the final lines of your **Output:** section (before END_LOG_ENTRY), listing the top priorities you chose in step 2. The learning ledger reads the full raw output, so the block will be found wherever it appears — but inline keeps the structure tidy:
 
    ```
    <!-- CEO-PREDICTED-PRIORITIES
@@ -31,7 +31,7 @@ You are the CEO arriving at the office. Produce ONE briefing from the pre-gather
 
 ## Output Format
 
-A briefing of <= 10 bullets (digest, priorities-with-justification, day plan, goals/todos), then the CEO-PREDICTED-PRIORITIES block. The shell writes it to CEO/reports/YYYY-MM-DD.md and posts to Discord.
+A briefing of <= 10 bullets (digest, priorities-with-justification, day plan, goals/todos), then the CEO-PREDICTED-PRIORITIES block (inside the Output section, before END_LOG_ENTRY). The shell writes it to CEO/reports/YYYY-MM-DD.md and posts to Discord.
 
 ## Constraints
 

--- a/docs/playbooks/morning.md
+++ b/docs/playbooks/morning.md
@@ -7,7 +7,7 @@ runner: claude
 model: sonnet
 preflight: none
 tier: read
-status: draft
+status: active
 inputs: [pr_data, pending_count, today_log, yesterday_log, daily_note, active_domains, pending_ask, current_sprint, yesterday_merged, ledger_recent]
 ---
 

--- a/docs/playbooks/morning.md
+++ b/docs/playbooks/morning.md
@@ -1,0 +1,40 @@
+---
+name: morning
+description: One coherent CEO morning briefing ranked by real priority signals
+trigger: cron
+schedule: "20 3 * * 1-5"
+runner: claude
+model: sonnet
+preflight: none
+tier: read
+status: draft
+inputs: [pr_data, pending_count, today_log, yesterday_log, daily_note, active_domains, pending_ask, current_sprint, yesterday_merged, ledger_recent]
+---
+
+# Morning Flow
+
+You are the CEO arriving at the office. Produce ONE briefing from the pre-gathered data below. Do NOT call Read/Grep/Glob/gh — everything is injected. Cap is `--max-turns 5`.
+
+## Steps
+
+1. **Overnight digest.** Summarize what changed: PRs needing review (`PR_REVIEW_REQUESTED`), pending approvals, firing alerts. 2-3 lines.
+2. **Priorities (ranked by REAL signal).** Rank today's work. **Sprint membership is the primary key: an item in `CURRENT_SPRINT_ITEMS` outranks an older non-sprint PR.** Never rank by age alone. For Personal, use `Daily note Top 3`. Show the top 3-5 with a one-clause justification each ("in current sprint", "Top 3 today").
+3. **Day plan.** Translate the priorities into a short ordered plan.
+4. **Goals/todos.** Surface relevant items from `Active Domains` + `Daily note Tasks` + 1-2 `Pending [ask] questions`.
+5. **Predicted-priorities block.** End the output with this exact machine-readable block (consumed by the learning ledger), listing the top priorities you chose in step 2:
+
+   ```
+   <!-- CEO-PREDICTED-PRIORITIES
+   - {repo}#{number}: {title}
+   -->
+   ```
+
+## Output Format
+
+A briefing of <= 10 bullets (digest, priorities-with-justification, day plan, goals/todos), then the CEO-PREDICTED-PRIORITIES block. The shell writes it to CEO/reports/YYYY-MM-DD.md and posts to Discord.
+
+## Constraints
+
+- Read-only. No write actions.
+- All data is pre-gathered; never run gh/git directly.
+- Rank by sprint/Top-3 signal, never by age alone.

--- a/docs/playbooks/pending-drip.md
+++ b/docs/playbooks/pending-drip.md
@@ -6,7 +6,7 @@ schedule: "33 9 * * *"
 model: haiku
 preflight: has_pending_items
 tier: read
-status: active
+status: disabled
 ---
 
 # Pending Drip

--- a/docs/playbooks/pr-triage.md
+++ b/docs/playbooks/pr-triage.md
@@ -6,7 +6,7 @@ schedule: "3 10 * * 1-5"
 model: sonnet
 preflight: has_prs_to_review
 tier: read
-status: active
+status: disabled
 ---
 
 # PR Triage

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1273,11 +1273,11 @@ cmd_playbook_scan() {
         # gate at dispatch, never silently coerce.
         local unknown_keys
         unknown_keys=$(echo "$inputs" | jq -r '
-          ["pr_data","pending_count","today_log","yesterday_log","daily_note","briefings_training","active_domains","pending_ask","scan_data","blessings"] as $valid
+          ["pr_data","pending_count","today_log","yesterday_log","daily_note","briefings_training","active_domains","pending_ask","scan_data","blessings","current_sprint","yesterday_merged","ledger_recent"] as $valid
           | .[]? | select(. as $k | $valid | index($k) | not)
         ' 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
         if [ -n "$unknown_keys" ]; then
-          echo "  WARN  $basename: 'inputs' contains unknown key(s): $unknown_keys — ignored at dispatch. Known: pr_data, pending_count, today_log, yesterday_log, daily_note, briefings_training, active_domains, pending_ask, scan_data, blessings" >&2
+          echo "  WARN  $basename: 'inputs' contains unknown key(s): $unknown_keys — ignored at dispatch. Known: pr_data, pending_count, today_log, yesterday_log, daily_note, briefings_training, active_domains, pending_ask, scan_data, blessings, current_sprint, yesterday_merged, ledger_recent" >&2
         fi
         ;;
       *)

--- a/scripts/ceo-cron-inputs.test.sh
+++ b/scripts/ceo-cron-inputs.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+
+test_pregathered_emits_new_signals_when_inputs_list_them() {
+  # Source the LIB (Task 0), not ceo-cron.sh (which runs dispatch on source).
+  # _inputs_includes reads the module-scope INPUTS_JSON; set it directly.
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-cron-lib.sh"
+  INPUTS_JSON='["current_sprint","yesterday_merged","ledger_recent"]'
+  export CURRENT_SPRINT_ITEMS='[{"number":7,"repo":"o/r","title":"S"}]'
+  export CURRENT_SPRINT_COUNT=1
+  export YESTERDAY_MERGED='[{"number":7,"repo":"o/r"}]'
+  export LEDGER_RECENT="predicted today: o/r#7"
+  block=$(ceo_build_pregathered_extras)   # helper extracted for testability
+  assert_contains "$block" "Current sprint" "sprint line emitted"
+  assert_contains "$block" '"number":7' "sprint items present"
+  assert_contains "$block" "Yesterday merged" "yesterday-merged line emitted"
+  assert_contains "$block" "model ledger" "ledger line emitted"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -20,5 +20,19 @@ ceo_build_pregathered_extras() {
   printf '%s' "$out"
 }
 
-# (ceo_morning_observe_hook, ceo_morning_raw_digest
-#  are added to this lib by Tasks 6, 7 respectively.)
+# Append the model-of-Nathan ledger entry after a successful morning run.
+# In the lib so it is unit-testable. Never fails the flow.
+ceo_morning_observe_hook() {
+  local trigger="$1" log_entry="$2"
+  [ "$trigger" = "morning" ] || return 0
+  [ "${CEO_DRY_RUN:-}" = "1" ] && return 0
+  if ! printf '%s\n' "$log_entry" \
+      | YESTERDAY_MERGED="${YESTERDAY_MERGED:-[]}" \
+        LEDGER_PREV_PREDICTED="${LEDGER_PREV_PREDICTED:-[]}" \
+        bash "${SCRIPT_DIR}/ceo-observe.sh" >/dev/null 2>&1; then
+    command -v _v >/dev/null 2>&1 && _v "observe step failed (non-fatal)"
+  fi
+  return 0
+}
+
+# (ceo_morning_raw_digest is added to this lib by Task 7.)

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -1,0 +1,14 @@
+# Sourceable pure-function library for ceo-cron.sh. NO top-level side effects —
+# safe to `source` from tests. Functions read the caller's module-scope globals.
+
+# Returns 0 if the pre-gather key should be injected. Reads global INPUTS_JSON
+# (a JSON array, or "null"/empty → default-all for pre-feature playbooks).
+_inputs_includes() {
+  local key="$1"
+  [ "${INPUTS_JSON:-null}" = "null" ] && return 0
+  [ -z "${INPUTS_JSON:-}" ] && return 0
+  echo "$INPUTS_JSON" | jq -e --arg k "$key" 'index($k) != null' >/dev/null 2>&1
+}
+
+# (ceo_build_pregathered_extras, ceo_morning_observe_hook, ceo_morning_raw_digest
+#  are added to this lib by Tasks 3B, 6, 7 respectively.)

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -6,7 +6,6 @@
 _inputs_includes() {
   local key="$1"
   [ "${INPUTS_JSON:-null}" = "null" ] && return 0
-  [ -z "${INPUTS_JSON:-}" ] && return 0
   echo "$INPUTS_JSON" | jq -e --arg k "$key" 'index($k) != null' >/dev/null 2>&1
 }
 

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -35,4 +35,13 @@ ceo_morning_observe_hook() {
   return 0
 }
 
-# (ceo_morning_raw_digest is added to this lib by Task 7.)
+# Deterministic fallback digest for morning trigger when synthesis produces no
+# usable LOG_ENTRY output. Reads module-scope globals set by the pre-gather phase.
+ceo_morning_raw_digest() {
+  echo "**Morning (raw digest — synthesis unavailable)**"
+  local sprint; sprint=$(echo "${CURRENT_SPRINT_ITEMS:-[]}" | jq -r '.[]? | "- [sprint] " + .repo + "#" + (.number|tostring) + " " + .title' 2>/dev/null)
+  [ -n "$sprint" ] && { echo "Current sprint:"; echo "$sprint"; }
+  local rev; rev=$(echo "${PR_REVIEW_REQUESTED:-[]}" | jq -r '.[]? | "- [review] " + (.title // "PR")' 2>/dev/null)
+  [ -n "$rev" ] && { echo "Needs review:"; echo "$rev"; }
+  [ -n "${DAILY_NOTE_TOP3:-}" ] && { echo "Top 3:"; echo "${DAILY_NOTE_TOP3}"; }
+}

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -10,5 +10,15 @@ _inputs_includes() {
   echo "$INPUTS_JSON" | jq -e --arg k "$key" 'index($k) != null' >/dev/null 2>&1
 }
 
-# (ceo_build_pregathered_extras, ceo_morning_observe_hook, ceo_morning_raw_digest
-#  are added to this lib by Tasks 3B, 6, 7 respectively.)
+# Emit the v1 morning-flow extra signals, gated by the playbook's inputs list.
+# In the lib so it is unit-testable without driving a full dispatch.
+ceo_build_pregathered_extras() {
+  local out=""
+  _inputs_includes current_sprint  && out+="- Current sprint (${CURRENT_SPRINT_COUNT:-0} items): ${CURRENT_SPRINT_ITEMS:-[]}"$'\n'
+  _inputs_includes yesterday_merged && out+="- Yesterday merged (observable positives): ${YESTERDAY_MERGED:-[]}"$'\n'
+  _inputs_includes ledger_recent    && out+="- model ledger (recent, model-of-Nathan): ${LEDGER_RECENT:-}"$'\n'
+  printf '%s' "$out"
+}
+
+# (ceo_morning_observe_hook, ceo_morning_raw_digest
+#  are added to this lib by Tasks 6, 7 respectively.)

--- a/scripts/ceo-cron-lib.test.sh
+++ b/scripts/ceo-cron-lib.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/ceo-cron-lib.sh"   # MUST be safe to source (no dispatch)
+
+test_inputs_includes_reads_inputs_json() {
+  INPUTS_JSON='["current_sprint","daily_note"]'
+  _inputs_includes current_sprint && r1=0 || r1=1
+  _inputs_includes nope && r2=0 || r2=1
+  assert_eq "$r1" "0" "present key returns 0"
+  assert_eq "$r2" "1" "absent key returns 1"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_inputs_includes_defaults_all_when_null() {
+  INPUTS_JSON="null"
+  _inputs_includes anything && r=0 || r=1
+  assert_eq "$r" "0" "null inputs → default-all (returns 0)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-cron-morning-fallback.test.sh
+++ b/scripts/ceo-cron-morning-fallback.test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+
+test_raw_digest_helper_emits_signals_when_synthesis_empty() {
+  # Source the LIB (Task 0), not ceo-cron.sh.
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-cron-lib.sh"
+  CURRENT_SPRINT_ITEMS='[{"number":7,"repo":"o/r","title":"Sprint Y"}]'
+  PR_REVIEW_REQUESTED='[]'; DAILY_NOTE_TOP3="Write spec"
+  out=$(ceo_morning_raw_digest)
+  assert_contains "$out" "Sprint Y" "digest includes sprint item"
+  assert_contains "$out" "Write spec" "digest includes Top 3"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-cron-morning-observe.test.sh
+++ b/scripts/ceo-cron-morning-observe.test.sh
@@ -70,4 +70,12 @@ test_call_site_passes_raw_output() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_dry_run_skips_observe() {
+  setup
+  CEO_DRY_RUN=1 ceo_morning_observe_hook "morning" "$ENTRY_OUT"
+  assert_fails "ledger not created in dry-run" test -f "$CEO_VAULT/CEO/model/2026-06.md"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-cron-morning-observe.test.sh
+++ b/scripts/ceo-cron-morning-observe.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TMP=$(mktemp -d); export CEO_VAULT="$TMP/v"; mkdir -p "$CEO_VAULT/CEO/model"
+  export TODAY="2026-06-20"
+  ENTRY_OUT=$'**Status:** ok\n<!-- CEO-PREDICTED-PRIORITIES\n- o/r#7: Ship\n-->'
+  # Source the LIB (Task 0), not ceo-cron.sh.
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-cron-lib.sh"
+  export SCRIPT_DIR  # ceo_morning_observe_hook resolves ceo-observe.sh via it
+}
+teardown() { rm -rf "$TMP"; unset CEO_VAULT TODAY; }
+
+test_morning_hook_writes_ledger_entry() {
+  setup
+  ceo_morning_observe_hook "morning" "$ENTRY_OUT"
+  assert_file_exists "$CEO_VAULT/CEO/model/2026-06.md" "ledger month file created"
+  assert_contains "$(cat "$CEO_VAULT/CEO/model/2026-06.md")" "2026-06-20" "dated entry written"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_non_morning_trigger_is_noop() {
+  setup
+  ceo_morning_observe_hook "morning-brief" "$ENTRY_OUT"
+  assert_fails "no ledger write for non-morning trigger" test -f "$CEO_VAULT/CEO/model/2026-06.md"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-cron-morning-observe.test.sh
+++ b/scripts/ceo-cron-morning-observe.test.sh
@@ -32,4 +32,42 @@ test_non_morning_trigger_is_noop() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+# Round-trip test: predicted block placed AFTER END_LOG_ENTRY (realistic model output).
+# Reproduces the production risky case — the block lives outside the log fence.
+# Proves the raw-output call site is what makes the ledger capture it.
+test_post_fence_predicted_block_captured() {
+  setup
+  # Raw model output: fenced briefing followed by the predicted block after END_LOG_ENTRY
+  local raw_with_post_fence=$'LOG_ENTRY:\n**Status:** ok\n**Summary:** things happened\nEND_LOG_ENTRY\n<!-- CEO-PREDICTED-PRIORITIES\n- o/r#7: Ship\n-->'
+  ceo_morning_observe_hook "morning" "$raw_with_post_fence"
+  local ledger_content
+  ledger_content=$(cat "$CEO_VAULT/CEO/model/2026-06.md" 2>/dev/null || true)
+  assert_contains "$ledger_content" "o/r#7" "post-fence predicted item captured in ledger"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+# Mutation check: passing only the fenced log_entry (block stripped) yields no predicted bullet.
+# This confirms the fix is load-bearing — stripped input fails to populate the ledger.
+test_stripped_input_yields_no_predicted_bullet() {
+  setup
+  # Simulate the old broken behavior: only the log_entry text (block stripped by sed)
+  local fenced_only=$'**Status:** ok\n**Summary:** things happened'
+  ceo_morning_observe_hook "morning" "$fenced_only"
+  local ledger_content
+  ledger_content=$(cat "$CEO_VAULT/CEO/model/2026-06.md" 2>/dev/null || true)
+  assert_not_contains "$ledger_content" "o/r#7" "stripped input produces no predicted bullet"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+# Call-site assertion: ceo_morning_observe_hook in ceo-cron.sh must pass the raw output var.
+test_call_site_passes_raw_output() {
+  local call_line
+  call_line=$(grep 'ceo_morning_observe_hook' "$SCRIPT_DIR/ceo-cron.sh" | grep -v '^#')
+  assert_not_contains "$call_line" '"$log_entry"' "call site passes raw output, not log_entry"
+  assert_contains "$call_line" '"$output"' "call site passes \$output variable"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1364,7 +1364,7 @@ if [ "$TIER" = "read" ]; then
     PRE_GATHERED+="- Daily note Top 3: $DAILY_NOTE_TOP3"$'\n'
     PRE_GATHERED+="- Daily note Tasks: $DAILY_NOTE_TASKS"$'\n'
   fi
-  PRE_GATHERED+="$(ceo_build_pregathered_extras)"$'\n'
+  _extras=$(ceo_build_pregathered_extras); [ -n "$_extras" ] && PRE_GATHERED+="$_extras"$'\n'
 
   BRIEFINGS_BLOCK=""
   if _inputs_includes briefings_training; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -335,6 +335,10 @@ _dispatch_single_output() {
     _report intake "$trigger" "$log_entry"
   fi
 
+  if [ "$self_reported_failed" -eq 0 ]; then
+    ceo_morning_observe_hook "$trigger" "$log_entry"
+  fi
+
   if [ "$self_reported_failed" -eq 1 ]; then
     _record_failure "$trigger self-reported **Status:** failed ($model_label)"
     return 1

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1352,6 +1352,7 @@ if [ "$TIER" = "read" ]; then
     PRE_GATHERED+="- Daily note Top 3: $DAILY_NOTE_TOP3"$'\n'
     PRE_GATHERED+="- Daily note Tasks: $DAILY_NOTE_TASKS"$'\n'
   fi
+  PRE_GATHERED+="$(ceo_build_pregathered_extras)"$'\n'
 
   BRIEFINGS_BLOCK=""
   if _inputs_includes briefings_training; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -342,7 +342,9 @@ _dispatch_single_output() {
   fi
 
   if [ "$self_reported_failed" -eq 0 ]; then
-    ceo_morning_observe_hook "$trigger" "$log_entry"
+    # Pass raw output so CEO-PREDICTED-PRIORITIES survives regardless of
+    # whether the model placed it inside or after the LOG_ENTRY fence.
+    ceo_morning_observe_hook "$trigger" "$output"
   fi
 
   if [ "$self_reported_failed" -eq 1 ]; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -309,13 +309,19 @@ _dispatch_single_output() {
   log_entry=$(printf '%s\n' "$output" | sed -n '/^LOG_ENTRY:/,/^END_LOG_ENTRY/p' | sed '1d;$d')
 
   if [ -z "$log_entry" ]; then
-    _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
-    _report action "$trigger" "**Status:** completed (unparseable output)
+    if [ "$trigger" = "morning" ]; then
+      _v "morning synthesis empty — using raw digest fallback"
+      log_entry=$(ceo_morning_raw_digest)
+      # fall through to the normal report path below with the digest as log_entry
+    else
+      _v "WARNING: Output couldn't be parsed — raw saved to cron-raw.log"
+      _report action "$trigger" "**Status:** completed (unparseable output)
 **Playbook:** $PLAYBOOK_REL
 **Note:** Execution succeeded but log format could not be parsed ($model_label)."
-    printf '%s [%s] Unparseable output (%s):\n%s\n---\n' "$(date)" "$trigger" "$model_label" "$output" >> "$LOG_DIR/cron-raw.log"
-    _record_success
-    return 0
+      printf '%s [%s] Unparseable output (%s):\n%s\n---\n' "$(date)" "$trigger" "$model_label" "$output" >> "$LOG_DIR/cron-raw.log"
+      _record_success
+      return 0
+    fi
   fi
 
   _v ""

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -147,6 +147,8 @@ if [ "$TEST_ALL" != "1" ] && [[ ! "$TRIGGER" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/ceo-cron-lib.sh"
 # shellcheck source=ceo-config.sh
 source "$SCRIPT_DIR/ceo-config.sh"
 
@@ -1001,13 +1003,6 @@ SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
 # rather than silently empty-prompt.
 INPUTS_JSON=$(echo "$ENTRY" | jq -c '.inputs' 2>/dev/null) || INPUTS_JSON="null"
 [ -z "$INPUTS_JSON" ] && INPUTS_JSON="null"
-_inputs_includes() {
-  local key="$1"
-  # Default-all when inputs is absent (backward-compat with playbooks that
-  # predate this feature).
-  [ "$INPUTS_JSON" = "null" ] && return 0
-  echo "$INPUTS_JSON" | jq -e --arg k "$key" 'index($k) != null' >/dev/null 2>&1
-}
 
 # Chat-only playbooks cannot run via cron
 if [ "$TRIGGER_TYPE" = "chat" ]; then

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -2937,6 +2937,33 @@ PB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_inputs_morning_flow_keys_do_not_warn() {
+  cat > "$CEO_DIR/playbooks/inputs-morning.md" << 'PB'
+---
+name: inputs-morning
+description: Morning flow playbook with new input keys
+trigger: cron
+schedule: "0 7 * * *"
+model: haiku
+preflight: none
+tier: read
+status: active
+inputs:
+  - current_sprint
+  - yesterday_merged
+  - ledger_recent
+---
+PB
+
+  local out
+  out=$(bash "$CEO_CLI" playbook scan 2>&1)
+  if echo "$out" | grep -q "unknown key.*current_sprint\|unknown key.*yesterday_merged\|unknown key.*ledger_recent"; then
+    printf '  FAIL [%s] scan must NOT warn on valid morning-flow keys (current_sprint, yesterday_merged, ledger_recent)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_inputs_non_array_warns_and_defaults_to_all() {
   cat > "$CEO_DIR/playbooks/inputs-scalar.md" << 'PB'
 ---

--- a/scripts/ceo-gather-actuals.test.sh
+++ b/scripts/ceo-gather-actuals.test.sh
@@ -47,4 +47,30 @@ test_exports_yesterday_merged_ledger_tail_and_prev_predicted() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_gh_failure_sets_degraded_flag() {
+  # Separate setup: override gh stub to fail for search prs
+  local TMP2; TMP2=$(mktemp -d)
+  local STUB2="$TMP2/bin"; mkdir -p "$STUB2"
+  cat > "$STUB2/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"search prs"*) echo "gh: auth error" >&2; exit 1 ;;
+  *) echo "stub gh: unexpected: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$STUB2/gh"
+  local OLD_PATH="$PATH"
+  export PATH="$STUB2:$PATH"
+  local OLD_VAULT="$CEO_VAULT"
+  export CEO_VAULT="$TMP2/vault"; mkdir -p "$CEO_VAULT/CEO"
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1 || true
+  assert_eq "$YESTERDAY_MERGED" "[]" "degraded: YESTERDAY_MERGED is []"
+  assert_eq "${YESTERDAY_MERGED_DEGRADED:-0}" "1" "degraded flag set to 1"
+  export PATH="$OLD_PATH"
+  export CEO_VAULT="$OLD_VAULT"
+  rm -rf "$TMP2"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-gather-actuals.test.sh
+++ b/scripts/ceo-gather-actuals.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TMP=$(mktemp -d)
+  export CEO_VAULT="$TMP/vault"; mkdir -p "$CEO_VAULT/CEO/model"
+  # Real ledger-entry format as written by ceo-observe.sh (Task 5).
+  cat > "$CEO_VAULT/CEO/model/2026-06.md" <<'LED'
+## 2026-06-19 — model update
+- yesterday hit-rate: n/a
+- predicted today:
+  - o/r#7: Ship the thing
+  - o/r#8: Review PR
+LED
+  STUB_BIN="$TMP/bin"; mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"search prs"*"--merged"*) echo '[{"number":7,"title":"Did it","repository":{"nameWithOwner":"o/r"}}]' ;;
+  *) echo "stub gh: unexpected: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/gh"; export PATH="$STUB_BIN:$PATH"
+  export CEO_SPRINT_HELPER="/bin/true"
+}
+teardown() { rm -rf "$TMP"; unset CEO_VAULT CEO_SPRINT_HELPER; }
+
+test_exports_yesterday_merged_ledger_tail_and_prev_predicted() {
+  setup
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1 || true
+  assert_contains "$YESTERDAY_MERGED" '"number":7' "merged PR captured"
+  assert_contains "$LEDGER_RECENT" 'predicted today' "ledger tail loaded"
+  assert_contains "$LEDGER_PREV_PREDICTED" 'o/r#7' "prev predicted parsed to JSON"
+  assert_contains "$LEDGER_PREV_PREDICTED" 'o/r#8' "all predicted bullets parsed"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-gather-actuals.test.sh
+++ b/scripts/ceo-gather-actuals.test.sh
@@ -16,11 +16,17 @@ setup() {
   - o/r#8: Review PR
 LED
   STUB_BIN="$TMP/bin"; mkdir -p "$STUB_BIN"
-  cat > "$STUB_BIN/gh" <<'STUB'
+  # Compute yesterday's date for the stub — same logic as ceo-gather.sh.
+  D=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+  # Emit two PRs: #7 merged yesterday (should be included), #99 merged in 2020 (should be excluded).
+  # The stub requires --author "@me" and --merged to prevent privacy leaks.
+  cat > "$STUB_BIN/gh" <<STUB
 #!/usr/bin/env bash
-case "$*" in
-  *"search prs"*"--merged"*) echo '[{"number":7,"title":"Did it","repository":{"nameWithOwner":"o/r"}}]' ;;
-  *) echo "stub gh: unexpected: $*" >&2; exit 99 ;;
+case "\$*" in
+  *"search prs"*"--author"*"@me"*"--merged"*)
+    echo '[{"number":7,"title":"Did it","repository":{"nameWithOwner":"o/r"},"mergedAt":"${D}T12:00:00Z"},{"number":99,"title":"Old PR","repository":{"nameWithOwner":"o/r"},"mergedAt":"2020-01-01T00:00:00Z"}]'
+    ;;
+  *) echo "stub gh: unexpected: \$*" >&2; exit 99 ;;
 esac
 STUB
   chmod +x "$STUB_BIN/gh"; export PATH="$STUB_BIN:$PATH"
@@ -33,6 +39,7 @@ test_exports_yesterday_merged_ledger_tail_and_prev_predicted() {
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1 || true
   assert_contains "$YESTERDAY_MERGED" '"number":7' "merged PR captured"
+  assert_no_match "$YESTERDAY_MERGED" '"number":99' "old PR excluded by date filter"
   assert_contains "$LEDGER_RECENT" 'predicted today' "ledger tail loaded"
   assert_contains "$LEDGER_PREV_PREDICTED" 'o/r#7' "prev predicted parsed to JSON"
   assert_contains "$LEDGER_PREV_PREDICTED" 'o/r#8' "all predicted bullets parsed"

--- a/scripts/ceo-gather-sprint.test.sh
+++ b/scripts/ceo-gather-sprint.test.sh
@@ -27,4 +27,24 @@ test_exports_sprint_items_and_count() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_sprint_helper_degrade_produces_empty_items() {
+  local TMP2; TMP2=$(mktemp -d)
+  cat > "$TMP2/fail-sprint.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$TMP2/fail-sprint.sh"
+  local OLD_VAULT="${CEO_VAULT:-}"
+  export CEO_VAULT="$TMP2/vault"; mkdir -p "$CEO_VAULT/CEO"
+  export CEO_SPRINT_HELPER="$TMP2/fail-sprint.sh"
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1 || true
+  assert_eq "${CURRENT_SPRINT_ITEMS:-[]}" "[]" "failing helper yields empty items"
+  assert_eq "${CURRENT_SPRINT_COUNT:-0}" "0" "failing helper yields count 0"
+  rm -rf "$TMP2"
+  export CEO_VAULT="$OLD_VAULT"
+  unset CEO_SPRINT_HELPER
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-gather-sprint.test.sh
+++ b/scripts/ceo-gather-sprint.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TMP=$(mktemp -d)
+  # stub the sprint helper to return one item
+  cat > "$SCRIPT_DIR/.ceo-zenhub-sprint.stub" <<'STUB'
+#!/usr/bin/env bash
+echo '[{"number":7,"repo":"awesomemotive/x","title":"Sprint Y"}]'
+STUB
+  chmod +x "$SCRIPT_DIR/.ceo-zenhub-sprint.stub"
+  export CEO_SPRINT_HELPER="$SCRIPT_DIR/.ceo-zenhub-sprint.stub"
+  export CEO_VAULT="$TMP/vault"; mkdir -p "$CEO_VAULT/CEO"
+}
+teardown() { rm -rf "$TMP" "$SCRIPT_DIR/.ceo-zenhub-sprint.stub"; unset CEO_SPRINT_HELPER CEO_VAULT; }
+
+test_exports_sprint_items_and_count() {
+  setup
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1 || true
+  assert_contains "$CURRENT_SPRINT_ITEMS" '"number":7' "sprint items exported"
+  assert_eq "$CURRENT_SPRINT_COUNT" "1" "sprint count exported"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -352,11 +352,21 @@ fi
 
 # --- Yesterday's observable actions (positives only) + recent ledger ---
 export YESTERDAY_MERGED
+export YESTERDAY_MERGED_DEGRADED=0
 _yday=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")
 if command -v gh >/dev/null 2>&1 && [ -n "$_yday" ]; then
-  YESTERDAY_MERGED=$(gh search prs --author "@me" --merged --json number,title,repository,mergedAt \
-    --limit 50 2>/dev/null | jq -c --arg d "$_yday" \
-    '[.[] | select(.mergedAt and (.mergedAt | startswith($d))) | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
+  _ym_err=$(mktemp)
+  _ym_raw=$(_CEO_TIMEOUT 30 gh search prs --author "@me" --merged \
+    --json number,title,repository,mergedAt --limit 50 2>"$_ym_err"); _ym_rc=$?
+  if [ "$_ym_rc" -ne 0 ]; then
+    echo "WARN: gh search prs (yesterday-merged) failed (rc=$_ym_rc): $(head -c 200 "$_ym_err")" >&2
+    YESTERDAY_MERGED="[]"
+    YESTERDAY_MERGED_DEGRADED=1
+  else
+    YESTERDAY_MERGED=$(printf '%s' "$_ym_raw" | jq -c --arg d "$_yday" \
+      '[.[] | select(.mergedAt and (.mergedAt | startswith($d))) | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
+  fi
+  rm -f "$_ym_err"
 else
   YESTERDAY_MERGED="[]"
 fi

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -350,6 +350,45 @@ else
   export PENDING_ASK_QUESTIONS=""
 fi
 
+# --- Yesterday's observable actions (positives only) + recent ledger ---
+export YESTERDAY_MERGED
+_yday=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")
+if command -v gh >/dev/null 2>&1 && [ -n "$_yday" ]; then
+  YESTERDAY_MERGED=$(gh search prs --author "@me" --merged --json number,title,repository \
+    --limit 50 2>/dev/null | jq -c --arg d "$_yday" \
+    '[.[] | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
+else
+  YESTERDAY_MERGED="[]"
+fi
+[ -n "$YESTERDAY_MERGED" ] || YESTERDAY_MERGED="[]"
+
+export LEDGER_RECENT
+export LEDGER_PREV_PREDICTED
+LEDGER_PREV_PREDICTED="[]"
+_ledger_dir="$CEO_DIR/model"
+if [ -d "$_ledger_dir" ]; then
+  _latest=$(ls -1 "$_ledger_dir"/*.md 2>/dev/null | sort | tail -1)
+  if [ -n "$_latest" ]; then
+    LEDGER_RECENT=$(tail -40 "$_latest" 2>/dev/null) || LEDGER_RECENT=""
+    # Parse the LAST "predicted today:" block's indented bullets into "repo#num" strings.
+    # awk sets f=1 at each header (resetting on each, so only the last block's lines survive
+    # into the final emitted set), captures "  - " bullets, stops at the next non-indented line.
+    _pred_lines=$(awk '
+      /predicted today:/ { f=1; out=""; next }
+      f && /^  - / { out=out $0 "\n"; next }
+      f && /^[^ ]/ { f=0 }
+      END { printf "%s", out }
+    ' "$_latest" 2>/dev/null | sed -E 's/^  - //; s/:.*$//' | sed '/^$/d')
+    if [ -n "$_pred_lines" ]; then
+      LEDGER_PREV_PREDICTED=$(printf '%s\n' "$_pred_lines" | jq -R . | jq -s . 2>/dev/null || echo "[]")
+    fi
+  else
+    LEDGER_RECENT=""
+  fi
+else
+  LEDGER_RECENT=""
+fi
+
 # --- Evaluate Gather Status ---
 export CEO_GATHER_STATUS="ok"
 export CEO_GATHER_REASONS=""

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -356,15 +356,18 @@ export YESTERDAY_MERGED_DEGRADED=0
 _yday=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")
 if command -v gh >/dev/null 2>&1 && [ -n "$_yday" ]; then
   _ym_err=$(mktemp)
-  _ym_raw=$(_CEO_TIMEOUT 30 gh search prs --author "@me" --merged \
-    --json number,title,repository,mergedAt --limit 50 2>"$_ym_err"); _ym_rc=$?
-  if [ "$_ym_rc" -ne 0 ]; then
-    echo "WARN: gh search prs (yesterday-merged) failed (rc=$_ym_rc): $(head -c 200 "$_ym_err")" >&2
-    YESTERDAY_MERGED="[]"
-    YESTERDAY_MERGED_DEGRADED=1
-  else
+  # `if assignment; then` keeps this set-e-safe: a failing command substitution
+  # in an if-condition does NOT trip errexit, so the degrade branch runs instead
+  # of aborting the gather. (Bare `_x=$(cmd); rc=$?` would abort under set -e
+  # before $? is ever read.)
+  if _ym_raw=$(_CEO_TIMEOUT 30 gh search prs --author "@me" --merged \
+    --json number,title,repository,mergedAt --limit 50 2>"$_ym_err"); then
     YESTERDAY_MERGED=$(printf '%s' "$_ym_raw" | jq -c --arg d "$_yday" \
       '[.[] | select(.mergedAt and (.mergedAt | startswith($d))) | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
+  else
+    echo "WARN: gh search prs (yesterday-merged) failed: $(head -c 200 "$_ym_err")" >&2
+    YESTERDAY_MERGED="[]"
+    YESTERDAY_MERGED_DEGRADED=1
   fi
   rm -f "$_ym_err"
 else

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -354,9 +354,9 @@ fi
 export YESTERDAY_MERGED
 _yday=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")
 if command -v gh >/dev/null 2>&1 && [ -n "$_yday" ]; then
-  YESTERDAY_MERGED=$(gh search prs --author "@me" --merged --json number,title,repository \
+  YESTERDAY_MERGED=$(gh search prs --author "@me" --merged --json number,title,repository,mergedAt \
     --limit 50 2>/dev/null | jq -c --arg d "$_yday" \
-    '[.[] | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
+    '[.[] | select(.mergedAt and (.mergedAt | startswith($d))) | {number, repo: .repository.nameWithOwner, title}]' 2>/dev/null || echo "[]")
 else
   YESTERDAY_MERGED="[]"
 fi

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -272,6 +272,21 @@ fi
 export SYNC_CONFLICT_COUNT
 SYNC_CONFLICT_COUNT=$(find "$CEO_DIR" -name "*.sync-conflict-*" -type f 2>/dev/null | wc -l | xargs)
 
+# --- Current-sprint signal (AM priority key; degrades to empty) ---
+_CEO_CREDS="${CEO_CREDS_FILE:-$HOME/.config/ceo/credentials.env}"
+[ -f "$_CEO_CREDS" ] && { set -a; # shellcheck source=/dev/null
+  . "$_CEO_CREDS"; set +a; }
+_SPRINT_HELPER="${CEO_SPRINT_HELPER:-$(dirname "${BASH_SOURCE[0]}")/ceo-zenhub-sprint.sh}"
+export CURRENT_SPRINT_ITEMS
+if [ -x "$_SPRINT_HELPER" ]; then
+  CURRENT_SPRINT_ITEMS=$(bash "$_SPRINT_HELPER" 2>/dev/null || echo "[]")
+else
+  CURRENT_SPRINT_ITEMS="[]"
+fi
+[ -n "$CURRENT_SPRINT_ITEMS" ] || CURRENT_SPRINT_ITEMS="[]"
+export CURRENT_SPRINT_COUNT
+CURRENT_SPRINT_COUNT=$(echo "$CURRENT_SPRINT_ITEMS" | jq 'if type=="array" then length else 0 end' 2>/dev/null || echo 0)
+
 # --- Daily note sections ---
 DAILY_NOTE="$VAULT/Daily/$TODAY.md"
 if [ -f "$DAILY_NOTE" ]; then

--- a/scripts/ceo-observe.sh
+++ b/scripts/ceo-observe.sh
@@ -37,20 +37,22 @@ _ceo_observe_main() {
     | awk '/CEO-PREDICTED-PRIORITIES/{f=1;next}/-->/{f=0}f' \
     | sed -E 's/^- //; s/:.*$//' | sed '/^$/d')
 
-  # Discretion scrub: drop any line containing a denied term.
-  # CEO_DISCRETION_DENY (regex) is the test/runtime override.
-  # The vault denylist (one term/regex per line, # comments and blanks ignored)
-  # extends the deny pattern in production without carrying real secrets in code.
   local denyfile="$CEO_VAULT/Profile/discretion-denylist.txt"
-  local deny="${CEO_DISCRETION_DENY:-}"
+  # Build fixed-string denylist: one term per line, from file + env var.
+  # Fixed strings (-F) prevent regex metachar in client/company names from
+  # causing grep to exit non-zero and the || true from silently wiping predicted.
+  local _deny_tmp
+  _deny_tmp=$(mktemp)
   if [ -f "$denyfile" ]; then
-    local fileterms
-    fileterms=$(grep -vE '^\s*(#|$)' "$denyfile" 2>/dev/null | paste -sd '|' - 2>/dev/null || true)
-    [ -n "$fileterms" ] && deny="${deny:+$deny|}$fileterms"
+    grep -vE '^\s*(#|$)' "$denyfile" 2>/dev/null >> "$_deny_tmp" || true
   fi
-  if [ -n "$deny" ]; then
-    predicted=$(printf '%s\n' "$predicted" | grep -viE "$deny" || true)
+  if [ -n "${CEO_DISCRETION_DENY:-}" ]; then
+    printf '%s\n' "${CEO_DISCRETION_DENY}" | tr '|' '\n' | sed '/^$/d' >> "$_deny_tmp"
   fi
+  if [ -s "$_deny_tmp" ]; then
+    predicted=$(printf '%s\n' "$predicted" | grep -viFf "$_deny_tmp" || true)
+  fi
+  rm -f "$_deny_tmp"
 
   local hit="n/a"
   if [ -n "${YESTERDAY_MERGED:-}" ] && [ -n "${LEDGER_PREV_PREDICTED:-}" ]; then

--- a/scripts/ceo-observe.sh
+++ b/scripts/ceo-observe.sh
@@ -55,7 +55,9 @@ _ceo_observe_main() {
   rm -f "$_deny_tmp"
 
   local hit="n/a"
-  if [ -n "${YESTERDAY_MERGED:-}" ] && [ -n "${LEDGER_PREV_PREDICTED:-}" ]; then
+  local _prev_len
+  _prev_len=$(printf '%s' "${LEDGER_PREV_PREDICTED:-[]}" | jq 'length' 2>/dev/null || echo 0)
+  if [ -n "${YESTERDAY_MERGED:-}" ] && [ "${_prev_len:-0}" -gt 0 ]; then
     hit=$(compute_hit_rate "$LEDGER_PREV_PREDICTED" "$YESTERDAY_MERGED")
   fi
 

--- a/scripts/ceo-observe.sh
+++ b/scripts/ceo-observe.sh
@@ -55,10 +55,14 @@ _ceo_observe_main() {
   rm -f "$_deny_tmp"
 
   local hit="n/a"
-  local _prev_len
-  _prev_len=$(printf '%s' "${LEDGER_PREV_PREDICTED:-[]}" | jq 'length' 2>/dev/null || echo 0)
-  if [ -n "${YESTERDAY_MERGED:-}" ] && [ "${_prev_len:-0}" -gt 0 ]; then
-    hit=$(compute_hit_rate "$LEDGER_PREV_PREDICTED" "$YESTERDAY_MERGED")
+  if [ "${YESTERDAY_MERGED_DEGRADED:-0}" = "1" ]; then
+    hit="n/a (actuals unavailable)"
+  else
+    local _prev_len
+    _prev_len=$(printf '%s' "${LEDGER_PREV_PREDICTED:-[]}" | jq 'length' 2>/dev/null || echo 0)
+    if [ -n "${YESTERDAY_MERGED:-}" ] && [ "${_prev_len:-0}" -gt 0 ]; then
+      hit=$(compute_hit_rate "$LEDGER_PREV_PREDICTED" "$YESTERDAY_MERGED")
+    fi
   fi
 
   {

--- a/scripts/ceo-observe.sh
+++ b/scripts/ceo-observe.sh
@@ -34,7 +34,7 @@ _ceo_observe_main() {
   local input; input=$(cat || true)
   # Extract predicted lines from the synthesis block.
   local predicted; predicted=$(printf '%s\n' "$input" \
-    | awk '/CEO-PREDICTED-PRIORITIES/{f=1;next}/-->/{f=0}f' \
+    | awk '/CEO-PREDICTED-PRIORITIES/{f=1;next}/^[[:space:]]*-->[[:space:]]*$/{f=0}f' \
     | sed -E 's/^- //; s/:.*$//' | sed '/^$/d')
 
   local denyfile="$CEO_VAULT/Profile/discretion-denylist.txt"

--- a/scripts/ceo-observe.sh
+++ b/scripts/ceo-observe.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ceo-observe.sh
+# Append a positives-only, discretion-scrubbed learning entry to the model ledger.
+# Sourced for unit tests (defines compute_hit_rate); executed as the observe step.
+set -uo pipefail
+
+compute_hit_rate() {
+  # $1 = JSON array of predicted "repo#num" strings (bare repo or owner/repo)
+  # $2 = JSON array of {number, repo} objects (repo may be owner/name from gh)
+  # Normalizes both sides to bare basename before comparing so owner-prefixed
+  # repos from gh match the bare names carried in the predicted sprint output.
+  local pred="$1" actual="$2" total hits
+  total=$(echo "$pred" | jq 'length' 2>/dev/null || echo 0)
+  hits=$(jq -n --argjson p "$pred" --argjson a "$actual" '
+    [ $p[] | . as $x |
+      # normalize predicted: strip owner prefix from repo portion
+      ($x | (split("#")[0] | split("/") | last) + "#" + (split("#")[1] // "")) as $xn |
+      $a[] |
+      # normalize actual: strip owner prefix from repo
+      select(( (.repo | split("/") | last) + "#" + (.number|tostring) ) == $xn)
+    ] | length
+  ' 2>/dev/null || echo 0)
+  echo "${hits}/${total}"
+}
+
+_ceo_observe_main() {
+  : "${CEO_VAULT:?CEO_VAULT must be set}"
+  : "${TODAY:?TODAY must be set}"
+  local ledger_dir="$CEO_VAULT/CEO/model"
+  mkdir -p "$ledger_dir"
+  local month="${TODAY%-*}"           # YYYY-MM
+  local ledger="$ledger_dir/$month.md"
+
+  local input; input=$(cat || true)
+  # Extract predicted lines from the synthesis block.
+  local predicted; predicted=$(printf '%s\n' "$input" \
+    | awk '/CEO-PREDICTED-PRIORITIES/{f=1;next}/-->/{f=0}f' \
+    | sed -E 's/^- //; s/:.*$//' | sed '/^$/d')
+
+  # Discretion scrub: drop any line containing a denied term.
+  # CEO_DISCRETION_DENY (regex) is the test/runtime override.
+  # The vault denylist (one term/regex per line, # comments and blanks ignored)
+  # extends the deny pattern in production without carrying real secrets in code.
+  local denyfile="$CEO_VAULT/Profile/discretion-denylist.txt"
+  local deny="${CEO_DISCRETION_DENY:-}"
+  if [ -f "$denyfile" ]; then
+    local fileterms
+    fileterms=$(grep -vE '^\s*(#|$)' "$denyfile" 2>/dev/null | paste -sd '|' - 2>/dev/null || true)
+    [ -n "$fileterms" ] && deny="${deny:+$deny|}$fileterms"
+  fi
+  if [ -n "$deny" ]; then
+    predicted=$(printf '%s\n' "$predicted" | grep -viE "$deny" || true)
+  fi
+
+  local hit="n/a"
+  if [ -n "${YESTERDAY_MERGED:-}" ] && [ -n "${LEDGER_PREV_PREDICTED:-}" ]; then
+    hit=$(compute_hit_rate "$LEDGER_PREV_PREDICTED" "$YESTERDAY_MERGED")
+  fi
+
+  {
+    echo ""
+    echo "## $TODAY — model update"
+    echo "- yesterday hit-rate: $hit"
+    echo "- predicted today:"
+    printf '%s\n' "$predicted" | sed 's/^/  - /'
+  } >> "$ledger"
+}
+
+# Only run main when executed, not when sourced for tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then _ceo_observe_main; fi

--- a/scripts/ceo-observe.test.sh
+++ b/scripts/ceo-observe.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+OBS="$SCRIPT_DIR/ceo-observe.sh"
+
+setup() { TMP=$(mktemp -d); export CEO_VAULT="$TMP/v"; mkdir -p "$CEO_VAULT/CEO/model"; export TODAY="2026-06-20"; }
+teardown() { rm -rf "$TMP"; unset CEO_VAULT TODAY; }
+
+test_hit_rate_counts_only_matches() {
+  setup
+  # shellcheck source=/dev/null
+  source "$OBS"
+  pred='["o/r#7","o/r#8"]'; actual='[{"number":7,"repo":"o/r"}]'
+  assert_eq "$(compute_hit_rate "$pred" "$actual")" "1/2" "1 of 2 predicted merged"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_hit_rate_normalizes_owner_prefix() {
+  setup
+  # shellcheck source=/dev/null
+  source "$OBS"
+  pred='["optin-monster-app#42"]'
+  actual='[{"number":42,"repo":"awesomemotive/optin-monster-app"}]'
+  assert_eq "$(compute_hit_rate "$pred" "$actual")" "1/1" "owner prefix stripped before comparison"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_no_deprioritized_inference() {
+  setup
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- o/r#9: Thing\n-->\n' | \
+    YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_no_match "$entry" "deprioritized" "never writes deprioritized/absence inference"
+  assert_contains "$entry" "2026-06-20" "dated entry appended"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_discretion_scrub_drops_employer_specifics() {
+  setup
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- altamira/secret-contract#1: ACME deal terms\n-->\n' | \
+    YESTERDAY_MERGED='[]' CEO_DISCRETION_DENY='ACME' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_no_match "$entry" "ACME" "employer-specific term scrubbed"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-observe.test.sh
+++ b/scripts/ceo-observe.test.sh
@@ -50,6 +50,17 @@ test_discretion_scrub_drops_employer_specifics() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_empty_prev_predicted_yields_na_hit_rate() {
+  setup
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- o/r#9: Thing\n-->\n' | \
+    YESTERDAY_MERGED='[{"number":9,"repo":"o/r"}]' LEDGER_PREV_PREDICTED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_contains "$entry" "yesterday hit-rate: n/a" "empty prev-predicted yields n/a not 0/0"
+  assert_no_match "$entry" "0/0" "no 0/0 on first run"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_denylist_metachar_is_matched_literally() {
   # The awk extractor strips ': description' leaving bare repo#num.
   # Denylist term with a regex metachar like 'a[cme/repo' must match literally

--- a/scripts/ceo-observe.test.sh
+++ b/scripts/ceo-observe.test.sh
@@ -50,6 +50,17 @@ test_discretion_scrub_drops_employer_specifics() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_degraded_actuals_yields_na_hit_rate() {
+  setup
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- o/r#7: thing\n-->\n' | \
+    YESTERDAY_MERGED_DEGRADED=1 LEDGER_PREV_PREDICTED='["o/r#7"]' YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_contains "$entry" "n/a (actuals unavailable)" "degraded actuals yields n/a not 0/1"
+  assert_no_match "$entry" "0/1" "no 0/1 on degraded actuals"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_empty_prev_predicted_yields_na_hit_rate() {
   setup
   printf '<!-- CEO-PREDICTED-PRIORITIES\n- o/r#9: Thing\n-->\n' | \

--- a/scripts/ceo-observe.test.sh
+++ b/scripts/ceo-observe.test.sh
@@ -50,4 +50,46 @@ test_discretion_scrub_drops_employer_specifics() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_denylist_metachar_is_matched_literally() {
+  # The awk extractor strips ': description' leaving bare repo#num.
+  # Denylist term with a regex metachar like 'a[cme/repo' must match literally
+  # against 'a[cme/repo#1' without crashing grep or wiping all predictions.
+  setup
+  mkdir -p "$CEO_VAULT/Profile"
+  printf 'a[cme/repo\n' > "$CEO_VAULT/Profile/discretion-denylist.txt"
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- a[cme/repo#1: sensitive item\n- legit/repo#2: regular item\n-->\n' | \
+    YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_no_match "$entry" "a\[cme" "metachar term scrubbed"
+  assert_contains "$entry" "legit/repo#2" "non-matching item preserved"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_denylist_file_scrubs_matching_term() {
+  setup
+  mkdir -p "$CEO_VAULT/Profile"
+  printf 'SecretClient\n' > "$CEO_VAULT/Profile/discretion-denylist.txt"
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- altamira/repo#1: SecretClient#1: confidential\n- public/repo#2: visible work\n-->\n' | \
+    YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_no_match "$entry" "SecretClient" "denylist file term scrubbed"
+  assert_contains "$entry" "public/repo#2" "non-matching item preserved"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_non_matching_denylist_leaves_predictions_intact() {
+  setup
+  mkdir -p "$CEO_VAULT/Profile"
+  printf 'NOMATCH_TERM\n' > "$CEO_VAULT/Profile/discretion-denylist.txt"
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- visible/repo#1: visible item 1\n- visible/repo#2: visible item 2\n-->\n' | \
+    YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_contains "$entry" "visible/repo#1" "first item preserved"
+  assert_contains "$entry" "visible/repo#2" "second item preserved"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-observe.test.sh
+++ b/scripts/ceo-observe.test.sh
@@ -50,6 +50,17 @@ test_discretion_scrub_drops_employer_specifics() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_predicted_block_with_arrow_in_title_not_truncated() {
+  setup
+  printf '<!-- CEO-PREDICTED-PRIORITIES\n- repo-a#1: Migrate A --> B\n- repo-b#2: Regular item\n-->\n' | \
+    YESTERDAY_MERGED='[]' bash "$OBS"
+  entry=$(cat "$CEO_VAULT/CEO/model/2026-06.md")
+  assert_contains "$entry" "repo-a#1" "item with --> in title preserved"
+  assert_contains "$entry" "repo-b#2" "subsequent item preserved"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_degraded_actuals_yields_na_hit_rate() {
   setup
   printf '<!-- CEO-PREDICTED-PRIORITIES\n- o/r#7: thing\n-->\n' | \

--- a/scripts/ceo-zenhub-sprint.sh
+++ b/scripts/ceo-zenhub-sprint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Print current-sprint issues as a JSON array, or [] on any failure. Never crashes.
+set -uo pipefail
+
+emit_empty() { echo "[]"; exit 0; }
+
+[ -n "${ZENHUB_TOKEN:-}" ] || emit_empty
+[ -n "${ZENHUB_WORKSPACE_ID:-}" ] || emit_empty
+command -v curl >/dev/null 2>&1 || emit_empty
+command -v jq >/dev/null 2>&1 || emit_empty
+
+read -r -d '' QUERY <<'GQL' || true
+query($ws: ID!) {
+  workspace(id: $ws) {
+    sprints(filters: {state: {eq: OPEN}}, first: 1) {
+      nodes { state issues(first: 100) { nodes {
+        number title repository { ownerName name }
+      } } }
+    }
+  }
+}
+GQL
+
+payload=$(jq -n --arg q "$QUERY" --arg ws "$ZENHUB_WORKSPACE_ID" \
+  '{query:$q, variables:{ws:$ws}}' 2>/dev/null) || emit_empty
+
+resp=$(curl -sS -X POST "https://api.zenhub.com/public/graphql" \
+  -H "Authorization: Bearer $ZENHUB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$payload" 2>/dev/null) || emit_empty
+
+echo "$resp" | jq -e '.data.workspace.sprints.nodes[0].issues.nodes' >/dev/null 2>&1 || emit_empty
+
+echo "$resp" | jq '[.data.workspace.sprints.nodes[0].issues.nodes[]
+  | {number, repo: (.repository.ownerName + "/" + .repository.name), title}]' 2>/dev/null || emit_empty

--- a/scripts/ceo-zenhub-sprint.sh
+++ b/scripts/ceo-zenhub-sprint.sh
@@ -14,7 +14,7 @@ query($ws: ID!) {
   workspace(id: $ws) {
     sprints(filters: {state: {eq: OPEN}}, first: 1) {
       nodes { state issues(first: 100) { nodes {
-        number title repository { ownerName name }
+        number title repository { id name }
       } } }
     }
   }
@@ -32,4 +32,4 @@ resp=$(curl -sS -X POST "https://api.zenhub.com/public/graphql" \
 echo "$resp" | jq -e '.data.workspace.sprints.nodes[0].issues.nodes' >/dev/null 2>&1 || emit_empty
 
 echo "$resp" | jq '[.data.workspace.sprints.nodes[0].issues.nodes[]
-  | {number, repo: (.repository.ownerName + "/" + .repository.name), title}]' 2>/dev/null || emit_empty
+  | {number, repo: .repository.name, title}]' 2>/dev/null || emit_empty

--- a/scripts/ceo-zenhub-sprint.test.sh
+++ b/scripts/ceo-zenhub-sprint.test.sh
@@ -23,7 +23,7 @@ case "$args" in
 esac
 cat <<'JSON'
 {"data":{"workspace":{"sprints":{"nodes":[{"state":"OPEN","issues":{"nodes":[
-{"number":42,"title":"Sprint task A","repository":{"ownerName":"awesomemotive","name":"optin-monster-app"}}
+{"number":42,"title":"Sprint task A","repository":{"id":"repo_abc123","name":"optin-monster-app"}}
 ]}}]}}}}
 JSON
 STUB

--- a/scripts/ceo-zenhub-sprint.test.sh
+++ b/scripts/ceo-zenhub-sprint.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+HELPER="$SCRIPT_DIR/ceo-zenhub-sprint.sh"
+
+setup() {
+  TMP=$(mktemp -d)
+  STUB_BIN="$TMP/bin"; mkdir -p "$STUB_BIN"
+  # curl stub: validates it's a POST to the zenhub graphql endpoint with auth,
+  # returns a canned current-sprint payload.
+  cat > "$STUB_BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"api.zenhub.com/public/graphql"*) : ;;
+  *) echo "stub curl: unexpected args: $args" >&2; exit 99 ;;
+esac
+case "$args" in
+  *"Authorization"*|*"-H"*) : ;;
+  *) echo "stub curl: missing auth header" >&2; exit 99 ;;
+esac
+cat <<'JSON'
+{"data":{"workspace":{"sprints":{"nodes":[{"state":"OPEN","issues":{"nodes":[
+{"number":42,"title":"Sprint task A","repository":{"ownerName":"awesomemotive","name":"optin-monster-app"}}
+]}}]}}}}
+JSON
+STUB
+  chmod +x "$STUB_BIN/curl"
+  export PATH="$STUB_BIN:$PATH"
+  export ZENHUB_TOKEN="test-token"
+  export ZENHUB_WORKSPACE_ID="ws_test"
+}
+teardown() { rm -rf "$TMP"; unset ZENHUB_TOKEN ZENHUB_WORKSPACE_ID; }
+
+test_emits_current_sprint_issues() {
+  setup
+  out=$(bash "$HELPER")
+  assert_contains "$out" '"number": 42' "sprint issue number present"
+  assert_contains "$out" 'optin-monster-app' "repo present"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_degrades_to_empty_array_when_token_missing() {
+  setup
+  unset ZENHUB_TOKEN
+  out=$(bash "$HELPER"); rc=$?
+  assert_eq "$rc" "0" "exit 0 when token missing"
+  assert_eq "$out" "[]" "empty array when token missing"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/ceo-zenhub-sprint.test.sh
+++ b/scripts/ceo-zenhub-sprint.test.sh
@@ -53,4 +53,14 @@ test_degrades_to_empty_array_when_token_missing() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_degrades_to_empty_array_when_workspace_id_missing() {
+  setup
+  unset ZENHUB_WORKSPACE_ID
+  out=$(bash "$HELPER"); rc=$?
+  assert_eq "$rc" "0" "exit 0 when workspace id missing"
+  assert_eq "$out" "[]" "empty array when workspace id missing"
+  teardown
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/morning-cutover.test.sh
+++ b/scripts/morning-cutover.test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+PB="$SCRIPT_DIR/../docs/playbooks"
+
+test_morning_active_legacy_disabled() {
+  assert_contains "$(cat "$PB/morning.md")" "status: active" "morning active"
+  for legacy in morning-scan morning-brief pending-drip pr-triage; do
+    assert_contains "$(cat "$PB/$legacy.md")" "status: disabled" "$legacy disabled"
+  done
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests

--- a/scripts/morning-playbook.test.sh
+++ b/scripts/morning-playbook.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+PB="$SCRIPT_DIR/../docs/playbooks/morning.md"
+
+test_frontmatter_and_contract_present() {
+  body=$(cat "$PB")
+  assert_contains "$body" "name: morning" "name set"
+  assert_contains "$body" "tier: read" "read tier"
+  assert_contains "$body" "sprint" "ranking references sprint"
+  assert_contains "$body" "older non-sprint" "states sprint-beats-age rule"
+  assert_contains "$body" "CEO-PREDICTED-PRIORITIES" "emits predicted block contract"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

Introduces the **CEO morning flow** — replacing four disconnected morning cron playbooks (`morning-scan`, `morning-brief`, `pending-drip`, `pr-triage`), each an independent `claude -p` run with no shared state, with **one orchestrated flow** that produces a single coherent briefing and starts a model-of-Nathan learning loop.

**New behavior:**
- **Gather (shell, model-free):** a current-sprint signal from Zenhub (`ceo-zenhub-sprint.sh`), yesterday's merged PRs, the recent learning ledger, and the prior day's predicted priorities (`ceo-gather.sh`) — injected into the prompt's `PRE_GATHERED` block (`ceo-cron-lib.sh` / `ceo-cron.sh`).
- **Synthesis (one read-tier LLM run):** the `morning` playbook (`docs/playbooks/morning.md`) emits one briefing where **sprint membership is the primary priority key — a sprint-member item outranks an older non-sprint PR** (the anti-"ranks by age" acceptance criterion). Ends with a machine-readable `CEO-PREDICTED-PRIORITIES` block. **Raw-digest fallback** if synthesis yields nothing — never delivers nothing.
- **Observe (shell):** `ceo-observe.sh` scores yesterday's prediction hit-rate (**positives-only** — never infers "deprioritized" from absence) and appends a **discretion-scrubbed** entry to the synced vault ledger `CEO/model/YYYY-MM.md`.
- **Cutover:** `morning` activated; the four legacy playbooks set to `status: disabled` (disabled-not-deleted, one cycle); runbook `docs/cutover-morning-flow.md` documents the **ML-1-only** `ceo playbook scan` + vault `settings.json` steps (not performed in this PR).

Spec: `docs/superpowers/specs/2026-06-20-ceo-morning-flow-design.md`
Plan: `docs/superpowers/plans/2026-06-20-ceo-morning-flow.md`

**Also includes (defects caught and fixed during TDD, each with a mutation-checked test):**
- Zenhub query corrected to the real API shape (`repository { id name }` — the live API has no `ownerName`).
- `YESTERDAY_MERGED` now actually date-filters to yesterday (was passing the date to `jq` but never using it).
- `gh` test stub tightened to require `--author "@me"` (privacy: a dropped flag would fetch all users' PRs).
- `compute_hit_rate` `jq` fix + owner-prefix basename normalization (sprint repos are bare names, gh repos are `owner/name`).
- The `scripts/ceo` `ceo playbook scan` input-key allowlist now recognizes the three new keys.
- Predicted-block round-trip: the observe step is fed the **raw** model output (not the fence-extracted `log_entry`), so the `CEO-PREDICTED-PRIORITIES` block survives regardless of where the model places it.

## Testing Procedure

1. Check out this branch.
2. Run the full bash test suite: `for t in scripts/*.test.sh; do bash "$t" >/dev/null 2>&1 && echo "ok $t" || echo "FAIL $t"; done` — all 34 suites pass.
3. Spot-check the new suites individually: `bash scripts/ceo-zenhub-sprint.test.sh`, `bash scripts/ceo-gather-sprint.test.sh`, `bash scripts/ceo-gather-actuals.test.sh`, `bash scripts/ceo-cron-inputs.test.sh`, `bash scripts/morning-playbook.test.sh`, `bash scripts/ceo-observe.test.sh`, `bash scripts/ceo-cron-morning-observe.test.sh`, `bash scripts/ceo-cron-morning-fallback.test.sh`, `bash scripts/morning-cutover.test.sh`.
4. Confirm the hit-rate normalization round-trip: `ceo-observe.test.sh::test_hit_rate_normalizes_owner_prefix` (`optin-monster-app#42` vs `awesomemotive/optin-monster-app` → `1/1`).
5. Confirm the predicted-block round-trip survives a post-fence block: `ceo-cron-morning-observe.test.sh::test_post_fence_predicted_block_captured`.
6. Confirm no regression in the large dispatcher suite: `bash scripts/ceo-cron.test.sh` (exit 0).

**Environment exercised:** local bash test harness (custom `scripts/test-harness.sh`), with stubbed `curl`/`gh` (argv-validated) plus one live Zenhub MCP call during development to confirm the real sprint API shape.

## Additional Notes / Deferred (ML-1 runtime)

- Cutover is **not** performed here: on ML-1 only, run `ceo playbook scan` and add `"morning"` to the vault `CEO/settings.json` `discord_report_triggers`, per `docs/cutover-morning-flow.md`. Keep `morning-brief` enabled for one diff cycle before retiring it.
- One-time live Zenhub sprint call on ML-1 recommended to confirm the GraphQL envelope (`.data.workspace.sprints.nodes[0].issues.nodes`) against a real OPEN sprint before relying on sprint-ranking (bounded by degrade-to-`[]`).
- Deferred minor cleanups: tighten the `ceo-zenhub-sprint` curl stub to require `Authorization: Bearer`; add a missing-`ZENHUB_WORKSPACE_ID` test; add a shebang to `ceo-cron-lib.sh`.
