### PR TITLE
Fix ceo-schedulerd deploy templates so a fresh install doesn't crash-loop

### DIFF
--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -115,16 +115,26 @@ used instead.
 
 ### Run / keep-alive
 
+First install dependencies (creates `node_modules/croner`) — **required** on
+every host, or the daemon crash-loops on a `croner` ENOENT:
+
 ```bash
+bun install                                          # in lib/scheduler (once per host)
 CEO_VAULT=~/Documents/Obsidian bun run src/main.ts   # foreground (either OS)
 ```
+
+Run the daemon **from `lib/scheduler`** (or set the agent's working directory
+there): it resolves the `@/*` tsconfig path alias relative to the working
+directory, so `bun run` from elsewhere fails to resolve `@/cron`. The deploy
+templates pin `WorkingDirectory` for exactly this reason.
 
 One OS-level agent keeps the daemon alive; the daemon does all scheduling.
 
 - **Linux/WSL:** install the systemd **user** unit template at
-  `deploy/ceo-schedulerd.service` (see its header comments). **Not smoke-tested on
-  a live always-on host** (ML-1 GPU-down) — only `Restart=always` is
-  hardware-unverified; the loop/guard/heartbeat are covered by fake-clock tests.
+  `deploy/ceo-schedulerd.service` (see its header comments). Smoke-tested live on
+  ML-1 (WSL) 2026-06-28 — comes up healthy and heartbeats with `bun install` run
+  and `WorkingDirectory` set; the loop/guard/heartbeat are also covered by
+  fake-clock tests.
 - **macOS (#144):** install the launchd **LaunchAgent** template at
   `deploy/com.ceo.schedulerd.plist` (see its header). It needs a logged-in GUI
   session (it's a LaunchAgent, not a headless LaunchDaemon, because it reads the

--- a/lib/scheduler/deploy/ceo-schedulerd.service
+++ b/lib/scheduler/deploy/ceo-schedulerd.service
@@ -1,13 +1,15 @@
 # ceo-schedulerd — systemd USER unit template (Linux/WSL keep-alive, #142).
 #
-# This is a TEMPLATE: edit the three paths below, then install as a user unit.
-# It has NOT been smoke-tested on a live always-on Linux host (ML-1 is GPU-down
-# as of 2026-06-07); the Restart=always semantics are unverified on hardware.
+# This is a TEMPLATE: edit the paths and host id below, then install as a user
+# unit. Smoke-tested live on ML-1 (WSL) 2026-06-28: with `bun install` run and
+# WorkingDirectory set, the daemon comes up healthy and heartbeats; the
+# Restart=always respawn floor is now exercised on hardware.
 #
 # Install (user scope, no root):
+#   ( cd ~/code/claude-ceo/lib/scheduler && bun install )  # REQUIRED: creates node_modules (croner); without it the daemon crash-loops on ENOENT
 #   mkdir -p ~/.config/systemd/user
 #   cp ceo-schedulerd.service ~/.config/systemd/user/
-#   # edit the paths in the copy
+#   # edit the copy: ExecStart, WorkingDirectory, CEO_VAULT, CEO_HOSTNAME
 #   systemctl --user daemon-reload
 #   systemctl --user enable --now ceo-schedulerd.service
 #   loginctl enable-linger "$USER"   # keep it running when you're logged out
@@ -26,10 +28,18 @@ StartLimitBurst=10
 
 [Service]
 Type=simple
+# EDIT: this repo's lib/scheduler dir. REQUIRED — the daemon resolves its `@/*`
+# tsconfig path alias (and node_modules) relative to the working directory; run
+# from elsewhere, `bun run` cannot resolve `@/cron` and the unit crash-loops.
+WorkingDirectory=%h/code/claude-ceo/lib/scheduler
 # EDIT: absolute path to bun and to this repo's lib/scheduler/src/main.ts.
 ExecStart=%h/.bun/bin/bun run %h/code/claude-ceo/lib/scheduler/src/main.ts
 # EDIT: the synced Obsidian vault root that contains CEO/registry.json.
 Environment=CEO_VAULT=%h/Documents/Obsidian
+# EDIT: this host's unique CEO id (install.md §2). systemd does NOT source
+# ~/.ceo/config, so the daemon cannot read CEO_HOSTNAME from there — set it here
+# or host identity silently falls back to `hostname -s`.
+Environment=CEO_HOSTNAME=CHANGEME
 # EDIT (optional): pin the dispatch binary if ceo-cron.sh is not on PATH.
 # Environment=CEO_CRON_BIN=%h/code/claude-ceo/scripts/ceo-cron.sh
 Restart=always

--- a/lib/scheduler/deploy/ceo-schedulerd.service
+++ b/lib/scheduler/deploy/ceo-schedulerd.service
@@ -36,9 +36,10 @@ WorkingDirectory=%h/code/claude-ceo/lib/scheduler
 ExecStart=%h/.bun/bin/bun run %h/code/claude-ceo/lib/scheduler/src/main.ts
 # EDIT: the synced Obsidian vault root that contains CEO/registry.json.
 Environment=CEO_VAULT=%h/Documents/Obsidian
-# EDIT: this host's unique CEO id (install.md §2). systemd does NOT source
-# ~/.ceo/config, so the daemon cannot read CEO_HOSTNAME from there — set it here
-# or host identity silently falls back to `hostname -s`.
+# REQUIRED: this host's unique CEO id (install.md §2). systemd does NOT source
+# ~/.ceo/config, so the daemon reads CEO_HOSTNAME only from here. Left as the
+# CHANGEME sentinel, the host registers literally as "CHANGEME" — it does NOT
+# fall back; delete this line entirely to fall back to `hostname -s`.
 Environment=CEO_HOSTNAME=CHANGEME
 # EDIT (optional): pin the dispatch binary if ceo-cron.sh is not on PATH.
 # Environment=CEO_CRON_BIN=%h/code/claude-ceo/scripts/ceo-cron.sh

--- a/lib/scheduler/deploy/com.ceo.schedulerd.plist
+++ b/lib/scheduler/deploy/com.ceo.schedulerd.plist
@@ -58,9 +58,11 @@
     <!-- EDIT: the synced Obsidian vault root that contains CEO/registry.json. -->
     <key>CEO_VAULT</key>
     <string>/Users/CHANGEME/Documents/Obsidian</string>
-    <!-- EDIT: this host's unique CEO id (install.md §2). launchd does NOT source
-         ~/.ceo/config, so the daemon cannot read CEO_HOSTNAME from there — set it
-         here or host identity silently falls back to `hostname -s`. -->
+    <!-- REQUIRED: this host's unique CEO id (install.md §2). launchd does NOT
+         source ~/.ceo/config, so the daemon reads CEO_HOSTNAME only from here.
+         Left as the CHANGEME sentinel, the host registers literally as
+         "CHANGEME" — it does NOT fall back; remove this key/string pair to fall
+         back to `hostname -s`. -->
     <key>CEO_HOSTNAME</key>
     <string>CHANGEME</string>
     <!-- EDIT (optional): pin the dispatch binary if ceo-cron.sh is not on PATH.

--- a/lib/scheduler/deploy/com.ceo.schedulerd.plist
+++ b/lib/scheduler/deploy/com.ceo.schedulerd.plist
@@ -5,16 +5,20 @@
   ONE keep-alive agent runs the Bun daemon, which owns cron matching and reads
   CEO/registry.json directly — replacing the retired per-playbook plist backend.
 
-  This is a TEMPLATE: edit the three absolute paths below, then install as a
-  user agent (no root). It has NOT been smoke-tested on a long-running host;
-  the loop/guard/heartbeat are covered by lib/scheduler tests and a throwaway
-  bootstrap smoke.
+  This is a TEMPLATE: edit the absolute paths and host id below, then install as
+  a user agent (no root). The loop/guard/heartbeat are covered by lib/scheduler
+  tests; the same daemon runs live on ML-1 (WSL) under the sibling systemd unit.
+
+  REQUIRED before installing — create node_modules (the croner dependency), or
+  the daemon crash-loops on a `croner` ENOENT and KeepAlive tight-loops it:
+
+    ( cd ~/code/claude-ceo/lib/scheduler && bun install )
 
   Install (user scope, logged-in GUI session required — this is a LaunchAgent,
   not a headless LaunchDaemon, because it must read the user's synced vault):
 
     cp com.ceo.schedulerd.plist ~/Library/LaunchAgents/
-    # edit the absolute paths in the copy
+    # edit the copy: ProgramArguments paths, WorkingDirectory, CEO_VAULT, CEO_HOSTNAME
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ceo.schedulerd.plist
     launchctl kickstart -p gui/$(id -u)/com.ceo.schedulerd   # verify it starts
     launchctl print gui/$(id -u)/com.ceo.schedulerd          # inspect state
@@ -42,11 +46,27 @@
     <string>/Users/CHANGEME/code/claude-ceo/lib/scheduler/src/main.ts</string>
   </array>
 
+  <!-- EDIT: this repo's lib/scheduler dir. REQUIRED — the daemon resolves its
+       `@/*` tsconfig path alias (and node_modules) relative to the working
+       directory; without it `bun run` cannot resolve `@/cron` and the agent
+       crash-loops. -->
+  <key>WorkingDirectory</key>
+  <string>/Users/CHANGEME/code/claude-ceo/lib/scheduler</string>
+
   <key>EnvironmentVariables</key>
   <dict>
     <!-- EDIT: the synced Obsidian vault root that contains CEO/registry.json. -->
     <key>CEO_VAULT</key>
     <string>/Users/CHANGEME/Documents/Obsidian</string>
+    <!-- EDIT: this host's unique CEO id (install.md §2). launchd does NOT source
+         ~/.ceo/config, so the daemon cannot read CEO_HOSTNAME from there — set it
+         here or host identity silently falls back to `hostname -s`. -->
+    <key>CEO_HOSTNAME</key>
+    <string>CHANGEME</string>
+    <!-- EDIT (optional): pin the dispatch binary if ceo-cron.sh is not on PATH.
+    <key>CEO_CRON_BIN</key>
+    <string>/Users/CHANGEME/code/claude-ceo/scripts/ceo-cron.sh</string>
+    -->
   </dict>
 
   <!-- Start at load and keep alive, but only respawn on a non-zero (crash) exit


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The `ceo-schedulerd` daemon deploy templates are not installable as written — a fresh host following either template gets a crash-looping daemon, never a running one. Three defects, both platforms:

1. **No `bun install` step.** The install instructions never create `node_modules`, so the daemon dies on a `croner` ENOENT. systemd `Restart=always` / launchd `KeepAlive` then tight-loop it. `bun install` was documented only in the README's `## Develop` section, never in the install path.
2. **No working directory.** Neither template sets one, so `bun run …/main.ts` resolves the `@/cron` tsconfig path alias (`paths: { "@/*": ["src/*"] }`) relative to the wrong directory and fails — even after `node_modules` exists.
3. **No `CEO_HOSTNAME`.** Both set only `CEO_VAULT`. The daemon runs in a stripped environment and does **not** source `~/.ceo/config`, so it cannot read `CEO_HOSTNAME` from there — host identity silently falls back to `hostname -s`, which can collide with swarm registration.

This was found while standing up the daemon on ML-1 (the systemd host): it crash-looped on `croner` ENOENT until `bun install` was run and `WorkingDirectory` was set. The launchd template the Mac would use has the identical defects. This PR fixes the templates at the source so any host installs clean.

### Changes
- `lib/scheduler/deploy/ceo-schedulerd.service` — add `WorkingDirectory` + `CEO_HOSTNAME` (EDIT placeholders); add the `bun install` prerequisite to the install steps; refresh the now-stale "not smoke-tested" note (it runs live on ML-1).
- `lib/scheduler/deploy/com.ceo.schedulerd.plist` — add the `WorkingDirectory` key + `CEO_HOSTNAME` and an optional `CEO_CRON_BIN` env; add the `bun install` prerequisite.
- `lib/scheduler/README.md` — document the `bun install` prerequisite and the run-from-`lib/scheduler` requirement in the keep-alive section.

No code (`src/`) changes; templates and docs only.

## Testing Procedure
1. Check out this branch.
2. `cd lib/scheduler && plutil -lint deploy/com.ceo.schedulerd.plist` → expect `OK`.
3. `bun install --frozen-lockfile && bun run typecheck && bun test` → expect lockfile honored, typecheck clean, `121 pass / 0 fail`.
4. Read `deploy/ceo-schedulerd.service` and `deploy/com.ceo.schedulerd.plist`: confirm each now has a working-directory directive, a `CEO_HOSTNAME` EDIT entry, and a `bun install` step in its install header.
5. (Hardware) On ML-1 the systemd unit with these settings comes up `active`, `NRestarts=0`, and `ceo doctor` reports the heartbeat alive.

## Additional Notes / HelpScout Tickets
Found during the single-host → swarm migration cutover. ML-1's running unit was hand-patched with exactly these settings; this PR makes that the canonical template before the macOS install. N/A tickets.