### PR TITLE
Slice 4: MCP tool adapter for ollama-agent

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -9,8 +9,9 @@ import argparse
 import json
 import sys
 
-from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, compose_system,
-                          load_skill_index, ollama_transport, render_catalog, run_agent)
+from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, MCPClient, StdioMCPTransport,
+                          compose_system, load_skill_index, mcp_tools_to_ollama,
+                          ollama_transport, render_catalog, run_agent)
 
 DEFAULT_SYSTEM = (
     "You are a local engineering agent operating inside a single working directory. "
@@ -39,6 +40,9 @@ def main(argv=None):
     p.add_argument("--skills-dir", default="~/.claude/skills",
                    help="Directory of skill dirs (each with a SKILL.md).")
     p.add_argument("--no-skills", action="store_true", help="Skip skill discovery entirely.")
+    p.add_argument("--mcp", default=None,
+                   help="Command to spawn an MCP server whose tools are bridged in (e.g. "
+                        "'npx -y @modelcontextprotocol/server-filesystem /path').")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
 
@@ -60,13 +64,32 @@ def main(argv=None):
         print(f"skills: {len(skills)} available (use_skill enabled)", file=sys.stderr)
     tools = TOOLS + ([USE_SKILL_TOOL] if skills else [])
 
-    toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills)
+    mcp_transport, mcp_client, mcp_names = None, None, {}
+    if a.mcp:
+        try:
+            mcp_transport = StdioMCPTransport(a.mcp, cwd=a.cwd)
+            mcp_client = MCPClient(mcp_transport)
+            mcp_client.initialize()
+            schemas, mcp_names = mcp_tools_to_ollama(mcp_client.list_tools())
+            tools = tools + schemas
+            print(f"mcp: {len(schemas)} tools from {a.mcp!r}", file=sys.stderr)
+        except Exception as e:
+            if mcp_transport:
+                mcp_transport.close()
+            print(f"mcp bridge failed: {e}", file=sys.stderr)
+            return 1
+
+    toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills,
+                      mcp_client=mcp_client, mcp_names=mcp_names)
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
     try:
         rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap)
     except RuntimeError as e:
         print(f"agent failed: {e}", file=sys.stderr)
         return 1
+    finally:
+        if mcp_transport:
+            mcp_transport.close()
 
     if a.json:
         print(json.dumps(rec, indent=2))

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -76,7 +76,7 @@ def main(argv=None):
         except Exception as e:
             if mcp_transport:
                 mcp_transport.close()
