### PR TITLE
Gate Discord report delivery on per-playbook frontmatter flag

### DIFF
--- a/docs/playbooks/morning.md
+++ b/docs/playbooks/morning.md
@@ -8,6 +8,8 @@ model: sonnet
 preflight: none
 tier: read
 status: active
+discord_report: true
+discord_prior_day_report: true
 inputs: [pr_data, pending_count, today_log, yesterday_log, daily_note, active_domains, pending_ask, current_sprint, yesterday_merged, ledger_recent]
 ---
 

--- a/docs/playbooks/weekly-synthesis.md
+++ b/docs/playbooks/weekly-synthesis.md
@@ -7,6 +7,7 @@ model: opus
 preflight: none
 tier: read
 status: active
+discord_report: true
 runner: skill
 skill: weekly-synthesis
 ---

--- a/scripts/ceo
+++ b/scripts/ceo
@@ -1173,7 +1173,7 @@ cmd_playbook_scan() {
     local from_repo=0
     [ "$d" = "$repo_playbook_dir" ] && from_repo=1
 
-    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual scope agent_task agent_registry
+    local name description trigger schedule model preflight tier status bin runner script inputs skill out_pattern requires artifact _artifact_residual scope agent_task agent_registry discord_report discord_prior_day_report
     name=$(_fm_scalar name "$f")
     if [ -z "$name" ]; then
       echo "  SKIP  $basename (no name in frontmatter)"
@@ -1380,6 +1380,31 @@ cmd_playbook_scan() {
       fi
     fi
 
+    # discord_report / discord_prior_day_report: opt-in booleans that carry the
+    # "post this playbook's report to Discord" intent from frontmatter into the
+    # registry, so ceo-discord-report.sh can gate on the playbook itself rather
+    # than a hand-maintained settings.json allow-list. Explicit true/false is
+    # authoritative; ABSENT is left null so delivery falls back to the settings
+    # allow-list (backward compat — an unflagged playbook must keep its old
+    # settings-driven behavior, not be silently blocked). A non true/false value
+    # is a typo — warn and leave null (fall back), never authoritatively block
+    # (enum-config-typo-fallback: validate at parse, don't silently coerce).
+    local discord_report_json="null" discord_prior_day_report_json="null"
+    discord_report=$(_fm_scalar discord_report "$f")
+    case "$discord_report" in
+      "true") discord_report_json="true" ;;
+      "false") discord_report_json="false" ;;
+      "") ;;
+      *) echo "  WARN  $basename: 'discord_report' must be true/false (got: $discord_report) — ignoring (delivery falls back to settings allow-list)" >&2 ;;
+    esac
+    discord_prior_day_report=$(_fm_scalar discord_prior_day_report "$f")
+    case "$discord_prior_day_report" in
+      "true") discord_prior_day_report_json="true" ;;
+      "false") discord_prior_day_report_json="false" ;;
+      "") ;;
+      *) echo "  WARN  $basename: 'discord_prior_day_report' must be true/false (got: $discord_prior_day_report) — ignoring (delivery falls back to settings allow-list)" >&2 ;;
+    esac
+
     local entry_file
     if [ "$from_repo" = "1" ]; then
       entry_file="$f"
@@ -1409,8 +1434,10 @@ cmd_playbook_scan() {
       --argjson inputs "$inputs" \
       --argjson requires "$requires" \
       --argjson hosts "$hosts" \
+      --argjson discord_report "$discord_report_json" \
+      --argjson discord_prior_day_report "$discord_prior_day_report_json" \
       --arg file "$entry_file" \
-      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, task:$task, registry:$registry, out_pattern:$out_pattern, artifact:$artifact, scope:$scope, inputs:$inputs, requires:$requires, hosts:$hosts, file:$file}')
+      '{name:$name, description:$description, trigger:$trigger, schedule:$schedule, model:$model, preflight:$preflight, tier:$tier, status:$status, bin:$bin, runner:$runner, script:$script, skill:$skill, task:$task, registry:$registry, out_pattern:$out_pattern, artifact:$artifact, scope:$scope, inputs:$inputs, requires:$requires, hosts:$hosts, discord_report:$discord_report, discord_prior_day_report:$discord_prior_day_report, file:$file}')
 
     new_registry=$(echo "$new_registry" | jq --argjson entry "$entry" '.playbooks += [$entry]')
     found=$((found + 1))
