### PR TITLE
Slice 5: governance + task registry (runner/tier gate) for ollama-agent

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -9,8 +9,9 @@ import argparse
 import json
 import sys
 
-from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, MCPClient, StdioMCPTransport,
-                          compose_system, load_skill_index, mcp_tools_to_ollama,
+from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, MCPClient, RegistryError,
+                          StdioMCPTransport, compose_system, filter_tools, gate,
+                          load_registry, load_skill_index, mcp_tools_to_ollama,
                           ollama_transport, render_catalog, run_agent)
 
 DEFAULT_SYSTEM = (
@@ -43,8 +44,37 @@ def main(argv=None):
     p.add_argument("--mcp", default=None,
                    help="Command to spawn an MCP server whose tools are bridged in (e.g. "
                         "'npx -y @modelcontextprotocol/server-filesystem /path').")
+    p.add_argument("--registry", default=None, help="Path/JSON of a task registry.")
+    p.add_argument("--task-name", default=None,
+                   help="Run a registered task by name (applies its model/tier/tools/rules).")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
+
+    # Governance: a registered task is gated before any model call. A non-delegable
+    # tier (high-stakes) or unknown runner/tier is refused here — never run.
+    spec = None
+    if a.task_name:
+        if not a.registry:
+            print("--task-name requires --registry", file=sys.stderr)
+            return 2
+        try:
+            specs = load_registry(a.registry)
+        except (RegistryError, ValueError, OSError) as e:
+            print(f"registry error: {e}", file=sys.stderr)
+            return 2
+        spec = specs.get(a.task_name)
+        if spec is None:
+            print(f"no registered task {a.task_name!r} (known: {sorted(specs)})", file=sys.stderr)
+            return 2
+        ok, reason = gate(spec)
+        if not ok:
+            print(f"REJECTED task {a.task_name!r}: {reason}", file=sys.stderr)
+            return 3
+        a.model = spec.model
+        a.no_rules = a.no_rules or not spec.rules
+        a.no_skills = a.no_skills or not spec.skills
+        print(f"task {a.task_name!r}: runner={spec.runner} tier={spec.tier} model={spec.model}",
+              file=sys.stderr)
 
     system = a.system
     if not a.no_rules:
@@ -78,6 +108,12 @@ def main(argv=None):
                 mcp_transport.close()
             print(f"mcp bridge failed for {a.mcp!r}: {e}", file=sys.stderr)
             return 1
+
+    if spec is not None:
+        tools = filter_tools(tools, spec.tools)
+        if spec.tools != "*":
+            print(f"tools restricted to: {', '.join(t['function']['name'] for t in tools)}",
+                  file=sys.stderr)
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills,
                       mcp_client=mcp_client, mcp_names=mcp_names)

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -109,11 +109,18 @@ def main(argv=None):
             print(f"mcp bridge failed for {a.mcp!r}: {e}", file=sys.stderr)
             return 1
 
