### PR TITLE
Slice 3: skill resolver — catalog + use_skill tool for ollama-agent

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -9,7 +9,8 @@ import argparse
 import json
 import sys
 
-from ollama_agent import ToolBox, TOOLS, compose_system, ollama_transport, run_agent
+from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, compose_system,
+                          load_skill_index, ollama_transport, render_catalog, run_agent)
 
 DEFAULT_SYSTEM = (
     "You are a local engineering agent operating inside a single working directory. "
@@ -35,6 +36,9 @@ def main(argv=None):
     p.add_argument("--rules-budget", type=int, default=24000,
                    help="Max chars of rule text to inject.")
     p.add_argument("--no-rules", action="store_true", help="Skip rule injection entirely.")
+    p.add_argument("--skills-dir", default="~/.claude/skills",
+                   help="Directory of skill dirs (each with a SKILL.md).")
+    p.add_argument("--no-skills", action="store_true", help="Skip skill discovery entirely.")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
 
@@ -50,10 +54,16 @@ def main(argv=None):
         for r, reason in sel.dropped:
             print(f"  dropped {r.name}: {reason}", file=sys.stderr)
 
-    toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout)
+    skills = [] if a.no_skills else load_skill_index(a.skills_dir)
+    if skills:
+        system = f"{render_catalog(skills)}\n\n{system}"
+        print(f"skills: {len(skills)} available (use_skill enabled)", file=sys.stderr)
+    tools = TOOLS + ([USE_SKILL_TOOL] if skills else [])
+
+    toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills)
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
     try:
