### PR TITLE
Add runner:ollama-agent bridge dispatch to ceo-cron (epic #197 spine)

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1171,7 +1171,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual scope
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual scope agent_task agent_registry
     name=$(_fm_scalar name "$f")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -1225,6 +1225,9 @@ cmd_playbook_scan() {
     runner=$(_fm_scalar runner "$f")
     script=$(_fm_scalar script "$f")
     skill=$(_fm_scalar skill "$f")
+    # runner:ollama-agent bridge dispatch fields (epic #197).
+    agent_task=$(_fm_scalar task "$f")
+    agent_registry=$(_fm_scalar registry "$f")
     out_pattern=$(_fm_scalar out_pattern "$f")
     artifact=$(_fm_scalar artifact "$f")
     # Validate at parse time per enum-config-typo-fallback: an artifact
@@ -1396,6 +1399,8 @@ cmd_playbook_scan() {
       --arg runner "$runner" \
       --arg script "$script" \
       --arg skill "$skill" \
+      --arg task "$agent_task" \
+      --arg registry "$agent_registry" \
       --arg out_pattern "$out_pattern" \
       --arg artifact "$artifact" \
       --arg scope "$scope" \
@@ -1403,7 +1408,7 @@ cmd_playbook_scan() {
       --argjson requires "$requires" \
       --argjson hosts "$hosts" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, out_pattern:$out_pattern, artifact:$artifact, scope:$scope, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, task:$task, registry:$registry, out_pattern:$out_pattern, artifact:$artifact, scope:$scope, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))

--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -464,7 +464,7 @@ _swarm_set_owner() {
   return 0
 }
 # shellcheck disable=SC2034
-CEO_VALID_RUNNERS=(claude script ollama ollama-think skill)
+CEO_VALID_RUNNERS=(claude script ollama ollama-think ollama-agent skill)
 # shellcheck disable=SC2034
 CEO_VALID_STATUSES=(active draft disabled)
 # Per-playbook fan-out scope. `single` runs the playbook once; `each` fans it

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1146,6 +1146,12 @@ if [ "$RUNNER" = "ollama-agent" ]; then
   fi
   [ -z "$AGENT_TASK" ] && AGENT_TASK="$TRIGGER"
 
+  # The bridge CLI requires --task (the natural-language instruction); --task-name
+  # only selects the registry entry's model/tier/tools. The playbook body (the
+  # markdown after the frontmatter) is that instruction.
+  AGENT_PROMPT=$(awk 'fence>=2{print} /^---[[:space:]]*$/{fence++}' "$PLAYBOOK_FILE")
+  [ -z "${AGENT_PROMPT//[[:space:]]/}" ] && AGENT_PROMPT="Run the $TRIGGER playbook."
+
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
     _preview "runner:ollama-agent — would run bridge task '$AGENT_TASK' (registry $AGENT_REGISTRY) at tier:$_ceo_tier (skipped: dry-run)."
     exit 0
@@ -1160,8 +1166,8 @@ if [ "$RUNNER" = "ollama-agent" ]; then
 
   _v "Runner: ollama-agent — bridge task '$AGENT_TASK' (tier:$_ceo_tier)"
   AGENT_RC=0
-  AGENT_OUT=$("${_agent_cmd[@]}" --task-name "$AGENT_TASK" --registry "$AGENT_REGISTRY" --json \
-    2>>"$LOG_DIR/cron-stderr.log") || AGENT_RC=$?
+  AGENT_OUT=$("${_agent_cmd[@]}" --task "$AGENT_PROMPT" --task-name "$AGENT_TASK" \
+    --registry "$AGENT_REGISTRY" --json 2>>"$LOG_DIR/cron-stderr.log") || AGENT_RC=$?
 
   if [ "$AGENT_RC" -ne 0 ]; then
     _record_failure "ollama-agent bridge exited $AGENT_RC for $TRIGGER"
@@ -1171,9 +1177,15 @@ if [ "$RUNNER" = "ollama-agent" ]; then
   # Success is explicit, not the mere absence of a non-zero exit
   # (non-throwing-client-success-check): a run that did not complete, OR that
   # emitted any unknown/hallucinated tool call, is a failure — not a success.
-  _agent_completed=$(printf '%s' "$AGENT_OUT" | jq -r '.completed // false' 2>/dev/null)
-  _agent_unknown=$(printf '%s' "$AGENT_OUT" | jq -r '(.unknown_calls // []) | length' 2>/dev/null)
-  [ -z "$_agent_unknown" ] && _agent_unknown=0
+  # Validate parseability first: a 0-exit bridge that emits non-JSON (truncated
+  # stream, a stray stdout line, a traceback) would otherwise trip `set -e` on
+  # the jq pipeline and abort the script *before* recording the failure.
+  if ! printf '%s' "$AGENT_OUT" | jq -e . >/dev/null 2>&1; then
+    _record_failure "ollama-agent task '$AGENT_TASK' emitted unparseable output for $TRIGGER"
+    exit 1
+  fi
+  _agent_completed=$(printf '%s' "$AGENT_OUT" | jq -r '.completed // false')
+  _agent_unknown=$(printf '%s' "$AGENT_OUT" | jq -r '(.unknown_calls // []) | length')
 
   if [ "$_agent_completed" != "true" ]; then
     _record_failure "ollama-agent task '$AGENT_TASK' did not complete for $TRIGGER"

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1008,6 +1008,10 @@ if [ "$_runner_valid" -eq 0 ]; then
   exit 1
 fi
 SCRIPT_PATH=$(echo "$ENTRY" | jq -r '.script // ""')
+# runner:ollama-agent dispatch fields. `task` = the bridge task-registry entry
+# name (defaults to the trigger); `registry` = path to the bridge task registry.
+AGENT_TASK=$(echo "$ENTRY" | jq -r '.task // ""')
+AGENT_REGISTRY=$(echo "$ENTRY" | jq -r '.registry // ""')
 # Per-playbook input filtering. INPUTS_JSON is the raw JSON value from the
 # registry: `null` (absent → all keys), `[]` (none), or `["key", …]`.
 # `_inputs_includes <key>` returns 0 if the key should be injected.
@@ -1099,6 +1103,90 @@ safe_read() {
     head -c "$max" "$file"
   fi
 }
+
+# Normalize a tier string to the canonical CEO set. Absorbs the live-registry
+# "low-stakes write" (space) vs canonical "low-stakes-write" (hyphen) drift at a
+# single point. An unrecognized tier is returned unchanged so the caller's case
+# rejects it — never coerced to a default (enum-config-typo-fallback).
+_normalize_tier() {
+  case "$1" in
+    read) echo "read" ;;
+    low-stakes-write|"low-stakes write") echo "low-stakes-write" ;;
+    high-stakes) echo "high-stakes" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# --- Ollama-agent (bridge) runner: tool-using local agent on a bounded task ---
+# Distinct from the raw read-only `ollama`/`ollama-think` runners: this shells to
+# the ollama-agent bridge (cli.py), which runs a governed tool-using loop. The
+# CEO tier gate here is the OUTER authority — high-stakes is refused before the
+# bridge process starts; the bridge's own registry.gate() is defense-in-depth.
+# At low-stakes-write the bridge's own loop is the execution model; it does NOT
+# enter the PLAN→FILTER→EXECUTE pipeline (deliberate, not a silent bypass).
+if [ "$RUNNER" = "ollama-agent" ]; then
+  export CEO_MODEL="$MODEL"
+  export CEO_MODEL_SOURCE="declared"
+  export CEO_RUNNER_ARTIFACT="$AGENT_REGISTRY"
+
+  _ceo_tier=$(_normalize_tier "$TIER")
+  case "$_ceo_tier" in
+    read|low-stakes-write) ;;
+    high-stakes)
+      _record_failure "runner:ollama-agent may not run high-stakes tier ($TRIGGER) — refused before any bridge call"
+      exit 1 ;;
+    *)
+      _record_failure "runner:ollama-agent unknown tier '$TIER' for $TRIGGER"
+      exit 1 ;;
+  esac
+
+  if [ -z "$AGENT_REGISTRY" ]; then
+    _record_failure "Playbook '$TRIGGER' has runner:ollama-agent but no 'registry' field"
+    exit 1
+  fi
+  [ -z "$AGENT_TASK" ] && AGENT_TASK="$TRIGGER"
+
+  if [ "${CEO_DRY_RUN:-}" = "1" ]; then
+    _preview "runner:ollama-agent — would run bridge task '$AGENT_TASK' (registry $AGENT_REGISTRY) at tier:$_ceo_tier (skipped: dry-run)."
+    exit 0
+  fi
+
+  if [ -n "${CEO_OLLAMA_AGENT_CMD:-}" ]; then
+    read -r -a _agent_cmd <<< "$CEO_OLLAMA_AGENT_CMD"
+  else
+    CEO_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+    _agent_cmd=(python3 "$CEO_REPO_ROOT/ollama-agent/cli.py")
+  fi
+
+  _v "Runner: ollama-agent — bridge task '$AGENT_TASK' (tier:$_ceo_tier)"
+  AGENT_RC=0
+  AGENT_OUT=$("${_agent_cmd[@]}" --task-name "$AGENT_TASK" --registry "$AGENT_REGISTRY" --json \
+    2>>"$LOG_DIR/cron-stderr.log") || AGENT_RC=$?
+
+  if [ "$AGENT_RC" -ne 0 ]; then
+    _record_failure "ollama-agent bridge exited $AGENT_RC for $TRIGGER"
+    exit 1
+  fi
+
+  # Success is explicit, not the mere absence of a non-zero exit
+  # (non-throwing-client-success-check): a run that did not complete, OR that
+  # emitted any unknown/hallucinated tool call, is a failure — not a success.
+  _agent_completed=$(printf '%s' "$AGENT_OUT" | jq -r '.completed // false' 2>/dev/null)
+  _agent_unknown=$(printf '%s' "$AGENT_OUT" | jq -r '(.unknown_calls // []) | length' 2>/dev/null)
+  [ -z "$_agent_unknown" ] && _agent_unknown=0
+
+  if [ "$_agent_completed" != "true" ]; then
+    _record_failure "ollama-agent task '$AGENT_TASK' did not complete for $TRIGGER"
+    exit 1
+  fi
+  if [ "$_agent_unknown" -gt 0 ]; then
+    _record_failure "ollama-agent task '$AGENT_TASK' emitted $_agent_unknown unknown tool call(s) for $TRIGGER"
+    exit 1
+  fi
+
+  _record_success
+  exit 0
+fi
 
 # --- Script-runner branch: exec named script, skip claude --print ---
 if [ "$RUNNER" = "script" ]; then

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4272,4 +4272,140 @@ test_dry_run_depth_preflight_skips_model_call() {
   assert_contains "$(cat "$(_preview_file dr-pre)" 2>/dev/null)" "preflight" "preview must note it stopped at preflight depth"
 }
 
