### PR TITLE
story-points playbook: require GH_PROJECT_TOKEN, ZenHub cutover complete

### DIFF
--- a/docs/playbooks/story-points.md
+++ b/docs/playbooks/story-points.md
@@ -9,7 +9,7 @@ status: active
 runner: skill
 skill: story-points
 out_pattern: Awesome Motive/reports/story-points/${TODAY}-backlog-pr-story-points.md
-requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]
+requires: [GH_PROJECT_TOKEN]
 ---
 
 # Story Points
@@ -32,9 +32,12 @@ manual captures live). Built as a CEO playbook rather than a hand-rolled cron so
 
 ## Credentials
 
-`requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]` — ceo-cron sources
-`~/.config/ceo/credentials.env` and validates both are set before exec. GitHub auth is
-resolved by the skill via `gh auth token -u nhangenam` (awesomemotive org access).
+`requires: [GH_PROJECT_TOKEN]` — ceo-cron sources `~/.config/ceo/credentials.env` and
+validates it is set before exec. `GH_PROJECT_TOKEN` must carry the `project` scope: story
+points are read from the org GitHub Projects boards (projects 72–75), not ZenHub. GitHub
+PR/issue auth is resolved by the skill via `gh auth token -u nhangenam` (awesomemotive org
+access); if that token already has `project` scope, the skill falls back to it for the
+board read, but the playbook requires an explicit `GH_PROJECT_TOKEN` for unattended runs.
 
 ## Outputs
 
@@ -50,11 +53,13 @@ filename carries the date, not the quarter).
 Run `ceo playbook scan` **on ML-1 only** (the `ceo-scan-only-on-ml1` rule). The skill
 lives in llm-tools at `home/.claude/skills/story-points/`; ML-1 must have that pulled.
 
-## ZenHub → GitHub Projects migration
+## ZenHub → GitHub Projects migration (complete)
 
-The skill bundles a copy of the ZenHub analyzer. When optin-monster-app moves ZH → GitHub
-Projects, swap the bundled `analyzer/` for a GH-Projects equivalent; this playbook is
-unchanged.
+The ZenHub cutover is done: the bundled `analyzer/` reads story points from the org
+GitHub Projects boards (projects 72–75) via `ghp-estimates.js`. The playbook contract is
+unchanged apart from `requires:` (now `GH_PROJECT_TOKEN` instead of the ZenHub vars).
+Before the next `ceo playbook scan` on ML-1, add `GH_PROJECT_TOKEN` (project scope) to
+ML-1's `~/.config/ceo/credentials.env` or the preflight will fail.
 
 ## Disable
 

--- a/docs/playbooks/story-points.md
+++ b/docs/playbooks/story-points.md
@@ -32,12 +32,19 @@ manual captures live). Built as a CEO playbook rather than a hand-rolled cron so
 
 ## Credentials
 
-`requires: [GH_PROJECT_TOKEN]` — ceo-cron sources `~/.config/ceo/credentials.env` and
-validates it is set before exec. `GH_PROJECT_TOKEN` must carry the `project` scope: story
-points are read from the org GitHub Projects boards (projects 72–75), not ZenHub. GitHub
-PR/issue auth is resolved by the skill via `gh auth token -u nhangenam` (awesomemotive org
-access); if that token already has `project` scope, the skill falls back to it for the
-board read, but the playbook requires an explicit `GH_PROJECT_TOKEN` for unattended runs.
+`requires: [GH_PROJECT_TOKEN]` — ceo-cron sources `~/.config/ceo/credentials.env` and the
+`requires:` credential gate (distinct from the `preflight:` function, which is `none`)
+aborts the run with a non-zero exit before exec if it is unset. `GH_PROJECT_TOKEN` must
+carry the `project` scope: story points are read from the org GitHub Projects boards
+(projects 72–75), not ZenHub.
+
+GitHub PR/issue auth uses a separate `GITHUB_TOKEN`, resolved by the skill from env or
+`gh auth token -u nhangenam` (awesomemotive org access). **`GITHUB_TOKEN` is not in
+`requires:`, so cron does not pre-validate it** — for unattended ML-1 runs put it in
+`~/.config/ceo/credentials.env` (or have `gh` logged in as `nhangenam`), or the skill
+aborts at its own token guard. A `GH_PROJECT_TOKEN` that is present but lacks `project`
+scope does not silently pass: the skill's all-zero trip-wire exits 3 and writes no report
+rather than emitting a zeroed one.
 
 ## Outputs
 
@@ -47,6 +54,11 @@ board read, but the playbook requires an explicit `GH_PROJECT_TOKEN` for unatten
 
 The quarter is recorded in the report body and frontmatter tags (the `out_pattern`
 filename carries the date, not the quarter).
+
+A successful run writes exactly one `${TODAY}-backlog-pr-story-points.md`. If that file is
+absent after 17:00 Friday, the run failed — analyzer error (exit 1) or the all-zero / scope
+trip-wire (exit 3), which writes no file. Check the ceo-cron run log for the non-zero exit
+and stderr.
 
 ## Install
 
@@ -59,7 +71,7 @@ The ZenHub cutover is done: the bundled `analyzer/` reads story points from the 
 GitHub Projects boards (projects 72–75) via `ghp-estimates.js`. The playbook contract is
 unchanged apart from `requires:` (now `GH_PROJECT_TOKEN` instead of the ZenHub vars).
 Before the next `ceo playbook scan` on ML-1, add `GH_PROJECT_TOKEN` (project scope) to
-ML-1's `~/.config/ceo/credentials.env` or the preflight will fail.
+ML-1's `~/.config/ceo/credentials.env` or the `requires:` credential gate will fail the run.
 
 ## Disable
 


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
The `story-points` skill now reads Story Points from the GitHub Projects boards instead of ZenHub (ZenHub access ended; the nightly sync was disabled). This updates the playbook contract to match.

- Frontmatter `requires:` → `[GH_PROJECT_TOKEN]` (was `[ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]`).
- Credentials section: documents `GH_PROJECT_TOKEN` must carry `project` scope; GitHub PR/issue auth still via `gh auth token -u nhangenam`.
- Migration section: marked complete.

Doc-only; no scheduler change here. The skill itself is updated in nhangen/llm-tools#108.

## Testing Procedure
1. Check out this branch; open `docs/playbooks/story-points.md`.
2. Confirm frontmatter `requires: [GH_PROJECT_TOKEN]` and no remaining `ZENHUB_*` references.
3. On ML-1 only: add `GH_PROJECT_TOKEN` (project scope) to `~/.config/ceo/credentials.env`, then `ceo playbook scan`; confirm the regenerated `registry.json` entry requires `GH_PROJECT_TOKEN` and the playbook preflight passes.

## Additional Notes / HelpScout Tickets
`ceo playbook scan` is ML-1-only (`ceo-scan-only-on-ml1`). The new `requires:` will fail preflight until ML-1's ceo `credentials.env` has `GH_PROJECT_TOKEN`. Pairs with nhangen/llm-tools#108.