-        rec = run_agent(a.task, system, transport, toolbox, TOOLS, turn_cap=a.turn_cap)
+        rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap)
     except RuntimeError as e:
         print(f"agent failed: {e}", file=sys.stderr)
         return 1

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -6,8 +6,10 @@ governed task registry (#190).
 """
 from .agent import run_agent
 from .rules import compose_system, load_rule_index, select_rules
+from .skills import USE_SKILL_TOOL, get_skill, load_skill_index, render_catalog
 from .tools import ToolBox, TOOLS
 from .transport import ollama_transport, parse_chat_response
 
 __all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response",
-           "compose_system", "load_rule_index", "select_rules"]
+           "compose_system", "load_rule_index", "select_rules",
+           "USE_SKILL_TOOL", "get_skill", "load_skill_index", "render_catalog"]

--- a/ollama-agent/ollama_agent/rules.py
+++ b/ollama-agent/ollama_agent/rules.py
@@ -90,7 +90,11 @@ def load_rule_index(rules_dir):
     if not d.is_dir():
         return rules
     for f in sorted(d.glob("*.md")):
-        text = f.read_text(errors="replace")
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            # One unreadable rule file must not abort loading the rest.
+            continue
         desc, _globs, title = _parse_frontmatter(text)
         rules.append(Rule(f.stem, str(f), desc, title, len(text)))
     return rules

--- a/ollama-agent/ollama_agent/skills.py
+++ b/ollama-agent/ollama_agent/skills.py
@@ -1,0 +1,89 @@
+"""Discover Claude-style skills and expose them to the local agent.
+
+A skill is a directory containing a `SKILL.md` with `name:`/`description:`
+frontmatter and a markdown procedure body. The agent gets a *catalog* (name +
+one-line description) in its system prompt and a `use_skill(name)` tool that
+returns a skill's full body on demand — the model loads a procedure only when it
+decides it needs one, rather than carrying every skill body in context.
+"""
+import re
+from pathlib import Path
+
+DEFAULT_SKILL_ROOT = "~/.claude/skills"
+MAX_SKILL_BODY = 24000   # chars of a skill body returned by use_skill
+
+
+def _parse_skill_frontmatter(text):
+    """Return (name, description) from SKILL.md frontmatter. Either may be empty
+    if absent; the caller falls back to the directory name."""
+    name, desc = "", ""
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            for line in text[3:end].splitlines():
+                if line.startswith("name:"):
+                    name = line.split(":", 1)[1].strip()
+                elif line.startswith("description:"):
+                    desc = line.split(":", 1)[1].strip()
+    return name, desc
+
+
+class Skill:
+    def __init__(self, name, path, description):
+        self.name = name
+        self.path = path
+        self.description = description
+
+    def body(self):
+        return Path(self.path).read_text(errors="replace")
+
+
+def load_skill_index(roots=DEFAULT_SKILL_ROOT):
+    """Scan each root for <root>/*/SKILL.md. `roots` is a path or list of paths.
+    The skill name is its frontmatter `name:`, falling back to the directory name.
+    Later roots do not override earlier ones on a name clash (first wins, logged
+    by the caller if it cares)."""
+    if isinstance(roots, (str, Path)):
+        roots = [roots]
+    index, seen = [], set()
+    for root in roots:
+        d = Path(root).expanduser()
+        if not d.is_dir():
+            continue
+        for skill_md in sorted(d.glob("*/SKILL.md")):
+            text = skill_md.read_text(errors="replace")
+            name, desc = _parse_skill_frontmatter(text)
+            name = name or skill_md.parent.name
+            if name in seen:
+                continue
+            seen.add(name)
+            index.append(Skill(name, str(skill_md), desc))
+    return index
+
+
+def render_catalog(index):
+    """A compact name + description list for the system prompt."""
+    if not index:
+        return ""
+    lines = ["# Available skills (call use_skill(name) to load one's full instructions)"]
+    for s in index:
+        desc = s.description or "(no description)"
+        lines.append(f"- {s.name}: {desc}")
+    return "\n".join(lines)
+
+
+def get_skill(index, name):
+    for s in index:
+        if s.name == name:
+            return s
+    return None
+
+
+USE_SKILL_TOOL = {
+    "type": "function", "function": {"name": "use_skill",
+        "description": "Load a skill's full instructions by name. Call this when a "
+                       "listed skill matches the task, then follow the returned procedure.",
+        "parameters": {"type": "object", "properties": {
+            "name": {"type": "string", "description": "The skill name from the catalog."}},
+            "required": ["name"]}},
+}

--- a/ollama-agent/ollama_agent/skills.py
+++ b/ollama-agent/ollama_agent/skills.py
@@ -6,25 +6,46 @@ one-line description) in its system prompt and a `use_skill(name)` tool that
 returns a skill's full body on demand — the model loads a procedure only when it
 decides it needs one, rather than carrying every skill body in context.
 """
-import re
 from pathlib import Path
 
 DEFAULT_SKILL_ROOT = "~/.claude/skills"
 MAX_SKILL_BODY = 24000   # chars of a skill body returned by use_skill
 
 
+_BLOCK_SCALAR = {">", ">-", ">+", "|", "|-", "|+", ""}
+
+
 def _parse_skill_frontmatter(text):
     """Return (name, description) from SKILL.md frontmatter. Either may be empty
-    if absent; the caller falls back to the directory name."""
+    if absent; the caller falls back to the directory name. A YAML block scalar
+    (`description: >-` + indented continuation) is folded into one line — several
+    real SKILL.md files use that form, and reading only the inline value would
+    capture a bare `>`."""
     name, desc = "", ""
-    if text.startswith("---"):
-        end = text.find("\n---", 3)
-        if end != -1:
-            for line in text[3:end].splitlines():
-                if line.startswith("name:"):
-                    name = line.split(":", 1)[1].strip()
-                elif line.startswith("description:"):
-                    desc = line.split(":", 1)[1].strip()
+    if not text.startswith("---"):
+        return name, desc
+    end = text.find("\n---", 3)
+    if end == -1:
+        return name, desc
+    lines = text[3:end].splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("name:"):
+            name = line.split(":", 1)[1].strip()
+        elif line.startswith("description:"):
+            val = line.split(":", 1)[1].strip()
+            if val in _BLOCK_SCALAR:
+                parts, j = [], i + 1
+                while j < len(lines) and (lines[j][:1] in (" ", "\t") or not lines[j].strip()):
+                    if lines[j].strip():
+                        parts.append(lines[j].strip())
+                    j += 1
+                desc = " ".join(parts)
+                i = j
+                continue
+            desc = val
+        i += 1
     return name, desc
 
 
