### PR TITLE
feat(ollama-agent): fail completed runs with mutating-tool errors (#215)

### DIFF
--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -64,4 +64,5 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
         "transcript": transcript,
         "calls": toolbox.calls,
         "unknown_calls": toolbox.unknown_calls,
+        "tool_errors": toolbox.tool_errors,
     }

--- a/ollama-agent/ollama_agent/tools.py
+++ b/ollama-agent/ollama_agent/tools.py
@@ -15,6 +15,13 @@ from .skills import MAX_SKILL_BODY
 MAX_OUTPUT = 4000      # chars of stdout/stderr returned to the model per call
 MAX_READ = 20000       # chars returned by read_file
 
+# Tools whose error result signals an operational failure the cron gate should
+# fail the run on. A read_file/list_dir "error" is a benign path probe, and a
+# run_shell non-zero returncode (grep no-match, [ -f x ]) is not an error key —
+# only a run_shell timeout/exception sets one. unknown tools/skills are gated
+# separately via .unknown_calls.
+ERROR_RELEVANT_TOOLS = {"write_file", "git", "run_shell"}
+
 
 def _clip(s, n):
     s = s or ""
@@ -30,6 +37,7 @@ class ToolBox:
         self.mcp_names = dict(mcp_names) if mcp_names else {}  # prefixed_name -> real MCP tool name
         self.calls = []            # (name, args) of every dispatched call
         self.unknown_calls = []    # tool/skill names the model hallucinated
+        self.tool_errors = []      # {tool, error} for mutating-tool failures (#215)
 
     def _resolve(self, path):
         p = Path(path)
@@ -107,12 +115,27 @@ class ToolBox:
             self.unknown_calls.append(name)
             return json.dumps({"error": f"unknown tool: {name}"})
         try:
-            return handler(args)
+            result = handler(args)
         except Exception as e:
             # A tool that raises (PermissionError, ENOSPC, UnicodeError, cwd
             # deleted, …) must return a recorded error to the model, never abort
             # the run — keep the loop and transcript alive (safety-invariant-scope).