-            print(f"mcp bridge failed: {e}", file=sys.stderr)
+            print(f"mcp bridge failed for {a.mcp!r}: {e}", file=sys.stderr)
             return 1
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills,

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -5,6 +5,7 @@ slices add rule loading (#187), skills (#188), an MCP adapter (#189), and a
 governed task registry (#190).
 """
 from .agent import run_agent
+from .mcp import MCPClient, MCPError, StdioMCPTransport, mcp_tools_to_ollama
 from .rules import compose_system, load_rule_index, select_rules
 from .skills import USE_SKILL_TOOL, get_skill, load_skill_index, render_catalog
 from .tools import ToolBox, TOOLS
@@ -12,4 +13,5 @@ from .transport import ollama_transport, parse_chat_response
 
 __all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response",
            "compose_system", "load_rule_index", "select_rules",
-           "USE_SKILL_TOOL", "get_skill", "load_skill_index", "render_catalog"]
+           "USE_SKILL_TOOL", "get_skill", "load_skill_index", "render_catalog",
+           "MCPClient", "MCPError", "StdioMCPTransport", "mcp_tools_to_ollama"]

--- a/ollama-agent/ollama_agent/mcp.py
+++ b/ollama-agent/ollama_agent/mcp.py
@@ -11,6 +11,7 @@ agent's failure path rather than reading as a successful tool turn
 (non-throwing-client-success-check).
 """
 import json
+import select
 import shlex
 import subprocess
 
@@ -40,10 +41,22 @@ class MCPClient:
     def _rpc(self, method, params=None):
         self._id += 1
         self.t.send({"jsonrpc": "2.0", "id": self._id, "method": method, "params": params or {}})
-        resp = self.t.recv()
-        if not isinstance(resp, dict):
-            raise MCPError(f"{method}: non-object response {resp!r}")
-        if resp.get("error"):
+        # Correlate the response to this request id. A server may interleave a
+        # notification/log frame (no id) before the reply; skip those (bounded, so
+        # a notification flood can't loop forever), and treat a mismatched id as a
+        # protocol desync rather than silently returning the wrong call's result.
+        for _ in range(100):
+            resp = self.t.recv()
+            if not isinstance(resp, dict):
+                raise MCPError(f"{method}: non-object response {resp!r}")
+            if "id" not in resp:
+                continue
+            if resp["id"] != self._id:
+                raise MCPError(f"{method}: response id {resp['id']} != request {self._id}")
+            break
+        else:
+            raise MCPError(f"{method}: no response with id {self._id} after 100 frames")
+        if "error" in resp:
             raise MCPError(f"{method}: {resp['error']}")
         return resp.get("result", {})
 
@@ -89,8 +102,9 @@ def mcp_tools_to_ollama(tools, prefix="mcp"):
 class StdioMCPTransport:
     """Spawn an MCP server subprocess and exchange newline-delimited JSON-RPC."""
 
-    def __init__(self, command, cwd=None):
+    def __init__(self, command, cwd=None, timeout=30):
         argv = command if isinstance(command, list) else shlex.split(command)
+        self.timeout = timeout
         self.proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                      stderr=subprocess.DEVNULL, text=True, cwd=cwd, bufsize=1)
 
@@ -101,16 +115,31 @@ class StdioMCPTransport:
         self.proc.stdin.flush()
 
     def recv(self):
-        line = self.proc.stdout.readline() if self.proc.stdout else ""
+        # Bound the read: a server that is alive but never writes a response would
+        # otherwise block readline() forever and hang the whole agent (the sibling
+        # ollama_transport bounds its read for the same reason). select on the pipe
+        # surfaces a stuck server as a typed error instead of a silent hang.
+        if not self.proc.stdout:
+            raise MCPError("server has no stdout")
+        ready, _, _ = select.select([self.proc.stdout], [], [], self.timeout)
+        if not ready:
+            raise MCPError(f"server did not respond within {self.timeout}s")
+        line = self.proc.stdout.readline()
         if not line:
             raise MCPError("server closed stdout (crashed or exited)")
         return json.loads(line)
 
     def close(self):
+        # Runs in a finally; must never raise, and must reap the process even when
+        # it ignores SIGTERM (otherwise a zombie lingers).
         try:
             if self.proc.stdin:
                 self.proc.stdin.close()
             self.proc.terminate()
             self.proc.wait(timeout=5)
         except Exception:
-            self.proc.kill()
+            try:
+                self.proc.kill()
+                self.proc.wait(timeout=5)
+            except Exception:
+                pass

--- a/ollama-agent/ollama_agent/mcp.py
+++ b/ollama-agent/ollama_agent/mcp.py
@@ -1,0 +1,116 @@
+"""Bridge an MCP server's tools into the ollama /api/chat tool schema.
+
+MCP speaks JSON-RPC 2.0 over a transport (stdio newline-delimited JSON is the
+common one). This module is transport-injectable: MCPClient takes any object with
+`send(obj)`/`recv()->obj`, so the protocol logic is testable with an in-memory
+fake and the real subprocess transport (StdioMCPTransport) is a thin wrapper.
+
+Success is checked explicitly on every call: a JSON-RPC `error` member and an
+MCP `isError` result both raise MCPError, so a server-side failure routes to the
+agent's failure path rather than reading as a successful tool turn
+(non-throwing-client-success-check).
+"""
+import json
+import shlex
+import subprocess
+
+PROTOCOL_VERSION = "2024-11-05"
+
+
+class MCPError(RuntimeError):
+    pass
+
+
+def _result_text(result):
+    """MCP tool results carry a content array; pull the text parts out for the
+    model. Falls back to the raw result for non-text content."""
+    content = result.get("content") if isinstance(result, dict) else None
+    if isinstance(content, list):
+        texts = [c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text"]
+        if texts:
+            return "\n".join(texts)
+    return result
+
+
+class MCPClient:
+    def __init__(self, transport):
+        self.t = transport
+        self._id = 0
+
+    def _rpc(self, method, params=None):
+        self._id += 1
+        self.t.send({"jsonrpc": "2.0", "id": self._id, "method": method, "params": params or {}})
+        resp = self.t.recv()
+        if not isinstance(resp, dict):
+            raise MCPError(f"{method}: non-object response {resp!r}")
+        if resp.get("error"):
+            raise MCPError(f"{method}: {resp['error']}")
+        return resp.get("result", {})
+
+    def _notify(self, method, params=None):
+        self.t.send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def initialize(self):
+        result = self._rpc("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "ollama-agent", "version": "0"},
+        })
+        self._notify("notifications/initialized")
+        return result
+
+    def list_tools(self):
+        return self._rpc("tools/list").get("tools", [])
+
+    def call_tool(self, name, arguments):
+        result = self._rpc("tools/call", {"name": name, "arguments": arguments or {}})
+        if isinstance(result, dict) and result.get("isError"):
+            raise MCPError(f"tool {name} returned isError: {_result_text(result)}")
+        return _result_text(result)
+
+
+def mcp_tools_to_ollama(tools, prefix="mcp"):
+    """Map MCP tool descriptors to ollama tool schemas. Names are prefixed
+    (mcp__<name>) so they can't collide with the built-in tools, and the schema
+    map back to (prefixed_name -> real_name) is returned for dispatch."""
+    schemas, name_map = [], {}
+    for t in tools:
+        real = t["name"]
+        prefixed = f"{prefix}__{real}"
+        schemas.append({"type": "function", "function": {
+            "name": prefixed,
+            "description": t.get("description", ""),
+            "parameters": t.get("inputSchema") or {"type": "object", "properties": {}},
+        }})
+        name_map[prefixed] = real
+    return schemas, name_map
+
+
+class StdioMCPTransport:
+    """Spawn an MCP server subprocess and exchange newline-delimited JSON-RPC."""
+
+    def __init__(self, command, cwd=None):
+        argv = command if isinstance(command, list) else shlex.split(command)
+        self.proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                     stderr=subprocess.DEVNULL, text=True, cwd=cwd, bufsize=1)
+
+    def send(self, obj):
+        if self.proc.stdin is None:
+            raise MCPError("server stdin closed")
+        self.proc.stdin.write(json.dumps(obj) + "\n")
+        self.proc.stdin.flush()
+
+    def recv(self):
+        line = self.proc.stdout.readline() if self.proc.stdout else ""
+        if not line:
+            raise MCPError("server closed stdout (crashed or exited)")
+        return json.loads(line)
+
+    def close(self):
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+            self.proc.terminate()
+            self.proc.wait(timeout=5)
+        except Exception:
+            self.proc.kill()