@@ -51,7 +72,12 @@ def load_skill_index(roots=DEFAULT_SKILL_ROOT):
         if not d.is_dir():
             continue
         for skill_md in sorted(d.glob("*/SKILL.md")):
-            text = skill_md.read_text(errors="replace")
+            try:
+                text = skill_md.read_text(errors="replace")
+            except OSError:
+                # A permission-denied / race-deleted SKILL.md must not abort
+                # discovery of every other skill (safety-invariant-scope).
+                continue
             name, desc = _parse_skill_frontmatter(text)
             name = name or skill_md.parent.name
             if name in seen:

--- a/ollama-agent/ollama_agent/tools.py
+++ b/ollama-agent/ollama_agent/tools.py
@@ -10,6 +10,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from .skills import MAX_SKILL_BODY
+
 MAX_OUTPUT = 4000      # chars of stdout/stderr returned to the model per call
 MAX_READ = 20000       # chars returned by read_file
 
@@ -20,11 +22,12 @@ def _clip(s, n):
 
 
 class ToolBox:
-    def __init__(self, cwd=".", timeout=30):
+    def __init__(self, cwd=".", timeout=30, skills=None):
         self.cwd = Path(cwd).resolve()
         self.timeout = timeout
+        self.skills = list(skills) if skills else []   # [Skill] for use_skill, if any
         self.calls = []            # (name, args) of every dispatched call
-        self.unknown_calls = []    # names the model hallucinated
+        self.unknown_calls = []    # tool/skill names the model hallucinated
 
     def _resolve(self, path):
         p = Path(path)
@@ -71,6 +74,14 @@ class ToolBox:
         return json.dumps({"path": str(d),
                            "entries": sorted(p.name + ("/" if p.is_dir() else "") for p in d.iterdir())})
 
+    def use_skill(self, name):
+        for s in self.skills:
+            if s.name == name:
+                return json.dumps({"name": s.name, "body": _clip(s.body(), MAX_SKILL_BODY)})
+        self.unknown_calls.append(name)
+        return json.dumps({"error": f"unknown skill: {name}",
+                           "available": [s.name for s in self.skills]})
+
     def dispatch(self, name, args):
         """Route one tool call. Records every call; unknown names are recorded
         separately and returned as an error string (never silently dropped)."""
@@ -81,6 +92,7 @@ class ToolBox:
             "read_file": lambda a: self.read_file(a.get("path", "")),
             "write_file": lambda a: self.write_file(a.get("path", ""), a.get("content", "")),
             "list_dir": lambda a: self.list_dir(a.get("path", ".")),
+            "use_skill": lambda a: self.use_skill(a.get("name", "")),
         }.get(name)
         if handler is None:
             self.unknown_calls.append(name)

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -24,9 +24,14 @@ def _stub(monkeypatch, captured):
 
     def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8):
         captured["system"] = system
+        captured["tools"] = tools
         return {"completed": True, "turns": 1, "transcript": [{"role": "assistant", "content": "done"}],
                 "calls": [], "unknown_calls": []}
     monkeypatch.setattr(cli, "run_agent", fake_run_agent)
+
+
+def _tool_names(tools):
+    return {t["function"]["name"] for t in tools}
 
 
 def test_cli_injects_matching_rule(tmp_path, monkeypatch, capsys):
@@ -34,7 +39,7 @@ def test_cli_injects_matching_rule(tmp_path, monkeypatch, capsys):
     captured = {}
     _stub(monkeypatch, captured)
     rc = cli.main(["--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
-                   "--rules-dir", str(rules)])
+                   "--rules-dir", str(rules), "--no-skills"])
     assert rc == 0
     assert "no-commit-tmp-logs" in captured["system"]
     err = capsys.readouterr().err
@@ -46,7 +51,7 @@ def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
     captured = {}
     _stub(monkeypatch, captured)
     rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
-                   "--rules-dir", str(rules), "--no-rules"])
+                   "--rules-dir", str(rules), "--no-rules", "--no-skills"])
     assert rc == 0
     assert "no-commit-tmp-logs" not in captured["system"]
     assert "rules:" not in capsys.readouterr().err
