### PR TITLE
Slice 2: rule loading + relevance selection for ollama-agent

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -9,7 +9,7 @@ import argparse
 import json
 import sys
 
-from ollama_agent import ToolBox, TOOLS, ollama_transport, run_agent
+from ollama_agent import ToolBox, TOOLS, compose_system, ollama_transport, run_agent
 
 DEFAULT_SYSTEM = (
     "You are a local engineering agent operating inside a single working directory. "
@@ -29,13 +29,27 @@ def main(argv=None):
     p.add_argument("--num-ctx", type=int, default=16384)
     p.add_argument("--turn-cap", type=int, default=8)
     p.add_argument("--shell-timeout", type=int, default=30)
+    p.add_argument("--rules-dir", default="~/.claude/rules",
+                   help="Directory of rule .md files to select from.")
+    p.add_argument("--max-rules", type=int, default=6)
+    p.add_argument("--rules-budget", type=int, default=24000,
+                   help="Max chars of rule text to inject.")
+    p.add_argument("--no-rules", action="store_true", help="Skip rule injection entirely.")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
+
+    system = a.system
+    if not a.no_rules:
+        system, sel = compose_system(a.system, a.task, a.rules_dir, a.max_rules, a.rules_budget)
+        injected = ", ".join(r.name for r in sel.selected) or "(none matched)"
+        print(f"rules injected: {injected}", file=sys.stderr)
+        for r, reason in sel.dropped:
+            print(f"rule dropped: {r.name} — {reason}", file=sys.stderr)
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout)
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
     try:
-        rec = run_agent(a.task, a.system, transport, toolbox, TOOLS, turn_cap=a.turn_cap)
+        rec = run_agent(a.task, system, transport, toolbox, TOOLS, turn_cap=a.turn_cap)
     except RuntimeError as e:
         print(f"agent failed: {e}", file=sys.stderr)
         return 1

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -3,7 +3,7 @@
 
     python cli.py --task "summarize the README" --model gpt-oss:20b --cwd /repo
 
