### PR TITLE
Persist scores.tsv from grade.py + wire selftest into CI (epic #197 B0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
           done
           [ "$count" -ge 1 ] || { echo "no tests ran"; exit 1; }
           exit "$fail"
+      - name: ollama-matrix grader selftest
+        run: python3 evals/ollama-matrix/grade.py --selftest
   scheduler:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/evals/ollama-matrix/grade.py
+++ b/evals/ollama-matrix/grade.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -223,6 +224,37 @@ GRADERS = {
 }
 
 
+def write_scores_tsv(scores, models, out_dir, generated_at, task_order=None):
+    """Persist per-(task, model) correctness as a stable, machine-readable
+    contract for downstream consumers (the CEO min_score delegation gate),
+    rather than forcing them to parse this script's printed table.
+
+    `scores` is {model: {task: (correct, total) | None}}. A None entry (absent
+    output or an ERR/infra failure) is omitted — the gate treats a missing
+    score as "refuse", so it must not appear as a row. A total of 0 yields a
+    blank ratio (never a div-by-zero). The write is atomic (temp + rename) so a
+    reader mid-grade never observes a partial file. Models are written in the
+    filename/dot form they already carry (e.g. `gpt-oss.20b`); the gate maps a
+    registry model id to this form by replacing `:` with `.`."""
+    out_dir = Path(out_dir)
+    tasks = task_order if task_order is not None else sorted({t for m in scores for t in scores[m]})
+    tmp = out_dir / "scores.tsv.tmp"
+    final = out_dir / "scores.tsv"
+    with tmp.open("w") as fh:
+        fh.write(f"# generated_at={generated_at}\n")
+        fh.write("task\tmodel\tcorrect\ttotal\tratio\n")
+        for task in tasks:
+            for m in models:
+                s = scores.get(m, {}).get(task)
+                if s is None:
+                    continue
+                got, tot = s
+                ratio = f"{got / tot:.4f}" if tot else ""
+                fh.write(f"{task}\t{m}\t{got}\t{tot}\t{ratio}\n")
+    os.replace(tmp, final)
+    return final
+
+
 def _selftest():
     """Lock the extractors against the failure modes a review panel found:
     KEEP whose reason prose says "close", list-prefixed lines, "S3 and S4"
@@ -270,6 +302,31 @@ def _selftest():
         if got != want:
             fails += 1
             print(f"SELFTEST FAIL: {fn.__name__}({text!r}) -> {got}, want {want}")
+
+    # write_scores_tsv: stable shape, total=0 handling, None/ERR omission, atomicity.
+    import tempfile
+    with tempfile.TemporaryDirectory() as _td:
+        _sample = {
+            "m1": {"think-01": (3, 4), "think-02": (0, 0), "think-03": None},
+            "m2": {"think-01": (4, 4)},
+        }
+        _p = write_scores_tsv(_sample, ["m1", "m2"], _td, "2026-01-01T00:00:00Z",
+                              task_order=["think-01", "think-02", "think-03"])
+        _lines = Path(_p).read_text().splitlines()
+        _checks = [
+            (_lines[0] == "# generated_at=2026-01-01T00:00:00Z", "generated_at header"),
+            (_lines[1] == "task\tmodel\tcorrect\ttotal\tratio", "column header"),
+            ("think-01\tm1\t3\t4\t0.7500" in _lines, "ratio computed"),
+            ("think-02\tm1\t0\t0\t" in _lines, "total=0 -> blank ratio, no div-by-zero"),
+            (not any("think-03" in _l for _l in _lines), "None/ERR row omitted"),
+            ("think-01\tm2\t4\t4\t1.0000" in _lines, "second model row"),
+            (not (Path(_td) / "scores.tsv.tmp").exists(), "tmp removed after atomic rename"),
+        ]
+        for _ok, _desc in _checks:
+            if not _ok:
+                fails += 1
+                print(f"SELFTEST FAIL: write_scores_tsv — {_desc}")
+
     print("selftest: OK" if not fails else f"selftest: {fails} FAILED")
     sys.exit(1 if fails else 0)
 
@@ -325,3 +382,8 @@ for m in models:
     errs = sum(1 for s in scores[m].values() if s is None)
     note = f"  [{errs} task(s) ERR, excluded]" if errs else ""
     print(f"  {m:<24} {got}/{tot}  ({pct:.0f}%){note}")
+
+generated_at = os.environ.get("CEO_SCORES_GENERATED_AT") \
+    or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+scores_path = write_scores_tsv(scores, models, OUT, generated_at, task_order=list(KEYS))
+print(f"\nwrote {scores_path}")

--- a/evals/ollama-matrix/grade.py
+++ b/evals/ollama-matrix/grade.py
@@ -224,6 +224,13 @@ GRADERS = {
 }
 
 
+def _resolve_generated_at():
+    """Timestamp for the scores.tsv header. `CEO_SCORES_GENERATED_AT` overrides
+    (deterministic CI / test output); otherwise current UTC."""
+    return os.environ.get("CEO_SCORES_GENERATED_AT") \
+        or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def write_scores_tsv(scores, models, out_dir, generated_at, task_order=None):
     """Persist per-(task, model) correctness as a stable, machine-readable
     contract for downstream consumers (the CEO min_score delegation gate),
@@ -233,25 +240,36 @@ def write_scores_tsv(scores, models, out_dir, generated_at, task_order=None):
     output or an ERR/infra failure) is omitted — the gate treats a missing
     score as "refuse", so it must not appear as a row. A total of 0 yields a
     blank ratio (never a div-by-zero). The write is atomic (temp + rename) so a