@@ -56,7 +61,7 @@ def test_cli_no_match_reports_zero(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
     _stub(monkeypatch, {})
     rc = cli.main(["--task", "paint the fence blue", "--cwd", str(tmp_path),
-                   "--rules-dir", str(rules)])
+                   "--rules-dir", str(rules), "--no-skills"])
     assert rc == 0
     err = capsys.readouterr().err
     assert "matched 0" in err and "(none matched)" in err
@@ -69,6 +74,37 @@ def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
         raise RuntimeError("ollama unreachable")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", boom)
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--rules-dir", str(rules), "--no-rules"])
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--rules-dir", str(rules), "--no-rules", "--no-skills"])
     assert rc == 1
     assert "agent failed" in capsys.readouterr().err
+
+
+def _fixture_skills(tmp_path):
+    r = tmp_path / "skills" / "obsidian-save"
+    r.mkdir(parents=True)
+    (r / "SKILL.md").write_text("---\nname: obsidian-save\ndescription: save to vault\n---\n\n# save\nbody\n")
+    return tmp_path / "skills"
+
+
+def test_cli_injects_skill_catalog_and_use_skill_tool(tmp_path, monkeypatch, capsys):
+    skills = _fixture_skills(tmp_path)
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do a thing", "--cwd", str(tmp_path),
+                   "--no-rules", "--skills-dir", str(skills)])
+    assert rc == 0
+    assert "obsidian-save" in captured["system"] and "use_skill" in captured["system"]
+    assert "use_skill" in _tool_names(captured["tools"])
+    assert "skills: 1 available" in capsys.readouterr().err
+
+
+def test_cli_no_skills_suppresses_catalog_and_tool(tmp_path, monkeypatch, capsys):
+    skills = _fixture_skills(tmp_path)
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do a thing", "--cwd", str(tmp_path),
+                   "--no-rules", "--skills-dir", str(skills), "--no-skills"])
+    assert rc == 0
+    assert "obsidian-save" not in captured["system"]
+    assert "use_skill" not in _tool_names(captured["tools"])
+    assert "skills:" not in capsys.readouterr().err

--- a/ollama-agent/tests/test_skills.py
+++ b/ollama-agent/tests/test_skills.py
@@ -12,10 +12,10 @@ from ollama_agent.skills import (  # noqa: E402
 )
 
 
-def _skill(root, name, desc=None, body="procedure body", fm_name=None):
+def _skill(root, name, desc=None, body="procedure body"):
     d = root / name
     d.mkdir()
-    nm = f"name: {fm_name}\n" if fm_name is not None else (f"name: {name}\n" if desc is not None else "")
+    nm = f"name: {name}\n" if desc is not None else ""
     ds = f"description: {desc}\n" if desc is not None else ""
     fm = f"---\n{nm}{ds}---\n\n" if (nm or ds) else ""
     (d / "SKILL.md").write_text(f"{fm}# {name}\n\n{body}\n")
@@ -38,6 +38,16 @@ def test_parse_skill_frontmatter():
 
 def test_parse_skill_frontmatter_missing_is_empty():
     assert _parse_skill_frontmatter("no frontmatter\nbody") == ("", "")
+
+
+def test_parse_skill_frontmatter_folded_scalar():
+    text = "---\nname: foo\ndescription: >-\n  a long\n  wrapped description\n---\n\n# Foo\nbody"
+    name, desc = _parse_skill_frontmatter(text)
+    assert name == "foo" and desc == "a long wrapped description"
+
+
+def test_parse_skill_frontmatter_no_closing_fence_is_empty():
+    assert _parse_skill_frontmatter("---\nname: foo\ndescription: bar\n\n# no closing fence") == ("", "")
 
 
 def test_load_skill_index(skills_root):
@@ -78,6 +88,24 @@ def test_render_catalog_empty():
     assert render_catalog([]) == ""
 
 
