### PR TITLE
playbook(cron-failure-digest): glm4 -> mistral-small3.2:24b

### DIFF
--- a/docs/playbooks/cron-failure-digest.md
+++ b/docs/playbooks/cron-failure-digest.md
@@ -10,9 +10,9 @@ preflight: none
 tier: read
 status: active
 runner: ollama-agent
-model: glm4:latest
+model: mistral-small3.2:24b
 task: cron-failure-digest
-registry: {"tasks":{"cron-failure-digest":{"runner":"ollama","model":"glm4:latest","tier":"low-stakes-write","tools":["read_file","run_shell","write_file","list_dir"],"rules":false,"skills":false}}}
+registry: {"tasks":{"cron-failure-digest":{"runner":"ollama","model":"mistral-small3.2:24b","tier":"low-stakes-write","tools":["read_file","run_shell","write_file","list_dir"],"rules":false,"skills":false}}}
 artifact: CEO/reports/cron-failures/{TODAY}-{HOST}.md
 ---
 You are writing a digest of recent CEO cron failures. Your working directory is the vault's CEO directory. Make EXACTLY two tool calls, then stop with a one-line summary — do NOT run extra searches, greps, or re-reads (over-exploring is what makes this task fail to finish).

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1718,15 +1718,19 @@ END_LOG_ENTRY"
     # with "pull model manifest: file does not exist". Native runner:ollama
     # playbooks still honor `model:` for explicit ollama-model overrides.
     if [ -z "$MODEL_FROM_FRONTMATTER" ] || [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" = "1" ]; then
-      # Model choice is gated by tool-use, not one model everywhere. Tool-using
-      # delegation (runner:ollama-agent) gates on the trust probes — glm4:latest
-      # passes, gpt-oss:20b fabricates tool results and is refused. The tool-free
-      # read-only runners below gate on capability instead: `ollama` carries
-      # summarize/light traffic (glm4 is adequate + fast + fits 12GB), while
-      # `ollama-think` is the reasoning tier where gpt-oss:20b is the clear
-      # model-matrix leader (glm4 scores 0 on the hard reasoning/code tasks).
-      # gpt-oss:20b is not currently installed — re-pull it before enabling any
-      # runner:ollama-think playbook.
+      # Model choice is gated by tool-use, not one model everywhere.
+      #   - Tool-using reason+act (runner:ollama-agent): gate on trust AND
+      #     capability. mistral-small3.2:24b is the pick — ties the trust lead,
+      #     reasons well, tops content-honesty. gpt-oss:20b is refused (fabricates
+      #     tool results, 44% trust). See cron-failure-digest.
+      #   - `ollama` (tool-free, summarize/light): glm4:latest — adequate + fast +
+      #     fits 12GB. Weak reasoner, but summarization doesn't need it.
+      #   - `ollama-think` (tool-free reasoning): gpt-oss:20b is the capability
+      #     leader (glm4 scores 0 on hard code). But the 2026-07-01 honesty tier
+      #     shows gpt-oss bails/fabricates on open prompts — when a real
+      #     ollama-think consumer lands, prefer mistral for honesty-sensitive
+      #     reasoning and pin gpt-oss only for hard, checkable code/math.
+      #     gpt-oss:20b is not installed on ML-1 — re-pull before enabling one.
       case "$RUNNER" in
         ollama)       OLLAMA_MODEL="glm4:latest" ;;
         ollama-think) OLLAMA_MODEL="gpt-oss:20b" ;;


### PR DESCRIPTION
Closes #none

## Description
Repoints the `cron-failure-digest` (the only live `runner: ollama-agent` consumer) from `glm4:latest` to `mistral-small3.2:24b`.

model-matrix combined scorecard (glm4 / mistral / gpt-oss):
- Capability tier1/2/3: 58% / 84% / 100% (hard code: 0% / 71% / 100%)
- Trust (tool-fabrication): 94% / 94% / 44%
- Content-honesty (new tier): 75% / 86% / 72%

glm4 is the worst reasoner and fabricated content (false premise + citations); mistral ties the trust lead, reasons well, and is the honesty leader — best-of-both for a tool-using reasoning agent. gpt-oss is disqualified for tool use (fabricates tool results). Updates both frontmatter `model` and the `registry` task model.

Also updates the `ceo-cron.sh` case-block comment to document the tool-use-gated routing + the `ollama-think` tradeoff (gpt-oss capability leader; prefer mistral for honesty-sensitive reasoning) — no pointer change.

## Testing Procedure
1. `python3` parse of the `registry:` line → model reads `mistral-small3.2:24b`.
2. `bash scripts/ceo-cron.test.sh` → green (exit 0); `ollama-think` default assertion unchanged (`gpt-oss:20b`).
3. `mistral-small3.2:24b` confirmed installed on ML-1.

## Additional Notes
mistral-small3.2:24b is already installed on both ML-1 and MBP. Honesty tier is exploratory (n=6, single judge) — used here as a tiebreaker behind capability + trust, not the sole driver.