### PR TITLE
Slice 1: ollama-agent bridge core + real shell/fs/git tool layer

### DIFF
--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -1,0 +1,49 @@
+# ollama-agent
+
+Run a local [ollama](https://ollama.com) model as a tool-using agent on **bounded** tasks — so a local model can do real work (inspect files, run commands, drive git) without burning Claude tokens, where its quality is good enough.
+
+Part of the [local-agent bridge epic (#185)](https://github.com/nhangen/claude-ceo/issues/185). This is **path A** — local models as cheap workers for bounded tasks under a *curated* slice of the rule/skill/tool stack — not a full reimplementation of the Claude Code harness.
+
+## Status
+
+| Slice | What | State |
+|------|------|-------|
+| 1 (#186) | Bridge core + real shell/fs/git tools over the `/api/chat` tools API | **this package** |
+| 2 (#187) | Rule loading + relevance selection | planned |
+| 3 (#188) | Skill resolver | planned |
+| 4 (#189) | MCP tool adapter | planned |
+| 5 (#190) | Governance + task registry (`runner: ollama`) | planned |
+
+## Usage
+
+```bash
+# requires a running ollama daemon with the model pulled
+python ollama-agent/cli.py --task "summarize the README in 3 bullets" \
+  --model gpt-oss:20b --cwd /path/to/repo
+```
+
+Flags: `--model`, `--cwd` (the directory tools operate in), `--host`, `--temperature`,
+`--num-ctx`, `--turn-cap`, `--shell-timeout`, `--json` (full record), `--system` (override the system prompt).
+
+## Tools
+
+The model is given five real tools, each bounded (timeout + truncated output) and scoped to `--cwd`:
+
+| Tool | Does |
+|------|------|
+| `run_shell` | run a shell command, return returncode/stdout/stderr |
+| `git` | run a git subcommand |
+| `read_file` | read a file under cwd |
+| `write_file` | write a file under cwd (creates parent dirs) |
+| `list_dir` | list a directory under cwd |
+
+**Trust boundary:** `run_shell` runs arbitrary commands by design — that *is* the tool.
+There is no command allowlist or path jail yet; per-task tool restriction and
+safe-delegation tiering arrive in the governance slice (#190). Until then, treat this
+as a deliberately-invoked local tool: you choose `--cwd` and the model you trust.
+
+## Tests
+
+```bash
+python -m pytest ollama-agent/tests -q   # logic tests, no daemon needed
+```

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""ollama-agent CLI — run a local model as a tool-using agent on a bounded task.
+
+    python cli.py --task "summarize the README" --model gpt-oss:20b --cwd /repo
+
+Slice 1 (#186): real shell/fs/git tools, no rule/skill loading yet.
+"""
+import argparse
+import json
+import sys
+
+from ollama_agent import ToolBox, TOOLS, ollama_transport, run_agent
+
+DEFAULT_SYSTEM = (
+    "You are a local engineering agent operating inside a single working directory. "
+    "Use the provided tools to inspect and modify files and run commands. "
+    "When the task is done, reply with a short summary and no further tool calls."
+)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Run a local ollama model as a tool-using agent.")
+    p.add_argument("--task", required=True, help="The task for the agent to perform.")
+    p.add_argument("--model", default="gpt-oss:20b")
+    p.add_argument("--cwd", default=".", help="Working directory the tools operate in.")
+    p.add_argument("--system", default=DEFAULT_SYSTEM)
+    p.add_argument("--host", default="127.0.0.1:11434")
+    p.add_argument("--temperature", type=float, default=0.7)
+    p.add_argument("--num-ctx", type=int, default=16384)
+    p.add_argument("--turn-cap", type=int, default=8)
+    p.add_argument("--shell-timeout", type=int, default=30)
+    p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
+    a = p.parse_args(argv)
+
+    toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout)
+    transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
+    try:
+        rec = run_agent(a.task, a.system, transport, toolbox, TOOLS, turn_cap=a.turn_cap)
+    except RuntimeError as e:
+        print(f"agent failed: {e}", file=sys.stderr)
+        return 1
+
+    if a.json:
+        print(json.dumps(rec, indent=2))
+    else:
+        final = rec["transcript"][-1]
+        print(f"completed={rec['completed']} turns={rec['turns']} "
+              f"calls={len(rec['calls'])} unknown={rec['unknown_calls']}")
+        print("--- final message ---")
+        print(final.get("content", "(no content)"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -1,0 +1,11 @@
+"""ollama-agent: run a local ollama model as a tool-using agent.
+
+Slice 1 (#186) — the bridge core and the real (non-stub) tool layer. Later
+slices add rule loading (#187), skills (#188), an MCP adapter (#189), and a
+governed task registry (#190).
+"""
+from .agent import run_agent
+from .tools import ToolBox, TOOLS
+from .transport import ollama_transport, parse_chat_response
+
+__all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response"]

--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -1,0 +1,54 @@
+"""The agent loop: drive a model through tool calls until it stops or hits the cap."""
+import json
+
+
+def _normalize_args(raw):
+    """ollama builds return tool-call arguments as either a dict or a JSON string.
+    Normalize to a dict; a non-JSON string becomes {} so a malformed call degrades
+    to an unknown/empty call rather than crashing the loop."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            v = json.loads(raw or "{}")
+            return v if isinstance(v, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def run_agent(task, system, transport, toolbox, tools, turn_cap=8):
+    """Run one task to completion (a turn with no tool calls) or the turn cap.
+
+    Returns a record: completed, turns, the full transcript, and the toolbox's
+    call log + unknown-tool list so a hallucinated tool reads as a hallucination,
+    not a silent capability loss.
+    """
+    messages = [{"role": "system", "content": system},
+                {"role": "user", "content": task}]
+    transcript = list(messages)
+    completed = False
+    turns = 0
+    while turns < turn_cap:
+        turns += 1
+        msg = transport(messages, tools)
+        transcript.append(msg)
+        messages.append(msg)
+        calls = msg.get("tool_calls") or []
+        if not calls:
+            completed = True
+            break
+        for c in calls:
+            fn = c["function"]["name"]
+            args = _normalize_args(c["function"].get("arguments"))
+            result = toolbox.dispatch(fn, args)
+            tool_msg = {"role": "tool", "content": result}
+            transcript.append(tool_msg)
+            messages.append(tool_msg)
+    return {
+        "completed": completed,
+        "turns": turns,
+        "transcript": transcript,
+        "calls": toolbox.calls,
+        "unknown_calls": toolbox.unknown_calls,
+    }

--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -39,9 +39,17 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8):
             completed = True
             break
         for c in calls:
-            fn = c["function"]["name"]
-            args = _normalize_args(c["function"].get("arguments"))
-            result = toolbox.dispatch(fn, args)
+            fn_obj = c.get("function") or {}
+            fn = fn_obj.get("name")
+            if not fn:
+                # A malformed call envelope (no function/name) is a hallucination,
+                # not a reason to crash the run — record it and feed an error back,
+                # mirroring dispatch's unknown-tool path.
+                toolbox.unknown_calls.append(fn)
+                result = json.dumps({"error": "malformed tool_call: missing function name"})
+            else:
+                args = _normalize_args(fn_obj.get("arguments"))
+                result = toolbox.dispatch(fn, args)
             tool_msg = {"role": "tool", "content": result}
             transcript.append(tool_msg)
             messages.append(tool_msg)

--- a/ollama-agent/ollama_agent/tools.py
+++ b/ollama-agent/ollama_agent/tools.py
@@ -60,8 +60,9 @@ class ToolBox:
     def write_file(self, path, content):
         f = self._resolve(path)
         f.parent.mkdir(parents=True, exist_ok=True)
-        f.write_text(content if content is not None else "")
-        return json.dumps({"path": str(f), "bytes": len(content or "")})
+        data = content if content is not None else ""
+        f.write_text(data)
+        return json.dumps({"path": str(f), "bytes": len(data.encode())})
 
     def list_dir(self, path="."):
         d = self._resolve(path)
@@ -84,7 +85,13 @@ class ToolBox:
         if handler is None:
             self.unknown_calls.append(name)
             return json.dumps({"error": f"unknown tool: {name}"})
-        return handler(args)
+        try:
+            return handler(args)
+        except Exception as e:
+            # A tool that raises (PermissionError, ENOSPC, UnicodeError, cwd
+            # deleted, …) must return a recorded error to the model, never abort
+            # the run — keep the loop and transcript alive (safety-invariant-scope).
+            return json.dumps({"error": f"{name} failed: {type(e).__name__}: {e}"})
 
 
 TOOLS = [

--- a/ollama-agent/ollama_agent/tools.py
+++ b/ollama-agent/ollama_agent/tools.py
@@ -1,0 +1,114 @@
+"""The real (non-stub) tool layer the local model drives.
+
+Trust boundary: every tool runs bounded inside a single working directory
+(`cwd`) with a wall-clock timeout and truncated output. There is intentionally
+no command allowlist or path jail yet — per-task tool restriction and
+safe-delegation tiering land in the governance slice (#190). Until then this is
+a deliberately-invoked local tool, not an unattended one; the caller picks cwd.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+MAX_OUTPUT = 4000      # chars of stdout/stderr returned to the model per call
+MAX_READ = 20000       # chars returned by read_file
+
+
+def _clip(s, n):
+    s = s or ""
+    return s if len(s) <= n else s[:n] + f"\n…[truncated {len(s) - n} chars]"
+
+
+class ToolBox:
+    def __init__(self, cwd=".", timeout=30):
+        self.cwd = Path(cwd).resolve()
+        self.timeout = timeout
+        self.calls = []            # (name, args) of every dispatched call
+        self.unknown_calls = []    # names the model hallucinated
+
+    def _resolve(self, path):
+        p = Path(path)
+        return p if p.is_absolute() else (self.cwd / p)
+
+    def run_shell(self, command):
+        try:
+            p = subprocess.run(command, shell=True, cwd=self.cwd, capture_output=True,
+                               text=True, timeout=self.timeout)
+        except subprocess.TimeoutExpired:
+            return json.dumps({"returncode": None, "error": f"timeout>{self.timeout}s"})
+        return json.dumps({"returncode": p.returncode,
+                           "stdout": _clip(p.stdout, MAX_OUTPUT),
+                           "stderr": _clip(p.stderr, MAX_OUTPUT)})
+
+    def git(self, args):
+        argv = args if isinstance(args, list) else str(args).split()
+        try:
+            p = subprocess.run(["git", *argv], cwd=self.cwd, capture_output=True,
+                               text=True, timeout=self.timeout)
+        except subprocess.TimeoutExpired:
+            return json.dumps({"returncode": None, "error": f"timeout>{self.timeout}s"})
+        return json.dumps({"returncode": p.returncode,
+                           "stdout": _clip(p.stdout, MAX_OUTPUT),
+                           "stderr": _clip(p.stderr, MAX_OUTPUT)})
+
+    def read_file(self, path):
+        f = self._resolve(path)
+        if not f.is_file():
+            return json.dumps({"error": f"not a file: {path}"})
+        return json.dumps({"path": str(f), "content": _clip(f.read_text(errors="replace"), MAX_READ)})
+
+    def write_file(self, path, content):
+        f = self._resolve(path)
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content if content is not None else "")
+        return json.dumps({"path": str(f), "bytes": len(content or "")})
+
+    def list_dir(self, path="."):
+        d = self._resolve(path)
+        if not d.is_dir():
+            return json.dumps({"error": f"not a directory: {path}"})
+        return json.dumps({"path": str(d),
+                           "entries": sorted(p.name + ("/" if p.is_dir() else "") for p in d.iterdir())})
+
+    def dispatch(self, name, args):
+        """Route one tool call. Records every call; unknown names are recorded
+        separately and returned as an error string (never silently dropped)."""
+        self.calls.append((name, args))
+        handler = {
+            "run_shell": lambda a: self.run_shell(a.get("command", "")),
+            "git": lambda a: self.git(a.get("args", [])),
+            "read_file": lambda a: self.read_file(a.get("path", "")),
+            "write_file": lambda a: self.write_file(a.get("path", ""), a.get("content", "")),
+            "list_dir": lambda a: self.list_dir(a.get("path", ".")),
+        }.get(name)
+        if handler is None:
+            self.unknown_calls.append(name)
+            return json.dumps({"error": f"unknown tool: {name}"})
+        return handler(args)
+
+
+TOOLS = [
+    {"type": "function", "function": {"name": "run_shell",
+        "description": "Run a shell command in the working directory and return its returncode, stdout, and stderr.",
+        "parameters": {"type": "object", "properties": {
+            "command": {"type": "string", "description": "The shell command to run."}},
+            "required": ["command"]}}},
+    {"type": "function", "function": {"name": "git",
+        "description": "Run a git subcommand in the working directory (e.g. args=[\"status\",\"--short\"]).",
+        "parameters": {"type": "object", "properties": {
+            "args": {"type": "array", "items": {"type": "string"}}},
+            "required": ["args"]}}},
+    {"type": "function", "function": {"name": "read_file",
+        "description": "Read a file (relative to the working directory) and return its content.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}}, "required": ["path"]}}},
+    {"type": "function", "function": {"name": "write_file",
+        "description": "Write content to a file (relative to the working directory), creating parent dirs.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"]}}},
+    {"type": "function", "function": {"name": "list_dir",
+        "description": "List the entries of a directory (relative to the working directory).",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"}}, "required": []}}},
+]

--- a/ollama-agent/ollama_agent/transport.py
+++ b/ollama-agent/ollama_agent/transport.py
@@ -1,0 +1,52 @@
+"""HTTP transport to ollama's /api/chat tools endpoint.
+
+The success check is explicit on both the urlopen and HTTPError paths: ollama
+returns a 200 body carrying an "error" key for some failures, and a non-200 for
+others. Treating "no exception" as success would record an HTTP error as a model
+turn (non-throwing-client-success-check).
+"""
+import json
+import urllib.error
+import urllib.request
+
+DEFAULT_HOST = "127.0.0.1:11434"
+
+
+def parse_chat_response(status, body):
+    if status != 200:
+        raise RuntimeError(f"ollama HTTP {status}: {body[:200]}")
+    data = json.loads(body)
+    if "error" in data:
+        raise RuntimeError(f"ollama error: {data['error']}")
+    if "message" not in data:
+        raise RuntimeError(f"ollama 200 with no message: {body[:200]}")
+    return data["message"]
+
+
+def ollama_transport(model, host=DEFAULT_HOST, temperature=0.7, num_ctx=16384, timeout=600):
+    """Return a transport(messages, tools) -> assistant message dict.
+
+    Raises RuntimeError on any non-success response and re-raises URLError
+    (daemon down) so the caller sees a failure rather than a silent hang.
+    """
+    url = f"http://{host}/api/chat"
+
+    def transport(messages, tools):
+        payload = json.dumps({
+            "model": model,
+            "messages": messages,
+            "tools": tools,
+            "stream": False,
+            "options": {"temperature": temperature, "num_ctx": num_ctx},
+        }).encode()
+        req = urllib.request.Request(url, data=payload,
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return parse_chat_response(resp.status, resp.read().decode())
+        except urllib.error.HTTPError as e:
+            return parse_chat_response(e.code, e.read().decode())
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"ollama unreachable at {url}: {e.reason}") from e
+
+    return transport

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -1,0 +1,150 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ollama_agent import ToolBox, TOOLS, run_agent  # noqa: E402
+from ollama_agent.agent import _normalize_args  # noqa: E402
+from ollama_agent.transport import parse_chat_response  # noqa: E402
+
+
+# --- real tools ---
+
+def test_run_shell_captures_returncode_and_stdout(tmp_path):
+    tb = ToolBox(cwd=tmp_path)
+    out = json.loads(tb.run_shell("echo hello"))
+    assert out["returncode"] == 0
+    assert "hello" in out["stdout"]
+
+
+def test_run_shell_nonzero_returncode_surfaced(tmp_path):
+    tb = ToolBox(cwd=tmp_path)
+    out = json.loads(tb.run_shell("exit 3"))
+    assert out["returncode"] == 3
+
+
+def test_run_shell_timeout(tmp_path):
+    tb = ToolBox(cwd=tmp_path, timeout=1)
+    out = json.loads(tb.run_shell("sleep 5"))
+    assert out["returncode"] is None and "timeout" in out["error"]
+
+
+def test_write_then_read_file_roundtrip(tmp_path):
+    tb = ToolBox(cwd=tmp_path)
+    tb.write_file("sub/a.txt", "content here")
+    out = json.loads(tb.read_file("sub/a.txt"))
+    assert out["content"] == "content here"
+
+
+def test_read_missing_file_is_error_not_crash(tmp_path):
+    out = json.loads(ToolBox(cwd=tmp_path).read_file("nope.txt"))
+    assert "error" in out
+
+
+def test_list_dir(tmp_path):
+    (tmp_path / "x.txt").write_text("")
+    (tmp_path / "d").mkdir()
+    out = json.loads(ToolBox(cwd=tmp_path).list_dir("."))
+    assert "x.txt" in out["entries"] and "d/" in out["entries"]
+
+
+def test_git_runs_in_cwd(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    out = json.loads(ToolBox(cwd=tmp_path).git(["status", "--short"]))
+    assert out["returncode"] == 0
+
+
+# --- dispatch ---
+
+def test_dispatch_records_every_call(tmp_path):
+    tb = ToolBox(cwd=tmp_path)
+    tb.dispatch("list_dir", {"path": "."})
+    assert tb.calls == [("list_dir", {"path": "."})]
+
+
+def test_dispatch_unknown_tool_recorded_and_errors(tmp_path):
+    tb = ToolBox(cwd=tmp_path)
+    res = json.loads(tb.dispatch("hallucinated", {}))
+    assert "error" in res and tb.unknown_calls == ["hallucinated"]
+
+
+# --- arg normalization ---
+
+@pytest.mark.parametrize("raw,expected", [
+    ({"a": 1}, {"a": 1}),
+    ('{"a": 1}', {"a": 1}),
+    ("not json", {}),
+    (None, {}),
+    ("[1,2]", {}),
+])
+def test_normalize_args(raw, expected):
+    assert _normalize_args(raw) == expected
+
+
+# --- loop ---
+
+def _script(*responses):
+    seq = iter(responses)
+    last = responses[-1]
+    def transport(messages, tools):
+        return next(seq, last)
+    return transport
+
+
+def test_loop_dispatches_tools_then_finishes(tmp_path):
+    transport = _script(
+        {"role": "assistant", "tool_calls": [
+            {"function": {"name": "write_file", "arguments": {"path": "f.txt", "content": "hi"}}}]},
+        {"role": "assistant", "content": "done"},
+    )
+    rec = run_agent("write a file", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, turn_cap=8)
+    assert rec["completed"] is True
+    assert rec["turns"] == 2
+    assert (tmp_path / "f.txt").read_text() == "hi"
+    assert rec["unknown_calls"] == []
+
+
+def test_loop_respects_turn_cap(tmp_path):
+    # Transport always asks for another tool call; a broken cap fails on the
+    # turns assertion (not by running out of scripted responses).
+    transport = _script({"role": "assistant", "tool_calls": [
+        {"function": {"name": "list_dir", "arguments": {"path": "."}}}]})
+    rec = run_agent("loop forever", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, turn_cap=4)
+    assert rec["completed"] is False
+    assert rec["turns"] == 4
+
+
+def test_loop_records_unknown_tool(tmp_path):
+    transport = _script(
+        {"role": "assistant", "tool_calls": [
+            {"function": {"name": "make_coffee", "arguments": {}}}]},
+        {"role": "assistant", "content": "cannot"},
+    )
+    rec = run_agent("brew", "sys", transport, ToolBox(cwd=tmp_path), TOOLS)
+    assert rec["unknown_calls"] == ["make_coffee"]
+
+
+# --- transport success check ---
+
+def test_parse_chat_response_ok():
+    assert parse_chat_response(200, json.dumps({"message": {"role": "assistant", "content": "hi"}})) \
+        == {"role": "assistant", "content": "hi"}
+
+
+def test_parse_chat_response_non_200_raises():
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        parse_chat_response(500, "boom")
+
+
+def test_parse_chat_response_error_body_raises():
+    with pytest.raises(RuntimeError, match="ollama error"):
+        parse_chat_response(200, json.dumps({"error": "model not found"}))
+
+
+def test_parse_chat_response_missing_message_raises():
+    with pytest.raises(RuntimeError, match="no message"):
+        parse_chat_response(200, json.dumps({"done": True}))

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -128,6 +128,86 @@ def test_loop_records_unknown_tool(tmp_path):
     assert rec["unknown_calls"] == ["make_coffee"]
 
 
+def test_loop_survives_malformed_tool_call_envelope(tmp_path):
+    # A tool_call missing function/name must not crash the loop — it records as
+    # an unknown call and feeds an error back to the model.
+    transport = _script(
+        {"role": "assistant", "tool_calls": [{"id": "1"}]},
+        {"role": "assistant", "content": "recovered"},
+    )
+    rec = run_agent("oops", "sys", transport, ToolBox(cwd=tmp_path), TOOLS)
+    assert rec["completed"] is True
+    assert rec["unknown_calls"] == [None]
+    assert "malformed" in rec["transcript"][3]["content"]
+
+
+def test_loop_survives_tool_handler_exception(tmp_path):
+    # write_file into a read-only dir raises PermissionError inside dispatch; the
+    # loop must keep running with a recorded error, not abort the run.
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o500)
+    transport = _script(
+        {"role": "assistant", "tool_calls": [
+            {"function": {"name": "write_file", "arguments": {"path": "ro/x.txt", "content": "hi"}}}]},
+        {"role": "assistant", "content": "noted the failure"},
+    )
+    try:
+        rec = run_agent("write", "sys", transport, ToolBox(cwd=tmp_path), TOOLS)
+    finally:
+        ro.chmod(0o700)
+    assert rec["completed"] is True
+    err = json.loads(rec["transcript"][3]["content"])
+    assert "error" in err and "write_file failed" in err["error"]
+
+
+def test_write_file_reports_byte_length_not_char_count(tmp_path):
+    out = json.loads(ToolBox(cwd=tmp_path).write_file("m.txt", "héllo"))
+    assert out["bytes"] == 6  # 5 chars, 6 UTF-8 bytes
+
+
+# --- transport error branches (the headline non-throwing-client claim) ---
+
+class _FakeResp:
+    def __init__(self, status, body):
+        self.status, self._body = status, body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+    def read(self):
+        return self._body.encode()
+
+
+def test_transport_success(monkeypatch):
+    import ollama_agent.transport as t
+    monkeypatch.setattr(t.urllib.request, "urlopen",
+                        lambda req, timeout: _FakeResp(200, json.dumps({"message": {"role": "assistant", "content": "ok"}})))
+    msg = t.ollama_transport("m")([{"role": "user", "content": "hi"}], [])
+    assert msg["content"] == "ok"
+
+
+def test_transport_httperror_routes_through_success_parser(monkeypatch):
+    import io
+    import ollama_agent.transport as t
+
+    def boom(req, timeout):
+        raise t.urllib.error.HTTPError("u", 500, "err", {}, io.BytesIO(b'{"error":"server"}'))
+    monkeypatch.setattr(t.urllib.request, "urlopen", boom)
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        t.ollama_transport("m")([{"role": "user", "content": "hi"}], [])
+
+
+def test_transport_urlerror_raises_unreachable(monkeypatch):
+    import ollama_agent.transport as t
+
+    def boom(req, timeout):
+        raise t.urllib.error.URLError("connection refused")
+    monkeypatch.setattr(t.urllib.request, "urlopen", boom)
+    with pytest.raises(RuntimeError, match="unreachable"):
+        t.ollama_transport("m")([{"role": "user", "content": "hi"}], [])
+
+
 # --- transport success check ---
 
 def test_parse_chat_response_ok():


### PR DESCRIPTION
Closes #186. Part of #185.

## Description (New Behavior)

Graduates the #184 agent-loop PoC into a real `ollama-agent` CLI that drives a local ollama model through **real (non-stub) tools** over the `/api/chat` tools API. This is Slice 1 of the local-agent bridge — bridge core + tool layer only; rule loading (#187), skills (#188), MCP (#189), and governance (#190) are later slices.

New package `ollama-agent/`:
- **`transport.py`** — `ollama_transport` / `parse_chat_response`. Explicit success check on the urlopen, `HTTPError`, and `URLError` paths; a 200 body carrying `error`, a non-200, or a missing `message` all raise rather than reading as a model turn (non-throwing-client-success-check).
- **`tools.py`** — `ToolBox` with five bounded tools scoped to a `cwd`: `run_shell`, `git`, `read_file`, `write_file`, `list_dir`. Timeout + truncated output. `dispatch()` records every call and surfaces an unknown tool as an error (recorded in `unknown_calls`), never a silent drop. `run_shell` is arbitrary-shell **by design** — that's the tool; per-task restriction + safe-delegation tiering are deferred to the governance slice (#190), documented in the module + README.
- **`agent.py`** — `run_agent` loop; normalizes tool-call `arguments` whether ollama returns a dict or a JSON string; returns `completed`/`turns`/`transcript`/`calls`/`unknown_calls`.
- **`cli.py`** — `--task/--model/--cwd/--host/--temperature/--num-ctx/--turn-cap/--shell-timeout/--json`.

## Testing Procedure

1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → `21 passed` (logic tests, no daemon).
3. (Requires ollama + `gpt-oss:20b`) In a temp dir with a `notes.txt`:
   `python3 ollama-agent/cli.py --task "read notes.txt then write count.txt with its line count, then summarize" --model gpt-oss:20b --cwd <dir>`
   → `completed=True`, tool calls listed, `count.txt` created with the correct count. Verified live: 3 tool calls (`list_dir`→`read_file`→`write_file`), correct result, no unknown calls.

## Additional Notes

Trust boundary (no command allowlist / path jail yet) is intentional for Slice 1 and called out in the README + module docstring; the governance slice (#190) adds per-task tool restriction and tiering. Eval outputs / caches gitignored.