### PR TITLE
ceo-cron: revert ollama-think default to gpt-oss:20b (capability tier)

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1718,9 +1718,18 @@ END_LOG_ENTRY"
     # with "pull model manifest: file does not exist". Native runner:ollama
     # playbooks still honor `model:` for explicit ollama-model overrides.
     if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
+      # Model choice is gated by tool-use, not one model everywhere. Tool-using
+      # delegation (runner:ollama-agent) gates on the trust probes — glm4:latest
+      # passes, gpt-oss:20b fabricates tool results and is refused. The tool-free
+      # read-only runners below gate on capability instead: `ollama` carries
+      # summarize/light traffic (glm4 is adequate + fast + fits 12GB), while
+      # `ollama-think` is the reasoning tier where gpt-oss:20b is the clear
+      # model-matrix leader (glm4 scores 0 on the hard reasoning/code tasks).
+      # gpt-oss:20b is not currently installed — re-pull it before enabling any
+      # runner:ollama-think playbook.
       case "$RUNNER" in
         ollama)       OLLAMA_MODEL="glm4:latest" ;;
-        ollama-think) OLLAMA_MODEL="glm4:latest" ;;
+        ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;
       esac
     else
       OLLAMA_MODEL="$MODEL_FROM_FRONTMATTER"

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -972,7 +972,7 @@ PB
 
   local model
   model=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
-  assert_eq "$model" "glm4:latest" "runner:ollama-think default must be glm4:latest"
+  assert_eq "$model" "gpt-oss:20b" "runner:ollama-think default must be gpt-oss:20b"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #none

## Description
Reverts the `ollama-think` default from `glm4:latest` (set in #231 under a flawed "trusted model everywhere" premise) back to `gpt-oss:20b`. Model choice is gated by **tool-use**, not one model everywhere:

- `runner: ollama-agent` (tool-using, e.g. `cron-failure-digest`) gates on the **trust** probes → `glm4:latest` (gpt-oss:20b fabricates tool results). Unchanged.
- `runner: ollama` (tool-free, read-only, summarize/light) → `glm4:latest` (adequate + fast + fits 12GB). Unchanged.
- `runner: ollama-think` (tool-free, read-only, **reasoning**) → **`gpt-oss:20b`**. Trust-fabrication cannot occur with no tools; capability governs. model-matrix shows gpt-oss:20b is the clear reasoning/code leader; glm4:latest scores 0 on the hard tasks (`think-02/03`, `t2-02`, `t3-01/02/04/06/07`).

Honest caveat (documented, not fixed here): the trust probes measure tool-result fabrication, not content-honesty in open reasoning — gpt-oss:20b is capability-superior but open-reasoning-honesty is unmeasured.

## Testing Procedure
1. `bash scripts/ceo-cron.test.sh` → passes; `ollama-think-dispatch` asserts default `gpt-oss:20b`.
2. `grep -n ollama-think scripts/ceo-cron.sh` → default reads `gpt-oss:20b`.

## Additional Notes
Config-only revert. `gpt-oss:20b` is not currently installed and no playbook uses `runner: ollama-think`, so re-pull is deferred until a consumer is added (noted in the case-block comment). No re-download performed now.