### PR TITLE
playbook(value-tracker): scope: each for per-host value reports

### DIFF
--- a/docs/playbooks/value-tracker.md
+++ b/docs/playbooks/value-tracker.md
@@ -8,7 +8,8 @@ tier: read
 status: active
 runner: script
 script: ceo-value-tracker.sh
-artifact: CEO/reports/value-tracker/{TODAY}.md
+artifact: CEO/reports/value-tracker/{TODAY}-{HOST}.md
+scope: each
 ---
 
 # Value Tracker
@@ -19,12 +20,12 @@ Shell-only playbook. The dispatcher invokes `scripts/ceo-value-tracker.sh` direc
 
 Runs `lib/value-tracker` against the last 24h of Claude Code session JSONLs and Cursor SQLite tool bubbles, classifies each MCP tool call as plausibly-used, trivially-wasted, or unclear, and writes:
 
-- `<VAULT>/CEO/reports/value-tracker/<TODAY>.md` — the report (sanctioned `reports/` location per `ceo-automated-writers-are-playbooks`)
+- `<VAULT>/CEO/reports/value-tracker/<TODAY>-<HOST>.md` — the report (sanctioned `reports/` location per `ceo-automated-writers-are-playbooks`; `{HOST}`-keyed because `scope: each` runs it on every enabled host)
 - A JSON snapshot under the tracker's default snapshot dir
 - One idempotent line in `CEO/inbox/<host>.md`:
 
 ```
-- [ ] Review daily value-tracker report [[CEO/reports/value-tracker/<TODAY>]]
+- [ ] Review daily value-tracker report [[CEO/reports/value-tracker/<TODAY>-<HOST>]]
 ```
 
 The chat-triggered `inbox` playbook surfaces the line via `ceo chat inbox`.

