### PR TITLE
Add CLAUDE.md with scheduling front-door pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# claude-ceo — project instructions
+
+Loaded at session start. Keep concise; the full architecture lives in `README.md`.
+
+## Scheduled work / crons
+
+Scheduling on CEO is run by the **`ceo-schedulerd`** daemon — a thin adapter over the
+[cronbird](https://github.com/nhangen/cronbird) engine — **not** crontab or launchd.
+Native crontab install is retired. To investigate, list, or create scheduled jobs,
+use the **`ceo` CLI** (the front door), not `cronbird` directly:
+
+- **Inspect / list:** `ceo playbook list` (registered jobs), `ceo doctor` (daemon
+  health + artifact checks), `ceo playbook info <name>`.
+- **Create / change:** edit the playbook `.md` (`docs/playbooks/<name>.md`, or the
+  synced `$CEO_VAULT/CEO/playbooks/<name>.md`), then `ceo playbook scan`
+  **on ML-1 only** — scan installs schedulers and rewrites the host-local
+  `~/.ceo/registry.json` (see the `ceo-scan-only-on-ml1` rule).
+- **Enable / disable per host:** `ceo playbook enable|disable <name>`.
+
+Do **not** hand-roll crontab lines, launchd plists, or systemd units for recurring
+CEO work — register a playbook (see the `ceo-automated-writers-are-playbooks` rule).
+
+`cronbird` is the engine underneath; its own `cronbird status|list|next-runs`
+commands are the front door only for a **standalone** cronbird deployment, not CEO.


### PR DESCRIPTION
Closes #236.

## Description

An agent told to "investigate crons on CEO" had no pointer in **session-start context**: `crontab -l` is empty (native cron retired), and the `ceo` CLI / cronbird relationship was documented only in `README.md` — which isn't auto-loaded the way a project `CLAUDE.md` is. The repo had no `CLAUDE.md`.

Adds a minimal `CLAUDE.md` whose focus is the **scheduling front door**:
- Inspect/list: `ceo playbook list`, `ceo doctor`, `ceo playbook info <name>`.
- Create/change: edit the playbook `.md` + `ceo playbook scan` (**ML-1 only**).
- The key orientation: on CEO the front door is the **`ceo` CLI, not cronbird** — cronbird is the engine underneath, and its own `status|list|next-runs` are for a standalone deployment.

Cross-references the `ceo-scan-only-on-ml1` and `ceo-automated-writers-are-playbooks` rules, and points to README for full architecture. Docs-only.

## Testing Procedure

1. Open `CLAUDE.md` — confirm the "Scheduled work / crons" section names the inspect/create commands and the "front door is `ceo`, engine is cronbird" note.
2. No code changed; existing tests/CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cev41V8cLJ7mWhm75PFF