--- a/ollama-agent/ollama_agent/tools.py
+++ b/ollama-agent/ollama_agent/tools.py
@@ -22,10 +22,12 @@ def _clip(s, n):
 
 
 class ToolBox:
-    def __init__(self, cwd=".", timeout=30, skills=None):
+    def __init__(self, cwd=".", timeout=30, skills=None, mcp_client=None, mcp_names=None):
         self.cwd = Path(cwd).resolve()
         self.timeout = timeout
         self.skills = list(skills) if skills else []   # [Skill] for use_skill, if any
+        self.mcp_client = mcp_client                   # MCPClient, if an MCP server is bridged
+        self.mcp_names = dict(mcp_names) if mcp_names else {}  # prefixed_name -> real MCP tool name
         self.calls = []            # (name, args) of every dispatched call
         self.unknown_calls = []    # tool/skill names the model hallucinated
 
@@ -82,6 +84,11 @@ class ToolBox:
         return json.dumps({"error": f"unknown skill: {name}",
                            "available": [s.name for s in self.skills]})
 
+    def call_mcp(self, prefixed_name, args):
+        real = self.mcp_names[prefixed_name]
+        result = self.mcp_client.call_tool(real, args)
+        return json.dumps({"tool": prefixed_name, "result": _clip(str(result), MAX_READ)})
+
     def dispatch(self, name, args):
         """Route one tool call. Records every call; unknown names are recorded
         separately and returned as an error string (never silently dropped)."""
@@ -94,6 +101,8 @@ class ToolBox:
             "list_dir": lambda a: self.list_dir(a.get("path", ".")),
             "use_skill": lambda a: self.use_skill(a.get("name", "")),
         }.get(name)
