### PR TITLE
ticket-triage-autopilot: restore frequent silent schedule + green the shellcheck CI

### DIFF
--- a/docs/playbooks/ticket-triage-autopilot.md
+++ b/docs/playbooks/ticket-triage-autopilot.md
@@ -2,7 +2,7 @@
 name: ticket-triage-autopilot
 description: Refresh the portable ticket-triage cache per owner, then escalate newly-appeared high-priority tickets to inbox as one line each (transition-gated). Silent on no transition — no top-N append on a clock.
 trigger: cron
-schedule: "0 9,13,17 * * 1-5"
+schedule: "*/30 * * * *"
 preflight: none
 tier: low-stakes write
 status: active
@@ -21,7 +21,7 @@ Per owner (default `nhangen`), each tick:
 2. **`triage_surface.py <owner>`** (preview) — reads the high-priority tickets that have *newly appeared* since the last surface. One inbox line per new ticket (deduped by a `<!-- triage-surface:<slug>#<num> -->` marker).
 3. **`triage_surface.py <owner> --mark`** — consumes the transition, but **only after** the inbox write succeeded, so a failed append is retried next tick rather than lost (credential-rotation-atomicity ordering).
 
-State machine, not signal generator. A tick with no new high-priority transition writes only the state file + a log line. This is the anti-nag contract: surfacing fires on a transition (a high-priority ticket landing), never on a clock — the every-30-min v1 poller is gone.
+State machine, not signal generator. A tick with no new high-priority transition writes only the state file + a log line. This is the anti-nag contract: surfacing fires on a transition (a high-priority ticket landing), never on a clock. The detector still ticks often (every 30 min) to keep the cache fresh — frequent activity is fine because it is **silent**; what v1 got wrong was *appending to inbox on every merge*, not ticking often. The detector tick is a cheap `gh search` that exits when nothing is new; the agent recompute fires only for repos with real events.
 
 ## v1 → v2
 

--- a/scripts/ceo-cron-inputs.test.sh
+++ b/scripts/ceo-cron-inputs.test.sh
@@ -9,6 +9,7 @@ test_pregathered_emits_new_signals_when_inputs_list_them() {
   # _inputs_includes reads the module-scope INPUTS_JSON; set it directly.
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/ceo-cron-lib.sh"
+  # shellcheck disable=SC2034  # read by the sourced lib's module-scope functions
   INPUTS_JSON='["current_sprint","yesterday_merged","ledger_recent"]'
   export CURRENT_SPRINT_ITEMS='[{"number":7,"repo":"o/r","title":"S"}]'
   export CURRENT_SPRINT_COUNT=1

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Sourceable pure-function library for ceo-cron.sh. NO top-level side effects —
 # safe to `source` from tests. Functions read the caller's module-scope globals.
 

--- a/scripts/ceo-cron-lib.test.sh
+++ b/scripts/ceo-cron-lib.test.sh
@@ -16,6 +16,7 @@ test_inputs_includes_reads_inputs_json() {
 }
 
 test_inputs_includes_defaults_all_when_null() {
+  # shellcheck disable=SC2034  # read by the sourced lib's module-scope functions
   INPUTS_JSON="null"
   _inputs_includes anything && r=0 || r=1
   assert_eq "$r" "0" "null inputs → default-all (returns 0)"

--- a/scripts/ceo-cron-morning-fallback.test.sh
+++ b/scripts/ceo-cron-morning-fallback.test.sh
@@ -8,8 +8,12 @@ test_raw_digest_helper_emits_signals_when_synthesis_empty() {
   # Source the LIB (Task 0), not ceo-cron.sh.
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/ceo-cron-lib.sh"
+  # shellcheck disable=SC2034  # all three read by the sourced lib's module-scope functions
   CURRENT_SPRINT_ITEMS='[{"number":7,"repo":"o/r","title":"Sprint Y"}]'
-  PR_REVIEW_REQUESTED='[]'; DAILY_NOTE_TOP3="Write spec"
+  # shellcheck disable=SC2034
+  PR_REVIEW_REQUESTED='[]'
+  # shellcheck disable=SC2034
+  DAILY_NOTE_TOP3="Write spec"
   out=$(ceo_morning_raw_digest)
   assert_contains "$out" "Sprint Y" "digest includes sprint item"
   assert_contains "$out" "Write spec" "digest includes Top 3"


### PR DESCRIPTION
Closes #none

## Description

Two small follow-ups to #210:

1. **Schedule: `0 9,13,17 * * 1-5` → `*/30 * * * *`.** The over-firing we killed was the *inbox/Discord write on every merge*, not the cadence. v2 is silent (cache-only + transition-gated inbox line), so the detector should tick often to keep the cache fresh. The 3×/weekday I shipped was too quiet; restore frequent. Each tick is a cheap `gh search` that exits when nothing is new; the agent recompute only fires for repos with real events; the inbox only gets a line on a genuine high-priority transition.

2. **Green the `shellcheck` CI job** (was red on `main`, unrelated to triage):
   - `ceo-cron-lib.sh`: deliberately shebang-less sourced lib → add `# shellcheck shell=bash` (SC2148 error).
   - `ceo-cron-{inputs,lib,morning-fallback}.test.sh`: fixture vars read by the sourced lib's module-scope functions but hidden behind `source=/dev/null` → targeted `# shellcheck disable=SC2034`.

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning scripts/*.sh` → exits 0 (only info-level SC1091 remains, which the CI severity threshold ignores).
3. `for t in scripts/*.test.sh; do bash "$t"; done` → all pass (spot-checked ceo-cron-inputs, ceo-cron-lib, ceo-cron-morning-fallback, ceo-triage-autopilot).
4. Confirm `schedule: "*/30 * * * *"` and `status: active` in `docs/playbooks/ticket-triage-autopilot.md`.

## Additional Notes

Activation/scheduling is via the running `ceo-schedulerd` on ML-1 reading the host registry; takes effect after `ceo playbook scan` on ML-1 (per `ceo-scan-only-on-ml1`).