-    reader mid-grade never observes a partial file. Models are written in the
-    filename/dot form they already carry (e.g. `gpt-oss.20b`); the gate maps a
-    registry model id to this form by replacing `:` with `.`."""
+    reader mid-grade never observes a partial file.
+
+    The `model` column is written in the filename/dot form the outputs already
+    carry (e.g. `gpt-oss.20b`) — run.sh derives filenames via `tr ':/' '.-'`, so
+    a `:` becomes `.` AND a `/` becomes `-`. This intentionally differs from the
+    sibling stats.tsv, whose `model` column keeps the registry form
+    (`gpt-oss:20b`); do not join the two on `model` without normalizing. The
+    gate maps a registry id to this form with the same `tr ':/' '.-'`."""
     out_dir = Path(out_dir)
     tasks = task_order if task_order is not None else sorted({t for m in scores for t in scores[m]})
     tmp = out_dir / "scores.tsv.tmp"
     final = out_dir / "scores.tsv"
-    with tmp.open("w") as fh:
-        fh.write(f"# generated_at={generated_at}\n")
-        fh.write("task\tmodel\tcorrect\ttotal\tratio\n")
-        for task in tasks:
-            for m in models:
-                s = scores.get(m, {}).get(task)
-                if s is None:
-                    continue
-                got, tot = s
-                ratio = f"{got / tot:.4f}" if tot else ""
-                fh.write(f"{task}\t{m}\t{got}\t{tot}\t{ratio}\n")
-    os.replace(tmp, final)
+    try:
+        with tmp.open("w") as fh:
+            fh.write(f"# generated_at={generated_at}\n")
+            fh.write("task\tmodel\tcorrect\ttotal\tratio\n")
+            for task in tasks:
+                for m in models:
+                    s = scores.get(m, {}).get(task)
+                    if s is None:
+                        continue
+                    got, tot = s
+                    ratio = f"{got / tot:.4f}" if tot else ""
+                    fh.write(f"{task}\t{m}\t{got}\t{tot}\t{ratio}\n")
+        os.replace(tmp, final)
+    finally:
+        # A mid-write exception leaves a partial temp; remove it so it can't
+        # linger (it's gitignored, but don't rely on the next run truncating it).
+        if tmp.exists():
+            tmp.unlink()
     return final
 
 
@@ -327,6 +345,27 @@ def _selftest():
                 fails += 1
                 print(f"SELFTEST FAIL: write_scores_tsv — {_desc}")
 
