### PR TITLE
docs: note ceo-schedulerd is a cronbird adapter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Output: CEO/reports/YYYY-MM-DD.md
 State:  CEO/log/, CEO/approvals/, CEO/cache/
 ```
 
-Playbooks self-register: `ceo playbook scan` walks `CEO/playbooks/*.md`, extracts each frontmatter block via `yq`, and rewrites the host-local `~/.ceo/registry.json`. Scheduling is owned by the `ceo-schedulerd` daemon (which reads that registry) — scan does not touch the crontab.
+Playbooks self-register: `ceo playbook scan` walks `CEO/playbooks/*.md`, extracts each frontmatter block via `yq`, and rewrites the host-local `~/.ceo/registry.json`. Scheduling is owned by the `ceo-schedulerd` daemon (which reads that registry) — scan does not touch the crontab. `ceo-schedulerd` is a thin adapter over [**cronbird**](https://github.com/nhangen/cronbird), the standalone host-aware scheduler engine (cron matching, host/scope selection, missed-slot catch-up, at-most-once dispatch); CEO adds the playbook registry, tiers, and approvals on top.
 
 ## Subagents
 
@@ -159,7 +159,7 @@ ceo swarm doctor [--fix]          # detect/heal swarm.json sync-conflict copies
 ceo swarm owners-health           # flag single-scope owners whose heartbeat is stale (offline)
 ```
 
-Scheduling is owned by the `ceo-schedulerd` daemon (native crontab install is retired); its run predicate (`selectRunnable`) is exactly the intersection above.
+Scheduling is owned by the `ceo-schedulerd` daemon (native crontab install is retired); its run predicate (`selectRunnable`, from the [cronbird](https://github.com/nhangen/cronbird) engine) is exactly the intersection above.
 
 See [`docs/install.md`](docs/install.md) for fresh multi-machine setup, [`docs/playbooks/SCHEMA.md`](docs/playbooks/SCHEMA.md#swarm-selection-model) for the full selection model, and [`docs/migration.md`](docs/migration.md) for migrating an existing single-host install.
 


### PR DESCRIPTION
Closes the README staleness gap left by #234: the README described `ceo-schedulerd` as self-contained and never mentioned cronbird, even though the scheduler was re-based on the extracted [cronbird](https://github.com/nhangen/cronbird) engine. Adds the cross-reference at both scheduler mentions (architecture blurb + swarm-selection note), matching the `CLAUDE.md` pointer from #238. Docs-only.

## Testing Procedure
1. Read README — the `ceo-schedulerd` description now names cronbird as the engine and `selectRunnable` as cronbird-sourced.
2. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cev41V8cLJ7mWhm75PFF