+# --- runner:ollama-agent (bridge) dispatch — epic #197 slice A (#199) ---
+
+# Stub for the bridge CLI. Per stub-cli-argv-validation it pattern-matches the
+# exact argv production uses and exits non-zero on any other shape; on a match
+# it records the invocation and emits the caller-supplied JSON on stdout.
+_make_agent_stub() {
+  local json="$1"
+  cat > "$HOME/.bun/bin/agent-stub" << STUB
+#!/bin/bash
+case " \$* " in
+  *" --task-name "*" --registry "*" --json "*) : ;;
+  *) echo "agent stub: unexpected argv: \$*" >&2; exit 97 ;;
+esac
+echo invoked >> "\$HOME/agent-invoked.txt"
+cat << 'AGENTJSON'
+$json
+AGENTJSON
+STUB
+  chmod +x "$HOME/.bun/bin/agent-stub"
+  export CEO_OLLAMA_AGENT_CMD="$HOME/.bun/bin/agent-stub"
+}
+
+_register_agent_pb() {
+  local name="$1" tier="$2"
+  printf '{"tasks":{}}' > "$CEO_DIR/bridge-registry.json"
+  cat > "$CEO_DIR/playbooks/$name.md" << PB
+---
+name: $name
+description: ollama-agent bridge dispatch test
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: $tier
+status: active
+runner: ollama-agent
+registry: $CEO_DIR/bridge-registry.json
+---
+# body
+PB
+}
+
+test_runner_ollama_agent_success() {
+  _register_agent_pb agent-ok low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 2, "calls": [], "unknown_calls": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-ok >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "ollama-agent success must exit 0"
+  [ -f "$HOME/agent-invoked.txt" ] || { printf '  FAIL [%s] bridge must be invoked on success\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)); }
+  assert_contains "$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null)" "agent-ok completed" "success must record to cron-runs.log"
+}
+
+test_runner_ollama_agent_high_stakes_refused_before_dispatch() {
+  _register_agent_pb agent-hs high-stakes
+  _make_agent_stub '{"completed": true, "turns": 1, "calls": [], "unknown_calls": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-hs >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] high-stakes ollama-agent must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ -f "$HOME/agent-invoked.txt" ]; then
+    printf '  FAIL [%s] high-stakes must NOT invoke the bridge (gate is cron-side)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "may not run high-stakes" "refusal reason must be logged"
+}
+
+test_runner_ollama_agent_hallucinated_calls_is_failure() {
+  _register_agent_pb agent-halluc low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": [{"name": "bogus_tool"}]}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-halluc >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] a run with unknown_calls must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unknown tool call" "hallucinated call must be recorded as failure"
+}
+
+test_runner_ollama_agent_incomplete_is_failure() {
+  _register_agent_pb agent-incomplete low-stakes-write
+  _make_agent_stub '{"completed": false, "turns": 8, "calls": [], "unknown_calls": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-incomplete >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] completed:false must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "did not complete" "incomplete run must be recorded as failure"
+}
+
+test_runner_ollama_agent_tier_drift_normalized() {
+  # The live registry carries "low-stakes write" (space); the canonical form is
+  # hyphenated. The boundary normalization must accept the space variant.
+  _register_agent_pb agent-drift "low-stakes write"
+  _make_agent_stub '{"completed": true, "turns": 1, "calls": [], "unknown_calls": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-drift >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "space-variant tier must normalize and run (got rc=$rc)"
+  [ -f "$HOME/agent-invoked.txt" ] || { printf '  FAIL [%s] normalized tier must reach the bridge\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)); }
+}
+
+test_runner_ollama_agent_missing_registry_is_failure() {
+  cat > "$CEO_DIR/playbooks/agent-noreg.md" << 'PB'
+---
+name: agent-noreg
+description: ollama-agent with no registry field
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: low-stakes-write
+status: active
+runner: ollama-agent
+---
+# body
+PB
+  _make_agent_stub '{"completed": true, "turns": 1, "calls": [], "unknown_calls": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-noreg >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] missing registry must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  if [ -f "$HOME/agent-invoked.txt" ]; then
+    printf '  FAIL [%s] missing registry must fail before invoking the bridge\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "no 'registry' field" "missing-registry error must be logged"
+}
+
 run_tests

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4282,8 +4282,8 @@ _make_agent_stub() {
   cat > "$HOME/.bun/bin/agent-stub" << STUB
 #!/bin/bash
 case " \$* " in
-  *" --task-name "*" --registry "*" --json "*) : ;;
-  *) echo "agent stub: unexpected argv: \$*" >&2; exit 97 ;;
+  *" --task "*" --task-name "*" --registry "*" --json "*) : ;;
+  *) echo "agent stub: unexpected argv (missing --task?): \$*" >&2; exit 97 ;;
 esac
 echo invoked >> "\$HOME/agent-invoked.txt"
 cat << 'AGENTJSON'
