### PR TITLE
feat(doctor): watchdog for playbooks that silently stop running/delivering

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -104,6 +104,64 @@ cmd_next() {
   fi
 }
 
+# Coarse staleness grace (seconds) for a cron schedule "min hour dom month dow".
+# Deliberately generous — the goal is catching a job DEAD FOR DAYS with zero false
+# positives, not precise cron math (which belongs in the daemon's croner). A
+# too-short threshold that false-flags trains the user to ignore doctor.
+_doctor_stale_grace() {
+  local sched="$1" dom dow
+  dom=$(printf '%s\n' "$sched" | awk '{print $3}')
+  dow=$(printf '%s\n' "$sched" | awk '{print $5}')
+  # monthly: a specific day-of-month with any weekday.
+  if [ -n "$dom" ] && [ "$dom" != "*" ] && [ "$dow" = "*" ]; then
+    echo $(( 35 * 86400 )); return
+  fi
+  # weekly: a single specific weekday (no range/list/step → fires once a week).
+  case "$dow" in
+    ''|'*') : ;;
+    *[-,/]*) : ;;
+    *) echo $(( 10 * 86400 )); return ;;
+  esac
+  # daily-ish: daily, sub-daily (*/Nh), or weekday ranges like 1-5. A 4-day grace
+  # clears the Fri→Mon weekend gap of a 1-5 job yet still catches a week-long death.
+  echo $(( 4 * 86400 ))
+}
+
+# Detect scheduled playbooks that silently stopped RUNNING or stopped DELIVERING
+# to Discord. Prints a "✗ ..." line per stale playbook and a trailing
+# "FRESH=<n> STALE=<n>" summary line. Absent signal files (never-run / never-
+# delivered) are treated as pending and NOT flagged, so a newly-enabled playbook
+# doesn't false-alarm. `now` (arg 3) is injectable for deterministic tests.
+_doctor_check_freshness() {
+  local reg="$1" logdir="$2" now="${3:-$(date +%s)}"
+  local fresh=0 stale=0
+  if [ ! -f "$reg" ]; then echo "FRESH=0 STALE=0"; return 0; fi
+  local name sched deliver grace t
+  while IFS='|' read -r name sched deliver; do
+    [ -n "$name" ] || continue
+    grace=$(_doctor_stale_grace "$sched")
+    if [ -f "$logdir/.last-run-$name" ]; then
+      t=$(cat "$logdir/.last-run-$name" 2>/dev/null)
+      case "$t" in ''|*[!0-9]*) t="" ;; esac
+      if [ -n "$t" ] && [ $(( now - t )) -gt "$grace" ]; then
+        echo "✗ playbook '$name' hasn't run in $(( (now - t) / 86400 ))d (schedule: $sched) — cron stopped?"
+        stale=$(( stale + 1 ))
+      elif [ -n "$t" ]; then
+        fresh=$(( fresh + 1 ))
+      fi
+    fi
+    if [ "$deliver" = "true" ] && [ -f "$logdir/.last-deliver-$name" ]; then
+      t=$(cat "$logdir/.last-deliver-$name" 2>/dev/null)
+      case "$t" in ''|*[!0-9]*) t="" ;; esac
+      if [ -n "$t" ] && [ $(( now - t )) -gt "$grace" ]; then
+        echo "✗ playbook '$name' ran but hasn't DELIVERED to Discord in $(( (now - t) / 86400 ))d — delivery gated/broken?"
+        stale=$(( stale + 1 ))
+      fi
+    fi
+  done < <(jq -r '.playbooks[]? | select(.status=="active") | select(.schedule != null and .schedule != "") | "\(.name)|\(.schedule)|\(.discord_report)"' "$reg" 2>/dev/null)
+  echo "FRESH=$fresh STALE=$stale"
+}
+
 cmd_doctor() {
   local ok=0
   local warn=0
@@ -450,6 +508,21 @@ cmd_doctor() {
         ok=$((ok + 1))
       fi
     fi
+  fi
+
+  # playbook run/delivery freshness — a scheduled playbook that silently stopped
+  # running, or (the morning-report bug) runs but silently stopped delivering to
+  # Discord. Complements the daemon-heartbeat check above: that catches the whole
+  # daemon dying; this catches one playbook wedged or gated while the daemon lives.
+  local _fresh_out _fr_stale
+  _fresh_out=$(_doctor_check_freshness "${CEO_REGISTRY_FILE:-$HOME/.ceo/registry.json}" "$CEO_DIR/log")
+  printf '%s\n' "$_fresh_out" | grep '^✗' | sed 's/^/  /'
+  _fr_stale=$(printf '%s\n' "$_fresh_out" | sed -n 's/.*STALE=\([0-9]*\).*/\1/p' | tail -1)
+  if [ "${_fr_stale:-0}" -gt 0 ]; then
+    fail=$(( fail + _fr_stale ))
+  else
+    echo "  ✓ playbook freshness: no scheduled playbook has silently stopped running or delivering"
+    ok=$(( ok + 1 ))
   fi
 
   echo ""

--- a/scripts/ceo-discord-report.sh
+++ b/scripts/ceo-discord-report.sh
@@ -172,6 +172,15 @@ total=0
 sent=$(_post_report "**CEO full report: ${TRIGGER} — ${TODAY} (${HOSTNAME_SHORT})**" "$CONTENT")
 total=$((total + sent))
 
+# Delivery-success signal for `ceo doctor`: we passed the enabled-gate and posted
+# the main report, so record when this trigger last DELIVERED. If the gate had
+# blocked us (the allow-list bug that silently killed the morning report for a
+# week), we'd have exited above and this timestamp would go stale — which is
+# exactly what doctor watches for.
+_deliver_dir="${CEO_DIR:-$HOME/Documents/Obsidian/CEO}/log"
+mkdir -p "$_deliver_dir" 2>/dev/null || true
+date +%s > "$_deliver_dir/.last-deliver-${TRIGGER}" 2>/dev/null || true
+
 # Prior-day full report append (morning-brief only by default). The Obsidian
 # report keeps its existing front matter and is untouched; the complete prior-day
 # report is delivered here, on Discord only. Gate on its own allow-list so other

--- a/scripts/ceo-discord-report.test.sh
+++ b/scripts/ceo-discord-report.test.sh
@@ -242,4 +242,28 @@ test_no_registry_flag_field_falls_back_to_settings() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_records_last_deliver_timestamp_on_successful_post() {
+  # The signal `ceo doctor` watches: a successful delivery writes a per-trigger
+  # timestamp. Its ABSENCE/staleness is how the watchdog detects a report that
+  # runs but silently stops posting.
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  printf 'full report body' | "$REPORT" morning-brief >/dev/null 2>&1
+  local f="$CEO_DIR/log/.last-deliver-morning-brief"
+  assert_eq "$([ -f "$f" ] && echo yes || echo no)" "yes" \
+    "a successful post must record .last-deliver-<trigger>"
+  assert_eq "$(cat "$f" 2>/dev/null | grep -cE '^[0-9]+$')" "1" \
+    ".last-deliver must hold a numeric epoch"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_no_last_deliver_when_gated_out() {
+  # The morning-report bug: trigger not in the allow-list → gated out → no post.
+  # No .last-deliver written → doctor sees it go stale (exactly the intent).
+  echo '{"discord_report_webhook":"http://127.0.0.1/reports"}' > "$CEO_SECRETS_FILE"
+  printf 'scan body' | "$REPORT" morning-scan >/dev/null 2>&1
+  assert_eq "$([ -f "$CEO_DIR/log/.last-deliver-morning-scan" ] && echo yes || echo no)" "no" \
+    "a gated-out trigger must NOT record a delivery (so its staleness surfaces)"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 run_tests

--- a/scripts/ceo-doctor-freshness.test.sh
+++ b/scripts/ceo-doctor-freshness.test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Unit tests for the `ceo doctor` playbook-freshness watchdog helpers:
+# _doctor_stale_grace (coarse cron→grace mapping) and _doctor_check_freshness
+# (per-playbook run + delivery staleness). Catches a scheduled playbook that
+# silently stopped running OR runs but stopped delivering to Discord (the
+# morning-report bug). Sources the lib directly; injects a fixed `now`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CEO_CLI="$SCRIPT_DIR/ceo"
+source "$SCRIPT_DIR/test-harness.sh"
+
+_load_ceo_helpers() {
+  export CEO_LIB_ONLY=1
+  set +u
+  # shellcheck disable=SC1090,SC1091
+  source "$CEO_CLI"
+  set +e +u
+  unset CEO_LIB_ONLY
+}
+_load_ceo_helpers
+
+setup() {
+  TMP=$(mktemp -d)
+  REG="$TMP/registry.json"
+  LOGDIR="$TMP/log"
+  mkdir -p "$LOGDIR"
+  NOW=1783000000   # fixed "now" for deterministic ages
+}
+teardown() { rm -rf "$TMP"; unset TMP REG LOGDIR NOW; }
+
+_reg() {
+  local name="$1" sched="$2" deliver="${3:-null}"
+  cat > "$REG" <<JSON
+{"schema_version":1,"playbooks":[{"name":"$name","status":"active","schedule":"$sched","discord_report":$deliver}]}
+JSON
+}
+_ago() { echo $(( NOW - $1 * 86400 )); }   # epoch N days before NOW
+
+# --- _doctor_stale_grace ---
+test_grace_daily_weekday_range() {
+  assert_eq "$(_doctor_stale_grace '20 3 * * 1-5')" "$((4*86400))" "weekday-range (1-5) -> daily-ish 4d grace"
+}
+test_grace_weekly_single_dow() {
+  assert_eq "$(_doctor_stale_grace '0 8 * * SUN')" "$((10*86400))" "single weekday -> weekly 10d grace"
+}
+test_grace_subdaily() {
+  assert_eq "$(_doctor_stale_grace '0 */6 * * *')" "$((4*86400))" "every-6h -> daily-ish 4d grace"
+}
+test_grace_monthly() {
+  assert_eq "$(_doctor_stale_grace '0 8 1 * *')" "$((35*86400))" "day-of-month set, dow * -> monthly 35d grace"
+}
+
+# --- run staleness ---
+test_stale_run_flagged() {
+  _reg morning "20 3 * * 1-5"
+  echo "$(_ago 6)" > "$LOGDIR/.last-run-morning"
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "hasn't run" "a daily playbook 6 days since last run must be flagged"
+  assert_contains "$out" "STALE=1" "one stale playbook"
+}
+test_fresh_run_not_flagged() {
+  _reg morning "20 3 * * 1-5"
+  echo "$(_ago 1)" > "$LOGDIR/.last-run-morning"
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "STALE=0" "a run 1 day ago is fresh"
+  assert_contains "$out" "FRESH=1" "counted as fresh"
+}
+test_weekly_within_grace_not_flagged() {
+  _reg weekly-synthesis "0 8 * * SUN"
+  echo "$(_ago 8)" > "$LOGDIR/.last-run-weekly-synthesis"
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "STALE=0" "a weekly playbook 8 days out is within its 10d grace"
+}
+
+# --- delivery staleness (the morning-report bug) ---
+test_stale_delivery_flagged_even_when_run_is_fresh() {
+  _reg morning "20 3 * * 1-5" true
+  echo "$(_ago 1)" > "$LOGDIR/.last-run-morning"
+  echo "$(_ago 7)" > "$LOGDIR/.last-deliver-morning"
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "hasn't DELIVERED" "runs-but-doesn't-deliver must be flagged (the morning bug)"
+  assert_contains "$out" "STALE=1" "delivery staleness counts as stale"
+}
+test_delivery_not_checked_for_non_discord_playbook() {
+  _reg disk-monitor "0 */6 * * *" false
+  echo "$(_ago 1)" > "$LOGDIR/.last-run-disk-monitor"
+  echo "$(_ago 30)" > "$LOGDIR/.last-deliver-disk-monitor"
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "STALE=0" "a non-discord playbook's delivery file must not be checked"
+}
+
+# --- bootstrapping: never-ran must not false-alarm ---
+test_absent_signal_file_not_flagged() {
+  _reg brand-new "20 3 * * 1-5" true
+  local out; out=$(_doctor_check_freshness "$REG" "$LOGDIR" "$NOW")
+  assert_contains "$out" "STALE=0" "a never-run playbook (no signal file) is pending, not stale"
+}
+
+run_tests


### PR DESCRIPTION
Closes #none

## Description
The morning report was dead for a week and `weekly-synthesis` failed every Sunday — both invisible until Discord delivery got fixed. Nothing watched for a scheduled playbook that quietly stopped, and **delivery had no durable success signal** (only a debug log). This adds that signal + a watchdog.

- **`ceo-discord-report.sh`**: on a successful post (past the enabled-gate), record `$CEO_DIR/log/.last-deliver-<trigger>`. A gated-out trigger (the allow-list bug) writes nothing → its staleness surfaces.
- **`ceo doctor`**: new freshness section. Per active scheduled playbook, flags a stale `.last-run-<name>` (cron stopped) and, for `discord_report` playbooks, a stale `.last-deliver-<name>` (runs but stopped delivering). Coarse/generous cron→grace (daily-ish 4d / weekly 10d / monthly 35d) — zero false positives over precise cron math a user learns to ignore. Never-run playbooks (no signal file) are pending, not flagged.

Scoped deliberately: no cron-parsing rabbit hole, no new subcommand, complements the existing daemon-heartbeat check (that catches the whole daemon dying; this catches one playbook wedged/gated while the daemon lives).

## Testing Procedure
1. `cd scripts && bash ceo-doctor-freshness.test.sh` → 10/10 (unit: grace mapping + run/delivery staleness + bootstrapping).
2. Mutation check: inflate the daily grace in `_doctor_stale_grace` → the stale-run/stale-delivery tests fail (proves they bite).
3. `bash ceo-discord-report.test.sh` → 15/15 (incl. `.last-deliver` written on success, NOT written when gated out).
4. `bash ceo-doctor.test.sh` → 20/20, `bash ceo-cron.test.sh` → 172/172 (no regression).

## Additional Notes
Not-in-this-PR (auditor-flagged): the true "who watches the watchdog" is one hand-managed external cron checking the daemon heartbeat age — separate from this. This PR is the per-playbook detection.