-            return json.dumps({"error": f"{name} failed: {type(e).__name__}: {e}"})
+            result = json.dumps({"error": f"{name} failed: {type(e).__name__}: {e}"})
+        self._note_tool_error(name, result)
+        return result
+
+    def _note_tool_error(self, name, result):
+        """Record a mutating-tool failure so the dispatcher (cron) can fail a
+        completed-but-errored run (#215). Inspects the result's "error" key —
+        absence-of-throw is not success (non-throwing-client-success-check)."""
+        if name not in ERROR_RELEVANT_TOOLS:
+            return
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return
+        if isinstance(parsed, dict) and parsed.get("error"):
+            self.tool_errors.append({"tool": name, "error": parsed["error"]})
 
 
 TOOLS = [

--- a/ollama-agent/tests/test_tools.py
+++ b/ollama-agent/tests/test_tools.py
@@ -1,0 +1,45 @@
+"""ToolBox.dispatch error capture (epic #197 Slice C / #215).
+
+A mutating tool whose result carries an "error" (write_file/git/run_shell
+exception or timeout) is recorded in .tool_errors so the cron gate can fail a
+completed-but-errored run. A benign read/list probe error and a non-zero shell
+returncode are NOT operational failures and must stay out of .tool_errors.
+"""
+import json
+
+from ollama_agent.tools import ToolBox
+
+
+def test_write_file_error_recorded(tmp_path):
+    (tmp_path / "blocker").write_text("x")  # a FILE where write_file needs a dir
+    tb = ToolBox(cwd=str(tmp_path))
+    result = json.loads(tb.dispatch("write_file", {"path": "blocker/child.txt", "content": "d"}))
+    assert "error" in result
+    assert [e["tool"] for e in tb.tool_errors] == ["write_file"]
+
+
+def test_successful_write_records_no_error(tmp_path):
+    tb = ToolBox(cwd=str(tmp_path))
+    tb.dispatch("write_file", {"path": "ok.txt", "content": "hi"})
+    assert tb.tool_errors == []
+
+
+def test_run_shell_nonzero_exit_is_not_an_error(tmp_path):
+    tb = ToolBox(cwd=str(tmp_path))
+    result = json.loads(tb.dispatch("run_shell", {"command": "exit 3"}))
+    assert result["returncode"] == 3
+    assert tb.tool_errors == []
+
+
+def test_read_file_missing_is_not_an_error(tmp_path):
+    tb = ToolBox(cwd=str(tmp_path))
+    result = json.loads(tb.dispatch("read_file", {"path": "nope.txt"}))
+    assert "error" in result
+    assert tb.tool_errors == []
+
+
+def test_run_shell_timeout_is_an_error(tmp_path):
+    tb = ToolBox(cwd=str(tmp_path), timeout=1)
+    result = json.loads(tb.dispatch("run_shell", {"command": "sleep 5"}))
+    assert "error" in result
+    assert [e["tool"] for e in tb.tool_errors] == ["run_shell"]

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1328,6 +1328,19 @@ if [ "$RUNNER" = "ollama-agent" ]; then
     exit 1
   fi
 
+  # completed != write-success: the bridge sets completed=true on a turn with no
+  # tool calls, regardless of whether a write_file/git/run_shell errored. The
+  # bridge records mutating-tool failures in .tool_errors (read/list probes and
+  # benign non-zero shell exits are excluded there), so a completed run whose
+  # report write failed surfaces here at dispatch time rather than only on the
+  # next `ceo doctor` artifact cross-check (#215, non-throwing-client-success-check).
+  _agent_tool_errors=$(printf '%s' "$AGENT_OUT" | jq -r '.tool_errors // [] | length')
+  if [ "$_agent_tool_errors" -gt 0 ]; then
+    _agent_tool_err_detail=$(printf '%s' "$AGENT_OUT" | jq -r '[.tool_errors[] | "\(.tool): \(.error)"] | join("; ")')
+    _record_failure "ollama-agent task '$AGENT_TASK' completed but hit $_agent_tool_errors tool error(s) for $TRIGGER: $_agent_tool_err_detail"
+    exit 1
+  fi
+
   _record_success
   exit 0
 fi

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -4425,6 +4425,41 @@ test_runner_ollama_agent_ingests_even_when_incomplete() {
   unset CEO_AGENT_RUN_ID
 }
 
+test_runner_ollama_agent_tool_error_records_failure() {
+  # A completed run whose bridge .tool_errors[] carries a mutating-tool failure
+  # (e.g. a write_file that errored) must record a FAILURE, not success — the
+  # report write silently failed. Reverting the dispatch-side tool_errors gate
+  # makes this run record success (exit 0), so the assertions flip.
+  _register_agent_pb agent-toolerr low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 2, "calls": [["write_file", {"path": "report.md"}]], "unknown_calls": [], "tool_errors": [{"tool": "write_file", "error": "write_file failed: PermissionError: [Errno 13]"}]}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-toolerr >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    printf '  FAIL [%s] a completed run with a tool error must exit non-zero\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  local skips_log
+  skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips_log" "tool error" "cron-skips.log must record the tool-error failure reason"
+  assert_contains "$skips_log" "write_file" "the failure reason must name the failing tool"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_runner_ollama_agent_clean_completed_run_succeeds() {
+  # Guards acceptance #2: a genuine no-op / clean completion (empty tool_errors,
+  # no writes) must NOT false-positive as a failure. A run_shell that exited
+  # non-zero benignly never reaches tool_errors (no "error" key), so the bridge
+  # reports tool_errors:[] and the run succeeds.
+  _register_agent_pb agent-clean low-stakes-write
+  _make_agent_stub '{"completed": true, "turns": 1, "calls": [], "unknown_calls": [], "tool_errors": []}'
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+  local rc=0
+  bash "$CRON" agent-clean >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "0" "a completed run with no tool errors must succeed (no false-positive on the no-op path)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_runner_ollama_agent_ingests_null_unknown_call() {
   # agent.py appends None for a malformed tool-call envelope (no function name),
   # so unknown_calls can contain null. It must still ingest, rendered (unnamed).


### PR DESCRIPTION
Closes #215

## Description (Issue Fixed & New Behavior)
The bridge sets `completed=true` on any turn with no tool calls, independent of whether a `write_file`/`git`/`run_shell` call errored (`ollama-agent/ollama_agent/agent.py:42-43`). The `runner:ollama-agent` cron branch gated only `.completed`/`.unknown_calls` — so a **failed report write could be recorded as success at dispatch time**, caught only later by the `ceo doctor` artifact cross-check (PR #214). Slice C of epic #197 closes that hole at dispatch time (defense-in-depth, per-run).

**Bridge:** `ToolBox.dispatch` now records mutating-tool failures in a new `.tool_errors` field (`[{tool, error}]`), surfaced in the run record. Scope is deliberate:
- **counts:** `write_file` / `git` / `run_shell` results carrying an `"error"` key (dispatch's exception wrapper, or a `run_shell` timeout).
- **excluded:** `read_file`/`list_dir` `"error"` results are benign path probes; a `run_shell` **non-zero `returncode`** (grep no-match, `[ -f x ]`) is *not* an error key. Neither false-positives the empty-log digest path (acceptance #2). Unknown tools/skills remain gated separately via `.unknown_calls`.

**Cron:** the `runner:ollama-agent` branch fails the run when `.tool_errors` is non-empty, after the completion + unknown-call gates.

### Deviation from the issue's literal prescription
#215 said scan `.calls[]` for error keys. But `ollama-agent/ollama_agent/tools.py:95` records `self.calls.append((name, args))` — **name + args only, no tool result**. The results (with `error`/`returncode`) live in `.transcript[]` tool messages, which carry no tool name (would require fragile index-correlation back to `.calls`). Capturing the error at dispatch into `.tool_errors` is the faithful, robust fix.

## Testing Procedure
1. Check out this branch.
2. `cd ollama-agent && conda run -n base python -m pytest tests -q` → **156 passed** (5 new in `test_tools.py`).
3. `bash scripts/ceo-cron.test.sh` → **172 passed** (2 new: errored-write→failure, clean→success).
4. `shellcheck -S warning $(find scripts -name '*.sh')` → clean.
5. Mutation check: revert the `.tool_errors` gate in `ceo-cron.sh` (or `_note_tool_error` in `tools.py`) → the new tests fail.

## Additional Notes
Last substantive slice of epic #197 (A0/A/B/D done, G dropped). Scope excludes `run_shell` non-zero exit by design — flagged here so reviewers don't read it as a miss.