@@ -4406,6 +4406,43 @@ PB
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "no 'registry' field" "missing-registry error must be logged"
+}
+
+test_runner_ollama_agent_malformed_output_is_failure() {
+  # A 0-exit bridge that emits non-JSON must be recorded as a failure, not crash
+  # ceo-cron.sh on the jq pipeline under set -euo pipefail (non-throwing-client-
+  # success-check): the parse-validity guard must route it through _record_failure.
+  _register_agent_pb agent-garbage low-stakes-write
+  cat > "$HOME/.bun/bin/agent-stub" << 'STUB'
+#!/bin/bash
+echo invoked >> "$HOME/agent-invoked.txt"
+echo "not json at all"
+STUB
+  chmod +x "$HOME/.bun/bin/agent-stub"
+  export CEO_OLLAMA_AGENT_CMD="$HOME/.bun/bin/agent-stub"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-garbage >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] malformed bridge output must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  # The failure must be RECORDED (fail-count incremented), not a bare set -e crash.
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null)" "1" "malformed output must increment the fail count (not crash before recording)"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unparseable output" "parse failure reason must be logged"
+}
+
+test_runner_ollama_agent_missing_bridge_command_is_failure() {
+  _register_agent_pb agent-nocmd low-stakes-write
+  export CEO_OLLAMA_AGENT_CMD="$HOME/.bun/bin/does-not-exist-agent"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-nocmd >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] a missing bridge command must exit non-zero (got rc=0)\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "bridge exited" "missing bridge command must be recorded as a failure"
 }
 
 run_tests


