### PR TITLE
playbook(cron-failure-digest): repoint gpt-oss:20b -> glm4:latest

### DIFF
--- a/docs/playbooks/cron-failure-digest.md
+++ b/docs/playbooks/cron-failure-digest.md
@@ -10,9 +10,9 @@ preflight: none
 tier: read
 status: active
 runner: ollama-agent
-model: gpt-oss:20b
+model: glm4:latest
 task: cron-failure-digest
-registry: {"tasks":{"cron-failure-digest":{"runner":"ollama","model":"gpt-oss:20b","tier":"low-stakes-write","tools":["read_file","run_shell","write_file","list_dir"],"rules":false,"skills":false}}}
+registry: {"tasks":{"cron-failure-digest":{"runner":"ollama","model":"glm4:latest","tier":"low-stakes-write","tools":["read_file","run_shell","write_file","list_dir"],"rules":false,"skills":false}}}
 artifact: CEO/reports/cron-failures/{TODAY}-{HOST}.md
 ---
 You are writing a digest of recent CEO cron failures. Your working directory is the vault's CEO directory. Make EXACTLY two tool calls, then stop with a one-line summary — do NOT run extra searches, greps, or re-reads (over-exploring is what makes this task fail to finish).


### PR DESCRIPTION
Closes #none

## Description
`gpt-oss:20b` fails the model-matrix trust gate — it fabricates tool results on the confabulated-agency probes. `cron-failure-digest` is a tool-using `runner: ollama-agent` playbook (`read_file`/`run_shell`/`write_file`/`list_dir`), so a fabricating model is the wrong fit. `glm4:latest` passes the gate and is already the `runner: ollama` default. Updates both the frontmatter `model` and the `registry` task model.

## Testing Procedure
1. Confirm the registry JSON still parses: extract the `registry:` line and `json.loads` it — `model` reads `glm4:latest`.
2. `cd ollama-agent && python3 -m pytest tests/ -q` → 151 passed.
3. Confirm `glm4:latest` is installed on the host (`ollama list`).

## Additional Notes
gpt-oss:20b remains the `ollama-think` default in `ceo-cron.sh`, but no playbook currently uses `runner: ollama-think`. Its trust-gate failure is tool-fabrication-specific, so it stays viable for a future tool-free reasoning tier.