+        if handler is None and name in self.mcp_names:
+            handler = lambda a: self.call_mcp(name, a)  # noqa: E731
         if handler is None:
             self.unknown_calls.append(name)
             return json.dumps({"error": f"unknown tool: {name}"})

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -108,3 +108,48 @@ def test_cli_no_skills_suppresses_catalog_and_tool(tmp_path, monkeypatch, capsys
     assert "obsidian-save" not in captured["system"]
     assert "use_skill" not in _tool_names(captured["tools"])
     assert "skills:" not in capsys.readouterr().err
+
+
+def _stub_mcp(monkeypatch, closed, *, init_raises=False):
+    class FT:
+        def __init__(self, *a, **k):
+            pass
+
+        def close(self):
+            closed["v"] = True
+    monkeypatch.setattr(cli, "StdioMCPTransport", FT)
+
+    class FC:
+        def __init__(self, t):
+            pass
+
+        def initialize(self):
+            if init_raises:
+                raise RuntimeError("no server there")
+
+        def list_tools(self):
+            return [{"name": "echo", "description": "e", "inputSchema": {"type": "object", "properties": {}}}]
+    monkeypatch.setattr(cli, "MCPClient", FC)
+
+
+def test_cli_mcp_bridges_tools_and_closes_transport(tmp_path, monkeypatch, capsys):
+    captured, closed = {}, {"v": False}
+    _stub(monkeypatch, captured)
+    _stub_mcp(monkeypatch, closed)
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--mcp", "fake-server arg"])
+    assert rc == 0
+    assert "mcp__echo" in _tool_names(captured["tools"])
+    assert "mcp: 1 tools" in capsys.readouterr().err
+    assert closed["v"] is True   # finally teardown ran
+
+
+def test_cli_mcp_bridge_failure_returns_1_and_closes(tmp_path, monkeypatch, capsys):
+    closed = {"v": False}
+    _stub(monkeypatch, {})
+    _stub_mcp(monkeypatch, closed, init_raises=True)
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--mcp", "broken-server"])
+    assert rc == 1
+    assert "mcp bridge failed for 'broken-server'" in capsys.readouterr().err
+    assert closed["v"] is True

--- a/ollama-agent/tests/test_mcp.py
+++ b/ollama-agent/tests/test_mcp.py
@@ -1,0 +1,179 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ollama_agent import ToolBox  # noqa: E402
+from ollama_agent.mcp import (  # noqa: E402
+    MCPClient, MCPError, StdioMCPTransport, mcp_tools_to_ollama, _result_text,
+)
+
+
+class FakeTransport:
+    """In-memory JSON-RPC server: send() computes the response, recv() returns it."""
+
+    def __init__(self, tools=None, tool_results=None, error_on=None, is_error_tools=None):
+        self.tools = tools or []
+        self.tool_results = tool_results or {}
+        self.error_on = error_on
+        self.is_error_tools = is_error_tools or set()
+        self._pending = None
+        self.notifications = []
+
+    def send(self, obj):
+        if "id" not in obj:
+            self.notifications.append(obj["method"])
+            return
+        method, rid = obj["method"], obj["id"]
+        if self.error_on == method:
+            self._pending = {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "boom"}}
+            return
+        if method == "initialize":
+            result = {"protocolVersion": "2024-11-05"}
+        elif method == "tools/list":
+            result = {"tools": self.tools}
+        elif method == "tools/call":
+            name = obj["params"]["name"]
+            if name in self.is_error_tools:
+                result = {"isError": True, "content": [{"type": "text", "text": "tool blew up"}]}
+            else:
+                result = self.tool_results.get(name, {"content": [{"type": "text", "text": "ok"}]})
+        else:
+            result = {}
+        self._pending = {"jsonrpc": "2.0", "id": rid, "result": result}
+
+    def recv(self):
+        r, self._pending = self._pending, None
+        return r
+
+
+def test_initialize_sends_initialized_notification():
+    t = FakeTransport()
+    MCPClient(t).initialize()
+    assert "notifications/initialized" in t.notifications
+
+
+def test_list_tools():
+    t = FakeTransport(tools=[{"name": "echo", "description": "e"}])
+    assert MCPClient(t).list_tools()[0]["name"] == "echo"
+
+
+def test_call_tool_returns_text():
+    t = FakeTransport(tool_results={"echo": {"content": [{"type": "text", "text": "hi there"}]}})
+    assert MCPClient(t).call_tool("echo", {"text": "x"}) == "hi there"
+
+
+def test_call_tool_iserror_raises():
+    t = FakeTransport(is_error_tools={"boom"})
+    with pytest.raises(MCPError, match="isError"):
+        MCPClient(t).call_tool("boom", {})
+
+
+def test_rpc_error_member_raises():
+    t = FakeTransport(error_on="tools/list")
+    with pytest.raises(MCPError, match="tools/list"):
+        MCPClient(t).list_tools()
+
+
+def test_result_text_falls_back_to_raw():
+    assert _result_text({"weird": 1}) == {"weird": 1}
+
+
+def test_mcp_tools_to_ollama_prefixes_and_maps():
+    schemas, name_map = mcp_tools_to_ollama(
+        [{"name": "read_file", "description": "d", "inputSchema": {"type": "object", "properties": {"p": {}}}}])
+    assert schemas[0]["function"]["name"] == "mcp__read_file"
+    assert schemas[0]["function"]["parameters"]["properties"] == {"p": {}}
+    assert name_map == {"mcp__read_file": "read_file"}
+
+
+def test_mcp_tools_to_ollama_default_schema_when_missing():
+    schemas, _ = mcp_tools_to_ollama([{"name": "noargs"}])
+    assert schemas[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+
+
+# --- ToolBox MCP dispatch ---
+
+class FakeClient:
+    def __init__(self, raises=False):
+        self.raises = raises
+        self.calls = []
+
+    def call_tool(self, name, args):
+        self.calls.append((name, args))
+        if self.raises:
+            raise MCPError("server down")
+        return f"result of {name}({args})"
+
+
+def test_toolbox_dispatches_mcp_tool(tmp_path):
+    client = FakeClient()
+    tb = ToolBox(cwd=tmp_path, mcp_client=client, mcp_names={"mcp__echo": "echo"})
+    out = json.loads(tb.dispatch("mcp__echo", {"text": "hi"}))
+    assert client.calls == [("echo", {"text": "hi"})]
+    assert "result of echo" in out["result"]
+
+
+def test_toolbox_mcp_error_recorded_not_crash(tmp_path):
+    tb = ToolBox(cwd=tmp_path, mcp_client=FakeClient(raises=True), mcp_names={"mcp__echo": "echo"})
+    out = json.loads(tb.dispatch("mcp__echo", {}))
+    assert "error" in out and "MCPError" in out["error"]
+
+
+def test_toolbox_unknown_mcp_name_still_unknown(tmp_path):
+    tb = ToolBox(cwd=tmp_path, mcp_client=FakeClient(), mcp_names={"mcp__echo": "echo"})
+    out = json.loads(tb.dispatch("mcp__not_a_tool", {}))
+    assert "unknown tool" in out["error"] and tb.unknown_calls == ["mcp__not_a_tool"]
+
+
+# --- real subprocess integration ---
+
+_SERVER = r'''
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if "id" not in msg:        # notification
+        continue
+    m, rid = msg["method"], msg["id"]
+    if m == "initialize":
+        res = {"protocolVersion": "2024-11-05"}
+    elif m == "tools/list":
+        res = {"tools": [{"name": "echo", "description": "echo text",
+                          "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}}}]}
+    elif m == "tools/call":
+        txt = msg["params"]["arguments"].get("text", "")
+        res = {"content": [{"type": "text", "text": "echo: " + txt}]}
+    else:
+        res = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": rid, "result": res}) + "\n")
+    sys.stdout.flush()
+'''
+
+
+def test_stdio_transport_real_subprocess_roundtrip(tmp_path):
+    server = tmp_path / "fake_mcp_server.py"
+    server.write_text(_SERVER)
+    transport = StdioMCPTransport([sys.executable, str(server)])
+    try:
+        client = MCPClient(transport)
+        client.initialize()
+        tools = client.list_tools()
+        assert tools[0]["name"] == "echo"
+        assert client.call_tool("echo", {"text": "hello"}) == "echo: hello"
+    finally:
+        transport.close()
+
+
+def test_stdio_transport_recv_on_dead_server_raises(tmp_path):
+    server = tmp_path / "exits.py"
+    server.write_text("import sys; sys.exit(0)")
+    transport = StdioMCPTransport([sys.executable, str(server)])
+    with pytest.raises(MCPError, match="closed stdout"):
+        transport.recv()
+    transport.close()

--- a/ollama-agent/tests/test_mcp.py
+++ b/ollama-agent/tests/test_mcp.py
@@ -82,6 +82,38 @@ def test_result_text_falls_back_to_raw():
     assert _result_text({"weird": 1}) == {"weird": 1}
 
 
+def test_result_text_empty_content_falls_back_to_raw():
+    assert _result_text({"content": []}) == {"content": []}
+
+
+class QueueTransport:
+    """Returns pre-scripted frames in order (for id-correlation tests)."""
+
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.sent = []
+
+    def send(self, obj):
+        self.sent.append(obj)
+
+    def recv(self):
+        return self.frames.pop(0)
+
+
+def test_rpc_skips_notification_frame_before_response():
+    t = QueueTransport([
+        {"jsonrpc": "2.0", "method": "notifications/log", "params": {}},  # no id — skipped
+        {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "echo"}]}},
+    ])
+    assert MCPClient(t).list_tools()[0]["name"] == "echo"
+
+
+def test_rpc_mismatched_id_raises():
+    t = QueueTransport([{"jsonrpc": "2.0", "id": 999, "result": {}}])
+    with pytest.raises(MCPError, match="!= request"):
+        MCPClient(t).list_tools()
+
+
 def test_mcp_tools_to_ollama_prefixes_and_maps():
     schemas, name_map = mcp_tools_to_ollama(
         [{"name": "read_file", "description": "d", "inputSchema": {"type": "object", "properties": {"p": {}}}}])
