### PR TITLE
fix(ollama-agent): recover tool calls serialized into content

### DIFF
--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -17,6 +17,43 @@ def _normalize_args(raw):
     return {}
 
 
+def _tool_calls_from_content(content):
+    """Recover tool calls a model serialized into `content` instead of the native
+    `tool_calls` field.
+
+    Some ollama chat templates (e.g. qwen2.5-coder) emit a correct
+    ``{"name": ..., "arguments": ...}`` object as assistant *text* while leaving
+    ``message.tool_calls`` empty, so the native read at the drop site loses the
+    call and the loop ends as if the model answered in prose. This parses that
+    object (optionally inside a ``` fence) back into the native envelope shape so
+    the dispatch loop handles it identically.
+
+    Returns [] when content is prose or JSON that isn't a tool call, so a
+    text-only model (e.g. glm, which narrates instead of calling) still completes
+    as a normal no-call turn rather than crashing. Requires both a non-empty
+    string ``name`` and an ``arguments`` key to avoid misreading an ordinary JSON
+    answer that merely happens to carry a ``name`` field as a call."""
+    if not isinstance(content, str):
+        return []
+    text = content.strip()
+    if text.startswith("```"):
+        # Drop the opening fence line (``` or ```json) and a trailing fence.
+        text = text.split("\n", 1)[1] if "\n" in text else ""
+        text = text.strip()
+        if text.endswith("```"):
+            text = text[:-3].strip()
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    items = parsed if isinstance(parsed, list) else [parsed]
+    calls = []
+    for it in items:
+        if isinstance(it, dict) and isinstance(it.get("name"), str) and it["name"] and "arguments" in it:
+            calls.append({"function": {"name": it["name"], "arguments": it["arguments"]}})
+    return calls
+
+
 def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
     """Run one task to completion (a turn with no tool calls) or the turn cap.
 
@@ -39,6 +76,11 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
         transcript.append(msg)
         messages.append(msg)
         calls = msg.get("tool_calls") or []
+        if not calls:
+            # Fallback: some templates serialize the call into content with an
+            # empty native tool_calls field — recover it before concluding the
+            # model answered in prose.
+            calls = _tool_calls_from_content(msg.get("content"))
         if not calls:
             completed = True
             break

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from ollama_agent import ToolBox, TOOLS, run_agent  # noqa: E402
-from ollama_agent.agent import _normalize_args  # noqa: E402
+from ollama_agent.agent import _normalize_args, _tool_calls_from_content  # noqa: E402
 from ollama_agent.tools import _clip, MAX_OUTPUT, MAX_READ  # noqa: E402
 from ollama_agent.transport import parse_chat_response  # noqa: E402
 
@@ -234,6 +234,56 @@ def test_loop_survives_tool_handler_exception(tmp_path):
 def test_write_file_reports_byte_length_not_char_count(tmp_path):
     out = json.loads(ToolBox(cwd=tmp_path).write_file("m.txt", "héllo"))
     assert out["bytes"] == 6  # 5 chars, 6 UTF-8 bytes
+
+
+# --- content-embedded tool-call recovery (qwen-class models) ---
+
+def test_content_fallback_parses_plain_json_object():
+    # The exact shape observed from qwen2.5-coder:14b: a {"name","arguments"}
+    # object serialized into content, native tool_calls empty.
+    calls = _tool_calls_from_content('{"name": "run_shell", "arguments": {"command": "echo hi"}}')
+    assert calls == [{"function": {"name": "run_shell", "arguments": {"command": "echo hi"}}}]
+
+
+def test_content_fallback_parses_fenced_json():
+    content = '```json\n{"name": "run_shell", "arguments": {"command": "echo hi"}}\n```'
+    calls = _tool_calls_from_content(content)
+    assert calls == [{"function": {"name": "run_shell", "arguments": {"command": "echo hi"}}}]
+
+
+def test_content_fallback_ignores_prose_and_non_call_json():
+    assert _tool_calls_from_content("I'll use the write_file tool to do this.") == []   # glm-style prose
+    assert _tool_calls_from_content('{"result": 42}') == []                              # JSON, but not a call
+    assert _tool_calls_from_content('{"name": "x"}') == []                               # name but no arguments
+    assert _tool_calls_from_content(None) == []
+    assert _tool_calls_from_content("") == []
+
+
+def test_loop_recovers_tool_call_embedded_in_content(tmp_path):
+    # qwen emits a correct call as JSON in content with an empty native
+    # tool_calls field; the loop must recover and dispatch it (the agent.py:41
+    # drop site). Drives the real run_agent + real ToolBox so the file write
+    # proves the recovered call actually executed.
+    transport = _script(
+        {"role": "assistant",
+         "content": json.dumps({"name": "write_file", "arguments": {"path": "f.txt", "content": "hi"}})},
+        {"role": "assistant", "content": "done"},
+    )
+    rec = run_agent("write a file", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, turn_cap=8)
+    assert rec["completed"] is True
+    assert rec["turns"] == 2
+    assert (tmp_path / "f.txt").read_text() == "hi"
+    assert rec["unknown_calls"] == []
+
+
+def test_loop_prose_content_still_completes_without_recovery(tmp_path):
+    # A text-only model (glm) whose content is prose must still complete as a
+    # normal no-tool-call turn — the fallback recovers nothing and does not crash.
+    transport = _script({"role": "assistant", "content": "Here is my answer in prose."})
+    rec = run_agent("answer", "sys", transport, ToolBox(cwd=tmp_path), TOOLS)
+    assert rec["completed"] is True
+    assert rec["turns"] == 1
+    assert rec["calls"] == []
 
 
 # --- transport error branches (the headline non-throwing-client claim) ---


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

**Bug fix.** The agent loop read only the native `message.tool_calls` field (`agent.py`, the `calls = msg.get("tool_calls") or []` drop site). Some ollama chat templates — notably **qwen2.5-coder:14b** — emit a correct `{"name": ..., "arguments": ...}` tool call as assistant **text** (`content`) while leaving `tool_calls` empty. The loop saw no calls, concluded the model had answered in prose, and ended — silently dropping a valid, actionable call.

This adds `_tool_calls_from_content(content)`: when the native `tool_calls` field is empty, it parses a `{name, arguments}` object (optionally inside a ` ``` ` / ` ```json ` fence, and lists of them) out of `content` and recovers it into the native envelope shape, so the existing dispatch path handles it identically.

**Deliberately conservative** so a text-only model isn't misread:
- Requires both a non-empty string `name` **and** an `arguments` key — an ordinary JSON answer that merely carries a `name` field is not treated as a call.
- Prose content (e.g. glm4, which narrates instead of calling) parses to nothing → the turn completes as a normal no-call turn, exactly as before. glm is genuinely text-only and is *not* recoverable this way; this fix targets qwen-class models whose template serializes real calls into content.

Discovered during the ollama-harness tool-capability comparison (glm4 / qwen2.5-coder / mistral): mistral drives the harness natively, qwen emits correct calls in the wrong channel, glm can't emit structured calls at all.

## Testing Procedure

1. Check out this branch; `cd ollama-agent`.
2. `python3 -m pytest tests/test_agent.py -q` → **40 passed**.
3. `python3 -m pytest -q` (full suite) → **161 passed**.
4. Key new tests:
   - `test_content_fallback_parses_plain_json_object` — the exact observed qwen shape.
   - `test_content_fallback_parses_fenced_json` — ` ```json ` fenced variant.
   - `test_content_fallback_ignores_prose_and_non_call_json` — prose, non-call JSON, `name`-without-`arguments`, `None`, `""` all recover nothing.
   - `test_loop_recovers_tool_call_embedded_in_content` — drives real `run_agent` + `ToolBox`; the file write proves the recovered call actually executed.
   - `test_loop_prose_content_still_completes_without_recovery` — glm-style prose still completes cleanly.

## Additional Notes / HelpScout Tickets

- Follow-on (separate): a **tool-emission probe tier** for model-matrix — grade a model on *did it emit a valid tool call and act on the result* — so the harness `min_score` gate can route tool tasks automatically instead of by hand.
- No behavior change for models that already use the native field (mistral) or that emit prose (glm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)