### PR TITLE
feat(playbook): add ceo playbook sync + scan drift warning

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -582,6 +582,7 @@ cmd_playbook() {
     list) cmd_playbook_list ;;
     info) cmd_playbook_info "$@" ;;
     diff) cmd_playbook_diff "$@" ;;
+    sync) cmd_playbook_sync "$@" ;;
     enable) cmd_playbook_enable "$@" ;;
     disable) cmd_playbook_disable "$@" ;;
     assign) cmd_playbook_assign "$@" ;;
@@ -593,6 +594,9 @@ cmd_playbook() {
       echo "  list               Show all registered playbooks with scope + state"
       echo "  info <name>        Show details for one playbook"
       echo "  diff [--quiet]     Detect drift between vault and repo playbooks"
+      echo "  sync [--check]     Reconcile vault playbooks from the repo (repo wins;"
+      echo "                     vault-only playbooks kept). --check: report + exit 1 on"
+      echo "                     drift, no writes."
       echo "  enable <name>      Run this each-scope playbook on THIS host"
       echo "  disable <name>     Stop running this each-scope playbook on THIS host"
       echo "  assign <name> <host>  Assign a single-scope playbook to an owner host"
@@ -1024,6 +1028,111 @@ cmd_playbook_diff() {
   fi
 }
 
+# Reconcile the syncthing vault playbook copies with the git repo. The repo
+# (git-reviewed) is the source of truth; scan reads the vault copy FIRST and
+# lets it shadow the repo, so a stale vault copy silently masks a merged repo
+# change (the weekly-synthesis incident). This is the fix `ceo playbook diff`
+# only diagnoses. One-way repo->vault: overwrite stale/missing vault copies,
+# never touch vault-only (intentional local) playbooks. Exit: 0 ok / 2 on
+# missing repo dir or copy failure; with --check, 1 signals drift (no writes).
+cmd_playbook_sync() {
+  : "${CEO_VAULT:?CEO_VAULT must be set before ceo playbook sync}"
+  local vault_dir="$CEO_DIR/playbooks"
+  local repo_dir="${CEO_REPO_PLAYBOOK_DIR:-$INSTALL_DIR/docs/playbooks}"
+  local check=0
+  for arg in "$@"; do
+    case "$arg" in
+      --check|--dry-run) check=1 ;;
+    esac
+  done
+
+  if [ ! -d "$repo_dir" ]; then
+    echo "ERROR: Repo playbooks directory not found at $repo_dir" >&2
+    return 2
+  fi
+
+  # Multi-host safety (verify-master-parity-before-branch-work): the vault is
+  # syncthing-synced across hosts. Syncing from a repo clone that is BEHIND its
+  # upstream would copy stale playbooks into the vault and propagate them to
+  # every other host. Warn (don't hard-fail — a detached/CI clone may have no
+  # upstream, which is fine) before writing.
+  if [ "$check" -eq 0 ] && command -v git >/dev/null 2>&1 \
+     && git -C "$repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$repo_dir" fetch -q 2>/dev/null || true
+    local _upstream _local _remote
+    _upstream=$(git -C "$repo_dir" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+    if [ -n "$_upstream" ]; then
+      _local=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || echo "")
+      _remote=$(git -C "$repo_dir" rev-parse "$_upstream" 2>/dev/null || echo "")
+      if [ -n "$_local" ] && [ -n "$_remote" ] && [ "$_local" != "$_remote" ] \
+         && git -C "$repo_dir" merge-base --is-ancestor HEAD "$_remote" 2>/dev/null; then
+        echo "  WARN  repo clone is BEHIND $_upstream — syncing now may propagate stale playbooks to all synced hosts. Pull first." >&2
+      fi
+    fi
+  fi
+
+  mkdir -p "$vault_dir"
+
+  local nullglob_was_set=0
+  shopt -q nullglob && nullglob_was_set=1
+  shopt -s nullglob
+
+  local synced=0 uptodate=0 vault_only="" rc=0
+  local f base dst tmp
+  # repo -> vault
+  for f in "$repo_dir"/*.md; do
+    base="${f##*/}"
+    case "$base" in *.sync-conflict-*) continue ;; esac
+    dst="$vault_dir/$base"
+    if [ -f "$dst" ] && cmp -s "$f" "$dst"; then
+      uptodate=$((uptodate + 1))
+      continue
+    fi
+    if [ "$check" -eq 1 ]; then
+      if [ -f "$dst" ]; then echo "Would update: $base"; else echo "Would create: $base"; fi
+      synced=$((synced + 1))
+      continue
+    fi
+    # Atomic within the vault fs: write a temp sibling, then rename. A crash
+    # mid-copy must never leave scan a half-written playbook to parse.
+    tmp=$(mktemp "$vault_dir/.sync.XXXXXX") || { echo "ERROR: mktemp failed in $vault_dir" >&2; rc=2; break; }
+    if cp "$f" "$tmp" && mv -f "$tmp" "$dst"; then
+      echo "Synced: $base"
+      synced=$((synced + 1))
+    else
+      rm -f "$tmp"
+      echo "ERROR: failed to sync $base" >&2
+      rc=2; break
+    fi
+  done
+
+  # Report vault-only playbooks (never delete): a repo playbook deleted upstream
+  # leaves a stale vault copy that keeps shadowing, and it is indistinguishable
+  # from an intentional local-only playbook — so surface, don't auto-prune.
+  for f in "$vault_dir"/*.md; do
+    base="${f##*/}"
+    case "$base" in *.sync-conflict-*) continue ;; esac
+    [ -f "$repo_dir/$base" ] && continue
+    vault_only="${vault_only} $base"
+  done
+
+  [ "$nullglob_was_set" -eq 0 ] && shopt -u nullglob
+
+  if [ -n "$vault_only" ]; then
+    echo "Vault-only (kept — review: intentional local playbook, or retired upstream?):$vault_only"
+  fi
+
+  [ "$rc" -ne 0 ] && return "$rc"
+
+  if [ "$check" -eq 1 ]; then
+    echo "Check: $uptodate up-to-date, $synced would change"
+    [ "$synced" -gt 0 ] && return 1
+    return 0
+  fi
+  echo "Sync: $synced synced, $uptodate up-to-date"
+  return 0
+}
+
 cmd_playbook_scan() {
   # Extract a scalar field from YAML frontmatter without requiring yq.
   # Handles quoted and unquoted values; returns empty string if absent.
@@ -1161,6 +1270,7 @@ cmd_playbook_scan() {
   local seen_names_vault=""
   local seen_names_repo=""
   local shadowed=0
+  local shadowed_drift=0
 
   local scan_dirs=( "$playbook_dir" )
   [ -d "$repo_playbook_dir" ] && scan_dirs+=( "$repo_playbook_dir" )
@@ -1193,6 +1303,12 @@ cmd_playbook_scan() {
       if [ "$from_repo" = "1" ]; then
         echo "  SHADOW $basename (vault override of repo playbook '$name')"
         shadowed=$((shadowed + 1))
+        # A shadow whose vault copy DIFFERS from the repo is the silent-stale
+        # foot-gun: scan used the (possibly outdated) vault version. Flag it so
+        # the fix is actionable rather than buried in a SHADOW line.
+        if [ ! -f "$playbook_dir/$basename" ] || ! cmp -s "$f" "$playbook_dir/$basename"; then
+          shadowed_drift=$((shadowed_drift + 1))
+        fi
       else
         echo "  DUP    $basename (duplicate name '$name')"
         skipped=$((skipped + 1))
@@ -1497,6 +1613,10 @@ cmd_playbook_scan() {
         fi
       done < <(jq -r --arg k "$_key" '(.[$k] // [])[]' "$_settings_file" 2>/dev/null)
     done
+  fi
+
+  if [ "$shadowed_drift" -gt 0 ]; then
+    echo "  WARN  $shadowed_drift repo playbook(s) shadowed by a DIFFERING vault copy — scan used the vault version, which may be stale. Run 'ceo playbook sync' to reconcile from the repo." >&2
   fi
 
   if [ "$dry_run" -eq 1 ]; then

--- a/scripts/ceo-scan.test.sh
+++ b/scripts/ceo-scan.test.sh
@@ -266,4 +266,32 @@ test_all_active_skill_runner_playbooks_declare_out_pattern() {
     "every active runner:skill playbook must declare a non-empty out_pattern (ceo-cron.sh :1408 fails the run otherwise)"
 }
 
+test_scan_warns_when_vault_shadows_repo_with_differing_copy() {
+  # The silent-stale foot-gun: a vault playbook shadows a repo playbook of the
+  # same name AND the two differ, so scan used the (possibly stale) vault copy.
+  # Scan must emit an actionable warning pointing at `ceo playbook sync`.
+  local repo="$TMP/repo-playbooks"
+  mkdir -p "$repo"
+  export CEO_REPO_PLAYBOOK_DIR="$repo"
+  # vault copy of 'scope-each' already exists (setup); write a DIFFERING repo copy.
+  {
+    echo "---"; echo "name: scope-each"; echo "description: scope-each desc"
+    echo "trigger: chat"; echo "schedule: \"\""; echo "status: active"
+    echo "runner: claude"; echo "scope: each"
+    echo "---"; echo ""; echo "# scope-each"; echo "REPO-SIDE DIVERGENT BODY"
+  } > "$repo/scope-each.md"
+  _run_scan
+  assert_contains "$SCAN_OUT" "ceo playbook sync" \
+    "scan must tell the user to run 'ceo playbook sync' when a stale vault copy shadows a differing repo playbook"
+  assert_contains "$SCAN_OUT" "DIFFERING vault copy" \
+    "scan drift warning must name the differing-shadow condition"
+}
+
+test_scan_no_shadow_drift_warning_when_no_repo_dir() {
+  # Default setup has no repo dir → no shadow possible → no drift warning noise.
+  _run_scan
+  assert_not_contains "$SCAN_OUT" "ceo playbook sync" \
+    "scan must not emit the sync warning when there is no repo dir to shadow"
+}
+
 run_tests

--- a/scripts/ceo-sync.test.sh
+++ b/scripts/ceo-sync.test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Tests for `ceo playbook sync` (cmd_playbook_sync): reconcile the syncthing
+# vault playbook copies with the git repo (repo = source of truth), closing the
+# silent shadow-and-win drift that let scan read a stale playbook.
+#
+# Invariants pinned here:
+#   - a stale vault copy of a repo playbook is overwritten to match the repo
+#   - a repo-only playbook is created in the vault
+#   - a vault-only (local) playbook is PRESERVED, never deleted, and reported
+#   - identical copies are a no-op
+#   - --check makes NO writes; exits 1 on drift, 0 when clean, 2 on missing repo
+#   - syncthing .sync-conflict-*.md files are skipped, not treated as playbooks
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+_load_ceo_helpers() {
+  export CEO_LIB_ONLY=1
+  set +u
+  # shellcheck disable=SC1090,SC1091
+  source "$CEO_CLI"
+  set +e +u
+  unset CEO_LIB_ONLY
+}
+
+_load_ceo_helpers
+
+setup() {
+  TMP=$(mktemp -d)
+  export HOME="$TMP/home"; mkdir -p "$HOME"
+  export CEO_VAULT="$TMP/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  VAULT_PB="$CEO_DIR/playbooks"
+  REPO_PB="$TMP/repo/docs/playbooks"
+  mkdir -p "$VAULT_PB" "$REPO_PB"
+  export CEO_REPO_PLAYBOOK_DIR="$REPO_PB"
+  export CEO_HOSTNAME="testhost"
+}
+
+teardown() {
+  rm -rf "$TMP"
+  unset HOME CEO_VAULT CEO_DIR CEO_REPO_PLAYBOOK_DIR CEO_HOSTNAME VAULT_PB REPO_PB
+}
+
+# Write a playbook file with a body marker so two copies of the same name can
+# differ byte-for-byte (drift).
+_pb() {
+  local file="$1" name="$2" body="${3:-body}"
+  {
+    echo "---"; echo "name: $name"; echo "status: active"; echo "runner: claude"
+    echo "---"; echo ""; echo "# $name"; echo "$body"
+  } > "$file"
+}
+
+_run_sync() { SYNC_OUT=$(cmd_playbook_sync "$@" 2>&1); SYNC_RC=$?; }
+
+test_sync_overwrites_stale_vault_copy() {
+  _pb "$REPO_PB/foo.md" foo "NEW-repo-content"
+  _pb "$VAULT_PB/foo.md" foo "OLD-stale-content"
+  _run_sync
+  assert_eq "$SYNC_RC" "0" "sync exits 0 on success"
+  # vault copy must now be byte-identical to the repo copy
+  assert_eq "$(cmp -s "$REPO_PB/foo.md" "$VAULT_PB/foo.md"; echo $?)" "0" \
+    "stale vault copy must be overwritten to match the repo (fails if sync is a no-op)"
+  assert_contains "$SYNC_OUT" "Synced: foo.md" "sync must report the file it updated"
+}
+
+test_sync_creates_repo_only_playbook_in_vault() {
+  _pb "$REPO_PB/bar.md" bar "repo-only"
+  _run_sync
+  assert_file_exists "$VAULT_PB/bar.md" "a repo-only playbook must be created in the vault"
+  assert_eq "$(cmp -s "$REPO_PB/bar.md" "$VAULT_PB/bar.md"; echo $?)" "0" \
+    "created vault copy must match the repo"
+}
+
+test_sync_preserves_vault_only_playbook() {
+  _pb "$VAULT_PB/local.md" local-only "local custom"
+  _pb "$REPO_PB/foo.md" foo "repo"
+  _run_sync
+  assert_file_exists "$VAULT_PB/local.md" "a vault-only playbook must NOT be deleted by sync"
+  assert_contains "$SYNC_OUT" "local.md" "vault-only playbook must be reported for review"
+  assert_contains "$SYNC_OUT" "Vault-only" "sync must label the vault-only report"
+}
+
+test_sync_noop_when_identical() {
+  _pb "$REPO_PB/foo.md" foo "same"
+  _pb "$VAULT_PB/foo.md" foo "same"
+  _run_sync
+  assert_not_contains "$SYNC_OUT" "Synced: foo.md" "identical copy must not be re-synced"
+  assert_contains "$SYNC_OUT" "up-to-date" "identical copy must count as up-to-date"
+}
+
+test_sync_check_makes_no_writes_and_exits_1_on_drift() {
+  _pb "$REPO_PB/foo.md" foo "NEW"
+  _pb "$VAULT_PB/foo.md" foo "OLD"
+  _run_sync --check
+  assert_eq "$SYNC_RC" "1" "--check must exit 1 when drift exists"
+  # vault must be UNCHANGED by --check
+  assert_eq "$(grep -c OLD "$VAULT_PB/foo.md")" "1" \
+    "--check must not modify the vault (stale content must remain)"
+}
+
+test_sync_check_exits_0_when_clean() {
+  _pb "$REPO_PB/foo.md" foo "same"
+  _pb "$VAULT_PB/foo.md" foo "same"
+  _run_sync --check
+  assert_eq "$SYNC_RC" "0" "--check must exit 0 when vault matches repo"
+}
+
+test_sync_skips_syncthing_conflict_files() {
+  _pb "$REPO_PB/foo.md" foo "repo"
+  _pb "$VAULT_PB/foo.sync-conflict-20260101-120000-ABCDEFG.md" foo "conflict junk"
+  _run_sync
+  # The conflict file is not a repo playbook, so it must be neither synced nor
+  # deleted, and must not be reported as a vault-only playbook to reconcile.
+  assert_file_exists "$VAULT_PB/foo.sync-conflict-20260101-120000-ABCDEFG.md" \
+    "sync must leave syncthing conflict files untouched"
+  assert_not_contains "$SYNC_OUT" "sync-conflict" \
+    "sync must not treat a .sync-conflict file as a playbook"
+}
+
+test_sync_missing_repo_dir_exits_2() {
+  export CEO_REPO_PLAYBOOK_DIR="$TMP/no-such-repo"
+  _run_sync
+  assert_eq "$SYNC_RC" "2" "sync must exit 2 when the repo playbook dir is missing"
+}
+
+run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)
`ceo playbook scan` reads the syncthing-synced vault playbooks (`$CEO_DIR/playbooks`) **before** the git repo (`docs/playbooks`) and lets the vault copy win on a duplicate name (`SHADOW`). Nothing reconciled the two, so a stale vault copy silently masked a merged repo change — the root of the `weekly-synthesis` failure. `ceo playbook diff` only *detects* drift; there was no fix command, and the unattended scheduled scan gave no actionable signal.

**New:**
- **`ceo playbook sync [--check]`** — one-way repo→vault reconcile (repo is source of truth). Overwrites stale/missing vault copies (atomic temp+`mv`), **preserves** vault-only local playbooks (never deletes) and reports them for review, skips syncthing `.sync-conflict` files. `--check` makes no writes and exits `1` on drift / `0` clean / `2` on missing repo dir. Warns if the repo clone is **behind upstream** before writing, so a stale clone can’t propagate old playbooks to other synced hosts.
- **scan drift warning** — when a vault copy shadows a repo playbook *and the two differ*, scan emits an actionable `WARN` naming `ceo playbook sync`. The silent case is now loud instead of buried in a `SHADOW` line.

Deliberately **not** done (would need their own decision): flipping scan precedence (removes the intentional vault-override feature) or auto-syncing from scan (a behind clone would push stale copies to all hosts).

## Testing Procedure
1. Check out this branch, `cd scripts`.
2. `bash ceo-sync.test.sh` → 8/8. Revert the `cp "$f" "$tmp" && mv` body in `cmd_playbook_sync` → `test_sync_overwrites_stale_vault_copy` fails (pins the fix).
3. `bash ceo-scan.test.sh` → 13/13, incl. `test_scan_warns_when_vault_shadows_repo_with_differing_copy`.
4. `bash ceo-cron.test.sh` → 172/172 (no dispatch regression).
5. `shellcheck -x ceo` → no new warnings vs main (10==10).

## Additional Notes
Follows the `weekly-synthesis out_pattern` fix (#243). On ML-1 this is what reconciles the drifted vault copies the scan reads; run `ceo playbook sync` there after merge.