### PR TITLE
feat(ollama-agent): return rules_loaded_hash in the run record

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -6,6 +6,7 @@
 Slice 2 (#187): real shell/fs/git tools + task-relevant rule injection.
 """
 import argparse
+import hashlib
 import json
 import sys
 from datetime import datetime, timezone
@@ -123,8 +124,16 @@ def main(argv=None):
               file=sys.stderr)
 
     system = a.system
+    # rules_loaded_hash: a stable fingerprint of the EXACT injected rule block
+    # (sel.render() is the names + bodies + order that go into the system prompt),
+    # so a downstream correlation pass (epic #197 slice D) can ask which injected
+    # rule set changed local-model behavior. "none" when no rules are injected —
+    # distinct from a hash, so a rules-off run is its own bucket.
+    rules_loaded_hash = "none"
     if not a.no_rules:
         system, sel = compose_system(a.system, a.task, a.rules_dir, a.max_rules, a.rules_budget)
+        if sel.selected:
+            rules_loaded_hash = hashlib.sha256(sel.render().encode()).hexdigest()[:16]
         injected = ", ".join(r.name for r in sel.selected) or "(none matched)"
         # Counts make a zero-match a visible selection decision, not an apparent
         # load failure: "matched 0 of 64" reads differently than "rules dir empty".
@@ -180,6 +189,8 @@ def main(argv=None):
     finally:
         if mcp_transport:
             mcp_transport.close()
+
+    rec["rules_loaded_hash"] = rules_loaded_hash
 
     if a.json:
         print(json.dumps(rec, indent=2))

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -127,13 +127,17 @@ def main(argv=None):
     # rules_loaded_hash: a stable fingerprint of the EXACT injected rule block
     # (sel.render() is the names + bodies + order that go into the system prompt),
     # so a downstream correlation pass (epic #197 slice D) can ask which injected
-    # rule set changed local-model behavior. "none" when no rules are injected —
-    # distinct from a hash, so a rules-off run is its own bucket.
+    # rule set changed local-model behavior. Three distinct buckets, never folded:
+    # "none" — rules disabled (--no-rules); "no-match" — rules active but zero
+    # scored against the task (a selector-coverage signal, NOT the same condition
+    # as rules-off); a 16-hex hash — the specific rule set that was injected.
     rules_loaded_hash = "none"
     if not a.no_rules:
         system, sel = compose_system(a.system, a.task, a.rules_dir, a.max_rules, a.rules_budget)
         if sel.selected:
             rules_loaded_hash = hashlib.sha256(sel.render().encode()).hexdigest()[:16]
+        else:
+            rules_loaded_hash = "no-match"
         injected = ", ".join(r.name for r in sel.selected) or "(none matched)"
         # Counts make a zero-match a visible selection decision, not an apparent
         # load failure: "matched 0 of 64" reads differently than "rules dir empty".

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -81,6 +81,35 @@ def test_cli_run_id_defaults_none(tmp_path, monkeypatch, capsys):
     assert captured["run_id"] is None
 
 
+def test_cli_rules_loaded_hash_none_when_rules_off(tmp_path, monkeypatch, capsys):
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["rules_loaded_hash"] == "none"
+
+
+def test_cli_rules_loaded_hash_stable_and_content_sensitive(tmp_path, monkeypatch, capsys):
+    # The hash fingerprints the exact injected rule block (epic #197 slice D), so
+    # it must be a stable 16-hex digest for a fixed rule set and CHANGE when a
+    # selected rule's body changes — otherwise it can't attribute a behavior shift.
+    rules = _fixture_rules(tmp_path)
+    args = ["--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
+            "--rules-dir", str(rules), "--no-skills", "--json"]
+
+    _stub(monkeypatch, {})
+    cli.main(args); h1 = json.loads(capsys.readouterr().out)["rules_loaded_hash"]
+    assert len(h1) == 16 and all(c in "0123456789abcdef" for c in h1)
+
+    cli.main(args); h2 = json.loads(capsys.readouterr().out)["rules_loaded_hash"]
+    assert h1 == h2, "same rule set must yield the same hash"
+
+    # Change the selected rule's body → hash must differ.
+    (rules / "no-commit-tmp-logs.md").write_text(
+        "---\ndescription: never commit tmp log files\nglobs:\n---\n\n# no-commit-tmp-logs\n\nDIFFERENT body\n")
+    cli.main(args); h3 = json.loads(capsys.readouterr().out)["rules_loaded_hash"]
+    assert h3 != h1, "editing a selected rule's body must change the hash"
+
+
 def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
     captured = {}

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -131,6 +131,18 @@ def test_cli_no_match_reports_zero(tmp_path, monkeypatch, capsys):
     assert "matched 0" in err and "(none matched)" in err
 
 
+def test_cli_rules_loaded_hash_no_match_distinct_from_none(tmp_path, monkeypatch, capsys):
+    # Rules active but zero matched is "no-match", NOT "none" (--no-rules). The
+    # slice-D correlation pass must tell a selector-coverage gap apart from a
+    # rules-off run. Revert the `else: "no-match"` branch and this reads "none".
+    rules = _fixture_rules(tmp_path)
+    _stub(monkeypatch, {})
+    rc = cli.main(["--task", "paint the fence blue", "--cwd", str(tmp_path),
+                   "--rules-dir", str(rules), "--no-skills", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["rules_loaded_hash"] == "no-match"
+
+
 def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
 


### PR DESCRIPTION
Part of #197 (slice D, bridge half).

## Description
The bridge run record (`--json`) now includes `rules_loaded_hash`: a stable 16-hex SHA-256 of the exact injected rule block (`sel.render()` — the rule names, bodies, and order that enter the system prompt), or the literal `"none"` when no rules are injected (`--no-rules` or zero matched). This is the input fingerprint the slice-D correlation needs: the cron dispatch will emit one `pt event-add` per local run carrying this hash, so "which injected rule set changed local-model behavior" becomes answerable across runs.

## Testing Procedure
1. `cd ollama-agent && python -m pytest tests -q` → 150 passed.
2. New cases: `none` when rules off; 16-hex + **stable** across identical runs; **content-sensitive** (editing a selected rule's body changes the hash).
3. Mutation: revert `sel.render()` → `str(sel)` (the object repr) and the stability test fails.

## Additional Notes
Pairs with cc-pattern-tracker#11 (the `event-add` verb). Remaining slice-D piece: the cron dispatch emits the event per run.