### PR TITLE
chore(ollama): repoint runner:ollama default to glm4:latest

### DIFF
--- a/docs/ollama-setup.md
+++ b/docs/ollama-setup.md
@@ -5,10 +5,10 @@ The CEO agent supports local inference via the `runner: ollama` and `runner: oll
 ## Default Models
 
 If a playbook uses an ollama runner but does not specify a `model:`, the system defaults to:
-- `runner: ollama`: `gemma4:12b-it-qat`
+- `runner: ollama`: `glm4:latest`
 - `runner: ollama-think`: `gpt-oss:20b`
 
-These models were chosen as the optimal balance between capability and speed for a local VRAM-constrained environment. `gemma4:12b-it-qat` (~7 GB) fits fully in 12 GB VRAM, avoiding the CPU spill that throttles larger 24B-class models to single-digit tokens/sec.
+These models were chosen as the optimal balance between capability and speed for a local VRAM-constrained environment. `glm4:latest` (GLM-4-9B, ~6 GB at Q4_0, 128K context) fits fully in 12 GB VRAM, avoiding the CPU spill that throttles larger 24B-class models to single-digit tokens/sec.
 
 ## Bootstrap Script
 
@@ -24,7 +24,7 @@ If you prefer to pull the models manually, or if you want to use custom models:
 
 ```bash
 # Pull the standard playbook runner (fast, capable)
-ollama pull gemma4:12b-it-qat
+ollama pull glm4:latest
 
 # Pull the thinking/reasoning runner (slower, methodical)
 ollama pull gpt-oss:20b

--- a/docs/playbooks/morning-brief.md
+++ b/docs/playbooks/morning-brief.md
@@ -4,7 +4,7 @@ description: Generate a prioritized overview of the day's work
 trigger: cron
 schedule: "57 8 * * 1-5"
 runner: ollama
-model: gemma4:12b-it-qat
+model: glm4:latest
 preflight: none
 tier: read
 status: disabled

--- a/docs/playbooks/morning-scan.md
+++ b/docs/playbooks/morning-scan.md
@@ -4,7 +4,7 @@ description: Scan vault for overnight changes, new notes, unresolved items, carr
 trigger: cron
 schedule: "50 8 * * 1-5"
 runner: ollama
-model: gemma4:12b-it-qat
+model: glm4:latest
 preflight: none
 tier: read
 status: disabled

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -569,7 +569,7 @@ _ollama_host() {
 #  1. `ollama run` exposes no way to set num_ctx, so it uses the server default
 #     (~4096 tokens). Our prompts run 27–50 KB (well past that), so the CLI path
 #     silently truncated them. The API takes options.num_ctx — set it to the
-#     model's real window (gemma4:12b-it-qat holds 256K; we use 32K, override
+#     model's real window (glm4:latest holds 128K; we use 32K, override
 #     via CEO_OLLAMA_NUM_CTX) so the whole prompt is actually ingested.
 #  2. curl --max-time bounds wall-clock natively, so a degenerate runaway (a 12B
 #     model emitting 65k tokens over ~18 min) can't hang a cron slot — no
@@ -1706,7 +1706,7 @@ END_LOG_ENTRY"
     # playbooks still honor `model:` for explicit ollama-model overrides.
     if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
       case "$RUNNER" in
-        ollama)       OLLAMA_MODEL="gemma4:12b-it-qat" ;;
+        ollama)       OLLAMA_MODEL="glm4:latest" ;;
         ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
       esac
     else

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -910,7 +910,7 @@ PB
 
   local model got_source numctx
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "gemma4:12b-it-qat" "runner:ollama default must be gemma4:12b-it-qat"
+  assert_eq "$model" "glm4:latest" "runner:ollama default must be glm4:latest"
   got_source=$(cat "$HOME/ollama-model-source.txt" 2>/dev/null || echo "MISSING")
   assert_eq "$got_source" "invoked" "ollama runner must export CEO_MODEL_SOURCE=invoked (harness drove the model)"
   # The headline fix: the request must carry the model's real context window, not
