### PR TITLE
fix(value-tracker): assert on analyzer-reported note path, not a reconstructed local date

### DIFF
--- a/scripts/ceo-value-tracker.sh
+++ b/scripts/ceo-value-tracker.sh
@@ -45,30 +45,39 @@ HOST="${CEO_HOSTNAME:-$(hostname -s)}"
 : "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
 INBOX_DIR="$CEO_DIR/inbox"
 INBOX_FILE="$INBOX_DIR/$HOST.md"
-TODAY=$(date +%Y-%m-%d)
 SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d 2>/dev/null || true)
 : "${SINCE:?SINCE computation failed; neither BSD nor GNU date resolved (check cron PATH)}"
 
 NOTE_DIR="$CEO_DIR/reports/value-tracker"
-NOTE_FILE="$NOTE_DIR/$TODAY-$HOST.md"
-WIKILINK="[[CEO/reports/value-tracker/$TODAY-$HOST]]"
-INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
 mkdir -p "$INBOX_DIR" "$NOTE_DIR"
 
-# Run the analyser. --obsidian-vault is auto-detected from $HOME/Documents/Obsidian
-# but pass it explicitly so non-default vault paths work via $CEO_VAULT.
-bun "$ENTRY" \
+# Run the analyser, capturing stdout so the fail-closed check and the inbox
+# wikilink key off the EXACT note path the analyzer reports (`Obsidian note:
+# <path>`), never a path the wrapper reconstructs. The wrapper used to rebuild
+# the filename from a local `date +%Y-%m-%d` while the analyzer dates it in UTC
+# (`new Date().toISOString()`); across the UTC-midnight boundary those diverged,
+# so the check asserted on a file the analyzer never wrote — a real report no
+# inbox line ever surfaced, plus a spurious cron failure (#227).
+# --obsidian-vault is auto-detected from $HOME/Documents/Obsidian but pass it
+# explicitly so non-default vault paths work via $CEO_VAULT.
+BUN_OUTPUT=$(bun "$ENTRY" \
   --since "$SINCE" \
   --obsidian-vault "$VAULT" \
-  --host "$HOST"
+  --host "$HOST")
+printf '%s\n' "$BUN_OUTPUT"
 
-# Fail-closed: bun can exit 0 without writing the daily note (zero sessions
-# found, wrong write path, silent error). That's the shape behind #88 where
-# cron-runs.log showed 'completed' weekdays for weeks with no artifact on
-# disk. Assert the daily note exists AND has a real markdown heading — a
-# bare newline / partial frontmatter / panic-traceback all pass `-s` but
-# aren't a real report.
+# The note path the analyzer actually wrote (last match wins if it ever prints
+# more than one). Empty means it wrote no note — the #88 silent-no-op shape.
+NOTE_FILE=$(printf '%s\n' "$BUN_OUTPUT" | sed -n 's/^Obsidian note: //p' | tail -1)
+if [ -z "$NOTE_FILE" ]; then
+  echo "ERROR: value-tracker exited 0 but did not write a note (no 'Obsidian note:' path in its output)" >&2
+  exit 1
+fi
+
+# Fail-closed (#88): the reported note must exist, be non-empty, and carry a
+# real h1 — a bare newline / partial frontmatter / panic-traceback all pass
+# `-s` but aren't a real report.
 if [ ! -s "$NOTE_FILE" ]; then
   echo "ERROR: value-tracker exited 0 but did not write $NOTE_FILE" >&2
   exit 1
@@ -77,6 +86,12 @@ if ! grep -q '^# value-tracker' "$NOTE_FILE"; then
   echo "ERROR: value-tracker wrote $NOTE_FILE but it has no '# value-tracker' h1 (truncated or panicked)" >&2
   exit 1
 fi
+
+# Inbox wikilink derived from the reported path (vault-relative, no extension)
+# so it can never point at a file the analyzer didn't write.
+REL="${NOTE_FILE#"$VAULT"/}"
+WIKILINK="[[${REL%.md}]]"
+INBOX_LINE="- [ ] Review daily value-tracker report $WIKILINK"
 
 # Idempotent inbox append — skip if the line is already there.
 if [ ! -f "$INBOX_FILE" ] || ! grep -qF -- "$WIKILINK" "$INBOX_FILE"; then

--- a/scripts/ceo-value-tracker.test.sh
+++ b/scripts/ceo-value-tracker.test.sh
@@ -39,7 +39,9 @@ done
 if [ -n "$vault" ]; then
   note_dir="$vault/CEO/reports/value-tracker"
   mkdir -p "$note_dir"
