### PR TITLE
fix(playbooks): add missing out_pattern to weekly-synthesis

### DIFF
--- a/docs/playbooks/weekly-synthesis.md
+++ b/docs/playbooks/weekly-synthesis.md
@@ -10,6 +10,7 @@ status: active
 discord_report: true
 runner: skill
 skill: weekly-synthesis
+out_pattern: CEO/reports/weekly-synthesis-${TODAY}.md
 ---
 
 # Weekly Synthesis

--- a/scripts/ceo-scan.test.sh
+++ b/scripts/ceo-scan.test.sh
@@ -243,4 +243,27 @@ test_scan_warns_on_stale_discord_report_trigger() {
     "scan must not warn about an allow-list entry that IS an active playbook"
 }
 
+test_all_active_skill_runner_playbooks_declare_out_pattern() {
+  # Invariant (ceo-cron.sh runner:skill branch, :1408): a runner:skill playbook
+  # with an empty out_pattern fails at cron time with "runner:skill but no
+  # 'out_pattern' field". weekly-synthesis shipped runner:skill without an
+  # out_pattern and failed silently every Sunday 08:00 until the CEO->Discord
+  # delivery fix surfaced it. Lint the real shipped docs so no skill-runner can
+  # ship without one again (test-expected-from-production-entry-point: reads the
+  # shipped files, does not rebuild the frontmatter).
+  local pdir="$SCRIPT_DIR/../docs/playbooks"
+  assert_file_exists "$pdir/weekly-synthesis.md" "shipped playbook docs must exist"
+  local f fm op offenders=""
+  for f in "$pdir"/*.md; do
+    [ -f "$f" ] || continue
+    fm=$(awk 'NR==1&&$0=="---"{f=1;next} f&&$0=="---"{exit} f{print}' "$f")
+    printf '%s\n' "$fm" | grep -qE '^runner:[[:space:]]*skill[[:space:]]*$' || continue
+    printf '%s\n' "$fm" | grep -qE '^status:[[:space:]]*(archived|disabled|retired)' && continue
+    op=$(printf '%s\n' "$fm" | grep -E '^out_pattern:' | head -1 | sed 's/^out_pattern:[[:space:]]*//')
+    [ -n "$op" ] || offenders="$offenders $(basename "$f")"
+  done
+  assert_eq "$offenders" "" \
+    "every active runner:skill playbook must declare a non-empty out_pattern (ceo-cron.sh :1408 fails the run otherwise)"
+}
+
 run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
`weekly-synthesis` declares `runner: skill` but never carried an `out_pattern`, so `ceo-cron.sh:1408` rejected every Sunday-08:00 run with *"has runner:skill but no out_pattern field"*. It has failed silently since the `runner: skill` primitive landed (`c823178`); the recent CEO→Discord delivery fix just made the failure visible in the channel.

Fix: add `out_pattern: CEO/reports/weekly-synthesis-${TODAY}.md`, matching the playbook's own `## Outputs` table and the skill's `run-report.sh:223` write path.

Also guards the class — `ceo-scan.test.sh` now lints every **active** `runner: skill` playbook doc for a non-empty `out_pattern`. `story-points` and `workload-report` already comply; `weekly-synthesis` was the sole offender.

## Testing Procedure
1. Check out this branch.
2. `cd scripts && bash ceo-scan.test.sh` → 11/11 pass, including the new guard test.
3. Revert the `out_pattern:` line and re-run → guard fails with `got: \ weekly-synthesis.md` (confirms it pins the fix).
4. `bash ceo-cron.test.sh` → 172/172 pass (no regression).

## Additional Notes
Goes live on ML-1 only after `git pull` + `ceo playbook scan` there (same deploy step as #240).