@@ -1170,7 +1170,7 @@ PB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to gemma4 default)"
+  assert_eq "$model" "sonnet" "explicit model:sonnet on runner:ollama must pass literally (not silently coerce to glm4 default)"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2006,7 +2006,7 @@ test_production_morning_brief_registers_with_ollama_runner() {
   model=$(jq -r '.playbooks[] | select(.name=="morning-brief") | .model' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-brief.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-brief.md must declare tier: read"
-  assert_eq "$model" "gemma4:12b-it-qat" "production morning-brief.md must declare model: gemma4:12b-it-qat"
+  assert_eq "$model" "glm4:latest" "production morning-brief.md must declare model: glm4:latest"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -2028,7 +2028,7 @@ test_production_morning_scan_registers_with_ollama_runner() {
   model=$(jq -r '.playbooks[] | select(.name=="morning-scan") | .model' "$REGISTRY_FILE" 2>/dev/null || echo "")
   assert_eq "$runner" "ollama" "production morning-scan.md must declare runner: ollama"
   assert_eq "$tier" "read" "production morning-scan.md must declare tier: read"
-  assert_eq "$model" "gemma4:12b-it-qat" "production morning-scan.md must declare model: gemma4:12b-it-qat"
+  assert_eq "$model" "glm4:latest" "production morning-scan.md must declare model: glm4:latest"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -3134,7 +3134,7 @@ STUB
   
   local ollama_invoked
   ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_contains "$ollama_invoked" "gemma4" "ollama must be invoked with default model during fallback"
+  assert_contains "$ollama_invoked" "glm4" "ollama must be invoked with default model during fallback"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
@@ -3172,7 +3172,7 @@ STUB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "gemma4:12b-it-qat" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
+  assert_eq "$model" "glm4:latest" "fallback must use the runner-default ollama model, not the Claude-tier frontmatter name"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-notify.sh
+++ b/scripts/ceo-notify.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 #                          harness drives no model itself)
 #     $CEO_RUNNER_ARTIFACT script file / skill name the harness executed
 #   Rendering:
-#     claude/ollama (invoked)  -> "claude (opus-4.8)", "ollama (gemma4:12b-it-qat)"
+#     claude/ollama (invoked)  -> "claude (opus-4.8)", "ollama (glm4:latest)"
 #     script/skill (declared)  -> "script: ticket-triage-autopilot.sh (opus, declared)",
 #                                 "skill: weekly-synthesis (opus, declared)"
 #     script/skill, no model   -> "script: disk-monitor.sh", "skill: workload-report"

--- a/scripts/ollama-setup.sh
+++ b/scripts/ollama-setup.sh
@@ -11,8 +11,8 @@ fi
 
 echo "Pulling default models for CEO agent runners..."
 
-echo "1/2: Pulling gemma4:12b-it-qat (default for 'runner: ollama')..."
-ollama pull gemma4:12b-it-qat
+echo "1/2: Pulling glm4:latest (default for 'runner: ollama')..."
+ollama pull glm4:latest
 echo "1/2: OK"
 
 echo "2/2: Pulling gpt-oss:20b (default for 'runner: ollama-think')..."


### PR DESCRIPTION
## Description
Moves the `runner: ollama` default model from `gemma4:12b-it-qat` to `glm4:latest`, aligning the cron default with the competence-gated keeper. On the trust-gate eval `glm4:latest` scored 1.0 while `gemma4` scored 0.0, and `glm4:latest` (GLM-4-9B, ~6 GB Q4_0, 128K ctx) fits 12 GB VRAM cleanly. The `runner: ollama-think` default (`gpt-oss:20b`) is unchanged.

Part of the agent-aptitude wiring (epic #197). Pairs with the ML-1 zoo cleanup (deleting the unused coding/large models that don't fit the 12 GB card), which is a separate operational step.

## Changes
Default + every operator-facing reference:
- `docs/playbooks/morning-scan.md`, `morning-brief.md` — production `model:`
- `scripts/ceo-cron.sh` — `_ollama_run` runtime default + num_ctx window comment (256K→128K)
- `scripts/ollama-setup.sh` bootstrap pull + `docs/ollama-setup.md` (default list + VRAM rationale)
- `scripts/ceo-notify.sh` render example
- `scripts/ceo-cron.test.sh` — the 4 default-locking assertions, plus 2 **bare-`gemma4`** sites (a fallback `assert_contains` and a message string) that the full-string grep initially missed

**Intentionally left as-is** (synthetic placeholder fixtures, decoupled from the default — flagged so they aren't read as misses):
- `ollama-agent/tests/test_registry.py` — `gemma4.12b-it-qat` is a coupled low-score sample in the `_scored()` gate fixture, not the default
- explicit-model fixtures in `ceo-cron.test.sh` (1409/1647/1664), `ceo-notify.test.sh`, `debug-chunked-test.sh`

## Testing
1. `bash scripts/ceo-cron.test.sh` → **170/170, exit 0** (local).
2. `bash scripts/ceo-notify.test.sh` → **18/18** (local).
3. Confirm no remaining tracked default-references: `git grep gemma4:12b-it-qat` returns only the intentional synthetic fixtures listed above.