### PR TITLE
Fix scheduler docs: registry is host-local, not in the synced vault

### DIFF
--- a/lib/scheduler/README.md
+++ b/lib/scheduler/README.md
@@ -46,10 +46,12 @@ that zone (defaults to host-local). Invalid or non-5-field expressions throw
 
 ## The daemon (`ceo-schedulerd`, #142)
 
-`src/main.ts` is the long-lived daemon. Each tick it re-reads
-`$CEO_VAULT/CEO/registry.json`, selects the playbooks **this host** runs on a
-schedule, dispatches every due one, writes a heartbeat, and sleeps until the
-soonest next fire (capped at 60s so registry edits and clock skew self-heal).
+`src/main.ts` is the long-lived daemon. Each tick it re-reads the host-local
+`~/.ceo/registry.json` (written by `ceo playbook scan`; the synced vault holds
+only `CEO/swarm.json` and `CEO/heartbeats/`, not the registry), selects the
+playbooks **this host** runs on a schedule, dispatches every due one, writes a
+heartbeat, and sleeps until the soonest next fire (capped at 60s so registry
+edits and clock skew self-heal).
 
 Pipeline, all of it unit-tested behind injected side effects:
 

--- a/lib/scheduler/deploy/ceo-schedulerd.service
+++ b/lib/scheduler/deploy/ceo-schedulerd.service
@@ -34,7 +34,8 @@ Type=simple
 WorkingDirectory=%h/code/claude-ceo/lib/scheduler
 # EDIT: absolute path to bun and to this repo's lib/scheduler/src/main.ts.
 ExecStart=%h/.bun/bin/bun run %h/code/claude-ceo/lib/scheduler/src/main.ts
-# EDIT: the synced Obsidian vault root that contains CEO/registry.json.
+# EDIT: the synced Obsidian vault root (holds CEO/swarm.json + CEO/heartbeats/;
+# the registry itself is host-local at ~/.ceo/registry.json).
 Environment=CEO_VAULT=%h/Documents/Obsidian
 # REQUIRED: this host's unique CEO id (install.md §2). systemd does NOT source
 # ~/.ceo/config, so the daemon reads CEO_HOSTNAME only from here. Left as the

--- a/lib/scheduler/deploy/com.ceo.schedulerd.plist
+++ b/lib/scheduler/deploy/com.ceo.schedulerd.plist
@@ -55,7 +55,7 @@
 
   <key>EnvironmentVariables</key>
   <dict>
-    <!-- EDIT: the synced Obsidian vault root that contains CEO/registry.json. -->
+    <!-- EDIT: the synced Obsidian vault root (holds CEO/swarm.json + CEO/heartbeats/; the registry itself is host-local at ~/.ceo/registry.json). -->
     <key>CEO_VAULT</key>
     <string>/Users/CHANGEME/Documents/Obsidian</string>
     <!-- REQUIRED: this host's unique CEO id (install.md §2). launchd does NOT

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -5,7 +5,8 @@
  * and shuts down cleanly on SIGINT/SIGTERM. All scheduling logic lives in the
  * unit-tested modules; this file is intentionally thin.
  *
- * Required env: `CEO_VAULT` (registry root), `HOME` (heartbeat dir).
+ * Required env: `CEO_VAULT` (swarm.json + synced-heartbeat root), `HOME`
+ * (host-local registry `~/.ceo/registry.json` + local heartbeat dir).
  * Optional env: `CEO_HOSTNAME` (host id override), `CEO_CRON_BIN` (dispatch
  * binary, default `ceo-cron.sh` on PATH).
  *


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
README, the `main.ts` env-doc comment, and both deploy templates said the daemon reads `$CEO_VAULT/CEO/registry.json`. It doesn't — `runtime.ts` resolves the registry host-local at `~/.ceo/registry.json` (`registryPath(home)`). `CEO_VAULT` is still required, but for `CEO/swarm.json` and `CEO/heartbeats/`, not the registry. The stale phrasing sends people to the dead synced-vault copy when debugging. Comment/doc only — no behavior change.

## Testing Procedure
1. Check out this branch.
2. `grep -rn 'CEO_VAULT/CEO/registry.json' lib/scheduler/` → no matches.
3. Confirm `lib/scheduler/src/runtime.ts` `registryPath(home)` still returns `${home}/.ceo/registry.json` — docs now match code.

## Additional Notes
Split from the frontmatter-gate PR (branch `nh/feat/discord-report-frontmatter-gate`) — separate concern.