+    # _resolve_generated_at: env override wins; default is a UTC ...Z timestamp.
+    _prev = os.environ.get("CEO_SCORES_GENERATED_AT")
+    try:
+        os.environ["CEO_SCORES_GENERATED_AT"] = "2030-09-09T09:09:09Z"
+        _gen_checks = [
+            (_resolve_generated_at() == "2030-09-09T09:09:09Z", "env override wins"),
+        ]
+        os.environ.pop("CEO_SCORES_GENERATED_AT", None)
+        _default = _resolve_generated_at()
+        _gen_checks.append((re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", _default) is not None,
+                            f"default is UTC ...Z (got {_default!r})"))
+        for _ok, _desc in _gen_checks:
+            if not _ok:
+                fails += 1
+                print(f"SELFTEST FAIL: _resolve_generated_at — {_desc}")
+    finally:
+        if _prev is not None:
+            os.environ["CEO_SCORES_GENERATED_AT"] = _prev
+        else:
+            os.environ.pop("CEO_SCORES_GENERATED_AT", None)
+
     print("selftest: OK" if not fails else f"selftest: {fails} FAILED")
     sys.exit(1 if fails else 0)
 
@@ -383,7 +422,5 @@ for m in models:
     note = f"  [{errs} task(s) ERR, excluded]" if errs else ""
     print(f"  {m:<24} {got}/{tot}  ({pct:.0f}%){note}")
 
-generated_at = os.environ.get("CEO_SCORES_GENERATED_AT") \
-    or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-scores_path = write_scores_tsv(scores, models, OUT, generated_at, task_order=list(KEYS))
+scores_path = write_scores_tsv(scores, models, OUT, _resolve_generated_at(), task_order=list(KEYS))
 print(f"\nwrote {scores_path}")


### PR DESCRIPTION
Closes #204

## Description (Issue Fixed & New Behavior)

Prerequisite slice for the min_score delegation gate (#200). `grade.py` computed per-task/per-model correctness but only printed it to stdout; this persists it as a stable, machine-readable contract so the gate reads a file, not the presentation layer (parsing a printed table would couple governance to grade.py's formatting — a fragile, non-throwing-shaped trap).

- New `write_scores_tsv()` emits `out/scores.tsv`: a `# generated_at=<ts>` header line, then columns `task / model / correct / total / ratio`, task-ordered.
- **Atomic write** (temp + `os.replace`) — a reader mid-grade never sees a partial file.
- **None/ERR entries omitted** — the gate treats a missing score as "refuse", so an un-graded/infra-failed cell must not appear as a row.
- **`total=0` → blank ratio** (never a div-by-zero/NaN).
- Models written in the filename/dot form (`gpt-oss.20b`); the gate (#200) maps a registry id (`gpt-oss:20b`) to this form by replacing `:` with `.` (only colon→dot is unambiguous — version dots like `mistral-small3.2` must survive).
- `out/scores.tsv` is **gitignored** (generated artifact, like the rest of `out/`).
- **Wires `grade.py --selftest` into the CI test job** — it was never run in CI, so the grader's selftest (the #184 extractor cases *and* the new `write_scores_tsv` cases) now actually gates.

## Testing Procedure

1. Check out this branch.
2. `python3 evals/ollama-matrix/grade.py --selftest` → `selftest: OK`.
3. Mutation: in `write_scores_tsv`, change `ratio = f"{got / tot:.4f}" if tot else ""` to a constant → re-run selftest → **3 failures** (ratio computed / total=0 / second model row). Revert.
4. `python3 evals/ollama-matrix/grade.py` against the committed `out/*.txt` → prints the usual table and writes `out/scores.tsv` (header + `generated_at` + dot-form models + ratios).
5. CI: the `test` job now includes the grader selftest step.

## Additional Notes / HelpScout Tickets

Unblocks #200 (the gate). The `shellcheck` CI job is pre-existing-red on `./scripts` (unrelated to this PR, which touches `evals/` + the workflow). `generated_at` can be pinned for deterministic runs via `CEO_SCORES_GENERATED_AT`.