@@ -176,4 +208,36 @@ def test_stdio_transport_recv_on_dead_server_raises(tmp_path):
     transport = StdioMCPTransport([sys.executable, str(server)])
     with pytest.raises(MCPError, match="closed stdout"):
         transport.recv()
+    transport.close()
+
+
+def test_stdio_transport_recv_times_out_on_silent_server(tmp_path):
+    # A server that is alive but never writes must surface as a timeout, not a hang.
+    server = tmp_path / "silent.py"
+    server.write_text("import time; time.sleep(30)")
+    transport = StdioMCPTransport([sys.executable, str(server)], timeout=1)
+    transport.send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    try:
+        with pytest.raises(MCPError, match="did not respond within"):
+            transport.recv()
+    finally:
+        transport.close()
+
+
+def test_stdio_transport_close_reaps_and_is_idempotent(tmp_path):
+    server = tmp_path / "idle.py"
+    server.write_text("import sys\nfor line in sys.stdin:\n    pass\n")
+    transport = StdioMCPTransport([sys.executable, str(server)])
+    transport.close()
+    assert transport.proc.poll() is not None   # reaped
+    transport.close()                            # second close must not raise
+
+
+def test_stdio_transport_send_on_none_stdin_raises(tmp_path):
+    server = tmp_path / "idle.py"
+    server.write_text("import sys\nfor line in sys.stdin:\n    pass\n")
+    transport = StdioMCPTransport([sys.executable, str(server)])
+    transport.proc.stdin = None
+    with pytest.raises(MCPError, match="stdin closed"):
+        transport.send({"x": 1})
     transport.close()


