### PR TITLE
Ingest hallucinated tool calls into pattern-tracker findings (epic #197 C)

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -70,6 +70,9 @@ def main(argv=None):
                         "(default: <repo>/evals/ollama-matrix/out/scores.tsv).")
     p.add_argument("--scores-stale-days", type=int, default=30,
                    help="Warn (do not refuse) if the eval scores are older than this.")
+    p.add_argument("--run-id", default=None,
+                   help="Caller-minted run identifier, echoed in the record so a "
+                        "downstream ingestion pass can dedup this run's findings.")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
     a = p.parse_args(argv)
 
@@ -169,7 +172,8 @@ def main(argv=None):
                       mcp_client=mcp_client, mcp_names=mcp_names)
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
     try:
-        rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap)
+        rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap,
+                        run_id=a.run_id)
     except RuntimeError as e:
         print(f"agent failed: {e}", file=sys.stderr)
         return 1

--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -17,12 +17,16 @@ def _normalize_args(raw):
     return {}
 
 
-def run_agent(task, system, transport, toolbox, tools, turn_cap=8):
+def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
     """Run one task to completion (a turn with no tool calls) or the turn cap.
 
     Returns a record: completed, turns, the full transcript, and the toolbox's
     call log + unknown-tool list so a hallucinated tool reads as a hallucination,
     not a silent capability loss.
+
+    `run_id` is an optional caller-minted identifier echoed back in the record so
+    a downstream ingestion pass can dedup this run's findings (the bridge itself
+    does not mint one — a standalone run leaves it None). Additive.
     """
     messages = [{"role": "system", "content": system},
                 {"role": "user", "content": task}]
@@ -56,6 +60,7 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8):
     return {
         "completed": completed,
         "turns": turns,
+        "run_id": run_id,
         "transcript": transcript,
         "calls": toolbox.calls,
         "unknown_calls": toolbox.unknown_calls,

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -108,6 +108,18 @@ def test_loop_dispatches_tools_then_finishes(tmp_path):
     assert rec["unknown_calls"] == []
 
 
+def test_run_id_echoed_in_record(tmp_path):
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, run_id="run-abc")
+    assert rec["run_id"] == "run-abc"
+
+
+def test_run_id_defaults_none(tmp_path):
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS)
+    assert rec["run_id"] is None
+
+
 def test_loop_respects_turn_cap(tmp_path):
     # Transport always asks for another tool call; a broken cap fails on the
     # turns assertion (not by running out of scripted responses).

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -23,10 +23,12 @@ def _stub(monkeypatch, captured):
     # run_agent receives so the test can assert what rule text was injected.
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: (lambda m, t: {"role": "assistant", "content": "ok"}))
 
-    def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8):
+    def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
         captured["system"] = system
         captured["tools"] = tools
-        return {"completed": True, "turns": 1, "transcript": [{"role": "assistant", "content": "done"}],
+        captured["run_id"] = run_id
+        return {"completed": True, "turns": 1, "run_id": run_id,
+                "transcript": [{"role": "assistant", "content": "done"}],
                 "calls": [], "unknown_calls": []}
     monkeypatch.setattr(cli, "run_agent", fake_run_agent)
 
@@ -45,6 +47,25 @@ def test_cli_injects_matching_rule(tmp_path, monkeypatch, capsys):
     assert "no-commit-tmp-logs" in captured["system"]
     err = capsys.readouterr().err
     assert "matched 1" in err and "no-commit-tmp-logs" in err
+
+
+def test_cli_threads_run_id_into_record(tmp_path, monkeypatch, capsys):
+    import json
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+                   "--run-id", "run-xyz", "--json"])
+    assert rc == 0
+    assert captured["run_id"] == "run-xyz"
+    assert json.loads(capsys.readouterr().out)["run_id"] == "run-xyz"
+
+
+def test_cli_run_id_defaults_none(tmp_path, monkeypatch, capsys):
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
+    assert rc == 0
+    assert captured["run_id"] is None
 
 
 def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
@@ -71,7 +92,7 @@ def test_cli_no_match_reports_zero(tmp_path, monkeypatch, capsys):
 def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
 