-    if spec is not None:
-        tools = filter_tools(tools, spec.tools)
-        if spec.tools != "*":
-            print(f"tools restricted to: {', '.join(t['function']['name'] for t in tools)}",
+    if spec is not None and spec.tools != "*":
+        available = {t["function"]["name"] for t in tools}
+        unknown = [n for n in spec.tools if n not in available]
+        if unknown:
+            # A typo'd allowlist name would otherwise silently shrink the tool set
+            # with no signal — surface it (enum-config-typo-fallback). Note: MCP
+            # tools match their bridged 'mcp__<name>' form here, not the raw name.
+            print(f"warning: registry tools not available (ignored): {', '.join(unknown)}",
                   file=sys.stderr)
+        tools = filter_tools(tools, spec.tools)
+        print(f"tools restricted to: {', '.join(t['function']['name'] for t in tools) or '(none)'}",
+              file=sys.stderr)
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills,
                       mcp_client=mcp_client, mcp_names=mcp_names)

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -6,6 +6,7 @@ governed task registry (#190).
 """
 from .agent import run_agent
 from .mcp import MCPClient, MCPError, StdioMCPTransport, mcp_tools_to_ollama
+from .registry import RegistryError, filter_tools, gate, load_registry
 from .rules import compose_system, load_rule_index, select_rules
 from .skills import USE_SKILL_TOOL, get_skill, load_skill_index, render_catalog
 from .tools import ToolBox, TOOLS
@@ -14,4 +15,5 @@ from .transport import ollama_transport, parse_chat_response
 __all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_response",
            "compose_system", "load_rule_index", "select_rules",
            "USE_SKILL_TOOL", "get_skill", "load_skill_index", "render_catalog",
-           "MCPClient", "MCPError", "StdioMCPTransport", "mcp_tools_to_ollama"]
+           "MCPClient", "MCPError", "StdioMCPTransport", "mcp_tools_to_ollama",
+           "RegistryError", "filter_tools", "gate", "load_registry"]

--- a/ollama-agent/ollama_agent/registry.py
+++ b/ollama-agent/ollama_agent/registry.py
@@ -1,0 +1,91 @@
+"""Task registry + safe-delegation gate.
+
+Declares which bounded tasks may run on a local model and how. Two enum fields
+select behavior — `runner` (who executes) and `tier` (how risky) — so both are
+validated at parse time AND gated at dispatch, and an unknown value is rejected,
+never defaulted (enum-config-typo-fallback: a `runner: scrpt` typo must fail
+loudly, not silently fall through to a default path). A high-stakes task can
+never be delegated to a local model regardless of what the entry says.
+"""
+import json
+from pathlib import Path
+
+RUNNERS = {"ollama"}                       # who may execute a registered task
+TIERS = ["deterministic", "low-stakes-write", "high-stakes"]
+# A local model may take deterministic + low-stakes-write work. high-stakes
+# (billing, credentials, multi-tenant writes, anything irreversible) is never
+# delegated — it stays with a human or a trusted (non-local) agent.
+DELEGABLE_TIERS = {"deterministic", "low-stakes-write"}
+
+
+class RegistryError(ValueError):
+    """A registry entry is structurally invalid (missing field or unknown enum).
+    Raised at parse time so a typo fails loudly instead of silently defaulting."""
+
+
+class TaskSpec:
+    def __init__(self, name, runner, model, tier, tools="*", rules=True, skills=False):
+        self.name = name
+        self.runner = runner
+        self.model = model
+        self.tier = tier
+        self.tools = tools          # "*" or a list of allowed tool names
+        self.rules = rules
+        self.skills = skills
+
+
+def _validate(name, entry):
+    for field in ("runner", "model", "tier"):
+        if not entry.get(field):
+            raise RegistryError(f"task {name!r}: missing required field {field!r}")
+    if entry["runner"] not in RUNNERS:
+        raise RegistryError(
+            f"task {name!r}: unknown runner {entry['runner']!r} (known: {sorted(RUNNERS)})")
+    if entry["tier"] not in TIERS:
+        raise RegistryError(
+            f"task {name!r}: unknown tier {entry['tier']!r} (known: {TIERS})")
+    tools = entry.get("tools", "*")
+    if tools != "*" and not isinstance(tools, list):
+        raise RegistryError(f"task {name!r}: tools must be \"*\" or a list, got {type(tools).__name__}")
+
+
+def load_registry(source):
+    """`source` is a path, a JSON string, or a dict shaped {"tasks": {name: {...}}}.
+    Every entry is validated; the first invalid entry raises RegistryError (a bad
+    registry is a configuration error, surfaced, not a quietly-skipped task)."""
+    if isinstance(source, dict):
+        data = source
+    else:
+        text = Path(source).read_text() if Path(str(source)).exists() else str(source)
+        data = json.loads(text)
+    tasks = data.get("tasks", {})
+    specs = {}
+    for name, entry in tasks.items():
+        _validate(name, entry)
+        specs[name] = TaskSpec(
+            name=name, runner=entry["runner"], model=entry["model"], tier=entry["tier"],
+            tools=entry.get("tools", "*"), rules=entry.get("rules", True),
+            skills=entry.get("skills", False))
+    return specs
+
+
+def gate(spec):
+    """Dispatch-time gate (defense in depth after parse validation). Returns
+    (ok, reason). A non-delegable tier or unknown runner/tier is rejected — the
+    caller routes the rejection through failure observability, never runs it."""
+    if spec.runner not in RUNNERS:
+        return False, f"unknown runner {spec.runner!r}"
+    if spec.tier not in TIERS:
+        return False, f"unknown tier {spec.tier!r}"
+    if spec.tier not in DELEGABLE_TIERS:
+        return False, f"tier {spec.tier!r} may not be delegated to a local model"
+    return True, "ok"
+
+
+def filter_tools(tools, allowed):
+    """Restrict a tool-schema list to the names a task is allowed to use. `allowed`
+    is "*" (no restriction) or a list of permitted tool names."""
+    if allowed == "*":
+        return tools
+    allow = set(allowed)
+    return [t for t in tools if t["function"]["name"] in allow]

--- a/ollama-agent/ollama_agent/registry.py
+++ b/ollama-agent/ollama_agent/registry.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 RUNNERS = {"ollama"}                       # who may execute a registered task
+# Ordered low→high stakes; the order is used verbatim in the "known: …" diagnostic.
 TIERS = ["deterministic", "low-stakes-write", "high-stakes"]
 # A local model may take deterministic + low-stakes-write work. high-stakes
 # (billing, credentials, multi-tenant writes, anything irreversible) is never

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -204,3 +204,40 @@ def test_cli_bad_registry_runner_returns_2(tmp_path, monkeypatch, capsys):
     assert rc == 2
     err = capsys.readouterr().err
     assert "registry error" in err and "unknown runner" in err
+
+
+def test_cli_task_name_without_registry_returns_2(tmp_path, monkeypatch, capsys):
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--task-name", "t"])
+    assert rc == 2
+    assert "requires --registry" in capsys.readouterr().err
+
+
+def test_cli_registry_tool_typo_is_warned_not_silent(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, t={"runner": "ollama", "model": "m", "tier": "deterministic",
+                                 "tools": ["read-file", "git"]})  # 'read-file' is a typo
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--registry", reg, "--task-name", "t"])
+    assert rc == 0
+    assert _tool_names(captured["tools"]) == {"git"}   # only the valid name survives
+    assert "not available (ignored): read-file" in capsys.readouterr().err
+
+
+def test_cli_registry_rules_skills_propagation(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, t={"runner": "ollama", "model": "m", "tier": "deterministic",
+                                 "rules": False, "skills": False})
+    captured = {}
+    _stub(monkeypatch, captured)
+    # rules-dir/skills-dir point at fixtures, but the spec forces them off
+    rules = _fixture_rules(tmp_path)
+    skills = _fixture_skills(tmp_path)
+    rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
+                   "--rules-dir", str(rules), "--skills-dir", str(skills),
+                   "--registry", reg, "--task-name", "t"])
+    assert rc == 0
+    assert "no-commit-tmp-logs" not in captured["system"]   # rules:false honored
+    assert "use_skill" not in _tool_names(captured["tools"])  # skills:false honored
+    err = capsys.readouterr().err
+    assert "rules:" not in err and "skills:" not in err

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -153,3 +154,53 @@ def test_cli_mcp_bridge_failure_returns_1_and_closes(tmp_path, monkeypatch, caps
     assert rc == 1
     assert "mcp bridge failed for 'broken-server'" in capsys.readouterr().err
     assert closed["v"] is True
+
+
+def _registry(tmp_path, **tasks):
+    f = tmp_path / "reg.json"
+    f.write_text(json.dumps({"tasks": tasks}))
+    return str(f)
+
+
+def test_cli_registered_deterministic_task_applies_model_and_runs(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, triage={"runner": "ollama", "model": "registry-model:7b",
+                                       "tier": "deterministic", "tools": ["run_shell", "git"]})
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do triage", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--registry", reg, "--task-name", "triage"])
+    assert rc == 0
+    assert _tool_names(captured["tools"]) == {"run_shell", "git"}   # restricted to allowlist
+    err = capsys.readouterr().err
+    assert "model=registry-model:7b" in err and "tools restricted to:" in err
+
+
+def test_cli_high_stakes_task_is_rejected_before_any_run(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, payout={"runner": "ollama", "model": "m", "tier": "high-stakes"})
+    captured = {}
+
+    def must_not_run(*a, **k):
+        raise AssertionError("run_agent must not be called for a rejected task")
+    monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "run_agent", must_not_run)
+    rc = cli.main(["--task", "pay the invoice", "--cwd", str(tmp_path),
+                   "--registry", reg, "--task-name", "payout"])
+    assert rc == 3
+    assert "REJECTED task 'payout'" in capsys.readouterr().err
+
+
+def test_cli_unknown_registered_task_returns_2(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, triage={"runner": "ollama", "model": "m", "tier": "deterministic"})
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--registry", reg, "--task-name", "nope"])
+    assert rc == 2
+    assert "no registered task 'nope'" in capsys.readouterr().err
+
+
+def test_cli_bad_registry_runner_returns_2(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, x={"runner": "scrpt", "model": "m", "tier": "deterministic"})
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--registry", reg, "--task-name", "x"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "registry error" in err and "unknown runner" in err

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ollama_agent.registry import (  # noqa: E402
+    RegistryError, TaskSpec, filter_tools, gate, load_registry,
+)
+
+
+def _reg(**tasks):
+    return {"tasks": tasks}
+
+
+def test_load_valid_registry():
+    specs = load_registry(_reg(
+        triage={"runner": "ollama", "model": "gpt-oss:20b", "tier": "deterministic"}))
+    s = specs["triage"]
+    assert s.model == "gpt-oss:20b" and s.tier == "deterministic" and s.tools == "*"
+
+
+def test_load_rejects_unknown_runner():
+    # The enum-config-typo-fallback incident: `runner: scrpt` must fail loudly.
+    with pytest.raises(RegistryError, match="unknown runner"):
+        load_registry(_reg(x={"runner": "scrpt", "model": "m", "tier": "deterministic"}))
+
+
+def test_load_rejects_unknown_tier():
+    with pytest.raises(RegistryError, match="unknown tier"):
+        load_registry(_reg(x={"runner": "ollama", "model": "m", "tier": "detrministic"}))
+
+
+def test_load_rejects_missing_field():
+    with pytest.raises(RegistryError, match="missing required field 'model'"):
+        load_registry(_reg(x={"runner": "ollama", "tier": "deterministic"}))
+
+
+def test_load_rejects_bad_tools_type():
+    with pytest.raises(RegistryError, match="tools must be"):
+        load_registry(_reg(x={"runner": "ollama", "model": "m", "tier": "deterministic", "tools": "run_shell"}))
+
+
+def test_load_from_json_string():
+    specs = load_registry('{"tasks": {"t": {"runner": "ollama", "model": "m", "tier": "deterministic"}}}')
+    assert "t" in specs
+
+
+def test_load_from_file(tmp_path):
+    f = tmp_path / "reg.json"
+    f.write_text('{"tasks": {"t": {"runner": "ollama", "model": "m", "tier": "low-stakes-write"}}}')
+    assert load_registry(str(f))["t"].tier == "low-stakes-write"
+
+
+def test_gate_allows_deterministic():
+    ok, reason = gate(TaskSpec("t", "ollama", "m", "deterministic"))
+    assert ok and reason == "ok"
+
+
+def test_gate_allows_low_stakes_write():
+    ok, _ = gate(TaskSpec("t", "ollama", "m", "low-stakes-write"))
+    assert ok
+
+
+def test_gate_rejects_high_stakes():
+    ok, reason = gate(TaskSpec("t", "ollama", "m", "high-stakes"))
+    assert not ok and "may not be delegated" in reason
+
+
+def test_gate_rejects_unknown_runner_defense_in_depth():
+    # gate re-checks even if a TaskSpec is hand-built bypassing load validation.
+    ok, reason = gate(TaskSpec("t", "bogus", "m", "deterministic"))
+    assert not ok and "unknown runner" in reason
+
+
+def test_filter_tools_star_is_passthrough():
+    tools = [{"function": {"name": "run_shell"}}, {"function": {"name": "git"}}]
+    assert filter_tools(tools, "*") == tools
+
+
+def test_filter_tools_restricts_to_allowlist():
+    tools = [{"function": {"name": "run_shell"}}, {"function": {"name": "git"}},
+             {"function": {"name": "write_file"}}]
+    kept = {t["function"]["name"] for t in filter_tools(tools, ["git", "read_file"])}
+    assert kept == {"git"}

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -84,3 +84,13 @@ def test_filter_tools_restricts_to_allowlist():
              {"function": {"name": "write_file"}}]
     kept = {t["function"]["name"] for t in filter_tools(tools, ["git", "read_file"])}
     assert kept == {"git"}
+
+
+def test_filter_tools_empty_allowlist_yields_nothing():
+    tools = [{"function": {"name": "run_shell"}}]
+    assert filter_tools(tools, []) == []
+
+
+def test_load_bad_json_raises_valueerror():
+    with pytest.raises(ValueError):
+        load_registry("{not valid json")


### PR DESCRIPTION
Closes #190. Part of #185 — the final slice.

## Description (New Behavior)

Adds the governance layer: a task registry that declares **which bounded tasks may run on a local model**, gated by a safe-delegation **tier** and an allowed-tool list.

- **`registry.py`**
  - `TaskSpec` + `load_registry` validate two enum fields **at parse time** — `runner` (∈ `RUNNERS`) and `tier` (∈ `TIERS`) — and **reject unknown values rather than defaulting** (`enum-config-typo-fallback`: the incident was a `runner: scrpt` typo silently routing to the wrong path). A missing required field or bad `tools` type also raises `RegistryError`.
  - `gate(spec)` re-checks at dispatch (defense in depth): **high-stakes tier is never delegated to a local model**; only `deterministic` + `low-stakes-write` are. Returns `(ok, reason)`.
  - `filter_tools(tools, allowed)` restricts a task to its permitted tool names (`"*"` = no restriction).
- **`cli.py`** — `--registry` + `--task-name` resolve and **gate a registered task before any model call**: a non-delegable tier → exit `3` (REJECTED), unknown task / bad registry → exit `2`, both surfaced on stderr (failure observability). A delegable task applies its `model`/`rules`/`skills` and its tool allowlist.

## Testing Procedure

1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → `105 passed` (12 registry + 5 cli governance tests new).
3. (Requires ollama + `gpt-oss:20b`) With a registry declaring a `deterministic` task (tools `["read_file","list_dir"]`) and a `high-stakes` task:
   - `--task-name <deterministic>` runs on the declared model with tools restricted (stderr: `task …`, `tools restricted to: …`).
   - `--task-name <high-stakes>` prints `REJECTED … may not be delegated to a local model` and exits `3` **without any model call**.
   Both verified live.

## Additional Notes

Completes the local-agent bridge epic (#185): bridge core + real tools (#186) → rule selection (#187) → skills (#188) → MCP adapter (#189) → this governance/registry layer. A local model can now run a registered bounded task end-to-end under the curated rules/skills/tools, with high-stakes work structurally refused.