-Slice 1 (#186): real shell/fs/git tools, no rule/skill loading yet.
+Slice 2 (#187): real shell/fs/git tools + task-relevant rule injection.
 """
 import argparse
 import json
@@ -42,9 +42,13 @@ def main(argv=None):
     if not a.no_rules:
         system, sel = compose_system(a.system, a.task, a.rules_dir, a.max_rules, a.rules_budget)
         injected = ", ".join(r.name for r in sel.selected) or "(none matched)"
-        print(f"rules injected: {injected}", file=sys.stderr)
+        # Counts make a zero-match a visible selection decision, not an apparent
+        # load failure: "matched 0 of 64" reads differently than "rules dir empty".
+        print(f"rules: considered {sel.considered}, matched {sel.matched}, "
+              f"injected {len(sel.selected)} ({injected}), dropped {len(sel.dropped)}",
+              file=sys.stderr)
         for r, reason in sel.dropped:
-            print(f"rule dropped: {r.name} — {reason}", file=sys.stderr)
+            print(f"  dropped {r.name}: {reason}", file=sys.stderr)
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout)
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -5,7 +5,9 @@ slices add rule loading (#187), skills (#188), an MCP adapter (#189), and a
 governed task registry (#190).
 """
 from .agent import run_agent
+from .rules import compose_system, load_rule_index, select_rules
 from .tools import ToolBox, TOOLS
 from .transport import ollama_transport, parse_chat_response
 
-__all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response"]
+__all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response",
+           "compose_system", "load_rule_index", "select_rules"]

--- a/ollama-agent/ollama_agent/rules.py
+++ b/ollama-agent/ollama_agent/rules.py
@@ -1,0 +1,117 @@
+"""Load Claude-style rule files and select the ones relevant to a task.
+
+Rules live as markdown with YAML-ish frontmatter (`description:`, `globs:`) and a
+`# Title`; the rule name is the filename stem. There are ~64 of them — injecting
+all of them every call is a context dump, not the always-check-rules discipline.
+This module loads the index cheaply (frontmatter only) and selects the few whose
+description/name actually overlap the task, under a character budget, logging
+every rule it drops (no silent truncation — enum-config-typo-fallback).
+"""
+import re
+from pathlib import Path
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+_STOP = {
+    "the", "a", "an", "and", "or", "but", "for", "to", "of", "in", "on", "at",
+    "is", "are", "be", "do", "does", "did", "you", "your", "it", "its", "this",
+    "that", "with", "as", "by", "if", "not", "no", "any", "all", "can", "will",
+    "should", "must", "when", "before", "after", "every", "use", "using", "from",
+}
+
+
+def _tokens(text):
+    return {t for t in _TOKEN.findall((text or "").lower()) if t not in _STOP and len(t) >= 3}
+
+
+def _parse_frontmatter(text):
+    """Return (description, globs, title) from a rule file's head. Missing fields
+    come back as empty strings rather than raising — a rule without frontmatter is
+    still usable, just less selectable."""
+    desc, globs, title = "", "", ""
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            for line in text[3:end].splitlines():
+                if line.startswith("description:"):
+                    desc = line.split(":", 1)[1].strip()
+                elif line.startswith("globs:"):
+                    globs = line.split(":", 1)[1].strip()
+    m = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
+    if m:
+        title = m.group(1).strip()
+    return desc, globs, title
+
+
+class Rule:
+    def __init__(self, name, path, description, title, size):
+        self.name = name
+        self.path = path
+        self.description = description
+        self.title = title
+        self.size = size            # body char count (full file)
+        self._tokens = _tokens(f"{name.replace('-', ' ')} {title} {description}")
+
+    def score(self, task_tokens):
+        return len(self._tokens & task_tokens)
+
+    def body(self):
+        return Path(self.path).read_text()
+
+
+class Selection:
+    def __init__(self, selected, dropped):
+        self.selected = selected            # [Rule], in score order
+        self.dropped = dropped              # [(Rule, reason)] for matched-but-excluded
+
+    def render(self):
+        if not self.selected:
+            return ""
+        parts = ["# Applicable rules (follow these — they override default behavior)\n"]
+        for r in self.selected:
+            parts.append(f"## Rule: {r.name}\n{r.body().strip()}\n")
+        return "\n".join(parts)
+
+
+def load_rule_index(rules_dir):
+    """Read frontmatter (not bodies) for every *.md in rules_dir. Returns [Rule]."""
+    d = Path(rules_dir).expanduser()
+    rules = []
+    if not d.is_dir():
+        return rules
+    for f in sorted(d.glob("*.md")):
+        text = f.read_text(errors="replace")
+        desc, _globs, title = _parse_frontmatter(text)
+        rules.append(Rule(f.stem, str(f), desc, title, len(text)))
+    return rules
+
+
+def compose_system(base_system, task, rules_dir, max_rules=6, budget_chars=24000):
+    """Return (system_text, selection): base prompt with the task-relevant rules
+    prepended. Selection is returned so the caller can log what was injected and
+    what was dropped."""
+    sel = select_rules(task, load_rule_index(rules_dir), max_rules, budget_chars)
+    block = sel.render()
+    system = f"{block}\n\n{base_system}" if block else base_system
+    return system, sel
+
+
+def select_rules(task, index, max_rules=6, budget_chars=24000):
+    """Pick the rules whose name/title/description overlap the task, highest score
+    first, until max_rules or budget_chars is hit. A rule that scored > 0 but
+    didn't fit is returned in `dropped` with a reason — never silently discarded.
+    """
+    task_tokens = _tokens(task)
+    scored = [(r.score(task_tokens), r) for r in index]
+    candidates = sorted((sr for sr in scored if sr[0] > 0),
+                        key=lambda sr: (-sr[0], sr[1].name))
+    selected, dropped, used = [], [], 0
+    for sc, r in candidates:
+        if len(selected) >= max_rules:
+            dropped.append((r, f"max_rules={max_rules} reached"))
+            continue
+        if used + r.size > budget_chars:
+            dropped.append((r, f"budget {budget_chars} exhausted (used {used}, +{r.size})"))
+            continue
+        selected.append(r)
+        used += r.size
+    return Selection(selected, dropped)

--- a/ollama-agent/ollama_agent/rules.py
+++ b/ollama-agent/ollama_agent/rules.py
@@ -28,15 +28,19 @@ def _parse_frontmatter(text):
     come back as empty strings rather than raising — a rule without frontmatter is
     still usable, just less selectable."""
     desc, globs, title = "", "", ""
+    body_start = 0
     if text.startswith("---"):
         end = text.find("\n---", 3)
         if end != -1:
+            body_start = end + 4
             for line in text[3:end].splitlines():
                 if line.startswith("description:"):
                     desc = line.split(":", 1)[1].strip()
                 elif line.startswith("globs:"):
                     globs = line.split(":", 1)[1].strip()
-    m = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
+    # Match the first heading after the frontmatter only — a `#` line inside the
+    # body (e.g. a shell comment in a code block) is not the rule's title.
+    m = re.search(r"^#\s+(.+)$", text[body_start:], re.MULTILINE)
     if m:
         title = m.group(1).strip()
     return desc, globs, title
@@ -48,27 +52,34 @@ class Rule:
         self.path = path
         self.description = description
         self.title = title
-        self.size = size            # body char count (full file)
+        self.size = size            # full-file char count (what the budget accounts against)
+        self.cached_body = None     # set when the rule is selected (read once, errors-tolerant)
         self._tokens = _tokens(f"{name.replace('-', ' ')} {title} {description}")
 
     def score(self, task_tokens):
         return len(self._tokens & task_tokens)
 
-    def body(self):
-        return Path(self.path).read_text()
+    def read_body(self):
+        # errors="replace" mirrors load_rule_index: a non-UTF-8 byte must not crash
+        # injection on a file the index already admitted. OSError (file deleted/
+        # unreadable after indexing) is left to the caller to route to `dropped`.
+        return Path(self.path).read_text(errors="replace")
 
 
 class Selection:
-    def __init__(self, selected, dropped):
-        self.selected = selected            # [Rule], in score order
-        self.dropped = dropped              # [(Rule, reason)] for matched-but-excluded
+    def __init__(self, selected, dropped, considered=0, matched=0):
+        self.selected = selected            # [Rule], in score order, bodies cached
+        self.dropped = dropped              # [(Rule, reason)] matched-but-excluded
+        self.considered = considered        # rules in the index
+        self.matched = matched              # rules with score > 0
 
     def render(self):
         if not self.selected:
             return ""
         parts = ["# Applicable rules (follow these — they override default behavior)\n"]
         for r in self.selected:
-            parts.append(f"## Rule: {r.name}\n{r.body().strip()}\n")
+            body = r.cached_body if r.cached_body is not None else r.read_body()
+            parts.append(f"## Rule: {r.name}\n{body.strip()}\n")
         return "\n".join(parts)
 
 
@@ -112,6 +123,11 @@ def select_rules(task, index, max_rules=6, budget_chars=24000):
         if used + r.size > budget_chars:
             dropped.append((r, f"budget {budget_chars} exhausted (used {used}, +{r.size})"))
             continue
+        try:
+            r.cached_body = r.read_body()
+        except OSError as e:
+            dropped.append((r, f"unreadable: {type(e).__name__}"))
+            continue
         selected.append(r)
         used += r.size
-    return Selection(selected, dropped)
+    return Selection(selected, dropped, considered=len(index), matched=len(candidates))

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import cli  # noqa: E402
+
+
+def _rule(d, name, desc):
+    (d / f"{name}.md").write_text(f"---\ndescription: {desc}\nglobs:\n---\n\n# {name}\n\nbody\n")
+
+
+def _fixture_rules(tmp_path):
+    d = tmp_path / "rules"
+    d.mkdir()
+    _rule(d, "no-commit-tmp-logs", "never commit tmp log files")
+    return d
+
+
+def _stub(monkeypatch, captured):
+    # Replace the network pieces so main() runs offline; capture the system prompt
+    # run_agent receives so the test can assert what rule text was injected.
+    monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: (lambda m, t: {"role": "assistant", "content": "ok"}))
+
+    def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8):
+        captured["system"] = system
+        return {"completed": True, "turns": 1, "transcript": [{"role": "assistant", "content": "done"}],
+                "calls": [], "unknown_calls": []}
+    monkeypatch.setattr(cli, "run_agent", fake_run_agent)
+
+
+def test_cli_injects_matching_rule(tmp_path, monkeypatch, capsys):
+    rules = _fixture_rules(tmp_path)
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
+                   "--rules-dir", str(rules)])
+    assert rc == 0
+    assert "no-commit-tmp-logs" in captured["system"]
+    err = capsys.readouterr().err
+    assert "matched 1" in err and "no-commit-tmp-logs" in err
+
+
+def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
+    rules = _fixture_rules(tmp_path)
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
+                   "--rules-dir", str(rules), "--no-rules"])
+    assert rc == 0
+    assert "no-commit-tmp-logs" not in captured["system"]
+    assert "rules:" not in capsys.readouterr().err
+
+
+def test_cli_no_match_reports_zero(tmp_path, monkeypatch, capsys):
+    rules = _fixture_rules(tmp_path)
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "paint the fence blue", "--cwd", str(tmp_path),
+                   "--rules-dir", str(rules)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "matched 0" in err and "(none matched)" in err
+
+
+def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
+    rules = _fixture_rules(tmp_path)
+
+    def boom(task, system, transport, toolbox, tools, turn_cap=8):
+        raise RuntimeError("ollama unreachable")
+    monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "run_agent", boom)
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--rules-dir", str(rules), "--no-rules"])
+    assert rc == 1
+    assert "agent failed" in capsys.readouterr().err

--- a/ollama-agent/tests/test_rules.py
+++ b/ollama-agent/tests/test_rules.py
@@ -68,7 +68,47 @@ def test_select_max_rules_cap_logs_dropped(rules_dir):
     task = "commit the stripe billing css changes and the tmp logs"
     sel = select_rules(task, load_rule_index(rules_dir), max_rules=1, budget_chars=10**9)
     assert len(sel.selected) == 1
-    assert sel.dropped and all("max_rules" in reason for _, reason in sel.dropped)
+    assert len(sel.dropped) == 2  # exactly the other two matched rules, not a partial drop
+    assert all("max_rules" in reason for _, reason in sel.dropped)
+
+
+def test_selection_reports_considered_and_matched(rules_dir):
+    sel = select_rules("commit tmp logs", load_rule_index(rules_dir))
+    assert sel.considered == 3       # all rules in the index
+    assert sel.matched == 1          # only no-commit-tmp-logs scored > 0
+    assert len(sel.selected) == 1
+
+
+def test_non_utf8_rule_body_does_not_crash_render(tmp_path):
+    d = tmp_path / "rules"
+    d.mkdir()
+    (d / "weird.md").write_bytes(
+        b"---\ndescription: handle the weird commit case\n---\n\n# Weird\n\n\xff\xfe bad bytes\n")
+    sel = select_rules("weird commit case", load_rule_index(d))
+    assert sel.selected[0].name == "weird"
+    block = sel.render()  # must not raise UnicodeDecodeError
+    assert "## Rule: weird" in block
+
+
+def test_unreadable_selected_rule_is_dropped_not_crash(tmp_path, monkeypatch):
+    d = tmp_path / "rules"
+    d.mkdir()
+    _rule(d, "no-commit-tmp-logs", "Never commit tmp log files", "tmp")
+    idx = load_rule_index(d)
+    monkeypatch.setattr(type(idx[0]), "read_body",
+                        lambda self: (_ for _ in ()).throw(OSError("gone")))
+    sel = select_rules("commit tmp logs", idx)
+    assert sel.selected == []
+    assert sel.dropped and "unreadable" in sel.dropped[0][1]
+
+
+def test_title_taken_after_frontmatter_not_body_hash(tmp_path):
+    d = tmp_path / "rules"
+    d.mkdir()
+    (d / "r.md").write_text(
+        "---\ndescription: a rule\n---\n\n# Real Title\n\n```\n# fake heading in code\n```\n")
+    title = load_rule_index(d)[0].title
+    assert title == "Real Title"
 
 
 def test_select_budget_drop_is_logged_not_silent(rules_dir):

--- a/ollama-agent/tests/test_rules.py
+++ b/ollama-agent/tests/test_rules.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ollama_agent.rules import (  # noqa: E402
+    compose_system, load_rule_index, select_rules, _parse_frontmatter, _tokens,
+)
+
+
+def _rule(d, name, desc, title, body=""):
+    (d / f"{name}.md").write_text(
+        f"---\ndescription: {desc}\nglobs:\n---\n\n# {title}\n\n{body or 'body of ' + name}\n")
+
+
+@pytest.fixture
+def rules_dir(tmp_path):
+    d = tmp_path / "rules"
+    d.mkdir()
+    _rule(d, "no-commit-tmp-logs", "Never commit tmp test log files", "No Committing tmp Logs")
+    _rule(d, "billing-write-verification", "Verify Stripe and EDD billing writes succeed", "Billing Write Verification")
+    _rule(d, "css-class-drift", "CSS classes in JSX must have matching stylesheet rules", "CSS Class Drift",
+          body="x" * 30000)  # oversized, to exercise the budget path
+    return d
+
+
+def test_parse_frontmatter():
+    desc, globs, title = _parse_frontmatter("---\ndescription: hello: world\nglobs: a,b\n---\n\n# Title Here\n\nbody")
+    assert desc == "hello: world" and globs == "a,b" and title == "Title Here"
+
+
+def test_parse_frontmatter_missing_is_empty_not_crash():
+    desc, globs, title = _parse_frontmatter("no frontmatter at all\njust text")
+    assert desc == "" and globs == "" and title == ""
+
+
+def test_tokens_drops_stopwords_and_short():
+    assert _tokens("the Stripe billing must be verified") == {"stripe", "billing", "verified"}
+
+
+def test_load_rule_index(rules_dir):
+    idx = load_rule_index(rules_dir)
+    names = {r.name for r in idx}
+    assert names == {"no-commit-tmp-logs", "billing-write-verification", "css-class-drift"}
+    billing = next(r for r in idx if r.name == "billing-write-verification")
+    assert "Stripe" in billing.description and billing.size > 0
+
+
+def test_load_missing_dir_returns_empty(tmp_path):
+    assert load_rule_index(tmp_path / "nope") == []
+
+
+def test_select_picks_relevant_rule(rules_dir):
+    sel = select_rules("I need to commit but there are tmp log files staged", load_rule_index(rules_dir))
+    assert sel.selected[0].name == "no-commit-tmp-logs"
+    assert "billing-write-verification" not in {r.name for r in sel.selected}
+
+
+def test_select_irrelevant_task_selects_nothing(rules_dir):
+    sel = select_rules("paint the fence a nice shade of blue", load_rule_index(rules_dir))
+    assert sel.selected == []
+
+
+def test_select_max_rules_cap_logs_dropped(rules_dir):
+    # task matches multiple rules; cap at 1 → the rest are recorded as dropped.
+    task = "commit the stripe billing css changes and the tmp logs"
+    sel = select_rules(task, load_rule_index(rules_dir), max_rules=1, budget_chars=10**9)
+    assert len(sel.selected) == 1
+    assert sel.dropped and all("max_rules" in reason for _, reason in sel.dropped)
+
+
+def test_select_budget_drop_is_logged_not_silent(rules_dir):
+    # css-class-drift body is 30k chars; a 1k budget must drop it with a reason.
+    sel = select_rules("fix the css class drift in jsx", load_rule_index(rules_dir),
+                        max_rules=6, budget_chars=1000)
+    assert all(r.name != "css-class-drift" for r in sel.selected)
+    assert any(r.name == "css-class-drift" and "budget" in reason for r, reason in sel.dropped)
+
+
+def test_render_includes_selected_body(rules_dir):
+    sel = select_rules("commit tmp logs", load_rule_index(rules_dir))
+    block = sel.render()
+    assert "## Rule: no-commit-tmp-logs" in block and "body of no-commit-tmp-logs" in block
+
+
+def test_render_empty_when_nothing_selected(rules_dir):
+    assert select_rules("xyzzy", load_rule_index(rules_dir)).render() == ""
+
+
+def test_compose_system_prepends_rules(rules_dir):
+    system, sel = compose_system("BASE PROMPT", "commit tmp logs", rules_dir)
+    assert "BASE PROMPT" in system
+    assert system.index("no-commit-tmp-logs") < system.index("BASE PROMPT")
+
+
+def test_compose_system_no_match_is_base_only(rules_dir):
+    system, sel = compose_system("BASE PROMPT", "xyzzy", rules_dir)
+    assert system == "BASE PROMPT" and sel.selected == []


### PR DESCRIPTION
Closes #187. Part of #185.

## Description (New Behavior)

Adds the rule layer: the agent now loads `~/.claude/rules/*.md` and injects **only the rules relevant to the task**, not all 64 — the always-check-rules discipline, not a context dump.

- **`rules.py`**
  - `load_rule_index(dir)` — parses frontmatter only (`description`/`globs`/`# title`); rule name is the filename stem (only 3 of 64 files have a `name:` field). Missing frontmatter degrades to empty strings, never raises.
  - `select_rules(task, index, max_rules=6, budget_chars=24000)` — token-overlap score of the task against each rule's name/title/description; highest first, capped by `max_rules` and a char budget. **Every rule that matched but didn't fit is returned in `dropped` with a reason** — no silent truncation (enum-config-typo-fallback).
  - `compose_system(base, task, dir, …)` — prepends the selected-rule block to the system prompt; returns the selection for logging.
- **`cli.py`** — `--rules-dir` (default `~/.claude/rules`), `--max-rules`, `--rules-budget`, `--no-rules`; logs injected + dropped rules to stderr.

## Testing Procedure

1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → `40 passed` (13 new, over a **fixture** rules dir — not the live `~/.claude/rules`, per test-reproduces-production-conditions).
3. (Requires ollama + `gpt-oss:20b`) In a temp git repo with a `tmp/debug.log`, `app.py`, `README.md`:
   `python3 ollama-agent/cli.py --task "stage all changed files for a commit" --cwd <repo>`
   → stderr shows `rules injected: …no-commit-tmp-logs…` + dropped rules; the model stages `app.py`+`README.md` and **leaves `tmp/` untracked, citing the rule.** Verified live.

## Additional Notes

Relevance is lightweight token overlap (no embedding dependency); a smarter selector is a future option but YAGNI for now. Budget/cap drops are logged, never silent.