### PR TITLE
ceo-cron: repoint ollama-think default to glm4:latest

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1707,7 +1707,7 @@ END_LOG_ENTRY"
     if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
       case "$RUNNER" in
         ollama)       OLLAMA_MODEL="glm4:latest" ;;
-        ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
+        ollama-think) OLLAMA_MODEL="glm4:latest" ;;
       esac
     else
       OLLAMA_MODEL="$MODEL_FROM_FRONTMATTER"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -972,7 +972,7 @@ PB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "gpt-oss:20b" "runner:ollama-think default must be gpt-oss:20b"
+  assert_eq "$model" "glm4:latest" "runner:ollama-think default must be glm4:latest"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #none

## Description
Repoints the `runner: ollama-think` default model from `gpt-oss:20b` to `glm4:latest`. The trust-gate-passing model should be the default for every ollama tier — `gpt-oss:20b` fails the model-matrix trust gate (fabricates tool results), `glm4:latest` passes and is already the `runner: ollama` default. With both tiers defaulting to glm4, `gpt-oss:20b` is no longer referenced by any default or playbook, so it can be removed without a dangling-default trap. A playbook that genuinely needs gpt-oss can still pin it via `model:`.

## Testing Procedure
1. `bash scripts/ceo-cron.test.sh` → passes; the `ollama-think-dispatch` test now asserts the default is `glm4:latest`.
2. `grep -n ollama-think scripts/ceo-cron.sh` → default reads `glm4:latest`.

## Additional Notes
No remaining `gpt-oss` references in `scripts/` or `docs/playbooks/` after this + #230.