--- a/lib/value-tracker/src/cli.ts
+++ b/lib/value-tracker/src/cli.ts
@@ -16,6 +16,7 @@ interface Args {
   session: string | null;
   sessionFile: string | null;
   obsidianVault: string | null;
+  host: string | null;
   noSnapshot: boolean;
   dryRun: boolean;
   help: boolean;
@@ -30,6 +31,7 @@ function parseArgs(argv: string[]): Args {
     obsidianVault: existsSync(join(homedir(), "Documents", "Obsidian"))
       ? join(homedir(), "Documents", "Obsidian")
       : null,
+    host: null,
     noSnapshot: false,
     dryRun: false,
     help: false,
@@ -62,6 +64,10 @@ function parseArgs(argv: string[]): Args {
         a.obsidianVault = v!;
         i++;
         break;
+      case "--host":
+        a.host = v!;
+        i++;
+        break;
       case "--no-snapshot":
         a.noSnapshot = true;
         break;
@@ -83,6 +89,7 @@ function usage(): string {
     "  --session <id>            analyse one session by id",
     "  --session-file <path>     analyse one JSONL file directly (testing)",
     "  --obsidian-vault <path>   override Obsidian vault path",
+    "  --host <id>               suffix the note filename with -<id> (per-host reports)",
     "  --no-snapshot             skip JSON snapshot write",
     "  --dry-run                 terminal output only, no files written",
     "  -h, --help                show this help",
@@ -153,7 +160,8 @@ async function main() {
   if (args.obsidianVault) {
     const noteDir = join(args.obsidianVault, "CEO", "reports", "value-tracker");
     mkdirSync(noteDir, { recursive: true });
-    const notePath = join(noteDir, `${snap.generatedAt.slice(0, 10)}.md`);
+    const suffix = args.host ? `-${args.host}` : "";
+    const notePath = join(noteDir, `${snap.generatedAt.slice(0, 10)}${suffix}.md`);
     writeFileSync(notePath, formatObsidian(snap));
     process.stdout.write(`Obsidian note: ${notePath}\n`);
   }

--- a/lib/value-tracker/tests/cli.test.ts
+++ b/lib/value-tracker/tests/cli.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "child_process";
+import { existsSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const CLI = join(import.meta.dir, "..", "src", "cli.ts");
@@ -18,5 +20,27 @@ describe("cli", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("value-tracker");
     expect(r.stdout).toContain("decisionSupport");
+  });
+
+  test("--host suffixes the obsidian note filename; omitting it does not", () => {
+    const fixture = join(import.meta.dir, "fixtures", "tiny-session.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+
+    const vaultWith = mkdtempSync(join(tmpdir(), "vt-host-"));
+    const rWith = spawnSync(
+      "bun",
+      [CLI, "--session-file", fixture, "--obsidian-vault", vaultWith, "--host", "myhost", "--no-snapshot"],
+      { encoding: "utf8" },
+    );
+    expect(rWith.status).toBe(0);
+    expect(existsSync(join(vaultWith, "CEO", "reports", "value-tracker", `${today}-myhost.md`))).toBe(true);
+
+    const vaultWithout = mkdtempSync(join(tmpdir(), "vt-nohost-"));
+    spawnSync(
+      "bun",
+      [CLI, "--session-file", fixture, "--obsidian-vault", vaultWithout, "--no-snapshot"],
+      { encoding: "utf8" },
+    );
+    expect(existsSync(join(vaultWithout, "CEO", "reports", "value-tracker", `${today}.md`))).toBe(true);
   });
 });

--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -50,8 +50,8 @@ SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev
 : "${SINCE:?SINCE computation failed; neither BSD nor GNU date resolved (check cron PATH)}"
 
 NOTE_DIR="$CEO_DIR/reports/value-tracker"
-NOTE_FILE="$NOTE_DIR/$TODAY.md"
-WIKILINK="[[CEO/reports/value-tracker/$TODAY]]"
+NOTE_FILE="$NOTE_DIR/$TODAY-$HOST.md"
+WIKILINK="[[CEO/reports/value-tracker/$TODAY-$HOST]]"
 INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
 mkdir -p "$INBOX_DIR" "$NOTE_DIR"
@@ -60,7 +60,8 @@ mkdir -p "$INBOX_DIR" "$NOTE_DIR"
 # but pass it explicitly so non-default vault paths work via $CEO_VAULT.
 bun "$ENTRY" \
   --since "$SINCE" \
-  --obsidian-vault "$VAULT"
+  --obsidian-vault "$VAULT" \
+  --host "$HOST"
 
 # Fail-closed: bun can exit 0 without writing the daily note (zero sessions
 # found, wrong write path, silent error). That's the shape behind #88 where

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -28,16 +28,18 @@ setup() {
 #!/bin/bash
 echo "bun-stub: $*"
 vault=""
+host=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --obsidian-vault) vault="$2"; shift 2 ;;
+    --host) host="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 if [ -n "$vault" ]; then
   note_dir="$vault/CEO/reports/value-tracker"
   mkdir -p "$note_dir"
-  printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+  printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
 fi
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
@@ -77,7 +79,7 @@ test_appends_inbox_line_and_invokes_bun() {
   local today inbox
   today=$(date +%Y-%m-%d)
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
-  local wikilink="$WIKILINK_PREFIX/$today]]"
+  local wikilink="$WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]"
   local expected_line="- [ ] Review daily value-tracker report $wikilink"
 
   assert_file_exists "$inbox" "per-host inbox shadow file must be created"
@@ -101,7 +103,7 @@ test_idempotent_inbox_append() {
   today=$(date +%Y-%m-%d)
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
 
-  count=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$inbox" || true)
+  count=$(grep -c -F "$WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]" "$inbox" || true)
   assert_eq "$count" "1" "two runs must leave exactly one inbox line"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -119,8 +121,8 @@ test_idempotent_preserves_checked_off_line() {
   bash "$TRACKER" >/dev/null 2>&1
 
   local checked unchecked
-  checked=$(grep -c -F -- "- [x] Review daily value-tracker report $WIKILINK_PREFIX/$today]]" "$inbox" || true)
-  unchecked=$(grep -c -F -- "- [ ] Review daily value-tracker report $WIKILINK_PREFIX/$today]]" "$inbox" || true)
+  checked=$(grep -c -F -- "- [x] Review daily value-tracker report $WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]" "$inbox" || true)
+  unchecked=$(grep -c -F -- "- [ ] Review daily value-tracker report $WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]" "$inbox" || true)
   assert_eq "$checked" "1" "checked-off line must survive re-run"
   assert_eq "$unchecked" "0" "must not re-append an unchecked line"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
@@ -201,8 +203,8 @@ test_two_hosts_write_to_disjoint_files() {
   assert_file_exists "$CEO_DIR/inbox/otherhost.md" "host2 inbox must exist"
 
   local h1 h2
-  h1=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$CEO_DIR/inbox/testhost.md" || true)
-  h2=$(grep -c -F "$WIKILINK_PREFIX/$today]]" "$CEO_DIR/inbox/otherhost.md" || true)
+  h1=$(grep -c -F "$WIKILINK_PREFIX/$today-testhost]]" "$CEO_DIR/inbox/testhost.md" || true)
+  h2=$(grep -c -F "$WIKILINK_PREFIX/$today-otherhost]]" "$CEO_DIR/inbox/otherhost.md" || true)
   assert_eq "$h1" "1" "host1 must have its own line"
   assert_eq "$h2" "1" "host2 must have its own line"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
@@ -231,7 +233,7 @@ STUB
   local today inbox
   today=$(date +%Y-%m-%d)
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
-  if [ -f "$inbox" ] && grep -qF "$WIKILINK_PREFIX/$today]]" "$inbox"; then
+  if [ -f "$inbox" ] && grep -qF "$WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]" "$inbox"; then
     printf '  FAIL [%s] inbox must NOT have a line when no note was written\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
@@ -244,15 +246,17 @@ test_fails_when_bun_writes_empty_note() {
   cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
 #!/bin/bash
 vault=""
+host=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --obsidian-vault) vault="$2"; shift 2 ;;
+    --host) host="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 note_dir="$vault/CEO/reports/value-tracker"
 mkdir -p "$note_dir"
-: > "$note_dir/$(date +%Y-%m-%d).md"
+: > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 
@@ -273,15 +277,17 @@ test_fails_when_note_has_no_h1() {
   cat > "$TEST_HOME/.bun/bin/bun" << 'STUB'
 #!/bin/bash
 vault=""
+host=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --obsidian-vault) vault="$2"; shift 2 ;;
+    --host) host="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 note_dir="$vault/CEO/reports/value-tracker"
 mkdir -p "$note_dir"
-printf -- '---\ndate: %s\n---\n\nno h1 here\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d).md"
+printf -- '---\ndate: %s\n---\n\nno h1 here\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 


### PR DESCRIPTION
## What & why

Makes `value-tracker` a per-host telemetry playbook, mirroring what #219 did for `token-intake`.

`value-tracker` analyses **this host's** Claude Code + Cursor sessions (used vs wasted tool calls), so like `token-intake` it should run on every host — not a single owner. But unlike `token-intake` (whose artifact already had `{HOST}`), value-tracker's artifact was keyed only by date (`CEO/reports/value-tracker/{TODAY}.md`), so two hosts running it would collide on one file. So this is more than the one-line `scope: each` add #219 was:

- **`lib/value-tracker/src/cli.ts`** — add a generic `--host <id>` arg that suffixes the note filename (`{TODAY}-{HOST}.md`). Kept CEO-agnostic (no `CEO_HOSTNAME` hardcode) so the analyzer stays extractable per its own README.
- **`scripts/ceo-value-tracker.sh`** — pass `--host "$HOST"` to the analyzer; host-key `NOTE_FILE` (the fail-closed check) and the inbox wikilink.
- **`docs/playbooks/value-tracker.md`** — `artifact: …/{TODAY}-{HOST}.md` + `scope: each`.

## Deployment note (not in this PR)

After merge + an ML-1 `ceo playbook scan`, each host that should report must `ceo playbook enable value-tracker` locally (same as `token-intake`). Single-scope ownership is unchanged for everything else.

## Testing

1. `bash scripts/ceo-value-tracker.test.sh` → **12/12 pass**. Stubs now parse `--host` and write the host-keyed note; assertions expect `…/{TODAY}-{HOST}]]` (incl. the two-hosts disjoint-file test). Mutation: drop `--host` from the wrapper or the `NOTE_FILE` host-key → the fail-closed check misses the note and the suite fails.
2. `bun test lib/value-tracker` → new `cli.test.ts` `--host` case passes (suffixed file present with `--host`, plain `{TODAY}.md` without). Mutation: revert the `cli.ts` suffix line → the `-myhost` file isn't written and the test fails.

## Pre-existing, unrelated

`cli.test.ts` `--dry-run … decisionSupport` fails on `origin/main` *before* this change (confirmed by stashing the diff) — a fixture/session-parsing issue, not touched here.