-  printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+  note="$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+  printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$(date +%Y-%m-%d)" "$(date +%Y-%m-%d)" > "$note"
+  echo "Obsidian note: $note"
 fi
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
@@ -256,7 +258,9 @@ while [ $# -gt 0 ]; do
 done
 note_dir="$vault/CEO/reports/value-tracker"
 mkdir -p "$note_dir"
-: > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+note="$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+: > "$note"
+echo "Obsidian note: $note"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 
@@ -287,7 +291,9 @@ while [ $# -gt 0 ]; do
 done
 note_dir="$vault/CEO/reports/value-tracker"
 mkdir -p "$note_dir"
-printf -- '---\ndate: %s\n---\n\nno h1 here\n' "$(date +%Y-%m-%d)" > "$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+note="$note_dir/$(date +%Y-%m-%d)${host:+-$host}.md"
+printf -- '---\ndate: %s\n---\n\nno h1 here\n' "$(date +%Y-%m-%d)" > "$note"
+echo "Obsidian note: $note"
 STUB
   chmod +x "$TEST_HOME/.bun/bin/bun"
 
@@ -298,6 +304,53 @@ STUB
     FAILS=$((FAILS + 1))
   fi
   assert_contains "$stderr" "no '# value-tracker' h1" "stderr must name the sentinel failure (got: $stderr)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_asserts_on_analyzer_reported_path_not_local_date() {
+  # Repro of #227: the analyzer dates the note filename by its OWN clock (UTC,
+  # `new Date().toISOString()`), which can differ from the wrapper's local
+  # `date +%Y-%m-%d` across the UTC-midnight boundary. The wrapper must key its
+  # fail-closed check and inbox wikilink off the path the analyzer REPORTS
+  # (`Obsidian note: <path>`), never a path it reconstructs from a second date.
+  local divergent="2099-01-01"
+  cat > "$TEST_HOME/.bun/bin/bun" << STUB
+#!/bin/bash
+vault=""
+host=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --obsidian-vault) vault="\$2"; shift 2 ;;
+    --host) host="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+note_dir="\$vault/CEO/reports/value-tracker"
+mkdir -p "\$note_dir"
+note="\$note_dir/$divergent\${host:+-\$host}.md"
+printf -- '---\ndate: %s\n---\n\n# value-tracker — %s\n\nstub body\n' "$divergent" "$divergent" > "\$note"
+echo "Obsidian note: \$note"
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/bun"
+
+  local rc=0 stderr
+  stderr=$(bash "$TRACKER" 2>&1 >/dev/null) || rc=$?
+  assert_eq "$rc" "0" "wrapper must succeed when the analyzer's date differs from the wrapper's local date (got rc=$rc; stderr: $stderr)"
+
+  local inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  local divergent_link="$WIKILINK_PREFIX/$divergent-$CEO_HOSTNAME]]"
+  local got
+  got=$(grep -c -F -- "$divergent_link" "$inbox" 2>/dev/null || true)
+  assert_eq "$got" "1" "inbox wikilink must point to the analyzer-reported note path"
+
+  local today
+  today=$(date +%Y-%m-%d)
+  if [ "$today" != "$divergent" ]; then
+    local local_link="$WIKILINK_PREFIX/$today-$CEO_HOSTNAME]]"
+    local bad
+    bad=$(grep -c -F -- "$local_link" "$inbox" 2>/dev/null || true)
+    assert_eq "$bad" "0" "inbox must not contain a wrapper-reconstructed local-date wikilink"
+  fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #227

## Description (Issue Fixed & New Behavior)
The cron wrapper `scripts/ceo-value-tracker.sh` reconstructed the report's note filename from a **local** `date +%Y-%m-%d`, while the analyzer (`lib/value-tracker/src/cli.ts`) writes the note from a **UTC** date (`new Date().toISOString().slice(0,10)`). When the daily run straddles the UTC-midnight boundary the two dates diverge, so the wrapper's fail-closed check asserted on a file the analyzer never wrote — a real report went unsurfaced and the cron spuriously failed.

Fix is wrapper-only (`cli.ts` untouched): capture the analyzer's stdout, parse the `Obsidian note: <path>` line it already prints, and key both the fail-closed existence/h1 check and the inbox wikilink off that exact path. The wrapper no longer reconstructs any date. A missing `Obsidian note:` line is treated as the #88 silent-no-op and fails closed.

Pre-existing on `main` (not introduced by #222).

## Testing Procedure
1. Check out this branch.
2. Run the wrapper suite: `bash scripts/ceo-value-tracker.test.sh` — 13/13 pass.
3. New reproduction test `test_asserts_on_analyzer_reported_path_not_local_date`: the bun stub writes/prints a divergent date (`2099-01-01`); confirm the wrapper succeeds and the inbox wikilink points at the analyzer-reported path, not a local-date reconstruction. Revert the wrapper change and confirm this test fails.
4. `bun test lib/value-tracker` — unchanged vs `main` baseline (no TS touched).

## Additional Notes / HelpScout Tickets
Follow-up to the #222 mini-panel review, which surfaced this as pre-existing and filed it as #227.