### PR DESCRIPTION
Closes #199

## Description (Issue Fixed & New Behavior)

Wires the `ollama-agent` bridge (`ollama-agent/cli.py`, epic #185) into the CEO control plane as a **new, distinct cron runner** — the spine of epic #197.

`runner: ollama-agent` is separate from the existing raw read-only `ollama`/`ollama-think` runners (which deliberately reject any tier but `read` because raw ollama can't reliably produce tool calls). The bridge *can* do governed tool calls, so it runs at a write tier with its own loop.

Key behaviors:
- **New runner** `ollama-agent` registered in `CEO_VALID_RUNNERS`.
- **Scan carries the dispatch fields.** `task` + `registry` frontmatter fields are now emitted by `ceo playbook scan`. They were silently dropped by the fixed-schema normalizer, so without this the dispatch branch could never see a `registry` (the branch read `$ENTRY` from the generated registry, not the raw frontmatter).
- **Outer tier gate.** The cron-side gate is authoritative: a `high-stakes` task is refused **before the bridge process starts** — the bridge is never invoked. The bridge's own `registry.gate()` remains defense-in-depth.
- **Tier-drift normalization.** `_normalize_tier` folds the live-registry `"low-stakes write"` (space) vs canonical `low-stakes-write` (hyphen) drift at one point; an unknown tier is rejected, never coerced (`enum-config-typo-fallback`).
- **Exit-code contract.** `completed:false` OR any non-empty `unknown_calls` is recorded as a failure (`non-throwing-client-success-check`) — a run that hallucinated every tool call is not logged as success.
- At `low-stakes-write` the bridge's governed loop is the execution model; it does **not** enter PLAN→FILTER→EXECUTE (deliberate, documented in the branch).

Re-scoped from the original A0+A after a planning re-audit found `runner: ollama` already existed and CEO's tier vocab is load-bearing (see #197 / #198).

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-cron.test.sh` → **All tests passed (156 tests)**, including 6 new `test_runner_ollama_agent_*`.
3. `bash scripts/ceo-scan.test.sh && bash scripts/ceo-list.test.sh && bash scripts/ceo-config.test.sh` → all pass (the scan-schema change adds two fields to every entry).
4. Mutation-verify the four guards: revert each in `scripts/ceo-cron.sh` and confirm the matching test fails —
   - allow `high-stakes` in the gate → high-stakes refusal breaks (rc 0, bridge invoked);
   - disable the `unknown_calls` check → hallucinated run passes (rc 0);
   - disable the `completed` check → incomplete run passes (rc 0);
   - drop the space-variant from `_normalize_tier` → `"low-stakes write"` rejected as unknown tier.
5. `shellcheck scripts/ceo-cron.sh scripts/ceo scripts/ceo-config.sh` → no new warnings in changed ranges (the pre-existing `ceo-cron.sh` warnings are the known-red baseline).

## Additional Notes / HelpScout Tickets

The `"low-stakes write"` (space) vs `low-stakes-write` (hyphen) drift exists in the **live** synced registry today — a latent `enum-config-typo-fallback` hazard surfaced during this work. The boundary normalization handles it for the bridge path. `ceo playbook scan` must be re-run **on ML-1** post-merge to pick up the new `task`/`registry` fields for any real `ollama-agent` playbook (never scanned locally per `ceo-scan-only-on-ml1`). The `shellcheck` CI job is pre-existing-red on `./scripts`; this PR adds no new warnings.
