### PR TITLE
playbook(token-intake): scope: each for per-host token reporting

### DIFF
--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -6,6 +6,7 @@ schedule: "45 8 * * 1-5"
 preflight: none
 tier: read
 status: active
+scope: each
 runner: script
 script: ceo-token-intake.sh
 artifact: CEO/reports/token/{TODAY}-{HOST}.md


### PR DESCRIPTION
## What

Sets `scope: each` on the `token-intake` playbook.

## Why

`token-intake` writes a `{HOST}`-namespaced artifact (`CEO/reports/token/{TODAY}-{HOST}.md`) and is meant to run on **every** host so each machine reports its own usage. With no explicit `scope` it defaults to `single` (runs on one owner host only) — which, under the swarm daemon, would silently drop per-host token reports on every host except the owner.

This is the one behavior-preserving scope edit needed to migrate the fleet from the legacy crontab block to `ceo-schedulerd`: every other playbook is correctly `single` (owned by ML-1), only `token-intake` fans out.

## Testing

- `bash scripts/ceo-scan.test.sh` → 7/7 pass
- `bun test lib/scheduler/tests/registry.test.ts` → 10/10 pass
- Frontmatter validated; `scope: each` is an accepted enum value.