-    def boom(task, system, transport, toolbox, tools, turn_cap=8):
+    def boom(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
         raise RuntimeError("ollama unreachable")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", boom)

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -276,7 +276,7 @@ ALERTEOF
 # the panel's Phase-3.5 skip semantics.
 _ingest_hallucinated_calls() {
   local run_id="$1" task_label="$2" unknown_json="$3"
-  local jsonl
+  local jsonl jq_rc=0
   jsonl=$(printf '%s' "$unknown_json" | jq -c \
     --arg rid "$run_id" --arg task "$task_label" '
       to_entries[] | {
@@ -288,8 +288,14 @@ _ingest_hallucinated_calls() {
         line_no: .key,
         panel_variant: "local-agent",
         source: "ollama-agent"
-      }' 2>/dev/null)
-  [ -z "$jsonl" ] && return 0
+      }' 2>>"$LOG_DIR/cron-stderr.log") || jq_rc=$?
+  # The caller only invokes this when unknown_calls is non-empty, so an empty or
+  # failed construction means the findings were LOST — surface it (skip-WITH-
+  # notice), never conflate a jq error with "nothing to ingest".
+  if [ "$jq_rc" -ne 0 ] || [ -z "$jsonl" ]; then
+    echo "$(date): NOTICE — hallucinated-call finding construction failed (jq rc=$jq_rc) for $TRIGGER; finding(s) NOT persisted" >> "$LOG_DIR/cron-skips.log"
+    return 0
+  fi
 
   local pt_rc=0
   if [ -n "${CEO_PT_FINDING_CMD:-}" ]; then
@@ -1250,7 +1256,10 @@ if [ "$RUNNER" = "ollama-agent" ]; then
   # before the completion/gate exits so a failed-but-hallucinating run is still
   # recorded into the failure taxonomy.
   if [ "$_agent_unknown" -gt 0 ]; then
-    _ingest_hallucinated_calls "$AGENT_RUN_ID" "$AGENT_TASK" "$_agent_unknown_json"
+    # `|| true`: ingestion is observability — it must never alter the run's
+    # pass/fail verdict, even if the helper itself hits an unwritable log under
+    # set -e. The gate checks below are the sole authority on the run's outcome.
+    _ingest_hallucinated_calls "$AGENT_RUN_ID" "$AGENT_TASK" "$_agent_unknown_json" || true
   fi
 
   if [ "$_agent_completed" != "true" ]; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -259,6 +259,59 @@ ALERTEOF
   fi
 }
 
+# Ingest the bridge's hallucinated (unknown) tool calls into pattern-tracker's
+# findings taxonomy, so local-model behavior joins the same failure corpus the
+# PR-review panel feeds. A hallucinated call IS a real finding (category
+# hallucinated_tool_use) whether or not the run completed, so this runs before
+# the completion/gate checks.
+#
+# Idempotent: the finding_id pattern-tracker derives from (pr_url, file_path,
+# line_no, summary) embeds the run id (pr_url) and the call's index (line_no),
+# so re-ingesting the same run record never double-inserts and two distinct
+# calls never collapse. Reverting either half of that key breaks the idempotency
+# / distinctness tests.
+#
+# Never blocks the run: pattern-tracker is absent or erroring → skip with a
+# notice to cron-skips.log (it needs Python 3.10+ the host may not have). Mirrors
+# the panel's Phase-3.5 skip semantics.
+_ingest_hallucinated_calls() {
+  local run_id="$1" task_label="$2" unknown_json="$3"
+  local jsonl
+  jsonl=$(printf '%s' "$unknown_json" | jq -c \
+    --arg rid "$run_id" --arg task "$task_label" '
+      to_entries[] | {
+        pr_url: ("local-run://" + $rid),
+        severity: "MEDIUM",
+        summary: ("hallucinated tool call: " + ((.value // "(unnamed)") | tostring)),
+        category: "hallucinated_tool_use",
+        file_path: $task,
+        line_no: .key,
+        panel_variant: "local-agent",
+        source: "ollama-agent"
+      }' 2>/dev/null)
+  [ -z "$jsonl" ] && return 0
+
+  local pt_rc=0
+  if [ -n "${CEO_PT_FINDING_CMD:-}" ]; then
+    local _pt_cmd
+    read -r -a _pt_cmd <<< "$CEO_PT_FINDING_CMD"
+    printf '%s\n' "$jsonl" | "${_pt_cmd[@]}" >>"$LOG_DIR/cron-stderr.log" 2>&1 || pt_rc=$?
+  else
+    local pt_repo="${CEO_PT_REPO:-$HOME/ML-AI/claude/pattern-tracker}"
+    if [ ! -d "$pt_repo" ]; then
+      echo "$(date): NOTICE — pattern-tracker absent at $pt_repo; skipped ingesting hallucinated-call finding(s) for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
+      return 0
+    fi
+    local pt_db="${CEO_PT_DB:-$pt_repo/data/events.db}"
+    printf '%s\n' "$jsonl" \
+      | ( cd "$pt_repo" && python3 -m lib.pt_cli finding-add --db "$pt_db" ) \
+        >>"$LOG_DIR/cron-stderr.log" 2>&1 || pt_rc=$?
+  fi
+  if [ "$pt_rc" -ne 0 ]; then
+    echo "$(date): NOTICE — pattern-tracker ingest failed (rc=$pt_rc) for $TRIGGER; hallucinated-call finding(s) NOT persisted" >> "$LOG_DIR/cron-skips.log"
+  fi
+}
+
 _release_lock() {
   if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
     exec 200>&- 2>/dev/null || true
@@ -1164,10 +1217,15 @@ if [ "$RUNNER" = "ollama-agent" ]; then
     _agent_cmd=(python3 "$CEO_REPO_ROOT/ollama-agent/cli.py")
   fi
 
-  _v "Runner: ollama-agent — bridge task '$AGENT_TASK' (tier:$_ceo_tier)"
+  # Cron mints the run id and threads it to the bridge (the bridge has no clock
+  # of its own and leaves run_id None on a standalone run). It is the dedup
+  # anchor for the post-run findings ingestion below. Overridable for tests.
+  AGENT_RUN_ID="${CEO_AGENT_RUN_ID:-${TRIGGER}-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+
+  _v "Runner: ollama-agent — bridge task '$AGENT_TASK' (tier:$_ceo_tier, run:$AGENT_RUN_ID)"
   AGENT_RC=0
   AGENT_OUT=$("${_agent_cmd[@]}" --task "$AGENT_PROMPT" --task-name "$AGENT_TASK" \
-    --registry "$AGENT_REGISTRY" --json 2>>"$LOG_DIR/cron-stderr.log") || AGENT_RC=$?
+    --registry "$AGENT_REGISTRY" --run-id "$AGENT_RUN_ID" --json 2>>"$LOG_DIR/cron-stderr.log") || AGENT_RC=$?
 
   if [ "$AGENT_RC" -ne 0 ]; then
     _record_failure "ollama-agent bridge exited $AGENT_RC for $TRIGGER"
@@ -1185,7 +1243,15 @@ if [ "$RUNNER" = "ollama-agent" ]; then
     exit 1
   fi
   _agent_completed=$(printf '%s' "$AGENT_OUT" | jq -r '.completed // false')
-  _agent_unknown=$(printf '%s' "$AGENT_OUT" | jq -r '(.unknown_calls // []) | length')
+  _agent_unknown_json=$(printf '%s' "$AGENT_OUT" | jq -c '.unknown_calls // []')
+  _agent_unknown=$(printf '%s' "$_agent_unknown_json" | jq -r 'length')
+
+  # A hallucinated call is a finding whether or not the run completed — ingest
+  # before the completion/gate exits so a failed-but-hallucinating run is still
+  # recorded into the failure taxonomy.
+  if [ "$_agent_unknown" -gt 0 ]; then
+    _ingest_hallucinated_calls "$AGENT_RUN_ID" "$AGENT_TASK" "$_agent_unknown_json"
+  fi
 
   if [ "$_agent_completed" != "true" ]; then
     _record_failure "ollama-agent task '$AGENT_TASK' did not complete for $TRIGGER"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4282,8 +4282,8 @@ _make_agent_stub() {
   cat > "$HOME/.bun/bin/agent-stub" << STUB
 #!/bin/bash
 case " \$* " in
-  *" --task "*" --task-name "*" --registry "*" --json "*) : ;;
-  *) echo "agent stub: unexpected argv (missing --task?): \$*" >&2; exit 97 ;;
+  *" --task "*" --task-name "*" --registry "*" --run-id "*" --json "*) : ;;
+  *) echo "agent stub: unexpected argv (missing --task/--run-id?): \$*" >&2; exit 97 ;;
 esac
 echo invoked >> "\$HOME/agent-invoked.txt"
 cat << 'AGENTJSON'
@@ -4311,6 +4311,117 @@ registry: $CEO_DIR/bridge-registry.json
 ---
 # body
 PB
+}
+
+# Faithful reproduction of pattern-tracker finding-add's dedup CONTRACT: one row
+# per distinct (pr_url|file_path|line_no|summary). pt hashes that 4-tuple into a
+# finding_id and INSERTs only on a new id; the stub stores the raw 4-tuple key —
+# the dedup behavior is identical, without coupling the test to sha1 internals.
+# Argv-validates --db (stub-cli-argv-validation). The "db" is a flat file, one
+# unique key per line, so the test just counts lines.
+_make_pt_stub() {
+  PT_STUB_DB="$HOME/pt-stub-db.txt"
+  cat > "$HOME/.bun/bin/pt-stub" << 'STUB'
+#!/bin/bash
+db=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --db) db="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -z "$db" ] && { echo "pt-stub: missing --db" >&2; exit 99; }
+touch "$db"
+ins=0; dup=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  key=$(printf '%s' "$line" | jq -r '[.pr_url, .file_path, (.line_no|tostring), .summary] | join("|")')
+  if grep -qxF "$key" "$db" 2>/dev/null; then
+    dup=$((dup + 1))
+  else
+    printf '%s\n' "$key" >> "$db"
+    ins=$((ins + 1))
+  fi
+done
+echo "inserted=$ins skipped_dup=$dup"
+STUB
+  chmod +x "$HOME/.bun/bin/pt-stub"
+  export CEO_PT_FINDING_CMD="$HOME/.bun/bin/pt-stub --db $PT_STUB_DB"
+}
+
+test_runner_ollama_agent_ingests_hallucinated_calls() {
+  _register_agent_pb agent-ingest low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["make_coffee", "teleport"]}'
+  _make_pt_stub
+  export CEO_AGENT_RUN_ID="run-ingest-1"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-ingest >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "2" "both hallucinated calls must be ingested as findings"
+  assert_contains "$(cat "$PT_STUB_DB" 2>/dev/null)" "local-run://run-ingest-1|agent-ingest|0|hallucinated tool call: make_coffee" "finding must embed run id (pr_url) + call index (line_no) + name"
+  unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_ingest_idempotent_across_reingest() {
+  # Dedup key = run_id (pr_url) + call index (line_no). Re-ingesting the SAME run
+  # must not double-insert, and two calls with the SAME name must stay distinct
+  # via their index. Revert either half of the key and this assertion fails.
+  _register_agent_pb agent-idem low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["make_coffee", "make_coffee", "teleport"]}'
+  _make_pt_stub
+  export CEO_AGENT_RUN_ID="run-idem-1"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-idem >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "3" "3 calls (one name repeated) must be 3 distinct findings via index"
+  bash "$CRON" agent-idem >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "3" "re-ingesting the same run must not double-insert (idempotent on run_id+index)"
+  unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_clean_run_ingests_nothing() {
+  _register_agent_pb agent-clean low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 2, "calls": [], "unknown_calls": []}'
+  _make_pt_stub
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-clean >/dev/null 2>&1 || true
+  local _rows
+  _rows=$([ -f "$PT_STUB_DB" ] && wc -l < "$PT_STUB_DB" | tr -d ' ' || echo 0)
+  assert_eq "$_rows" "0" "a clean run (no unknown_calls) must ingest nothing"
+}
+
+test_runner_ollama_agent_ingest_skips_when_pt_absent() {
+  # pattern-tracker absent must never block the run — skip with a notice. The run
+  # still fails its gate (unknown_calls), but on the gate, not on a missing pt.
+  _register_agent_pb agent-noptt low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["bogus_tool"]}'
+  unset CEO_PT_FINDING_CMD
+  export CEO_PT_REPO="$HOME/no-such-pattern-tracker"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-noptt >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] hallucinated run must still fail its gate even when pt is absent\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "pattern-tracker absent" "pt-absent must log a skip notice"
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unknown tool call" "the gate failure must still be recorded"
+  unset CEO_PT_REPO
+}
+
+test_runner_ollama_agent_ingest_skips_on_pt_failure() {
+  _register_agent_pb agent-ptfail low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["bogus_tool"]}'
+  cat > "$HOME/.bun/bin/pt-fail" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+echo "pt boom" >&2
+exit 1
+STUB
+  chmod +x "$HOME/.bun/bin/pt-fail"
+  export CEO_PT_FINDING_CMD="$HOME/.bun/bin/pt-fail --db /tmp/x"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-ptfail >/dev/null 2>&1 || true
+  assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "ingest failed" "a pt ingest failure must log a notice, never crash the run"
+  unset CEO_PT_FINDING_CMD
 }
 
 test_runner_ollama_agent_success() {
@@ -4343,7 +4454,7 @@ test_runner_ollama_agent_high_stakes_refused_before_dispatch() {
 
 test_runner_ollama_agent_hallucinated_calls_is_failure() {
   _register_agent_pb agent-halluc low-stakes-write
-  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": [{"name": "bogus_tool"}]}'
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["bogus_tool"]}'
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   local rc=0
   bash "$CRON" agent-halluc >/dev/null 2>&1 || rc=$?

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4327,7 +4327,7 @@ db=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --db) db="$2"; shift 2 ;;
-    *) shift ;;
+    *) echo "pt-stub: unexpected argv: $1" >&2; exit 99 ;;
   esac
 done
 [ -z "$db" ] && { echo "pt-stub: missing --db" >&2; exit 99; }