### PR DESCRIPTION
Closes #189. Part of #185. The biggest slice.

## Description (New Behavior)

Bridges an **MCP server's tools** into the ollama `/api/chat` tool schema, so a local model can drive real MCP tools (gh, filesystem, etc.) through the same loop.

- **`mcp.py`**
  - `MCPClient` over a **transport-injectable** JSON-RPC 2.0 layer (`initialize` + `notifications/initialized`, `tools/list`, `tools/call`). **Success is checked explicitly:** a JSON-RPC `error` member *and* an MCP `isError` result both raise `MCPError`, so a server-side failure routes to the agent's failure path rather than reading as a successful turn (non-throwing-client-success-check).
  - `mcp_tools_to_ollama` maps tool descriptors to ollama schemas with an `mcp__` prefix (no collision with built-ins) and returns a `prefixed→real` name map for dispatch.
  - `StdioMCPTransport` spawns a server subprocess and exchanges newline-delimited JSON-RPC; `close()` tears it down.
- **`tools.py`** — `ToolBox(mcp_client, mcp_names)` routes a prefixed tool call to `client.call_tool`; an `MCPError` is caught by `dispatch`'s `try/except` and recorded, never a crash. Unknown names still record as `unknown`.
- **`cli.py`** — `--mcp 'cmd …'` spawns and bridges a server; transport closed in a `finally`.

## Testing Procedure

1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → `80 passed` (13 new), including a **real-subprocess** round-trip (a tiny Python MCP server) and a dead-server `recv` raising cleanly.
3. (Requires ollama + `gpt-oss:20b`) Write a tiny stdio JSON-RPC echo server, then:
   `python3 ollama-agent/cli.py --task "call mcp__shout with text='bridge works'" --mcp "python3 echo_server.py" --cwd <dir> --no-rules --no-skills`
   → stderr `mcp: 1 tools from …`; the model calls `mcp__shout` and reports the result. **Verified live** end-to-end (model → ollama tool-call → MCP JSON-RPC over stdio → subprocess → back).

## Additional Notes

Transport-injectable design keeps the protocol logic unit-testable without a live server; the real `StdioMCPTransport` is a thin wrapper exercised by the subprocess integration test. Per-tool gating / which MCP servers a task may use lands in the governance slice (#190).