### PR TITLE
Add local-model harness integration + smoke test

### DIFF
--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -65,9 +65,9 @@ The bridge is one of three ways to put a local ollama model behind a harness:
 
 | Command | Harness | Tools | Use for |
 |---------|---------|-------|---------|
-| `oll "task"` | the bridge (this dir) | 6 native + skills + 1 MCP (`--mcp`) | autonomous bounded local work; broad MCP via `--mcp` |
+| `oll "task"` | the bridge (this dir) | 5 native + `use_skill` + 1 MCP (`--mcp`) | autonomous bounded local work; broad MCP via `--mcp` |
 | `oll` | codex REPL | codex's | interactive read/explore |
-| `oll-code` | **real Claude Code** via [claude-code-router](https://github.com/musistudio/claude-code-router) → ollama | curated always-loaded set (~24) | the full Claude harness on a local model |
+| `oll-code` | **real Claude Code** via [claude-code-router](https://github.com/musistudio/claude-code-router) → ollama | curated always-loaded set (capped below the ~25 ceiling) | the full Claude harness on a local model |
 
 `oll-code` routes Claude Code's Anthropic API through ccr to ollama's OpenAI
 endpoint. ccr needs the `ollama-compat` transformer (`use: ["openai",

--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -59,8 +59,32 @@ There is no command allowlist or path jail yet; per-task tool restriction and
 safe-delegation tiering arrive in the governance slice (#190). Until then, treat this
 as a deliberately-invoked local tool: you choose `--cwd` and the model you trust.
 
+## Driving a local model three ways
+
+The bridge is one of three ways to put a local ollama model behind a harness:
+
+| Command | Harness | Tools | Use for |
+|---------|---------|-------|---------|
+| `oll "task"` | the bridge (this dir) | 6 native + skills + 1 MCP (`--mcp`) | autonomous bounded local work; broad MCP via `--mcp` |
+| `oll` | codex REPL | codex's | interactive read/explore |
+| `oll-code` | **real Claude Code** via [claude-code-router](https://github.com/musistudio/claude-code-router) → ollama | curated always-loaded set (~24) | the full Claude harness on a local model |
+
+`oll-code` routes Claude Code's Anthropic API through ccr to ollama's OpenAI
+endpoint. ccr needs the `ollama-compat` transformer (`use: ["openai",
+"ollama-compat", ["maxtoken", …]]`): the `openai` transformer carries the tools
+array (a bare custom transformer list makes ccr drop it), and `ollama-compat`
+strips `thinking`/`reasoning` and caps the tool count.
+
+**Tool ceiling (measured):** Claude Code exposes 100+ tools; past ~25 a local
+model stops emitting structured `tool_calls` and dumps the call into `content`
+as text, breaking the loop. Native tool-search (deferring tools behind a
+`ToolSearch` tool) wires all tools but **no installed local model drives it** —
+gpt-oss:20b refuses, deepseek-r1:70b hallucinates calls. So `oll-code` defaults
+to a curated always-loaded set; for broad MCP with a local model, use the bridge.
+
 ## Tests
 
 ```bash
-python -m pytest ollama-agent/tests -q   # logic tests, no daemon needed
+python -m pytest ollama-agent/tests -q          # logic tests, no daemon needed
+bash ollama-agent/tests/integration_smoke.sh    # live stack: bridge + ccr + oll-code (guarded, self-skips)
 ```

--- a/ollama-agent/tests/integration_smoke.sh
+++ b/ollama-agent/tests/integration_smoke.sh
@@ -10,12 +10,18 @@
 #   OLL_MODEL=gpt-oss:20b bash ollama-agent/tests/integration_smoke.sh
 set -uo pipefail
 
+# Required harness tooling. A missing one is a distinct error (exit 2), NOT an
+# all-SKIP green run that would hide that nothing was exercised.
+for t in curl mktemp python3; do
+  command -v "$t" >/dev/null 2>&1 || { echo "missing required tool: $t" >&2; exit 2; }
+done
+
 MODEL="${OLL_MODEL:-gpt-oss:20b}"
 OLLAMA="${OLLAMA_HOST:-http://127.0.0.1:11434}"
 CCR="${CCR_URL:-http://127.0.0.1:3456}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BRIDGE="$REPO_ROOT/ollama-agent/cli.py"
-PY="${OLL_PY:-/opt/anaconda3/bin/python}"
+PY="${OLL_PY:-$(command -v python3 || command -v python)}"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -27,13 +33,25 @@ section() { printf '\n\033[1m%s\033[0m\n' "$1"; }
 
 have() { command -v "$1" >/dev/null 2>&1; }
 ollama_up() { curl -s -m 5 "$OLLAMA/api/tags" 2>/dev/null | grep -q '"models"'; }
-model_present() { curl -s -m 5 "$OLLAMA/api/tags" 2>/dev/null | grep -q "\"$MODEL\""; }
+model_present() { curl -s -m 5 "$OLLAMA/api/tags" 2>/dev/null | grep -q "\"name\":\"$MODEL\""; }
 ccr_up() { curl -s -m 5 "$CCR/" >/dev/null 2>&1 || curl -s -m 5 "$CCR/v1/messages" -X POST -d '{}' >/dev/null 2>&1; }
 
-anthropic_msg() { # $1=json body -> response body on stdout
+anthropic_msg() { # $1=json body -> raw response body on stdout (incl. transport errors)
   curl -s -m 120 "$CCR/v1/messages" \
     -H 'content-type: application/json' -H 'x-api-key: test' \
     -H 'anthropic-version: 2023-06-01' -d "$1" 2>&1
+}
+
+# Extract only the assistant's content text from an Anthropic response. Asserting
+# against this (not the raw body) prevents a false-green when an error envelope
+# echoes the request prompt back — only a real completion populates content[].text.
+msg_text() {
+  python3 -c "import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(''.join(b.get('text','') for b in d.get('content',[]) if isinstance(b,dict)))
+except Exception:
+    pass" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -53,10 +71,10 @@ elif [ ! -x "$PY" ]; then
   skip "bridge edit" "python not at $PY (set OLL_PY)"
 else
   printf 'alpha\nbeta\ngamma\n' > "$WORK/b.txt"
-  "$PY" "$BRIDGE" --model "$MODEL" --cwd "$WORK" --no-rules --no-skills --turn-cap 6 \
-    --task "Edit b.txt: change 'beta' to 'BETA-OK'. Read it then write it back." >/dev/null 2>&1
+  BOUT=$("$PY" "$BRIDGE" --model "$MODEL" --cwd "$WORK" --no-rules --no-skills --turn-cap 6 \
+    --task "Edit b.txt: change 'beta' to 'BETA-OK'. Read it then write it back." 2>&1)
   if grep -q "BETA-OK" "$WORK/b.txt"; then pass "bridge edited a file via native tools"; else
-    fail "bridge edit did not land (b.txt unchanged)"; fi
+    fail "bridge edit did not land ($(printf '%s' "$BOUT" | tail -c 140))"; fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -70,14 +88,14 @@ else
   # reasoning before the visible answer, so the cap must be generous or the
   # response truncates (stop_reason=max_tokens, empty content) before "PONG".
   R=$(anthropic_msg "{\"model\":\"ollama,$MODEL\",\"max_tokens\":1024,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: PONG\"}]}")
-  if echo "$R" | grep -qi "PONG"; then pass "ccr chat round-trip"; else
+  if printf '%s' "$R" | msg_text | grep -qi "PONG"; then pass "ccr chat round-trip"; else
     fail "ccr chat round-trip ($(echo "$R" | head -c 140))"; fi
 
   # thinking field must not 400
   R=$(anthropic_msg "{\"model\":\"ollama,$MODEL\",\"max_tokens\":1024,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: PONG\"}]}")
   if echo "$R" | grep -qi "does not support thinking"; then
     fail "thinking-strip: ollama 400'd on thinking field"
-  elif echo "$R" | grep -qi "PONG"; then pass "ccr thinking-strip (no 400)"; else
+  elif printf '%s' "$R" | msg_text | grep -qi "PONG"; then pass "ccr thinking-strip (no 400)"; else
     fail "thinking-strip: unexpected ($(echo "$R" | head -c 140))"; fi
 
   # tool round-trip via real claude -p (single tool call = deterministic plumbing)

--- a/ollama-agent/tests/integration_smoke.sh
+++ b/ollama-agent/tests/integration_smoke.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# integration_smoke.sh — live, end-to-end verification of the local-model stack:
+#   bridge (oll)  ·  claude-code-router (ccr)  ·  oll-code (real Claude Code on ollama)
+#
+# Every check guards its own prerequisites and SKIPs (not fails) when a service
+# is absent, so this is safe to run anywhere. Exit code is non-zero only on a
+# real FAIL. Not a unit test — it hits live ollama/ccr/claude and is slow.
+#
+#   bash ollama-agent/tests/integration_smoke.sh
+#   OLL_MODEL=gpt-oss:20b bash ollama-agent/tests/integration_smoke.sh
+set -uo pipefail
+
+MODEL="${OLL_MODEL:-gpt-oss:20b}"
+OLLAMA="${OLLAMA_HOST:-http://127.0.0.1:11434}"
+CCR="${CCR_URL:-http://127.0.0.1:3456}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BRIDGE="$REPO_ROOT/ollama-agent/cli.py"
+PY="${OLL_PY:-/opt/anaconda3/bin/python}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+skip() { printf '  \033[33mSKIP\033[0m %s (%s)\n' "$1" "$2"; SKIP=$((SKIP+1)); }
+section() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+ollama_up() { curl -s -m 5 "$OLLAMA/api/tags" 2>/dev/null | grep -q '"models"'; }
+model_present() { curl -s -m 5 "$OLLAMA/api/tags" 2>/dev/null | grep -q "\"$MODEL\""; }
+ccr_up() { curl -s -m 5 "$CCR/" >/dev/null 2>&1 || curl -s -m 5 "$CCR/v1/messages" -X POST -d '{}' >/dev/null 2>&1; }
+
+anthropic_msg() { # $1=json body -> response body on stdout
+  curl -s -m 120 "$CCR/v1/messages" \
+    -H 'content-type: application/json' -H 'x-api-key: test' \
+    -H 'anthropic-version: 2023-06-01' -d "$1" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+section "Prerequisites"
+if ollama_up; then pass "ollama daemon reachable at $OLLAMA"; else
+  skip "ollama daemon" "not reachable at $OLLAMA"; fi
+if ollama_up && model_present; then pass "model $MODEL present"; else
+  ollama_up && skip "model $MODEL" "not pulled"; fi
+
+# ---------------------------------------------------------------------------
+section "Bridge (oll) — native ollama tool API"
+if ! ollama_up || ! model_present; then
+  skip "bridge edit" "ollama/model unavailable"
+elif [ ! -f "$BRIDGE" ]; then
+  skip "bridge edit" "bridge not found at $BRIDGE"
+elif [ ! -x "$PY" ]; then
+  skip "bridge edit" "python not at $PY (set OLL_PY)"
+else
+  printf 'alpha\nbeta\ngamma\n' > "$WORK/b.txt"
+  "$PY" "$BRIDGE" --model "$MODEL" --cwd "$WORK" --no-rules --no-skills --turn-cap 6 \
+    --task "Edit b.txt: change 'beta' to 'BETA-OK'. Read it then write it back." >/dev/null 2>&1
+  if grep -q "BETA-OK" "$WORK/b.txt"; then pass "bridge edited a file via native tools"; else
+    fail "bridge edit did not land (b.txt unchanged)"; fi
+fi
+
+# ---------------------------------------------------------------------------
+section "ccr proxy — chat + thinking strip + tool round-trip"
+if ! ccr_up; then
+  skip "ccr chat" "ccr not reachable at $CCR (run: ccr start)"
+  skip "ccr thinking-strip" "ccr down"
+  skip "ccr tool round-trip" "ccr down"
+else
+  # chat round-trip. gpt-oss and other reasoning models spend output tokens on
+  # reasoning before the visible answer, so the cap must be generous or the
+  # response truncates (stop_reason=max_tokens, empty content) before "PONG".
+  R=$(anthropic_msg "{\"model\":\"ollama,$MODEL\",\"max_tokens\":1024,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: PONG\"}]}")
+  if echo "$R" | grep -qi "PONG"; then pass "ccr chat round-trip"; else
+    fail "ccr chat round-trip ($(echo "$R" | head -c 140))"; fi
+
+  # thinking field must not 400
+  R=$(anthropic_msg "{\"model\":\"ollama,$MODEL\",\"max_tokens\":1024,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: PONG\"}]}")
+  if echo "$R" | grep -qi "does not support thinking"; then
+    fail "thinking-strip: ollama 400'd on thinking field"
+  elif echo "$R" | grep -qi "PONG"; then pass "ccr thinking-strip (no 400)"; else
+    fail "thinking-strip: unexpected ($(echo "$R" | head -c 140))"; fi
+
+  # tool round-trip via real claude -p (single tool call = deterministic plumbing)
+  if have claude; then
+    printf 'WATERMELON\n' > "$WORK/probe.txt"
+    OUT=$(ANTHROPIC_BASE_URL="$CCR" ANTHROPIC_API_KEY="test" ANTHROPIC_MODEL="ollama,$MODEL" \
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS="4096" \
+      claude -p "Read $WORK/probe.txt and tell me the single word inside it." \
+      --model "ollama,$MODEL" --dangerously-skip-permissions 2>&1)
+    if echo "$OUT" | grep -qi "WATERMELON"; then pass "ccr tool round-trip (claude -p read a file)"; else
+      fail "ccr tool round-trip ($(echo "$OUT" | grep -iv connectors | head -c 140))"; fi
+  else
+    skip "ccr tool round-trip" "claude CLI not installed"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+section "oll-code — real Claude Code harness on the local model"
+if ! ccr_up || ! have claude; then
+  skip "oll-code" "ccr or claude unavailable"
+elif ! have oll-code; then
+  skip "oll-code" "oll-code not on PATH"
+else
+  # Default oll-code: curated always-loaded toolset (ccr ollama-compat cap), no
+  # tool-search — local models don't drive ToolSearch reliably (gpt-oss refuses,
+  # deepseek hallucinates), so deferred tools are unreachable. Read is in the
+  # always-loaded core, so this exercises the real harness end to end.
+  printf 'WATERMELON\n' > "$WORK/probe.txt"
+  OUT=$(oll-code -p "Read $WORK/probe.txt and tell me the single word inside it." \
+    --dangerously-skip-permissions 2>&1)
+  if echo "$OUT" | grep -qi "WATERMELON"; then
+    pass "oll-code read a file (curated toolset)"
+  else
+    fail "oll-code read ($(echo "$OUT" | grep -iv connectors | head -c 140))"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+section "Summary"
+printf 'PASS=%d  FAIL=%d  SKIP=%d\n' "$PASS" "$FAIL" "$SKIP"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Description

Makes a local ollama model usable behind a full harness, three ways, and adds a guarded end-to-end smoke test.

- **`oll "task"`** — the existing bridge (native ollama tool API; 6 tools + skills + 1 MCP via `--mcp`).
- **`oll`** — codex REPL on a local model (read/explore).
- **`oll-code`** — the **real Claude Code** harness with a local model as the brain, routed through claude-code-router (ccr). Inherits Claude Code's tools/hooks/MCP/subagents.

The ccr integration needs the `ollama-compat` transformer in `use: ["openai", "ollama-compat", ["maxtoken", …]]`:
- the built-in `openai` transformer carries the tools array (a bare custom transformer list makes ccr silently drop it),
- `ollama-compat` strips `thinking`/`reasoning` (ollama 400s on non-reasoning models) and caps the tool count.

**Measured tool ceiling:** Claude Code exposes 100+ tools; past ~25 a local model stops emitting structured `tool_calls` and dumps the call into `content` as text (runaway). Native tool-search defers tools behind a `ToolSearch` tool, which wires all tools but **no installed local model drives it** (gpt-oss:20b refuses; deepseek-r1:70b hallucinates calls + fabricates results). So `oll-code` defaults to a curated always-loaded set; broad MCP for local models goes through the bridge.

Repo change is scoped to docs + tests; `oll`/`oll-code`/`ollama-compat`/ccr config are machine-local.

## Testing Procedure
1. Check out this branch.
2. `cd ollama-agent && conda run -n base python -m pytest tests -q` — expect 141 passed.
3. `bash ollama-agent/tests/integration_smoke.sh` — with ollama + ccr + `oll-code` present, expect 7 PASS; otherwise the missing-service checks SKIP (never FAIL). Exit is non-zero only on a real FAIL.
4. `shellcheck ollama-agent/tests/integration_smoke.sh` — clean.

## Additional Notes
Related to the ollama-agent epic (#197). Verified end-to-end: `oll-code` read a file and performed an edit through the full Claude Code harness on gpt-oss:20b.