@@ -1451,6 +1478,26 @@ cmd_playbook_scan() {
 
   # Apply schedule overrides — registry should reflect effective schedules.
   new_registry=$(_playbook_apply_schedule_overrides "$new_registry")
+
+  # Surface stale Discord report allow-list entries: a name in settings.json's
+  # discord_report_triggers / discord_prior_day_report_triggers that matches no
+  # active playbook is almost always a leftover from a rename (the exact drift
+  # that silently orphaned morning-brief). The per-playbook discord_report flag
+  # is the fix going forward; this warn makes any residual allow-list rot loud
+  # at scan time instead of invisible in a /tmp debug log.
+  local _settings_file="$CEO_DIR/settings.json"
+  if [ -f "$_settings_file" ]; then
+    local _active_names _key _trig
+    _active_names=$(echo "$new_registry" | jq -r '.playbooks[] | select(.status=="active") | .name')
+    for _key in discord_report_triggers discord_prior_day_report_triggers; do
+      while IFS= read -r _trig; do
+        [ -z "$_trig" ] && continue
+        if ! grep -qxF "$_trig" <<< "$_active_names"; then
+          echo "  WARN  stale $_key entry: '$_trig' in settings.json has no matching active playbook (rename leftover?)" >&2
+        fi
+      done < <(jq -r --arg k "$_key" '(.[$k] // [])[]' "$_settings_file" 2>/dev/null)
+    done
+  fi
 
   if [ "$dry_run" -eq 1 ]; then
     echo ""

--- a/scripts/ceo-discord-report.sh
+++ b/scripts/ceo-discord-report.sh
@@ -41,6 +41,34 @@ _dlog() {
     >> "$log" 2>/dev/null || true
 }
 
+# Resolve a boolean delivery flag for $TRIGGER from the host-local registry
+# ($HOME/.ceo/registry.json), written from playbook frontmatter by
+# `ceo playbook scan`. Echoes `true`, `false`, or `absent`. `absent` covers a
+# missing registry, a missing entry, or an entry that predates the flag field —
+# in all three the caller falls back to the settings.json allow-list. Making the
+# flag travel with the playbook is what stops a trigger rename from silently
+# orphaning delivery (settings.json is hand-maintained and never synced to names).
+_registry_report_flag() {
+  local field="$1"
+  local reg="${CEO_REGISTRY_FILE:-$HOME/.ceo/registry.json}"
+  [ -f "$reg" ] || { echo absent; return; }
+  local val
+  # Deliberately avoid jq's `//` here: `false // "absent"` returns "absent"
+  # because jq treats false as empty, which would collapse an explicit
+  # discord_report:false into the settings fallback. Branch on array length and
+  # an explicit null check instead so false stays distinct from absent.
+  val=$(jq -r --arg t "$TRIGGER" --arg f "$field" \
+    '[.playbooks[]? | select(.name==$t) | .[$f]] as $v
+     | if ($v | length) == 0 then "absent"
+       elif ($v[0] == null) then "absent"
+       else ($v[0] | tostring) end' \
+    "$reg" 2>/dev/null)
+  case "$val" in
+    true|false) echo "$val" ;;
+    *) echo absent ;;
+  esac
+}
+
 if ! command -v jq >/dev/null 2>&1; then
   _dlog "jq not on PATH, bailing 0"
   exit 0
