### PR TITLE
Add min_score delegation gate to the task registry (epic #197 B)

### DIFF
--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -8,11 +8,12 @@ Part of the [local-agent bridge epic (#185)](https://github.com/nhangen/claude-c
 
 | Slice | What | State |
 |------|------|-------|
-| 1 (#186) | Bridge core + real shell/fs/git tools over the `/api/chat` tools API | **this package** |
-| 2 (#187) | Rule loading + relevance selection | planned |
-| 3 (#188) | Skill resolver | planned |
-| 4 (#189) | MCP tool adapter | planned |
-| 5 (#190) | Governance + task registry (`runner: ollama`) | planned |
+| 1 (#186) | Bridge core + real shell/fs/git tools over the `/api/chat` tools API | shipped |
+| 2 (#187) | Rule loading + relevance selection | shipped |
+| 3 (#188) | Skill resolver | shipped |
+| 4 (#189) | MCP tool adapter | shipped |
+| 5 (#190) | Governance + task registry (`runner: ollama`) | shipped |
+| #200 | `min_score` delegation gate (eval-score-pinned competence) | shipped |
 
 ## Usage
 
@@ -24,6 +25,22 @@ python ollama-agent/cli.py --task "summarize the README in 3 bullets" \
 
 Flags: `--model`, `--cwd` (the directory tools operate in), `--host`, `--temperature`,
 `--num-ctx`, `--turn-cap`, `--shell-timeout`, `--json` (full record), `--system` (override the system prompt).
+
+Governance flags: `--registry` + `--task-name` run a registered task (its model/tier/tools/rules
+apply, gated before any model call); `--scores` points at an ollama-matrix `scores.tsv` for the
+`min_score` gate (`--scores-stale-days` warns on old scores).
+
+## Governance (registry + delegation gate)
+
+A registered task (`--registry reg.json --task-name <name>`) is gated **before any model call**:
+
+- `tier: high-stakes` is never delegated to a local model (refused, exit 3); only `deterministic`
+  and `low-stakes-write` run. Unknown `runner`/`tier` is rejected, never defaulted.
+- `min_score` (optional) refuses delegation unless the model's measured ratio on a pinned
+  `eval_task` (from ollama-matrix `scores.tsv`) meets the threshold. `eval_task` is **required**
+  when `min_score` is set — use `eval_task: "*"` to opt into the cross-task mean; an aggregate
+  default would let a model that fails the task that matters pass on unrelated tasks. A missing
+  score is a refusal, not a silent pass. `eval_model` overrides which model's score is checked.
 
 ## Tools
 

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -8,10 +8,12 @@ Slice 2 (#187): real shell/fs/git tools + task-relevant rule injection.
 import argparse
 import json
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, MCPClient, RegistryError,
                           StdioMCPTransport, compose_system, filter_tools, gate,
-                          load_registry, load_skill_index, mcp_tools_to_ollama,
+                          load_registry, load_scores, load_skill_index, mcp_tools_to_ollama,
                           ollama_transport, render_catalog, run_agent)
 
 DEFAULT_SYSTEM = (
@@ -19,6 +21,22 @@ DEFAULT_SYSTEM = (
     "Use the provided tools to inspect and modify files and run commands. "
     "When the task is done, reply with a short summary and no further tool calls."
 )
+
+
+def _warn_if_stale_scores(generated_at, stale_days):
+    """Eval-score staleness logs a warning but never refuses (a re-pulled model
+    against an old eval is a soft signal, not a hard governance failure)."""
+    try:
+        gen = datetime.strptime(generated_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        print(f"warning: eval scores have an unparseable generated_at {generated_at!r}",
+              file=sys.stderr)
+        return
+    age_days = (datetime.now(timezone.utc) - gen).days
+    if age_days > stale_days:
+        print(f"warning: eval scores are {age_days}d old (generated_at {generated_at}, "
+              f"stale after {stale_days}d) — gating on possibly outdated competence data",
+              file=sys.stderr)
 
 
 def main(argv=None):
@@ -47,6 +65,11 @@ def main(argv=None):
     p.add_argument("--registry", default=None, help="Path/JSON of a task registry.")
     p.add_argument("--task-name", default=None,
                    help="Run a registered task by name (applies its model/tier/tools/rules).")
+    p.add_argument("--scores", default=None,
+                   help="Path to ollama-matrix scores.tsv for the min_score gate "
+                        "(default: <repo>/evals/ollama-matrix/out/scores.tsv).")
+    p.add_argument("--scores-stale-days", type=int, default=30,
+                   help="Warn (do not refuse) if the eval scores are older than this.")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
 
@@ -66,7 +89,17 @@ def main(argv=None):
         if spec is None:
             print(f"no registered task {a.task_name!r} (known: {sorted(specs)})", file=sys.stderr)
             return 2
-        ok, reason = gate(spec)
+        scores = None
+        if spec.min_score is not None:
+            scores_path = a.scores or str(
+                Path(__file__).resolve().parent.parent / "evals/ollama-matrix/out/scores.tsv")
+            try:
+                scores, generated_at = load_scores(scores_path)
+            except OSError:
+                scores, generated_at = None, None  # gate refuses on a missing score set
+            if generated_at:
+                _warn_if_stale_scores(generated_at, a.scores_stale_days)
+        ok, reason = gate(spec, scores)
         if not ok:
             print(f"REJECTED task {a.task_name!r}: {reason}", file=sys.stderr)
             return 3

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -93,10 +93,20 @@ def main(argv=None):
         if spec.min_score is not None:
             scores_path = a.scores or str(
                 Path(__file__).resolve().parent.parent / "evals/ollama-matrix/out/scores.tsv")
+            # An absent file is a configuration error, surfaced distinctly — not
+            # folded into the gate's generic "model not evaluated" refusal.
+            # (load_scores treats a non-existent path as inline text, so the
+            # check must happen here, before the call.)
+            if not Path(scores_path).is_file():
+                print(f"REJECTED task {a.task_name!r}: eval scores file not found at "
+                      f"{scores_path} (min_score gate requires it)", file=sys.stderr)
+                return 3
             try:
                 scores, generated_at = load_scores(scores_path)
-            except OSError:
-                scores, generated_at = None, None  # gate refuses on a missing score set
+            except (OSError, UnicodeDecodeError) as e:
+                print(f"REJECTED task {a.task_name!r}: cannot read eval scores "
+                      f"({scores_path}: {e})", file=sys.stderr)
+                return 3
             if generated_at:
                 _warn_if_stale_scores(generated_at, a.scores_stale_days)
         ok, reason = gate(spec, scores)

--- a/ollama-agent/ollama_agent/__init__.py
+++ b/ollama-agent/ollama_agent/__init__.py
@@ -6,7 +6,8 @@ governed task registry (#190).
 """
 from .agent import run_agent
 from .mcp import MCPClient, MCPError, StdioMCPTransport, mcp_tools_to_ollama
-from .registry import RegistryError, filter_tools, gate, load_registry
+from .registry import (RegistryError, filter_tools, gate, load_registry,
+                       load_scores, normalize_model, score_for)
 from .rules import compose_system, load_rule_index, select_rules
 from .skills import USE_SKILL_TOOL, get_skill, load_skill_index, render_catalog
 from .tools import ToolBox, TOOLS
@@ -16,4 +17,5 @@ __all__ = ["run_agent", "ToolBox", "TOOLS", "ollama_transport", "parse_chat_resp
            "compose_system", "load_rule_index", "select_rules",
            "USE_SKILL_TOOL", "get_skill", "load_skill_index", "render_catalog",
            "MCPClient", "MCPError", "StdioMCPTransport", "mcp_tools_to_ollama",
-           "RegistryError", "filter_tools", "gate", "load_registry"]
+           "RegistryError", "filter_tools", "gate", "load_registry",
+           "load_scores", "normalize_model", "score_for"]

--- a/ollama-agent/ollama_agent/registry.py
+++ b/ollama-agent/ollama_agent/registry.py
@@ -25,7 +25,8 @@ class RegistryError(ValueError):
 
 
 class TaskSpec:
-    def __init__(self, name, runner, model, tier, tools="*", rules=True, skills=False):
+    def __init__(self, name, runner, model, tier, tools="*", rules=True, skills=False,
+                 min_score=None, eval_task=None, eval_model=None):
         self.name = name
         self.runner = runner
         self.model = model
@@ -33,6 +34,58 @@ class TaskSpec:
         self.tools = tools          # "*" or a list of allowed tool names
         self.rules = rules
         self.skills = skills
+        # Empirical-competence gate: refuse delegation unless the model scored
+        # >= min_score on the pinned eval_task class. eval_task is REQUIRED when
+        # min_score is set (an aggregate-mean default would let a model that
+        # fails the task that matters pass on the strength of unrelated tasks);
+        # eval_task="*" opts into the cross-task mean explicitly. eval_model
+        # defaults to the run model.
+        self.min_score = min_score
+        self.eval_task = eval_task
+        self.eval_model = eval_model
+
+
+def normalize_model(model):
+    """Map a registry model id to the filename/score form. run.sh derives output
+    filenames via `tr ':/' '.-'`, so scores.tsv carries `gpt-oss.20b`, not
+    `gpt-oss:20b`. Mirror that transform exactly (colon→dot AND slash→dash)."""
+    return model.replace(":", ".").replace("/", "-")
+
+
+def load_scores(source):
+    """Parse a scores.tsv (emitted by evals/ollama-matrix/grade.py). Returns
+    (scores, generated_at) where scores is {(task, model): ratio} for rows with
+    a non-empty ratio (total>0). A blank ratio (total=0) is omitted — the gate
+    treats it as missing → refuse. `source` is a path or the tsv text itself."""
+    text = Path(source).read_text() if Path(str(source)).exists() else str(source)
+    scores, generated_at = {}, None
+    for line in text.splitlines():
+        if line.startswith("# generated_at="):
+            generated_at = line.split("=", 1)[1].strip()
+            continue
+        if not line.strip() or line.startswith("task\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 5:
+            continue
+        task, model, _correct, _total, ratio = parts[:5]
+        if ratio.strip() == "":          # total=0 → no usable score
+            continue
+        try:
+            scores[(task, model)] = float(ratio)
+        except ValueError:
+            continue
+    return scores, generated_at
+
+
+def score_for(scores, eval_task, model):
+    """Look up the model's ratio for eval_task (model already normalized).
+    eval_task="*" averages the model's ratios across all tasks. Returns None
+    when there is no usable score (the gate then refuses)."""
+    if eval_task == "*":
+        vals = [r for (t, m), r in scores.items() if m == model]
+        return sum(vals) / len(vals) if vals else None
+    return scores.get((eval_task, model))
 
 
 def _validate(name, entry):
@@ -48,6 +101,15 @@ def _validate(name, entry):
     tools = entry.get("tools", "*")
     if tools != "*" and not isinstance(tools, list):
         raise RegistryError(f"task {name!r}: tools must be \"*\" or a list, got {type(tools).__name__}")
+    if "min_score" in entry and entry["min_score"] is not None:
+        ms = entry["min_score"]
+        if isinstance(ms, bool) or not isinstance(ms, (int, float)):
+            raise RegistryError(f"task {name!r}: min_score must be a number, got {type(ms).__name__}")
+        if not entry.get("eval_task"):
+            # No aggregate-mean default: a gate that averages away a task-class
+            # failure fails open on its whole purpose. Require an explicit pin
+            # (use eval_task "*" to opt into the cross-task mean).
+            raise RegistryError(f"task {name!r}: min_score requires eval_task (use \"*\" for the cross-task mean)")
 
 
 def load_registry(source):
@@ -66,20 +128,37 @@ def load_registry(source):
         specs[name] = TaskSpec(
             name=name, runner=entry["runner"], model=entry["model"], tier=entry["tier"],
             tools=entry.get("tools", "*"), rules=entry.get("rules", True),
-            skills=entry.get("skills", False))
+            skills=entry.get("skills", False), min_score=entry.get("min_score"),
+            eval_task=entry.get("eval_task"), eval_model=entry.get("eval_model"))
     return specs
 
 
-def gate(spec):
+def gate(spec, scores=None):
     """Dispatch-time gate (defense in depth after parse validation). Returns
     (ok, reason). A non-delegable tier or unknown runner/tier is rejected — the
-    caller routes the rejection through failure observability, never runs it."""
+    caller routes the rejection through failure observability, never runs it.
+
+    When `spec.min_score` is set, `scores` (from load_scores) must be supplied;
+    the model is refused unless its ratio on the pinned eval_task is >= min_score.
+    A missing/unreadable score is a refusal (reject-don't-default) — never a
+    silent pass. Staleness is the caller's concern (log, don't refuse)."""
     if spec.runner not in RUNNERS:
         return False, f"unknown runner {spec.runner!r}"
     if spec.tier not in TIERS:
         return False, f"unknown tier {spec.tier!r}"
     if spec.tier not in DELEGABLE_TIERS:
         return False, f"tier {spec.tier!r} may not be delegated to a local model"
+    if spec.min_score is not None:
+        model = normalize_model(spec.eval_model or spec.model)
+        if scores is None:
+            return False, "min_score set but no eval scores available"
+        score = score_for(scores, spec.eval_task, model)
+        if score is None:
+            return False, (f"no eval score for model {model!r} on task "
+                           f"{spec.eval_task!r} — cannot confirm competence")
+        if score < spec.min_score:
+            return False, (f"model {model!r} scored {score:.4f} on {spec.eval_task!r}, "
+                           f"below min_score {spec.min_score}")
     return True, "ok"
 
 

--- a/ollama-agent/ollama_agent/registry.py
+++ b/ollama-agent/ollama_agent/registry.py
@@ -8,6 +8,7 @@ loudly, not silently fall through to a default path). A high-stakes task can
 never be delegated to a local model regardless of what the entry says.
 """
 import json
+import math
 from pathlib import Path
 
 RUNNERS = {"ollama"}                       # who may execute a registered task
@@ -72,9 +73,12 @@ def load_scores(source):
         if ratio.strip() == "":          # total=0 → no usable score
             continue
         try:
-            scores[(task, model)] = float(ratio)
+            val = float(ratio)
         except ValueError:
             continue
+        if not math.isfinite(val):       # nan/inf is not a usable score — a
+            continue                     # corrupt value must not slip past the
+        scores[(task, model)] = val      # threshold (nan < x is always False)
     return scores, generated_at
 
 

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -241,3 +241,57 @@ def test_cli_registry_rules_skills_propagation(tmp_path, monkeypatch, capsys):
     assert "use_skill" not in _tool_names(captured["tools"])  # skills:false honored
     err = capsys.readouterr().err
     assert "rules:" not in err and "skills:" not in err
+
+
+def _scores_file(tmp_path, body):
+    f = tmp_path / "scores.tsv"
+    f.write_text(body)
+    return str(f)
+
+
+def test_cli_min_score_missing_scores_file_rejects(tmp_path, monkeypatch, capsys):
+    reg = _registry(tmp_path, t={"runner": "ollama", "model": "gpt-oss:20b",
+                                 "tier": "deterministic", "min_score": 0.8,
+                                 "eval_task": "think-02"})
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--registry", reg, "--task-name", "t",
+                   "--scores", str(tmp_path / "nope.tsv")])
+    assert rc == 3
+    assert "eval scores file not found" in capsys.readouterr().err
+
+
+def test_cli_min_score_below_threshold_rejects(tmp_path, monkeypatch, capsys):
+    sc = _scores_file(tmp_path, "task\tmodel\tcorrect\ttotal\tratio\nthink-02\tgpt-oss.20b\t2\t10\t0.2000\n")
+    reg = _registry(tmp_path, t={"runner": "ollama", "model": "gpt-oss:20b",
+                                 "tier": "deterministic", "min_score": 0.8,
+                                 "eval_task": "think-02"})
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--registry", reg, "--task-name", "t", "--scores", sc])
+    assert rc == 3
+    assert "below min_score" in capsys.readouterr().err
+
+
+def test_cli_min_score_passing_with_stale_scores_warns_but_runs(tmp_path, monkeypatch, capsys):
+    sc = _scores_file(tmp_path, "# generated_at=2000-01-01T00:00:00Z\n"
+                                "task\tmodel\tcorrect\ttotal\tratio\nthink-02\tgpt-oss.20b\t9\t10\t0.9000\n")
+    reg = _registry(tmp_path, t={"runner": "ollama", "model": "gpt-oss:20b",
+                                 "tier": "deterministic", "min_score": 0.8,
+                                 "eval_task": "think-02"})
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--registry", reg, "--task-name", "t", "--scores", sc])
+    assert rc == 0
+    assert "stale" in capsys.readouterr().err   # warned, but did not refuse
+
+
+def test_warn_if_stale_scores_branches(capsys):
+    cli._warn_if_stale_scores("2000-01-01T00:00:00Z", 30)
+    assert "eval scores are" in capsys.readouterr().err          # old → warns
+    cli._warn_if_stale_scores("not-a-timestamp", 30)
+    assert "unparseable generated_at" in capsys.readouterr().err  # bad format → warns
+    from datetime import datetime, timezone
+    fresh = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    cli._warn_if_stale_scores(fresh, 30)
+    assert capsys.readouterr().err == ""                          # fresh → silent

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -199,3 +199,70 @@ def test_gate_no_min_score_ignores_scores():
     spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic")
     ok, _ = gate(spec, None)
     assert ok
+
+
+def test_load_scores_omits_non_finite_ratio():
+    # A corrupt nan/inf must not slip past the threshold (nan < x is False).
+    tsv = ("# generated_at=2026-06-26T00:00:00Z\n"
+           "task\tmodel\tcorrect\ttotal\tratio\n"
+           "t\tm\t1\t1\tnan\n"
+           "t2\tm\t1\t1\tinf\n")
+    scores, _ = load_scores(tsv)
+    assert scores == {}
+
+
+def test_gate_refuses_nan_score_fail_open_guard():
+    tsv = ("task\tmodel\tcorrect\ttotal\tratio\n"
+           "think-x\tm\t1\t1\tnan\n")
+    scores, _ = load_scores(tsv)
+    spec = TaskSpec("t", "ollama", "m", "deterministic", min_score=0.5, eval_task="think-x")
+    ok, reason = gate(spec, scores)
+    assert not ok and "cannot confirm competence" in reason
+
+
+def test_gate_refuses_total_zero_row_via_behavior():
+    # total=0 row (blank ratio) is omitted → gate refuses. Asserts the refusal
+    # behavior, not mere dict absence, so it fails if a future change leaked a 0.0.
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.0, eval_task="think-04-temporal")
+    ok, reason = gate(spec, _scored())
+    assert not ok and "cannot confirm competence" in reason
+
+
+def test_gate_score_exactly_at_threshold_passes():
+    # boundary: score == min_score must pass (>=, not >)
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.9, eval_task="think-02-prioritization")  # exactly 0.9
+    ok, _ = gate(spec, _scored())
+    assert ok
+
+
+def test_gate_aggregate_star_through_gate():
+    # gpt-oss.20b mean = 0.55 → passes 0.5, refuses 0.6
+    passes, _ = gate(TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                              min_score=0.5, eval_task="*"), _scored())
+    refused, reason = gate(TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                                    min_score=0.6, eval_task="*"), _scored())
+    assert passes and not refused and "below min_score" in reason
+
+
+def test_gate_eval_model_override_passing_redirect():
+    # run model (gemma, 0.3) would fail, but eval_model redirects to gpt-oss (0.9) → passes
+    spec = TaskSpec("t", "ollama", "gemma4:12b-it-qat", "deterministic",
+                    min_score=0.8, eval_task="think-02-prioritization",
+                    eval_model="gpt-oss:20b")
+    ok, _ = gate(spec, _scored())
+    assert ok
+
+
+def test_gate_min_score_zero_is_a_real_threshold():
+    # min_score=0.0 still requires a present score (not no-gate); a 0.2 score passes
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.0, eval_task="think-03-contradiction")
+    ok, _ = gate(spec, _scored())
+    assert ok
+    # but a missing score still refuses even at threshold 0.0
+    miss = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.0, eval_task="think-99")
+    ok2, _ = gate(miss, _scored())
+    assert not ok2

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -7,11 +7,25 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from ollama_agent.registry import (  # noqa: E402
     RegistryError, TaskSpec, filter_tools, gate, load_registry,
+    load_scores, normalize_model, score_for,
+)
+
+SCORES_TSV = (
+    "# generated_at=2026-06-26T00:00:00Z\n"
+    "task\tmodel\tcorrect\ttotal\tratio\n"
+    "think-02-prioritization\tgpt-oss.20b\t9\t10\t0.9000\n"
+    "think-02-prioritization\tgemma4.12b-it-qat\t3\t10\t0.3000\n"
+    "think-03-contradiction\tgpt-oss.20b\t2\t10\t0.2000\n"
+    "think-04-temporal\tgpt-oss.20b\t0\t0\t\n"   # total=0 → omitted (blank ratio)
 )
 
 
 def _reg(**tasks):
     return {"tasks": tasks}
+
+
+def _scored():
+    return load_scores(SCORES_TSV)[0]
 
 
 def test_load_valid_registry():
@@ -94,3 +108,94 @@ def test_filter_tools_empty_allowlist_yields_nothing():
 def test_load_bad_json_raises_valueerror():
     with pytest.raises(ValueError):
         load_registry("{not valid json")
+
+
+# --- Slice B: min_score delegation gate (#200) ---
+
+def test_normalize_model_colon_and_slash():
+    assert normalize_model("gpt-oss:20b") == "gpt-oss.20b"
+    assert normalize_model("library/foo:1b") == "library-foo.1b"
+    # a legitimate version dot must survive (only ':'/'/' are transformed)
+    assert normalize_model("mistral-small3.2:24b") == "mistral-small3.2.24b"
+
+
+def test_load_scores_parses_and_captures_generated_at():
+    scores, gen = load_scores(SCORES_TSV)
+    assert gen == "2026-06-26T00:00:00Z"
+    assert scores[("think-02-prioritization", "gpt-oss.20b")] == 0.9
+    assert scores[("think-03-contradiction", "gpt-oss.20b")] == 0.2
+
+
+def test_load_scores_omits_total_zero_rows():
+    scores, _ = load_scores(SCORES_TSV)
+    assert ("think-04-temporal", "gpt-oss.20b") not in scores
+
+
+def test_score_for_pinned_task():
+    assert score_for(_scored(), "think-02-prioritization", "gpt-oss.20b") == 0.9
+    assert score_for(_scored(), "think-02-prioritization", "gemma4.12b-it-qat") == 0.3
+
+
+def test_score_for_missing_is_none():
+    assert score_for(_scored(), "think-99-nonexistent", "gpt-oss.20b") is None
+
+
+def test_score_for_aggregate_star_is_mean():
+    # gpt-oss.20b has 0.9 and 0.2 (the total=0 row is omitted) → mean 0.55
+    assert score_for(_scored(), "*", "gpt-oss.20b") == pytest.approx(0.55)
+
+
+def test_min_score_without_eval_task_is_config_error():
+    with pytest.raises(RegistryError, match="min_score requires eval_task"):
+        load_registry(_reg(t={"runner": "ollama", "model": "m", "tier": "deterministic",
+                              "min_score": 0.8}))
+
+
+def test_min_score_non_number_is_config_error():
+    with pytest.raises(RegistryError, match="min_score must be a number"):
+        load_registry(_reg(t={"runner": "ollama", "model": "m", "tier": "deterministic",
+                              "min_score": "high", "eval_task": "think-02-prioritization"}))
+
+
+def test_gate_passes_when_score_meets_threshold():
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.8, eval_task="think-02-prioritization")
+    ok, reason = gate(spec, _scored())
+    assert ok and reason == "ok"
+
+
+def test_gate_refuses_when_score_below_threshold():
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.8, eval_task="think-03-contradiction")  # 0.2 < 0.8
+    ok, reason = gate(spec, _scored())
+    assert not ok and "below min_score" in reason
+
+
+def test_gate_refuses_when_score_missing():
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.5, eval_task="think-99-nonexistent")
+    ok, reason = gate(spec, _scored())
+    assert not ok and "cannot confirm competence" in reason
+
+
+def test_gate_refuses_when_no_scores_supplied():
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.5, eval_task="think-02-prioritization")
+    ok, reason = gate(spec, None)
+    assert not ok and "no eval scores available" in reason
+
+
+def test_gate_eval_model_override():
+    # run model is gpt-oss:20b but competence is checked against gemma (0.3 < 0.8)
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic",
+                    min_score=0.8, eval_task="think-02-prioritization",
+                    eval_model="gemma4:12b-it-qat")
+    ok, reason = gate(spec, _scored())
+    assert not ok and "below min_score" in reason
+
+
+def test_gate_no_min_score_ignores_scores():
+    # absent min_score = no gate (explicit pass-through, not a 0-threshold)
+    spec = TaskSpec("t", "ollama", "gpt-oss:20b", "deterministic")
+    ok, _ = gate(spec, None)
+    assert ok


### PR DESCRIPTION
Closes #200

## Description (Issue Fixed & New Behavior)

The empirical-competence gate: a registered task may require the model to have passed a pinned eval before it's delegated to a local model. Builds on B0 (#204), which made `grade.py` persist `out/scores.tsv`.

- `TaskSpec` gains optional `min_score` + `eval_task` + `eval_model`. `gate(spec, scores)` refuses unless the model's ratio on `eval_task` (from `scores.tsv`) meets `min_score`.
- **`eval_task` is REQUIRED when `min_score` is set** (`RegistryError` otherwise) — no aggregate-mean default, because averaging would let a model that fails the task that matters pass on the strength of unrelated tasks. `eval_task: "*"` explicitly opts into the cross-task mean.
- **Model-name normalization** mirrors `run.sh`'s `tr ':/' '.-'`: registry `gpt-oss:20b` → scores `gpt-oss.20b`. Only `:` and `/` transform, so a version dot (`mistral-small3.2`) survives. Tested round-trip.
- A **missing/unreadable score** for a `min_score` task is a refusal, not a silent pass (reject-don't-default). `total=0` rows carry no usable score → treated as missing.
- CLI loads `scores.tsv` (default `<repo>/evals/ollama-matrix/out/scores.tsv`, override `--scores`) and **warns — does not refuse — on stale scores** (`--scores-stale-days`, default 30).

## Testing Procedure

1. Check out this branch.
2. `cd ollama-agent && python3 -m pytest -q` → **124 passed** (14 new in `test_registry.py`).
3. Mutation: revert the `score < min_score` check, the `score is None` refusal, the `eval_task` requirement, or the `normalize_model` slash→dash → the matching test fails (verified: 4/4 fail cleanly; `total=0` omission has defense-in-depth via the numeric-parse guard, so the behavior — not the single line — is what's asserted).
4. Live CLI smoke (no ollama needed): a registered task with `min_score: 0.8, eval_task: think-03-contradiction` against a `scores.tsv` row of `0.2` →
   `REJECTED task 'weak-task': model 'gpt-oss.20b' scored 0.2000 … below min_score 0.8`, **exit 3, before any model call**.

## Additional Notes / HelpScout Tickets

The default design call (auditor-confirmed): `eval_task` pin required, not aggregate-mean — a governance gate must not average away a task-class failure. `shellcheck` CI is pre-existing-red on `./scripts` (this PR touches only `ollama-agent/` + `evals/`). Remaining epic #197 slices: C+D (#201, pattern-tracker; needs a run-id primitive on the bridge return) and G (#202, claude-mem).