+def test_render_catalog_no_description_placeholder(tmp_path):
+    r = tmp_path / "skills"
+    r.mkdir()
+    _skill(r, "bare", desc=None)  # no frontmatter → empty description
+    cat = render_catalog(load_skill_index(r))
+    assert "bare: (no description)" in cat
+
+
+def test_load_skill_index_folded_scalar_in_catalog(tmp_path):
+    r = tmp_path / "skills"
+    d = r / "auto-review"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        "---\nname: auto-review\ndescription: >\n  reviews a PR\n  automatically\n---\n\n# auto-review\nbody")
+    desc = load_skill_index(r)[0].description
+    assert desc == "reviews a PR automatically"  # not a bare ">"
+
+
 def test_use_skill_tool_returns_body(skills_root):
     tb = ToolBox(cwd=skills_root, skills=load_skill_index(skills_root))
     out = json.loads(tb.dispatch("use_skill", {"name": "obsidian-save"}))
@@ -95,6 +123,23 @@ def test_use_skill_with_no_skills_loaded_errors_cleanly(tmp_path):
     tb = ToolBox(cwd=tmp_path)  # no skills
     out = json.loads(tb.dispatch("use_skill", {"name": "anything"}))
     assert "error" in out and out["available"] == []
+    assert tb.unknown_calls == ["anything"]
+
+
+def test_load_skill_index_skips_unreadable_file(tmp_path, monkeypatch):
+    r = tmp_path / "skills"
+    r.mkdir()
+    _skill(r, "good", "fine")
+    _skill(r, "bad", "broken")
+    real = Path.read_text
+
+    def selective(self, *a, **k):
+        if self.parent.name == "bad":
+            raise PermissionError("nope")
+        return real(self, *a, **k)
+    monkeypatch.setattr(Path, "read_text", selective)
+    idx = load_skill_index(r)  # must not raise; bad skill skipped
+    assert {s.name for s in idx} == {"good"}
 
 
 def test_use_skill_body_is_clipped(tmp_path):