@@ -51,13 +79,22 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 SETTINGS_FILE="${CEO_DIR:-$HOME/Documents/Obsidian/CEO}/settings.json"
-if [ -f "$SETTINGS_FILE" ]; then
-  enabled=$(jq -e --arg trig "$TRIGGER" \
-    '(.discord_report_triggers // ["morning-brief"]) | index($trig) != null' \
-    "$SETTINGS_FILE" >/dev/null 2>&1 && echo 1 || echo 0)
-else
-  [ "$TRIGGER" = "morning-brief" ] && enabled=1 || enabled=0
-fi
+report_flag=$(_registry_report_flag discord_report)
+case "$report_flag" in
+  true)  enabled=1; _dlog "delivery enabled by registry discord_report flag" ;;
+  false) enabled=0; _dlog "delivery disabled by registry discord_report flag" ;;
+  absent)
+    # Backward-compat fallback: no per-playbook flag in the registry, so honor
+    # the hand-maintained settings.json allow-list (default: morning-brief only).
+    if [ -f "$SETTINGS_FILE" ]; then
+      enabled=$(jq -e --arg trig "$TRIGGER" \
+        '(.discord_report_triggers // ["morning-brief"]) | index($trig) != null' \
+        "$SETTINGS_FILE" >/dev/null 2>&1 && echo 1 || echo 0)
+    else
+      [ "$TRIGGER" = "morning-brief" ] && enabled=1 || enabled=0
+    fi
+    ;;
+esac
 [ "$enabled" = "1" ] || {
   _dlog "trigger not enabled for full report delivery"
   exit 0
@@ -139,13 +176,20 @@ total=$((total + sent))
 # report keeps its existing front matter and is untouched; the complete prior-day
 # report is delivered here, on Discord only. Gate on its own allow-list so other
 # report triggers don't carry yesterday's report.
-if [ -f "$SETTINGS_FILE" ]; then
-  prior_enabled=$(jq -e --arg trig "$TRIGGER" \
-    '(.discord_prior_day_report_triggers // ["morning-brief"]) | index($trig) != null' \
-    "$SETTINGS_FILE" >/dev/null 2>&1 && echo 1 || echo 0)
-else
-  [ "$TRIGGER" = "morning-brief" ] && prior_enabled=1 || prior_enabled=0
-fi
+prior_flag=$(_registry_report_flag discord_prior_day_report)
+case "$prior_flag" in
+  true)  prior_enabled=1 ;;
+  false) prior_enabled=0 ;;
+  absent)
+    if [ -f "$SETTINGS_FILE" ]; then
+      prior_enabled=$(jq -e --arg trig "$TRIGGER" \
+        '(.discord_prior_day_report_triggers // ["morning-brief"]) | index($trig) != null' \
+        "$SETTINGS_FILE" >/dev/null 2>&1 && echo 1 || echo 0)
+    else
+      [ "$TRIGGER" = "morning-brief" ] && prior_enabled=1 || prior_enabled=0
+    fi
+    ;;
+esac
 
 if [ "$prior_enabled" = "1" ]; then
   report_dir="${CEO_DIR:-$HOME/Documents/Obsidian/CEO}/reports"

--- a/scripts/ceo-discord-report.test.sh
+++ b/scripts/ceo-discord-report.test.sh
@@ -195,4 +195,51 @@ test_empty_prior_day_allowlist_disables_append() {
   unset TODAY
 }
 
