### PR TITLE
feat(ceo-cron): emit a pattern-tracker event per ollama-agent run (slice D)

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -332,7 +332,7 @@ _ingest_hallucinated_calls() {
 # real grouping dimension.
 _emit_run_event() {
   local run_id="$1" task_label="$2" model="$3" agent_out="$4"
-  local branch row
+  local branch row pt_rc=0
   branch=$(cd "$SCRIPT_DIR/.." 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   row=$(printf '%s' "$agent_out" | jq -c \
     --arg rid "$run_id" --arg task "$task_label" --arg model "$model" \
@@ -353,7 +353,7 @@ _emit_run_event() {
   if [ -n "${CEO_PT_EVENT_CMD:-}" ]; then
     local _pt_cmd
     read -r -a _pt_cmd <<< "$CEO_PT_EVENT_CMD"
-    printf '%s\n' "$row" | "${_pt_cmd[@]}" >>"$LOG_DIR/cron-stderr.log" 2>&1 || true
+    printf '%s\n' "$row" | "${_pt_cmd[@]}" >>"$LOG_DIR/cron-stderr.log" 2>&1 || pt_rc=$?
   else
     local pt_repo="${CEO_PT_REPO:-$HOME/ML-AI/claude/pattern-tracker}"
     if [ ! -d "$pt_repo" ]; then
@@ -363,7 +363,10 @@ _emit_run_event() {
     local pt_db="${CEO_PT_DB:-$pt_repo/data/events.db}"
     printf '%s\n' "$row" \
       | ( cd "$pt_repo" && python3 -m lib.pt_cli event-add --db "$pt_db" ) \
-        >>"$LOG_DIR/cron-stderr.log" 2>&1 || true
+        >>"$LOG_DIR/cron-stderr.log" 2>&1 || pt_rc=$?
+  fi
+  if [ "$pt_rc" -ne 0 ]; then
+    echo "$(date): NOTICE — pattern-tracker event-add failed (rc=$pt_rc) for $TRIGGER; run event NOT persisted" >> "$LOG_DIR/cron-skips.log"
   fi
 }
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -318,6 +318,55 @@ _ingest_hallucinated_calls() {
   fi
 }
 
+# Emit one pattern-tracker `events` row per ollama-agent run (epic #197 slice D).
+# Observability only — every caller wraps it in `|| true`; it must never change a
+# run's verdict. Mapping onto the fixed events columns (per an audit):
+#   event_id/session_id = run_id (deterministic → INSERT OR IGNORE idempotent),
+#   tool_name = "ollama-agent:<task>" (namespaced so consumers can include/exclude
+#     the synthetic class via LIKE 'ollama-agent:%' and per-task grouping survives),
+#   rules_loaded_hash = the bridge's hash (// "none" — forward-compatible before the
+#     bridge ships it), exit_code = 0 ALWAYS (completion lives in error_tail, NOT
+#     exit_code, so these rows don't inflate `pt summary`'s headline error count),
+#   error_tail = compact JSON {run_id,model,completed,turns,calls,unknown}.
+# `plugin_or_skill` is left empty — overloading it with the model would corrupt a
+# real grouping dimension.
+_emit_run_event() {
+  local run_id="$1" task_label="$2" model="$3" agent_out="$4"
+  local branch row
+  branch=$(cd "$SCRIPT_DIR/.." 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  row=$(printf '%s' "$agent_out" | jq -c \
+    --arg rid "$run_id" --arg task "$task_label" --arg model "$model" \
+    --arg cwd "$CEO_DIR" --arg branch "$branch" '
+    {
+      event_id: $rid,
+      session_id: $rid,
+      tool_name: ("ollama-agent:" + $task),
+      rules_loaded_hash: (.rules_loaded_hash // "none"),
+      exit_code: 0,
+      cwd: $cwd,
+      branch: $branch,
+      error_tail: ({run_id: $rid, model: $model, completed: (.completed // false),
+                    turns: (.turns // 0), calls: ((.calls // []) | length),
+                    unknown: ((.unknown_calls // []) | length)} | tojson)
+    }' 2>>"$LOG_DIR/cron-stderr.log") || return 0
+  [ -z "$row" ] && return 0
+  if [ -n "${CEO_PT_EVENT_CMD:-}" ]; then
+    local _pt_cmd
+    read -r -a _pt_cmd <<< "$CEO_PT_EVENT_CMD"
+    printf '%s\n' "$row" | "${_pt_cmd[@]}" >>"$LOG_DIR/cron-stderr.log" 2>&1 || true
+  else
+    local pt_repo="${CEO_PT_REPO:-$HOME/ML-AI/claude/pattern-tracker}"
+    if [ ! -d "$pt_repo" ]; then
+      echo "$(date): NOTICE — pattern-tracker absent at $pt_repo; skipped event-add for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
+      return 0
+    fi
+    local pt_db="${CEO_PT_DB:-$pt_repo/data/events.db}"
+    printf '%s\n' "$row" \
+      | ( cd "$pt_repo" && python3 -m lib.pt_cli event-add --db "$pt_db" ) \
+        >>"$LOG_DIR/cron-stderr.log" 2>&1 || true
+  fi
+}
+
 _release_lock() {
   if command -v flock &>/dev/null && [ -z "${CEO_TEST_FORCE_MKDIR_LOCK:-}" ]; then
     exec 200>&- 2>/dev/null || true
@@ -1251,6 +1300,12 @@ if [ "$RUNNER" = "ollama-agent" ]; then
   _agent_completed=$(printf '%s' "$AGENT_OUT" | jq -r '.completed // false')
   _agent_unknown_json=$(printf '%s' "$AGENT_OUT" | jq -c '.unknown_calls // []')
   _agent_unknown=$(printf '%s' "$_agent_unknown_json" | jq -r 'length')
+
+  # Record one events row per run (epic #197 slice D) so a downstream pass can
+  # correlate the injected rule set (rules_loaded_hash) with completion. Fires on
+  # every parseable run — completed or not — and like the ingest below is pure
+  # observability: `|| true` so it never alters the run's pass/fail verdict.
+  _emit_run_event "$AGENT_RUN_ID" "$AGENT_TASK" "$MODEL" "$AGENT_OUT" || true
 
   # A hallucinated call is a finding whether or not the run completed — ingest
   # before the completion/gate exits so a failed-but-hallucinating run is still

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4353,6 +4353,28 @@ STUB
   export CEO_PT_FINDING_CMD="$HOME/.bun/bin/pt-stub --db $PT_STUB_DB"
 }
 
+# Stub for `pt event-add` (slice D run-event emit). Argv-validates --db
+# (stub-cli-argv-validation) and appends each emitted JSONL row verbatim so a
+# test can assert the row shape the cron dispatch built.
+_make_pt_event_stub() {
+  PT_EVENT_DB="$HOME/pt-event-db.txt"
+  cat > "$HOME/.bun/bin/pt-event-stub" << 'STUB'
+#!/bin/bash
+db=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --db) db="$2"; shift 2 ;;
+    *) echo "pt-event-stub: unexpected argv: $1" >&2; exit 99 ;;
+  esac
+done
+[ -z "$db" ] && { echo "pt-event-stub: missing --db" >&2; exit 99; }
+cat >> "$db"
+echo "inserted=1 skipped_dup=0 invalid=0"
+STUB
+  chmod +x "$HOME/.bun/bin/pt-event-stub"
+  export CEO_PT_EVENT_CMD="$HOME/.bun/bin/pt-event-stub --db $PT_EVENT_DB"
+}
+
 test_runner_ollama_agent_ingests_hallucinated_calls() {
   _register_agent_pb agent-ingest low-stakes-write
   _make_agent_stub '{"completed": true, "turns": 3, "calls": [], "unknown_calls": ["make_coffee", "teleport"]}'
@@ -4487,6 +4509,39 @@ test_runner_ollama_agent_success() {
   assert_eq "$rc" "0" "ollama-agent success must exit 0"
   [ -f "$HOME/agent-invoked.txt" ] || { printf '  FAIL [%s] bridge must be invoked on success\n' "$CURRENT_TEST"; FAILS=$((FAILS + 1)); }
   assert_contains "$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null)" "agent-ok completed" "success must record to cron-runs.log"
+}
+
+test_runner_ollama_agent_emits_run_event() {
+  # Slice D: every run emits one events row via pt event-add carrying the run id,
+  # namespaced tool_name, rules_loaded_hash, and a compact error_tail JSON.
+  # Revert the `_emit_run_event` call in ceo-cron.sh and this fails (no row).
+  _register_agent_pb agent-evt low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 3, "calls": [["run_shell",{}],["write_file",{}]], "unknown_calls": [], "rules_loaded_hash": "abc123def4567890"}'
+  _make_pt_event_stub
+  export CEO_AGENT_RUN_ID="run-evt-1"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-evt >/dev/null 2>&1 || true
+  local row; row=$(cat "$PT_EVENT_DB" 2>/dev/null)
+  assert_contains "$row" "\"tool_name\":\"ollama-agent:agent-evt\"" "tool_name must be namespaced ollama-agent:<task>"
+  assert_contains "$row" "\"session_id\":\"run-evt-1\"" "session_id must be the run id"
+  assert_contains "$row" "\"rules_loaded_hash\":\"abc123def4567890\"" "rules_loaded_hash must pass through from the bridge record"
+  assert_contains "$row" "\"exit_code\":0" "exit_code must be 0 — completion lives in error_tail, not exit_code"
+  unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_emits_event_even_on_non_completion() {
+  # The event must record runs that did NOT complete (that is the signal slice D
+  # correlates), even though the run itself is recorded as a failure.
+  _register_agent_pb agent-evt2 low-stakes-write
+  _make_agent_stub '{"completed": false, "turns": 8, "calls": [], "unknown_calls": []}'
+  _make_pt_event_stub
+  export CEO_AGENT_RUN_ID="run-evt-2"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-evt2 >/dev/null 2>&1 || true
+  local row; row=$(cat "$PT_EVENT_DB" 2>/dev/null)
+  assert_contains "$row" "\"session_id\":\"run-evt-2\"" "a non-completing run must still emit its event"
+  assert_contains "$row" "completed" "error_tail must carry the completion flag"
+  unset CEO_AGENT_RUN_ID
 }
 
 test_runner_ollama_agent_dispatches_with_cwd_in_vault() {

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4526,6 +4526,9 @@ test_runner_ollama_agent_emits_run_event() {
   assert_contains "$row" "\"session_id\":\"run-evt-1\"" "session_id must be the run id"
   assert_contains "$row" "\"rules_loaded_hash\":\"abc123def4567890\"" "rules_loaded_hash must pass through from the bridge record"
   assert_contains "$row" "\"exit_code\":0" "exit_code must be 0 — completion lives in error_tail, not exit_code"
+  assert_contains "$row" "\"event_id\":\"run-evt-1\"" "event_id must equal the run id — the INSERT OR IGNORE idempotency key (drop event_id: \$rid and this fails)"
+  assert_contains "$row" 'completed\":true' "error_tail must record completion"
+  assert_contains "$row" 'calls\":2' "error_tail must carry the tool-call count"
   unset CEO_AGENT_RUN_ID
 }
 
@@ -4540,8 +4543,31 @@ test_runner_ollama_agent_emits_event_even_on_non_completion() {
   bash "$CRON" agent-evt2 >/dev/null 2>&1 || true
   local row; row=$(cat "$PT_EVENT_DB" 2>/dev/null)
   assert_contains "$row" "\"session_id\":\"run-evt-2\"" "a non-completing run must still emit its event"
-  assert_contains "$row" "completed" "error_tail must carry the completion flag"
+  assert_contains "$row" 'completed\":false' "error_tail must record completed=false for a non-completing run (revert .completed // false and this fails)"
+  assert_contains "$row" 'turns\":8' "error_tail must carry the non-completing run's turn count"
   unset CEO_AGENT_RUN_ID
+}
+
+test_runner_ollama_agent_breadcrumb_on_event_add_failure() {
+  # A failed event-add must leave a grep-able NOTICE in cron-skips.log, not vanish
+  # into cron-stderr.log noise — a permanently-broken emit path must be detectable
+  # (the disk-monitor incident class). Revert the `|| pt_rc=$?` + NOTICE in
+  # _emit_run_event and this fails.
+  _register_agent_pb agent-evt3 low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 1, "calls": [], "unknown_calls": []}'
+  cat > "$HOME/.bun/bin/pt-event-failstub" << 'STUB'
+#!/bin/bash
+cat >/dev/null
+exit 7
+STUB
+  chmod +x "$HOME/.bun/bin/pt-event-failstub"
+  export CEO_PT_EVENT_CMD="$HOME/.bun/bin/pt-event-failstub"
+  export CEO_AGENT_RUN_ID="run-evt-3"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  bash "$CRON" agent-evt3 >/dev/null 2>&1 || true
+  local skips; skips=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)
+  assert_contains "$skips" "event-add failed (rc=7)" "a failed event-add must write a NOTICE to cron-skips.log"
+  unset CEO_AGENT_RUN_ID CEO_PT_EVENT_CMD
 }
 
 test_runner_ollama_agent_dispatches_with_cwd_in_vault() {


### PR DESCRIPTION
Part of #197 (slice D, final piece). Completes the chain with cc-pattern-tracker#11 (event-add) and #217 (bridge rules_loaded_hash).

## Description
After a parseable `runner:ollama-agent` run — **completed or not** — the dispatch emits one `events` row via `pt event-add`, so a downstream pass can correlate which injected rule set (`rules_loaded_hash`) changed local-model behavior/completion.

**Mapping onto the fixed events columns** (decided via an audit; deliberately conservative):
- `event_id`/`session_id` = run_id (deterministic → `INSERT OR IGNORE` idempotent)
- `tool_name` = `ollama-agent:<task>` — namespaced so consumers include/exclude the synthetic class via `LIKE 'ollama-agent:%'` and per-task grouping survives
- `rules_loaded_hash` = from the bridge record (`// "none"` — works before #217 merges)
- `exit_code` = **0 always** — completion lives in `error_tail`, NOT exit_code, so these rows never inflate `pt summary`'s headline error count
- `error_tail` = compact JSON `{run_id,model,completed,turns,calls,unknown}`
- `plugin_or_skill` left empty (overloading with the model would corrupt a real grouping axis)

Fire-and-forget: `|| true`, pt-absent notice, `CEO_PT_EVENT_CMD` override for tests — never alters the run's pass/fail verdict (mirrors `_ingest_hallucinated_calls`).

## Testing Procedure
1. `TEST_FILTER=ollama_agent bash scripts/ceo-cron.test.sh` → 19 pass.
2. New: emits a namespaced row with run_id + rules_loaded_hash + exit_code 0; **emits even on non-completion**. Mutation: drop the `_emit_run_event` call → 4 assertions fail. shellcheck clean.

## Additional Notes
Signal is empty until a **rules-injecting** ollama-agent playbook exists (cron-failure-digest is rules:false → hash "none") — this lands the plumbing so the first rules-on playbook lights it up with no further cron work.