--- a/ollama-agent/tests/test_skills.py
+++ b/ollama-agent/tests/test_skills.py
@@ -1,0 +1,107 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ollama_agent import ToolBox  # noqa: E402
+from ollama_agent.skills import (  # noqa: E402
+    _parse_skill_frontmatter, get_skill, load_skill_index, render_catalog,
+)
+
+
+def _skill(root, name, desc=None, body="procedure body", fm_name=None):
+    d = root / name
+    d.mkdir()
+    nm = f"name: {fm_name}\n" if fm_name is not None else (f"name: {name}\n" if desc is not None else "")
+    ds = f"description: {desc}\n" if desc is not None else ""
+    fm = f"---\n{nm}{ds}---\n\n" if (nm or ds) else ""
+    (d / "SKILL.md").write_text(f"{fm}# {name}\n\n{body}\n")
+    return d
+
+
+@pytest.fixture
+def skills_root(tmp_path):
+    r = tmp_path / "skills"
+    r.mkdir()
+    _skill(r, "pr-review-panel", "Multi-agent PR review with specialists and an auditor")
+    _skill(r, "obsidian-save", "Save the conversation to the Obsidian vault")
+    return r
+
+
+def test_parse_skill_frontmatter():
+    name, desc = _parse_skill_frontmatter("---\nname: foo\ndescription: does a thing\n---\n\n# Foo\nbody")
+    assert name == "foo" and desc == "does a thing"
+
+
+def test_parse_skill_frontmatter_missing_is_empty():
+    assert _parse_skill_frontmatter("no frontmatter\nbody") == ("", "")
+
+
+def test_load_skill_index(skills_root):
+    idx = load_skill_index(skills_root)
+    assert {s.name for s in idx} == {"pr-review-panel", "obsidian-save"}
+    panel = get_skill(idx, "pr-review-panel")
+    assert "auditor" in panel.description
+
+
+def test_name_falls_back_to_dir_when_frontmatter_lacks_name(tmp_path):
+    r = tmp_path / "skills"
+    r.mkdir()
+    _skill(r, "no-name-skill", desc=None)  # no frontmatter at all
+    idx = load_skill_index(r)
+    assert idx[0].name == "no-name-skill"
+
+
+def test_load_missing_root_returns_empty(tmp_path):
+    assert load_skill_index(tmp_path / "nope") == []
+
+
+def test_first_root_wins_on_name_clash(tmp_path):
+    r1, r2 = tmp_path / "a", tmp_path / "b"
+    r1.mkdir(); r2.mkdir()
+    _skill(r1, "dup", "from r1")
+    _skill(r2, "dup", "from r2")
+    idx = load_skill_index([r1, r2])
+    assert len(idx) == 1 and get_skill(idx, "dup").description == "from r1"
+
+
+def test_render_catalog(skills_root):
+    cat = render_catalog(load_skill_index(skills_root))
+    assert "use_skill" in cat
+    assert "pr-review-panel: Multi-agent PR review" in cat
+
+
+def test_render_catalog_empty():
+    assert render_catalog([]) == ""
+
+
+def test_use_skill_tool_returns_body(skills_root):
+    tb = ToolBox(cwd=skills_root, skills=load_skill_index(skills_root))
+    out = json.loads(tb.dispatch("use_skill", {"name": "obsidian-save"}))
+    assert out["name"] == "obsidian-save" and "procedure body" in out["body"]
+
+
+def test_use_skill_unknown_records_and_errors(skills_root):
+    tb = ToolBox(cwd=skills_root, skills=load_skill_index(skills_root))
+    out = json.loads(tb.dispatch("use_skill", {"name": "no-such-skill"}))
+    assert "error" in out and "pr-review-panel" in out["available"]
+    assert tb.unknown_calls == ["no-such-skill"]
+
+
+def test_use_skill_with_no_skills_loaded_errors_cleanly(tmp_path):
+    tb = ToolBox(cwd=tmp_path)  # no skills
+    out = json.loads(tb.dispatch("use_skill", {"name": "anything"}))
+    assert "error" in out and out["available"] == []
+
+
+def test_use_skill_body_is_clipped(tmp_path):
+    from ollama_agent.skills import MAX_SKILL_BODY
+    r = tmp_path / "skills"
+    r.mkdir()
+    _skill(r, "huge", "big skill", body="x" * (MAX_SKILL_BODY + 5000))
+    tb = ToolBox(cwd=r, skills=load_skill_index(r))
+    out = json.loads(tb.dispatch("use_skill", {"name": "huge"}))
+    assert "truncated" in out["body"] and len(out["body"]) < MAX_SKILL_BODY + 200


### PR DESCRIPTION
Closes #188. Part of #185.

## Description (New Behavior)

The agent discovers Claude-style skills and loads one **on demand** via a `use_skill` tool, rather than carrying every skill body in context.

- **`skills.py`** — `load_skill_index(roots)` scans `<root>/*/SKILL.md`; skill name comes from frontmatter `name:`, falling back to the directory name; first root wins on a name clash; reads are `errors="replace"`-tolerant. `render_catalog(index)` builds a compact `name: description` list for the system prompt. `USE_SKILL_TOOL` schema + `get_skill` resolver.
- **`tools.py`** — `ToolBox(skills=…)` adds a `use_skill` handler returning the skill body (clipped to `MAX_SKILL_BODY`). An unknown skill is recorded in `unknown_calls` and returns `{error, available:[…]}` — never a crash.
- **`cli.py`** — `--skills-dir` (default `~/.claude/skills`), `--no-skills`; injects the catalog and adds `use_skill` to the tool set when skills exist.

## Testing Procedure

1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → `60 passed` (12 new, over fixture skill dirs).
3. (Requires ollama + `gpt-oss:20b`) `python3 ollama-agent/cli.py --task "load the obsidian-save skill with use_skill and report one step" --cwd <dir> --no-rules`
   → stderr shows `skills: N available`; the model calls `use_skill`, receives the body, and reports a real procedure step. Verified live (28 skills discovered; a hallucinated tool was recorded as `unknown`, not a crash).

## Additional Notes

Catalog is name + one-line description (cheap); full bodies load only on `use_skill`. Plugin-skill-dir discovery beyond `~/.claude/skills` can be a follow-up; `load_skill_index` already accepts multiple roots.