+# --- Registry-frontmatter gate (prevents trigger-rename allow-list drift) ---
+# The authoritative signal for "post this playbook's report to Discord" is the
+# discord_report flag carried in the host-local registry from playbook
+# frontmatter. settings.json's discord_report_triggers remains a backward-compat
+# fallback used only when the trigger's registry entry lacks the flag field.
+
+test_registry_flag_enables_report_without_settings_entry() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  # A renamed playbook: settings.json still lists the OLD name, not "morning".
+  echo '{"discord_report_triggers":["morning-brief"]}' > "$CEO_DIR/settings.json"
+  mkdir -p "$HOME/.ceo"
+  echo '{"playbooks":[{"name":"morning","discord_report":true}]}' > "$HOME/.ceo/registry.json"
+
+  printf 'orchestrated brief' | "$REPORT" morning >/dev/null 2>&1
+
+  assert_contains "$(cat "$CURL_CAPTURE_DIR"/payload-*.json 2>/dev/null)" "orchestrated brief" \
+    "registry discord_report:true must post even when the trigger is absent from settings allow-list"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_registry_flag_false_blocks_report_despite_settings() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  echo '{"discord_report_triggers":["morning-scan"]}' > "$CEO_DIR/settings.json"
+  mkdir -p "$HOME/.ceo"
+  echo '{"playbooks":[{"name":"morning-scan","discord_report":false}]}' > "$HOME/.ceo/registry.json"
+
+  printf 'scan report' | "$REPORT" morning-scan >/dev/null 2>&1
+
+  assert_eq "$(find "$CURL_CAPTURE_DIR" -type f | wc -l | tr -d ' ')" "0" \
+    "registry discord_report:false must block delivery even when the trigger is in the settings allow-list"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_no_registry_flag_field_falls_back_to_settings() {
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  echo '{"discord_report_triggers":["legacy-brief"]}' > "$CEO_DIR/settings.json"
+  mkdir -p "$HOME/.ceo"
+  # Old registry: entry exists but carries no discord_report field.
+  echo '{"playbooks":[{"name":"legacy-brief"}]}' > "$HOME/.ceo/registry.json"
+
+  printf 'legacy body' | "$REPORT" legacy-brief >/dev/null 2>&1
+
+  assert_contains "$(cat "$CURL_CAPTURE_DIR"/payload-*.json 2>/dev/null)" "legacy body" \
+    "an entry without a discord_report field must fall back to the settings allow-list (backward compat)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-scan.test.sh
+++ b/scripts/ceo-scan.test.sh
@@ -211,4 +211,36 @@ test_scan_registers_real_cron_failure_digest_with_inline_registry() {
     "inline-JSON registry must survive scan and re-parse to the bridge task tier"
 }
 
+test_discord_report_flags_carried_to_registry() {
+  {
+    echo "---"; echo "name: flagged"; echo "description: d"; echo "trigger: cron"
+    echo "schedule: \"0 9 * * *\""; echo "status: active"; echo "runner: claude"
+    echo "discord_report: true"; echo "discord_prior_day_report: true"
+    echo "---"; echo ""; echo "# flagged"
+  } > "$CEO_DIR/playbooks/flagged.md"
+  _run_scan
+  local reg="$HOME/.ceo/registry.json"
+  assert_eq "$(jq -r '.playbooks[]|select(.name=="flagged").discord_report' "$reg")" "true" \
+    "scan must carry discord_report:true from frontmatter into the registry entry"
+  assert_eq "$(jq -r '.playbooks[]|select(.name=="flagged").discord_prior_day_report' "$reg")" "true" \
+    "scan must carry discord_prior_day_report:true from frontmatter into the registry entry"
+}
+
+test_discord_report_flag_null_when_frontmatter_omits() {
+  _run_scan
+  local reg="$HOME/.ceo/registry.json"
+  assert_eq "$(jq -r '.playbooks[]|select(.name=="scope-absent").discord_report' "$reg")" "null" \
+    "a playbook with no discord_report frontmatter must leave the registry flag null so delivery falls back to the settings allow-list (backward compat)"
+}
+
+test_scan_warns_on_stale_discord_report_trigger() {
+  # scope-each is an active playbook this scan produces; no-such-playbook is stale.
+  echo '{"discord_report_triggers":["scope-each","no-such-playbook"]}' > "$CEO_DIR/settings.json"
+  _run_scan
+  assert_contains "$SCAN_OUT" "no-such-playbook" \
+    "scan must warn when a discord_report_triggers entry has no matching active playbook"
+  assert_not_contains "$SCAN_OUT" "WARN: stale discord_report_trigger: scope-each" \
+    "scan must not warn about an allow-list entry that IS an active playbook"
+}
+
 run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
A playbook trigger rename silently orphaned Discord report delivery. `discord_report_triggers` in `settings.json` is hand-maintained and never synced to trigger names, and `ceo-discord-report.sh` exits silently when a trigger isn't listed — so the `morning-brief` → `morning` rename stopped the morning briefing reaching Discord for ~a week with no signal.

This moves the "post this report to Discord" intent into playbook frontmatter (`discord_report` / `discord_prior_day_report`). `ceo playbook scan` carries the flags into the host-local registry; `ceo-discord-report.sh` gates on the flag when present and falls back to the settings allow-list only for entries without it (backward compat). Explicit `true`/`false` is authoritative; absent stays `null` so unflagged playbooks keep their prior settings-driven behavior. A rename now carries the flag automatically, so the drift class can't recur. Scan also warns on stale `discord_report_triggers` entries with no matching active playbook.

Also flags `morning` (report + prior-day) and `weekly-synthesis` (report).

## Testing Procedure
1. Check out this branch.
2. `bash scripts/ceo-discord-report.test.sh` — 13 pass (registry-flag enable/block/settings-fallback).
3. `bash scripts/ceo-scan.test.sh` — 10 pass (flags carried to registry, null-when-absent, stale-trigger warn).
4. `bash scripts/ceo-cron.test.sh` — 172 pass (delivery side-channel unbroken).
5. Post-merge: run `ceo playbook scan` on the scheduler host (ML-1) so the registry regenerates with the flags.

## Additional Notes
Prevention follow-up to the live hotfix (adding `morning` to the `settings.json` allow-list). Doc twin on branch `nh/docs/scheduler-registry-path`. No registry schema bump — the two fields are additive/optional.