@@ -4372,9 +4372,59 @@ test_runner_ollama_agent_ingest_idempotent_across_reingest() {
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
   bash "$CRON" agent-idem >/dev/null 2>&1 || true
   assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "3" "3 calls (one name repeated) must be 3 distinct findings via index"
-  bash "$CRON" agent-idem >/dev/null 2>&1 || true
+  # CEO_FORCE=1 bypasses the per-trigger "last run too recent" guard so the
+  # second run genuinely re-executes and re-ingests — otherwise this assertion
+  # is vacuous (the run would be skipped, not deduped).
+  CEO_FORCE=1 bash "$CRON" agent-idem >/dev/null 2>&1 || true
   assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "3" "re-ingesting the same run must not double-insert (idempotent on run_id+index)"
   unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_ingests_even_when_incomplete() {
+  # The ingest runs BEFORE the completion gate, so a hallucinating-but-incomplete
+  # run still records its findings. Move the ingest call below the incomplete gate
+  # and this assertion drops to 0 rows.
+  _register_agent_pb agent-inchal low-stakes-write
+  _make_agent_stub '{"completed": false, "turns": 8, "calls": [], "unknown_calls": ["bogus_tool"]}'
+  _make_pt_stub
+  export CEO_AGENT_RUN_ID="run-inchal-1"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-inchal >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] an incomplete run must still exit non-zero\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "1" "a hallucinating-but-incomplete run must still ingest the finding (ingest precedes the gate exit)"
+  unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_ingests_null_unknown_call() {
+  # agent.py appends None for a malformed tool-call envelope (no function name),
+  # so unknown_calls can contain null. It must still ingest, rendered (unnamed).
+  _register_agent_pb agent-null low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": [null, "teleport"]}'
+  _make_pt_stub
+  export CEO_AGENT_RUN_ID="run-null-1"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-null >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "2" "a null (malformed-envelope) unknown_call must still ingest as a finding"
+  assert_contains "$(cat "$PT_STUB_DB" 2>/dev/null)" "hallucinated tool call: (unnamed)" "a null name must render as (unnamed)"
+  unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_distinct_runs_not_deduped() {
+  # The run_id half of the dedup key: two DIFFERENT runs with identical call
+  # names/indices must NOT collide. Drop run_id from pr_url and this drops to 2.
+  _register_agent_pb agent-tworun low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["make_coffee", "teleport"]}'
+  _make_pt_stub
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  # CEO_FORCE=1 on the second run bypasses the per-trigger interval guard so both
+  # runs actually execute (same trigger, back-to-back).
+  CEO_AGENT_RUN_ID="run-A" bash "$CRON" agent-tworun >/dev/null 2>&1 || true
+  CEO_FORCE=1 CEO_AGENT_RUN_ID="run-B" bash "$CRON" agent-tworun >/dev/null 2>&1 || true
+  assert_eq "$(wc -l < "$PT_STUB_DB" 2>/dev/null | tr -d ' ')" "4" "two distinct runs with identical calls must produce 4 findings (run_id half of the dedup key)"
 }
 
 test_runner_ollama_agent_clean_run_ingests_nothing() {


### PR DESCRIPTION
Closes #201

## Description (Issue Fixed & New Behavior)

Slice C of epic #197. Wires the ollama-agent bridge's **unknown (hallucinated) tool calls** into pattern-tracker's `findings` taxonomy, so local-model behavior joins the same failure corpus the PR-review panel feeds. A hallucinated tool call is a real finding (category `hallucinated_tool_use`).

**Bridge (additive):**
- `run_agent` gains an optional caller-minted `run_id`, echoed in the record. A standalone run leaves it `None` — the bridge has no clock of its own. Existing callers/tests unaffected.
- `cli.py` exposes `--run-id`.

**Cron (the integration point):**
- `ceo-cron` mints a `run_id` at dispatch (`CEO_AGENT_RUN_ID`-overridable), threads it to the bridge via `--run-id`, and after the run ingests each `unknown_call` as a finding — **before** the completion/gate exits, so a failed-but-hallucinating run is still recorded.
- **Idempotent.** The `finding_id` pattern-tracker derives from `(pr_url, file_path, line_no, summary)` embeds the `run_id` (in `pr_url`) and the call index (in `line_no`). Re-ingesting the same run never double-inserts; two same-named calls stay distinct via their index. Both halves mutation-verified (revert either → the idempotency/distinctness test fails).
- **Never blocks the run.** pattern-tracker absent or erroring → skip with a notice to `cron-skips.log` (it requires Python 3.10+ the host may lack), mirroring the panel's Phase-3.5 skip semantics. Ingest command configurable via `CEO_PT_FINDING_CMD` / `CEO_PT_REPO` / `CEO_PT_DB`.

Also corrects an unfaithful test fixture: `unknown_calls` were modeled as objects (`[{"name": ...}]`); production emits **strings** (`tools.py`, `agent.py`) — fixed to match (`test-reproduces-production-conditions`).

**Scope note:** the D half (`rules_loaded_hash → events`) is deferred to #207 — it needs an `event-add` verb that pt_cli does not yet expose (`events` is currently mined from transcripts, not added).

## Testing Procedure
1. Check out this branch.
2. `python3 -m pytest ollama-agent/tests -q` → 139 pass (incl. 4 new `run_id` round-trip tests in `test_agent.py` / `test_cli.py`).
3. `TEST_FILTER=ollama_agent bash scripts/ceo-cron.test.sh` → 13 pass (8 existing + 5 new: ingest, idempotent-reingest, clean-run-noop, pt-absent skip, pt-failure skip).
4. Mutation check (dedup key): in `_ingest_hallucinated_calls`, change `line_no: .key` → `line_no: 0` → `test_runner_ollama_agent_ingest_idempotent_across_reingest` fails (3→2). Revert. Change the `pr_url` `$rid` → a constant → `test_runner_ollama_agent_ingests_hallucinated_calls` fails. Revert.
5. `shellcheck --severity=warning scripts/ceo-cron.sh` → clean.

## Additional Notes / HelpScout Tickets
The pt stub in the tests faithfully reproduces pattern-tracker's dedup *contract* (one row per distinct 4-tuple) and argv-validates `--db`, rather than coupling to sha1 internals. Part of #197 (slices A/B0/B already merged).