### PR TITLE
feat(playbook): nathan-inbox reply-channel ingest (confirm-before-commit)

### DIFF
--- a/docs/playbooks/nathan-inbox.md
+++ b/docs/playbooks/nathan-inbox.md
@@ -4,8 +4,9 @@ description: Ingest Nathan's freeform replies from the CEO/from-nathan.md dropbo
 trigger: cron
 schedule: "15 3 * * *"
 preflight: none
-tier: low-stakes write
+tier: low-stakes-write
 status: active
+scope: single
 runner: script
 script: ceo-nathan-inbox.sh
 model: sonnet
@@ -75,6 +76,7 @@ one-line convention in whatever writes `Pending.md`.
 | `Pending.md` | edit | Stage `[confirm]` lines; flip `[ask]`→`[done]` on commit. Only file whose `[done]` state gates immutability. |
 | `CEO/log/proposed-answers.md` | append/rewrite | Frozen proposal records `nb\|qid\|hash\|confidence\|created_epoch` (machine-owned state). |
 | `CEO/log/.from-nathan-seen` | append | Processed-entry hash set (reprocessing guard). |
+| `CEO/log/.nathan-nb-counter` | overwrite | Global append-only counter minting stable `nb-` ids (never reused). |
 | `CEO/log/from-nathan/YYYY-MM.md` | append | Durable archive; one line per processed entry (content withheld for discretion-flagged). |
 | `CEO/training/_candidates.md` | append | Freeform notes; **never** the live corpus (a human promotes later). |
 | `CEO/needs-review/nathan-inbox.md` | append | Everything held: low-confidence, hallucinated qid, expired, drifted, discretion-flagged (withheld), sync-conflict. **Nothing is ever silently dropped.** |
@@ -103,7 +105,15 @@ supervision) are later subsystems. Design lives in Obsidian, not the repo.
 - The bounded LLM proposal (`CEO_NATHAN_PROPOSE_CMD`, default `ceo llm-propose`)
   is the only non-deterministic step. If it fails or is unavailable, candidates
   fall through to needs-review — no silent loss. Every other path is
-  deterministic bash and unit-tested.
+  deterministic bash and unit-tested. The `ceo llm-propose` CLI itself is not yet
+  implemented (follow-up); until then set `CEO_NATHAN_PROPOSE_CMD` to a working
+  proposer or every candidate lands in needs-review.
+- **No lock:** a cron run racing a manual `ceo cron nathan-inbox` could read the
+  seen-set before either appends and double-propose one bullet. `scope: single`
+  on one scheduler makes this rare; a `flock` guard is a follow-up.
+- Proposing among *several* open questions and two bullets matching one qid in a
+  single run are correctly handled by the qid-`[done]` guard but not yet
+  regression-tested (follow-up).
 - Substring discretion matching has an acknowledged false-negative risk; the
   needs-review bucket is the backstop.
 - Re-targeting a proposal to a *different specific* question is out of scope for
@@ -113,4 +123,4 @@ supervision) are later subsystems. Design lives in Obsidian, not the repo.
 ## Install / Disable
 
 Registered by `ceo playbook scan` (ML-1 only, `scope: single`). Disable via
-`status: inactive` + re-scan.
+`status: disabled` + re-scan.

--- a/docs/playbooks/nathan-inbox.md
+++ b/docs/playbooks/nathan-inbox.md
@@ -1,0 +1,116 @@
+---
+name: nathan-inbox
+description: Ingest Nathan's freeform replies from the CEO/from-nathan.md dropbox; propose answers to open Pending.md questions (confirm-before-commit), route notes, never auto-commit or silently drop
+trigger: cron
+schedule: "15 3 * * *"
+preflight: none
+tier: low-stakes write
+status: active
+runner: script
+script: ceo-nathan-inbox.sh
+model: sonnet
+---
+
+# Nathan Inbox
+
+Shell-only ingest for the CEO **reply channel**. The daily report is send-only;
+this is the inbound half. Nathan writes freeform bullets in a synced dropbox
+from any device; this playbook routes them on the next CEO run, **before**
+`morning`, so proposals surface in that morning's report.
+
+Runs all 7 days at ~03:15 (weekend answers must not wait for Monday).
+
+## The dropbox — `CEO/from-nathan.md`
+
+Single-writer by convention: **only Nathan edits it; this playbook reads it and
+never writes or clears it.** Bullets live under a `## For the CEO` heading:
+
+```markdown
+## For the CEO
+- my single most important goal this quarter is closing the 2nd Altamira CoP
+- note: stop surfacing dependabot PRs as priorities, I batch them
+- ok nb-2026-07-06-03
+- nb-2026-07-06-04 → note
+```
+
+- plain bullet → **candidate** answer (classified by a bounded LLM proposal).
+- `note: <text>` → freeform note (skips question-matching).
+- `ok <nb-id>` → confirm a proposed match.
+- `<nb-id> → note` / `<nb-id> → dismiss` → correct or dismiss a proposal.
+
+No `qid` typing. The `nb-…` ids Nathan references are pre-printed in the report.
+
+## Confirm-before-commit (the safety mechanism)
+
+A wrong auto-answer would *silently and permanently* close a question Nathan
+never answered. So a fuzzy LLM match is **never** auto-committed:
+
+1. A candidate bullet gets an LLM proposal `{qid, confidence}`. The proposed qid
+   is **validated against the live open-`[ask]` set** — a hallucinated qid is
+   discarded (→ needs-review).
+2. A validated, confident match is *staged*: a frozen record in
+   `CEO/log/proposed-answers.md` **and** a `- [ ] [ask] [confirm] …` line
+   written into `Pending.md` (which `morning` already quotes). The question is
+   **not** yet answered.
+3. Nathan replies `ok <nb>` next time → the answer commits: the `[ask]` line
+   flips to `[x] [done]`, the answer stages to `Profile/_inbox/<host>.md`.
+
+Commit is idempotent (guarded by the qid's live `[done]` state) and
+binding-checked: the `ok` commits only if the frozen `(nb → qid, content-hash)`
+still matches what was reported. Unconfirmed proposals expire to needs-review
+after `CEO_NATHAN_EXPIRY_DAYS` (default 7).
+
+## qid prerequisite
+
+Every `Pending.md [ask]` line must carry an explicit `qid:` token, e.g.
+`- [ ] [ask] (qid: q-2026-07-06-01) top goal this quarter`. An `[ask]` line
+**without** a qid is not matchable → the un-tagged question is surfaced in
+needs-review rather than guessed at. Authoring qids on new questions is a
+one-line convention in whatever writes `Pending.md`.
+
+## Outputs
+
+| File | Mode | When |
+|---|---|---|
+| `Pending.md` | edit | Stage `[confirm]` lines; flip `[ask]`→`[done]` on commit. Only file whose `[done]` state gates immutability. |
+| `CEO/log/proposed-answers.md` | append/rewrite | Frozen proposal records `nb\|qid\|hash\|confidence\|created_epoch` (machine-owned state). |
+| `CEO/log/.from-nathan-seen` | append | Processed-entry hash set (reprocessing guard). |
+| `CEO/log/from-nathan/YYYY-MM.md` | append | Durable archive; one line per processed entry (content withheld for discretion-flagged). |
+| `CEO/training/_candidates.md` | append | Freeform notes; **never** the live corpus (a human promotes later). |
+| `CEO/needs-review/nathan-inbox.md` | append | Everything held: low-confidence, hallucinated qid, expired, drifted, discretion-flagged (withheld), sync-conflict. **Nothing is ever silently dropped.** |
+| `Profile/_inbox/<host>.md` | append | Committed answers staged for profile promotion. |
+
+## Discretion
+
+Before writing any bullet content to a synced/logged file, a fixed-string
+denylist (`Profile/discretion-denylist.txt` + `CEO_DISCRETION_DENY`, same
+mechanism as `ceo-observe.sh`) is applied. A hit is held in needs-review with
+its **content withheld** (only a hash recorded) — the flagged text is not
+written to proposals, candidates, archive, or profile.
+
+## On-demand
+
+`ceo cron nathan-inbox` runs it immediately (`CEO_FORCE=1`), bypassing cooldown.
+
+## Origin
+
+v1 of the CEO training loop's *enabler* (the reply channel). Capture
+(auto-detecting recurring instructions) and Enforce (in-session agent
+supervision) are later subsystems. Design lives in Obsidian, not the repo.
+
+## Documented gaps
+
+- The bounded LLM proposal (`CEO_NATHAN_PROPOSE_CMD`, default `ceo llm-propose`)
+  is the only non-deterministic step. If it fails or is unavailable, candidates
+  fall through to needs-review — no silent loss. Every other path is
+  deterministic bash and unit-tested.
+- Substring discretion matching has an acknowledged false-negative risk; the
+  needs-review bucket is the backstop.
+- Re-targeting a proposal to a *different specific* question is out of scope for
+  v1 (Nathan doesn't see qids); a wrong match is dismissed and re-answered as a
+  fresh bullet.
+
+## Install / Disable
+
+Registered by `ceo playbook scan` (ML-1 only, `scope: single`). Disable via
+`status: inactive` + re-scan.

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -143,8 +143,12 @@ _stage_proposal() {  # nb qid hash conf bullet
 
 _mark_proposal() {  # nb newstatus
   local nb="$1" st="$2" tmp
-  tmp="$(mktemp)"
-  awk -F'|' -v OFS='|' -v nb="$nb" -v st="$st" '$1==nb {$6=st} {print}' "$PROPOSALS" > "$tmp" && mv "$tmp" "$PROPOSALS"
+  tmp="$(mktemp)" || { echo "ERROR: mktemp for _mark_proposal" >&2; return 1; }
+  if awk -F'|' -v OFS='|' -v nb="$nb" -v st="$st" '$1==nb {$6=st} {print}' "$PROPOSALS" > "$tmp"; then
+    mv "$tmp" "$PROPOSALS"
+  else
+    rm -f "$tmp"; return 1
+  fi
 }
 
 _mint_nb() {
@@ -169,8 +173,19 @@ handle_confirm() {  # nb
     _needs_review "confirmation $nb changed since you saw it (binding drift) — re-propose"; return
   fi
   bullet="$(_b64dec "$(_prop_field "$line" 7)")"
+  if [ -z "$bullet" ]; then _needs_review "confirm $nb — answer empty/undecodable; re-issue \`ok $nb\`"; return; fi
+  # Re-check discretion at commit time: the denylist reloads each run, so a term
+  # added after the bullet was staged must still block the answer from egressing
+  # to the (synced) Profile/_inbox.
+  if _is_flagged "$bullet"; then
+    _needs_review "confirm $nb held — answer now matches the discretion denylist (content withheld)"; return
+  fi
   q="$(_question_for_qid "$qid")"
-  _commit_ask_done "$qid" "$(_date_ymd "$NOW_EPOCH")" "$bullet"
+  # Only tear down the proposal + stage the profile answer if the Pending.md
+  # commit actually succeeded — otherwise the explicit ok is silently lost.
+  if ! _commit_ask_done "$qid" "$(_date_ymd "$NOW_EPOCH")" "$bullet"; then
+    _needs_review "commit failed for $nb (could not write Pending.md) — re-issue \`ok $nb\` to retry"; return
+  fi
   _remove_confirm_line "$nb"
   _mark_proposal "$nb" committed
   printf -- '- (%s) answered "%s": %s\n' "$(_date_ymd "$NOW_EPOCH")" "$q" "$bullet" >> "$PROFILE_INBOX"
@@ -188,17 +203,26 @@ handle_correct() {  # nb action(note|dismiss)
   _mark_proposal "$nb" "$action"
   if [ "$action" = "note" ]; then
     bullet="$(_b64dec "$(_prop_field "$line" 7)")"
-    printf -- '- %s\n' "$bullet" >> "$CANDIDATES"
+    if _is_flagged "$bullet"; then
+      _needs_review "correction $nb → note held — content now matches the discretion denylist (withheld)"
+    else
+      printf -- '- %s\n' "$bullet" >> "$CANDIDATES"
+    fi
   fi
 }
 
 handle_candidate() {  # bullet
-  local bullet="$1" out qid conf nb hash q
+  local bullet="$1" out qid conf nb hash q prc
+  local -a pcmd
   if _is_flagged "$bullet"; then
     _needs_review "discretion-flagged candidate held (content withheld) — hash $(_hash "$bullet")"
     return
   fi
-  out="$(printf '%s' "$OPEN_Q_LIST" | "$PROPOSE_CMD" "$bullet" 2>/dev/null)"
+  # PROPOSE_CMD may be multi-word (the default is "ceo llm-propose"): split into
+  # argv so bash does not try to exec a single binary with an embedded space.
+  read -ra pcmd <<< "$PROPOSE_CMD"
+  out="$(printf '%s' "$OPEN_Q_LIST" | "${pcmd[@]}" "$bullet" 2>/dev/null)"; prc=$?
+  if [ "$prc" -ne 0 ]; then _needs_review "LLM proposer unavailable (exit $prc) — held: $bullet"; return; fi
   qid="$(printf '%s' "$out" | head -1 | cut -f1)"
   conf="$(printf '%s' "$out" | head -1 | cut -f2)"
   if [ -z "$qid" ]; then _needs_review "unmatched: $bullet"; return; fi

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# ceo-nathan-inbox.sh — Reply-channel ingest for the CEO training loop.
+#
+# Reads Nathan's freeform bullets from a synced dropbox (CEO/from-nathan.md),
+# and routes them WITHOUT ever auto-committing a fuzzy answer or silently
+# dropping an entry. A candidate answer is *proposed* (staged + surfaced via a
+# Pending.md [confirm] line); only an explicit `ok <nb>` commits it. Everything
+# unhandled — low-confidence, hallucinated qid, expired, drifted, discretion-
+# flagged, sync-conflict — lands in needs-review.
+#
+# The dropbox is single-writer (only Nathan): this script reads it and NEVER
+# writes or clears it. Invoked by ceo-cron.sh when the nathan-inbox playbook
+# (runner:script) fires, or on demand via `ceo cron nathan-inbox`.
+#
+# -e is intentionally OFF: the routing loop runs many greps whose non-zero exit
+# is normal control flow, not failure. Errors are handled explicitly.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+ceo_pin_home_or_warn || true
+ceo_augment_path
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+HOST="${CEO_HOSTNAME:-$(hostname -s)}"
+: "${HOST:?HOST resolution failed; set CEO_HOSTNAME or fix hostname}"
+
+DROPBOX="${CEO_NATHAN_DROPBOX:-$CEO_DIR/from-nathan.md}"
+PENDING="${CEO_PENDING_FILE:-$VAULT/Pending.md}"
+PROPOSE_CMD="${CEO_NATHAN_PROPOSE_CMD:-ceo llm-propose}"
+CONF_MIN="${CEO_NATHAN_CONFIDENCE_MIN:-0.6}"
+EXPIRY_DAYS="${CEO_NATHAN_EXPIRY_DAYS:-7}"
+
+LOG_DIR="$CEO_DIR/log"
+PROPOSALS="$LOG_DIR/proposed-answers.md"
+SEEN="$LOG_DIR/.from-nathan-seen"
+NB_COUNTER="$LOG_DIR/.nathan-nb-counter"
+ARCHIVE_DIR="$LOG_DIR/from-nathan"
+CANDIDATES="$CEO_DIR/training/_candidates.md"
+NEEDS_REVIEW="$CEO_DIR/needs-review/nathan-inbox.md"
+PROFILE_INBOX="$VAULT/Profile/_inbox/$HOST.md"
+
+mkdir -p "$LOG_DIR" "$ARCHIVE_DIR" "$CEO_DIR/training" "$CEO_DIR/needs-review" \
+         "$VAULT/Profile/_inbox"
+touch "$PROPOSALS" "$SEEN"
+
+NOW_EPOCH="${CEO_NATHAN_NOW_EPOCH:-$(date +%s)}"
+
+# ---------- small helpers ----------
+
+_hash() { printf '%s' "$1" | { command -v sha1sum >/dev/null 2>&1 && sha1sum || shasum -a 1; } | awk '{print $1}'; }
+_date_ymd() { date -r "$1" +%Y-%m-%d 2>/dev/null || date -d "@$1" +%Y-%m-%d; }
+_month()    { date -r "$1" +%Y-%m    2>/dev/null || date -d "@$1" +%Y-%m; }
+_b64enc()   { printf '%s' "$1" | base64 | tr -d '\n'; }
+_b64dec()   { printf '%s' "$1" | base64 -d 2>/dev/null || printf '%s' "$1" | base64 -D 2>/dev/null; }
+
+ARCHIVE="$ARCHIVE_DIR/$(_month "$NOW_EPOCH").md"
+touch "$ARCHIVE"
+
+_archive()      { printf '%s\n' "$1" >> "$ARCHIVE"; }
+_needs_review() { printf -- '- %s\n' "$1" >> "$NEEDS_REVIEW"; }
+_seen_add()     { printf '%s\n' "$1" >> "$SEEN"; }
+_is_seen()      { grep -qxF "$1" "$SEEN" 2>/dev/null; }
+
+# Discretion denylist (same mechanism as ceo-observe.sh): fixed strings from
+# Profile/discretion-denylist.txt + CEO_DISCRETION_DENY (pipe-separated).
+_DENY_TMP="$(mktemp)"
+trap 'rm -f "$_DENY_TMP"' EXIT
+_denyfile="$VAULT/Profile/discretion-denylist.txt"
+[ -f "$_denyfile" ] && grep -vE '^\s*(#|$)' "$_denyfile" 2>/dev/null >> "$_DENY_TMP"
+[ -n "${CEO_DISCRETION_DENY:-}" ] && printf '%s\n' "$CEO_DISCRETION_DENY" | tr '|' '\n' | sed '/^$/d' >> "$_DENY_TMP"
+
+_is_flagged() {
+  [ -s "$_DENY_TMP" ] || return 1
+  printf '%s' "$1" | grep -qiFf "$_DENY_TMP"
+}
+
+# ---------- Pending.md queries + mutations ----------
+
+# qid is "done" if a Pending line carries its (qid: X) token and a [done] mark.
+_qid_done() {
+  local qid="$1"
+  grep -F "(qid: $qid)" "$PENDING" 2>/dev/null | grep -q '\[done\]'
+}
+
+# question text for an open (qid: X) [ask] line (excludes [confirm] lines).
+_question_for_qid() {
+  local qid="$1"
+  grep -F "(qid: $qid)" "$PENDING" 2>/dev/null \
+    | grep '^- \[ \] \[ask\]' | grep -v '\[confirm\]' | head -1 \
+    | sed -E "s/^- \[ \] \[ask\][[:space:]]*\(qid: $qid\)[[:space:]]*//"
+}
+
+_qid_is_open() { grep -F "(qid: $1)" "$PENDING" 2>/dev/null | grep '^- \[ \] \[ask\]' | grep -qv '\[confirm\]'; }
+
+_pending_rewrite() {  # reads an awk program on $1, atomically rewrites Pending
+  local prog="$1" tmp
+  tmp="$(mktemp)" || { echo "ERROR: mktemp for Pending rewrite" >&2; return 1; }
+  if awk "$prog" "$PENDING" > "$tmp"; then mv "$tmp" "$PENDING"; else rm -f "$tmp"; return 1; fi
+}
+
+_append_confirm_line() {  # nb qid hash bullet question
+  local nb="$1" qid="$2" hash="$3" bullet="$4" q="$5"
+  printf -- '- [ ] [ask] [confirm] "%s" → answers "%s"? Reply `ok %s` <!-- nathan-inbox nb:%s qid:%s h:%s -->\n' \
+    "$bullet" "$q" "$nb" "$nb" "$qid" "$hash" >> "$PENDING"
+}
+
+_remove_confirm_line() {  # nb — drop the [confirm] line carrying nb:<nb>
+  _pending_rewrite '/\[confirm\]/ && /nb:'"$1"' / { next } { print }'
+}
+
+_confirm_line_hash() {  # nb — the h: recorded in the live confirm line
+  grep -F "nb:$1 " "$PENDING" 2>/dev/null | grep '\[confirm\]' | head -1 \
+    | sed -E 's/.* h:([a-f0-9]+) -->.*/\1/'
+}
+
+_commit_ask_done() {  # qid date bullet — bullet/qid via -v to avoid awk-program injection
+  local qid="$1" date="$2" bullet="$3" tmp
+  tmp="$(mktemp)" || { echo "ERROR: mktemp for commit" >&2; return 1; }
+  awk -v qid="$qid" -v d="$date" -v b="$bullet" '
+    $0 ~ /^- \[ \] \[ask\]/ && index($0, "(qid: " qid ")") && $0 !~ /\[confirm\]/ {
+      sub(/^- \[ \] \[ask\]/, "- [x] [done]")
+      print $0 " — answered " d ": " b
+      next
+    } { print }
+  ' "$PENDING" > "$tmp" && mv "$tmp" "$PENDING" || { rm -f "$tmp"; return 1; }
+}
+
+# ---------- proposal store ----------
+# record: nb|qid|hash|confidence|created_epoch|status|bullet_b64
+
+_proposal_line() { grep "^$1|" "$PROPOSALS" 2>/dev/null | head -1; }
+_prop_field()    { printf '%s' "$1" | cut -d'|' -f"$2"; }
+
+_stage_proposal() {  # nb qid hash conf bullet
+  printf '%s|%s|%s|%s|%s|staged|%s\n' "$1" "$2" "$3" "$4" "$NOW_EPOCH" "$(_b64enc "$5")" >> "$PROPOSALS"
+}
+
+_mark_proposal() {  # nb newstatus
+  local nb="$1" st="$2" tmp
+  tmp="$(mktemp)"
+  awk -F'|' -v OFS='|' -v nb="$nb" -v st="$st" '$1==nb {$6=st} {print}' "$PROPOSALS" > "$tmp" && mv "$tmp" "$PROPOSALS"
+}
+
+_mint_nb() {
+  local n=0
+  [ -f "$NB_COUNTER" ] && n="$(cat "$NB_COUNTER" 2>/dev/null)"
+  n=$((n + 1)); printf '%s' "$n" > "$NB_COUNTER"
+  printf 'nb-%s-%02d' "$(_date_ymd "$NOW_EPOCH")" "$n"
+}
+
+# ---------- classifiers / handlers ----------
+
+handle_confirm() {  # nb
+  local nb="$1" line qid storehash status linehash bullet q
+  line="$(_proposal_line "$nb")"
+  if [ -z "$line" ]; then _needs_review "late/unknown \`ok $nb\` — no live proposal (expired?)"; return; fi
+  qid="$(_prop_field "$line" 2)"; storehash="$(_prop_field "$line" 3)"; status="$(_prop_field "$line" 6)"
+  if [ "$status" = "committed" ] || _qid_done "$qid"; then
+    _mark_proposal "$nb" committed; return   # idempotent no-op
+  fi
+  linehash="$(_confirm_line_hash "$nb")"
+  if [ -n "$linehash" ] && [ "$linehash" != "$storehash" ]; then
+    _needs_review "confirmation $nb changed since you saw it (binding drift) — re-propose"; return
+  fi
+  bullet="$(_b64dec "$(_prop_field "$line" 7)")"
+  q="$(_question_for_qid "$qid")"
+  _commit_ask_done "$qid" "$(_date_ymd "$NOW_EPOCH")" "$bullet"
+  _remove_confirm_line "$nb"
+  _mark_proposal "$nb" committed
+  printf -- '- (%s) answered "%s": %s\n' "$(_date_ymd "$NOW_EPOCH")" "$q" "$bullet" >> "$PROFILE_INBOX"
+}
+
+handle_correct() {  # nb action(note|dismiss)
+  local nb="$1" action="$2" line qid bullet
+  line="$(_proposal_line "$nb")"
+  if [ -z "$line" ]; then _needs_review "\`$nb → $action\` — no live proposal"; return; fi
+  qid="$(_prop_field "$line" 2)"
+  if _qid_done "$qid"; then
+    _needs_review "\`$nb → $action\` refused — that question is already confirmed (immutable)"; return
+  fi
+  _remove_confirm_line "$nb"
+  _mark_proposal "$nb" "$action"
+  if [ "$action" = "note" ]; then
+    bullet="$(_b64dec "$(_prop_field "$line" 7)")"
+    printf -- '- %s\n' "$bullet" >> "$CANDIDATES"
+  fi
+}
+
+handle_candidate() {  # bullet
+  local bullet="$1" out qid conf nb hash q
+  if _is_flagged "$bullet"; then
+    _needs_review "discretion-flagged candidate held (content withheld) — hash $(_hash "$bullet")"
+    return
+  fi
+  out="$(printf '%s' "$OPEN_Q_LIST" | "$PROPOSE_CMD" "$bullet" 2>/dev/null)"
+  qid="$(printf '%s' "$out" | head -1 | cut -f1)"
+  conf="$(printf '%s' "$out" | head -1 | cut -f2)"
+  if [ -z "$qid" ]; then _needs_review "unmatched: $bullet"; return; fi
+  if ! _qid_is_open "$qid"; then _needs_review "proposed qid ($qid) not an open question — held: $bullet"; return; fi
+  if ! awk -v c="$conf" -v m="$CONF_MIN" 'BEGIN{exit !((c+0) >= (m+0))}'; then
+    _needs_review "low-confidence ($conf) match — held: $bullet"; return
+  fi
+  nb="$(_mint_nb)"; hash="$(_hash "$bullet")"; q="$(_question_for_qid "$qid")"
+  _stage_proposal "$nb" "$qid" "$hash" "$conf" "$bullet"
+  _append_confirm_line "$nb" "$qid" "$hash" "$bullet" "$q"
+}
+
+handle_note() {  # text
+  if _is_flagged "$1"; then
+    _needs_review "discretion-flagged note held (content withheld) — hash $(_hash "$1")"
+    return
+  fi
+  printf -- '- %s\n' "$1" >> "$CANDIDATES"
+}
+
+# ---------- 1. sync-conflict surfacing (read the copy's NAME, never its body) ----------
+for _c in "${DROPBOX%.md}".sync-conflict-*.md "${DROPBOX}".sync-conflict-*; do
+  [ -e "$_c" ] || continue
+  _key="conflict:$(_hash "$_c")"
+  _is_seen "$_key" && continue
+  _needs_review "sync conflict on $(basename "$DROPBOX") — reconcile $_c into the primary, then delete the copy"
+  _seen_add "$_key"
+done
+
+# ---------- 2. open-question map (for the LLM proposer + confirm-line text) ----------
+OPEN_Q_LIST="$(grep '^- \[ \] \[ask\]' "$PENDING" 2>/dev/null | grep -v '\[confirm\]' \
+  | sed -E 's/^- \[ \] \[ask\][[:space:]]*\(qid:[[:space:]]*([^)]+)\)[[:space:]]*/\1\t/')"
+
+# ---------- 3. route each unseen bullet under "## For the CEO" ----------
+[ -f "$DROPBOX" ] || DROPBOX=/dev/null
+# awk emits "<occurrence>\t<content>" per bullet. Occurrence-count keying (not
+# ordinal position) is stable under mid-list insertion yet keeps intentionally-
+# identical bullets distinct. awk's assoc arrays keep this portable to bash 3.2.
+while IFS=$'\t' read -r occ content; do
+  [ -n "$content" ] || continue
+  key="$(_hash "$content"$'\x1f'"$occ")"
+  _is_seen "$key" && continue
+
+  cls="candidate"
+  if [[ "$content" =~ ^ok[[:space:]]+(nb-[A-Za-z0-9-]+)$ ]]; then
+    cls="confirm"; handle_confirm "${BASH_REMATCH[1]}"
+  elif [[ "$content" =~ ^(nb-[A-Za-z0-9-]+)[[:space:]]*(->|→)[[:space:]]*(note|dismiss)$ ]]; then
+    cls="correct"; handle_correct "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}"
+  elif [[ "$content" =~ ^note:[[:space:]]*(.*)$ ]]; then
+    cls="note"; handle_note "${BASH_REMATCH[1]}"
+  else
+    handle_candidate "$content"
+  fi
+
+  _seen_add "$key"
+  if _is_flagged "$content"; then
+    _archive "$NOW_EPOCH class=$cls key=$key content=<withheld:discretion>"
+  else
+    _archive "$NOW_EPOCH class=$cls key=$key content=$content"
+  fi
+done < <(awk '
+  /^##[[:space:]]+For the CEO[[:space:]]*$/ { insec=1; next }
+  /^##[[:space:]]/ { insec=0 }
+  insec && /^-[[:space:]]/ { line=$0; sub(/^-[[:space:]]+/, "", line); cnt[line]++; print cnt[line] "\t" line }
+' "$DROPBOX")
+
+# ---------- 4. expiry sweep: stale staged proposals → needs-review ----------
+EXPIRY_SECS=$((EXPIRY_DAYS * 86400))
+while IFS='|' read -r nb qid hash conf created status _; do
+  [ -n "${nb:-}" ] || continue
+  [ "${status:-}" = "staged" ] || continue
+  if [ $((NOW_EPOCH - created)) -gt "$EXPIRY_SECS" ]; then
+    _remove_confirm_line "$nb"
+    _mark_proposal "$nb" expired
+    _needs_review "proposal $nb expired after ${EXPIRY_DAYS}d without confirmation — re-propose if still relevant"
+  fi
+done < "$PROPOSALS"
+
+exit 0

--- a/scripts/ceo-nathan-inbox.test.sh
+++ b/scripts/ceo-nathan-inbox.test.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# Self-contained test harness for ceo-nathan-inbox.sh — verifies the reply-channel
+# ingest: confirm-before-commit, no-auto-commit, no-silent-drop, discretion,
+# watermark idempotency, expiry, and binding-drift invariants.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INGEST="$SCRIPT_DIR/ceo-nathan-inbox.sh"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  PATH_BACKUP="$PATH"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_DIR="$CEO_VAULT/CEO"
+  export CEO_HOSTNAME="testhost"
+  mkdir -p "$CEO_DIR"
+  touch "$CEO_DIR/inbox.md"  # satisfy ceo_validate_vault
+
+  export CEO_NATHAN_DROPBOX="$CEO_DIR/from-nathan.md"
+  export CEO_PENDING_FILE="$CEO_VAULT/Pending.md"
+  export CEO_NATHAN_EXPIRY_DAYS=7
+  export CEO_NATHAN_CONFIDENCE_MIN=0.6
+  # Injectable clock — default "now" for most tests.
+  export CEO_NATHAN_NOW_EPOCH=1751846400   # 2025-07-07T00:00:00Z-ish fixed base
+
+  # LLM propose stub. Controlled by PROPOSE_QID / PROPOSE_CONF / PROPOSE_FAIL.
+  mkdir -p "$TEST_HOME/stubs"
+  cat > "$TEST_HOME/stubs/propose-stub.sh" << 'STUB'
+#!/bin/bash
+[ -n "${PROPOSE_FAIL:-}" ] && exit 1
+cat >/dev/null   # consume the open-questions list on stdin
+if [ -n "${PROPOSE_QID:-}" ]; then
+  printf '%s\t%s\n' "$PROPOSE_QID" "${PROPOSE_CONF:-0.9}"
+fi
+exit 0
+STUB
+  chmod +x "$TEST_HOME/stubs/propose-stub.sh"
+  export CEO_NATHAN_PROPOSE_CMD="$TEST_HOME/stubs/propose-stub.sh"
+  unset PROPOSE_QID PROPOSE_CONF PROPOSE_FAIL
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+  export HOME="$HOME_BACKUP"
+  export PATH="$PATH_BACKUP"
+  unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP
+  unset CEO_NATHAN_DROPBOX CEO_PENDING_FILE CEO_NATHAN_EXPIRY_DAYS
+  unset CEO_NATHAN_CONFIDENCE_MIN CEO_NATHAN_NOW_EPOCH CEO_NATHAN_PROPOSE_CMD
+  unset PROPOSE_QID PROPOSE_CONF PROPOSE_FAIL
+}
+
+# ---------- fixtures ----------
+
+write_dropbox() {
+  { echo "## For the CEO"; printf '%s\n' "$@"; } > "$CEO_NATHAN_DROPBOX"
+}
+
+write_pending() {
+  printf '%s\n' "$@" > "$CEO_PENDING_FILE"
+}
+
+run_ingest() { bash "$INGEST" >/dev/null 2>&1; }
+run_ingest_v() { bash "$INGEST" 2>&1; }
+
+PENDING()      { cat "$CEO_PENDING_FILE" 2>/dev/null; }
+PROPOSALS()    { cat "$CEO_DIR/log/proposed-answers.md" 2>/dev/null; }
+CANDIDATES()   { cat "$CEO_DIR/training/_candidates.md" 2>/dev/null; }
+NEEDS_REVIEW() { cat "$CEO_DIR/needs-review/nathan-inbox.md" 2>/dev/null; }
+ARCHIVE()      { cat "$CEO_DIR"/log/from-nathan/*.md 2>/dev/null; }
+PROFILE_INBOX(){ cat "$CEO_VAULT/Profile/_inbox/$CEO_HOSTNAME.md" 2>/dev/null; }
+
+# nb-id of the (only) staged proposal.
+first_nb() { PROPOSALS | head -1 | cut -d'|' -f1; }
+
+# ---------- tests ----------
+
+test_candidate_stages_proposal_but_does_not_commit() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal this quarter"
+  write_dropbox "- closing the 2nd Altamira CoP is my top goal"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+
+  assert_contains "$(PROPOSALS)" "q-1" "proposal record should be staged"
+  assert_contains "$(PENDING)" "[confirm]" "a confirm line should be written into Pending.md"
+  assert_contains "$(PENDING)" "- [ ] [ask]" "the original ask stays unchecked (not committed)"
+  assert_not_contains "$(PENDING)" "[done]" "the question must NOT be auto-committed"
+}
+
+test_confirm_commits_qid_done_and_stages_profile() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal this quarter"
+  write_dropbox "- closing the 2nd Altamira CoP is my top goal"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+
+  write_dropbox "- closing the 2nd Altamira CoP is my top goal" "- ok $nb"
+  run_ingest
+
+  assert_contains "$(PENDING)" "[done]" "confirming should flip the ask to done"
+  assert_contains "$(PROFILE_INBOX)" "Altamira" "committed answer should stage to Profile/_inbox"
+}
+
+test_correct_note_removes_proposal_routes_to_candidates() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal this quarter"
+  write_dropbox "- some ambiguous bullet"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+
+  write_dropbox "- some ambiguous bullet" "- $nb → note"
+  run_ingest
+
+  assert_contains "$(CANDIDATES)" "some ambiguous bullet" "corrected bullet routes to candidates"
+  assert_not_contains "$(PENDING)" "[confirm]" "the confirm line is withdrawn"
+}
+
+test_note_prefix_goes_to_candidates() {
+  write_pending "- [ ] [ask] (qid: q-1) anything"
+  write_dropbox "- note: stop surfacing dependabot PRs, I batch them"
+  run_ingest
+
+  assert_contains "$(CANDIDATES)" "dependabot" "note: bullet lands in _candidates"
+  assert_not_contains "$(PROPOSALS)" "q-1" "a note is never proposed as an answer"
+}
+
+test_low_confidence_held_in_needs_review() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- maybe something"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.3" run_ingest
+
+  assert_contains "$(NEEDS_REVIEW)" "maybe something" "low-confidence candidate held in needs-review"
+  assert_not_contains "$(PENDING)" "[confirm]" "no proposal staged below the confidence floor"
+}
+
+test_hallucinated_qid_held_in_needs_review() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-DOES-NOT-EXIST" PROPOSE_CONF="0.99" run_ingest
+
+  assert_contains "$(NEEDS_REVIEW)" "an answer" "qid absent from open set → needs-review"
+  assert_not_contains "$(PROPOSALS)" "q-DOES-NOT-EXIST" "no proposal against a non-existent qid"
+}
+
+test_llm_unavailable_candidate_to_needs_review_note_still_works() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- a candidate answer" "- note: a deterministic note"
+  PROPOSE_FAIL=1 run_ingest
+
+  assert_contains "$(NEEDS_REVIEW)" "a candidate answer" "candidate falls through when LLM is down"
+  assert_contains "$(CANDIDATES)" "deterministic note" "deterministic note path works without the LLM"
+}
+
+test_unconfirmed_proposal_relisted_not_committed() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  run_ingest   # second run, no ok
+
+  assert_not_contains "$(PENDING)" "[done]" "still not committed without an explicit ok"
+  assert_contains "$(PROPOSALS)" "q-1" "the proposal persists across runs"
+}
+
+test_proposal_expires_to_needs_review() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+
+  # Advance the injectable clock past the expiry window and re-run.
+  export CEO_NATHAN_NOW_EPOCH=$((CEO_NATHAN_NOW_EPOCH + 8 * 86400))
+  run_ingest
+
+  assert_contains "$(NEEDS_REVIEW)" "expired" "an expired proposal is surfaced, not silently held forever"
+  assert_not_contains "$(PENDING)" "[confirm]" "the stale confirm line is withdrawn on expiry"
+}
+
+test_ok_after_binding_drift_not_committed() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+
+  # Simulate drift: the frozen store hash no longer matches what was reported.
+  sed -i.bak "s/^\($nb|q-1|\)[a-f0-9]*/\1deadbeefdrift/" "$CEO_DIR/log/proposed-answers.md"
+  rm -f "$CEO_DIR/log/proposed-answers.md.bak"
+
+  write_dropbox "- an answer" "- ok $nb"
+  run_ingest
+
+  assert_not_contains "$(PENDING)" "[done]" "a drifted confirmation must not commit the stale qid"
+  assert_contains "$(NEEDS_REVIEW)" "$nb" "drifted confirmation surfaces in needs-review"
+}
+
+test_reconfirm_already_done_is_noop() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+  write_dropbox "- an answer" "- ok $nb"
+  run_ingest
+  local after_first; after_first=$(grep -c '\[done\]' "$CEO_PENDING_FILE")
+
+  # Replay the same ok (crash/replay) — must not double-commit or error.
+  write_dropbox "- an answer" "- ok $nb" "- ok $nb"
+  run_ingest
+  local after_replay; after_replay=$(grep -c '\[done\]' "$CEO_PENDING_FILE")
+
+  assert_eq "$after_replay" "$after_first" "re-confirming an already-done qid is a no-op"
+}
+
+test_dismiss_against_confirmed_qid_refused() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+  write_dropbox "- an answer" "- ok $nb"
+  run_ingest
+
+  write_dropbox "- an answer" "- ok $nb" "- $nb → dismiss"
+  run_ingest
+
+  assert_contains "$(PENDING)" "[done]" "an already-confirmed answer stays committed (immutable)"
+  assert_contains "$(NEEDS_REVIEW)" "refused" "a dismiss against a confirmed qid is refused, not applied"
+}
+
+test_duplicate_entry_skipped_on_rerun() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local before; before=$(PROPOSALS | wc -l | tr -d ' ')
+  run_ingest   # unchanged dropbox
+  local after; after=$(PROPOSALS | wc -l | tr -d ' ')
+
+  assert_eq "$after" "$before" "an unchanged entry is skipped by the watermark on re-run"
+}
+
+test_two_identical_notes_both_ingested() {
+  write_pending "- [ ] [ask] (qid: q-1) x"
+  write_dropbox "- note: batch the deps" "- note: batch the deps"
+  run_ingest
+
+  local n; n=$(CANDIDATES | grep -c "batch the deps")
+  assert_eq "$n" "2" "two intentionally-identical notes both ingest (occurrence-count keying)"
+}
+
+test_midlist_insertion_only_new_ingested() {
+  write_pending "- [ ] [ask] (qid: q-1) x"
+  write_dropbox "- note: alpha" "- note: gamma"
+  run_ingest
+  # Insert a bullet between the two existing ones.
+  write_dropbox "- note: alpha" "- note: beta" "- note: gamma"
+  run_ingest
+
+  assert_eq "$(CANDIDATES | grep -c 'alpha')" "1" "alpha not re-ingested"
+  assert_eq "$(CANDIDATES | grep -c 'beta')"  "1" "the inserted bullet is ingested once"
+  assert_eq "$(CANDIDATES | grep -c 'gamma')" "1" "gamma not re-ingested despite shifting position"
+}
+
+test_discretion_flag_withholds_content() {
+  export CEO_DISCRETION_DENY="SecretClientCorp"
+  write_pending "- [ ] [ask] (qid: q-1) x"
+  write_dropbox "- note: the SecretClientCorp deal closes next week"
+  run_ingest
+  unset CEO_DISCRETION_DENY
+
+  assert_not_contains "$(CANDIDATES)"   "SecretClientCorp" "flagged content not written to candidates"
+  assert_not_contains "$(ARCHIVE)"      "SecretClientCorp" "flagged content not written to archive"
+  assert_not_contains "$(PROPOSALS)"    "SecretClientCorp" "flagged content not written to proposals"
+  assert_contains     "$(NEEDS_REVIEW)" "withheld" "a discretion hit is surfaced (content withheld)"
+}
+
+test_sync_conflict_surfaced_not_ingested() {
+  write_pending "- [ ] [ask] (qid: q-1) x"
+  write_dropbox "- note: primary bullet"
+  # A syncthing conflict copy sitting next to the dropbox.
+  { echo "## For the CEO"; echo "- note: conflicted content only in the copy"; } \
+    > "$CEO_DIR/from-nathan.sync-conflict-20260707-abcdef.md"
+  run_ingest
+
+  assert_contains     "$(NEEDS_REVIEW)" "conflict" "sync conflict is surfaced for reconciliation"
+  assert_not_contains "$(CANDIDATES)"   "conflicted content only in the copy" "conflict copy contents are not auto-ingested"
+}
+
+test_nothing_dropped_no_match() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- a bullet the model cannot place"
+  # Stub returns no proposal at all.
+  run_ingest
+
+  assert_contains "$(NEEDS_REVIEW)" "a bullet the model cannot place" "an unmatched candidate is never silently dropped"
+}
+
+run_tests

--- a/scripts/ceo-nathan-inbox.test.sh
+++ b/scripts/ceo-nathan-inbox.test.sh
@@ -30,8 +30,12 @@ setup() {
 
   # LLM propose stub. Controlled by PROPOSE_QID / PROPOSE_CONF / PROPOSE_FAIL.
   mkdir -p "$TEST_HOME/stubs"
+  # The stub records every invocation to PROPOSE_INVOKED_LOG so a test can assert
+  # a bullet did NOT reach the LLM (discretion egress guard).
+  export PROPOSE_INVOKED_LOG="$TEST_HOME/propose-invoked"
   cat > "$TEST_HOME/stubs/propose-stub.sh" << 'STUB'
 #!/bin/bash
+[ -n "${PROPOSE_INVOKED_LOG:-}" ] && echo called >> "$PROPOSE_INVOKED_LOG"
 [ -n "${PROPOSE_FAIL:-}" ] && exit 1
 cat >/dev/null   # consume the open-questions list on stdin
 if [ -n "${PROPOSE_QID:-}" ]; then
@@ -44,6 +48,8 @@ STUB
   unset PROPOSE_QID PROPOSE_CONF PROPOSE_FAIL
 }
 
+proposer_was_invoked() { [ -f "$PROPOSE_INVOKED_LOG" ] && echo yes || echo no; }
+
 teardown() {
   rm -rf "$TEST_HOME"
   export HOME="$HOME_BACKUP"
@@ -51,7 +57,7 @@ teardown() {
   unset CEO_VAULT CEO_DIR CEO_HOSTNAME TEST_HOME HOME_BACKUP PATH_BACKUP
   unset CEO_NATHAN_DROPBOX CEO_PENDING_FILE CEO_NATHAN_EXPIRY_DAYS
   unset CEO_NATHAN_CONFIDENCE_MIN CEO_NATHAN_NOW_EPOCH CEO_NATHAN_PROPOSE_CMD
-  unset PROPOSE_QID PROPOSE_CONF PROPOSE_FAIL
+  unset PROPOSE_QID PROPOSE_CONF PROPOSE_FAIL PROPOSE_INVOKED_LOG
 }
 
 # ---------- fixtures ----------
@@ -289,6 +295,82 @@ test_nothing_dropped_no_match() {
   run_ingest
 
   assert_contains "$(NEEDS_REVIEW)" "a bullet the model cannot place" "an unmatched candidate is never silently dropped"
+}
+
+# --- regression tests from the mini-panel review of PR #248 ---
+
+# Finding A: a multi-word proposer command (production default is "ceo llm-propose")
+# must be invoked as argv, not sought as one binary with an embedded space.
+test_multiword_proposer_command_is_invoked() {
+  export CEO_NATHAN_PROPOSE_CMD="bash $TEST_HOME/stubs/propose-stub.sh"
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+
+  assert_contains "$(PROPOSALS)" "q-1" "a multi-word proposer command must still stage a proposal"
+  assert_eq "$(proposer_was_invoked)" "yes" "the multi-word command must actually run"
+}
+
+# Finding C: the discretion guard on the CANDIDATE path (the default classification)
+# must hold — a flagged bullet must never reach the external LLM proposer.
+test_discretion_candidate_path_no_llm_egress() {
+  export CEO_DISCRETION_DENY="SecretClientCorp"
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- the SecretClientCorp merger is my top priority"   # candidate path (no note:)
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  unset CEO_DISCRETION_DENY
+
+  assert_eq       "$(proposer_was_invoked)" "no" "a flagged candidate must NOT reach the LLM proposer"
+  assert_not_contains "$(PROPOSALS)"  "SecretClientCorp" "flagged candidate not staged"
+  assert_not_contains "$(ARCHIVE)"    "SecretClientCorp" "flagged candidate content not archived"
+  assert_contains     "$(NEEDS_REVIEW)" "withheld" "flagged candidate surfaced, content withheld"
+}
+
+# Finding B: if the Pending.md commit write fails, the ok must NOT be reported as
+# committed (no confirm-line deletion, no profile write) and must surface.
+test_commit_write_failure_not_reported_committed() {
+  if [ "$(id -u)" = "0" ]; then assert_eq root root "perms test skipped as root"; return; fi
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an answer"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest
+  local nb; nb=$(first_nb)
+  chmod 500 "$CEO_VAULT"                 # Pending.md's dir (vault root) unwritable → mv fails
+  write_dropbox "- an answer" "- ok $nb"
+  run_ingest
+  chmod 700 "$CEO_VAULT"                 # restore for teardown's rm -rf
+
+  assert_not_contains "$(PENDING)"      "[done]"        "a failed Pending write must not look committed"
+  assert_not_contains "$(PROFILE_INBOX)" "an answer"    "no profile answer staged when the commit failed"
+  assert_contains     "$(NEEDS_REVIEW)" "commit failed" "commit failure surfaced to needs-review"
+}
+
+# Finding E: discretion re-checked at commit time — a denylist term added AFTER a
+# bullet was staged must still block the answer from reaching Profile/_inbox.
+test_discretion_rechecked_on_confirm() {
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- the Zephyr project is my focus"
+  PROPOSE_QID="q-1" PROPOSE_CONF="0.9" run_ingest      # no denylist yet → staged
+  local nb; nb=$(first_nb)
+  export CEO_DISCRETION_DENY="Zephyr"                  # term added after staging
+  write_dropbox "- the Zephyr project is my focus" "- ok $nb"
+  run_ingest
+  unset CEO_DISCRETION_DENY
+
+  assert_not_contains "$(PROFILE_INBOX)" "Zephyr" "a term added after staging must not leak on confirm"
+  assert_not_contains "$(PENDING)"       "[done]" "flagged-on-confirm answer is not committed"
+  assert_contains     "$(NEEDS_REVIEW)"  "withheld" "held with content withheld"
+}
+
+# L2: a sync conflict is surfaced once, not re-surfaced on every subsequent run.
+test_sync_conflict_surfaced_once() {
+  write_pending "- [ ] [ask] (qid: q-1) x"
+  write_dropbox "- note: primary"
+  { echo "## For the CEO"; echo "- note: conflicted"; } \
+    > "$CEO_DIR/from-nathan.sync-conflict-20260707-a.md"
+  run_ingest
+  run_ingest
+
+  assert_eq "$(NEEDS_REVIEW | grep -c 'sync conflict')" "1" "a sync conflict is surfaced once, not every run"
 }
 
 run_tests


### PR DESCRIPTION
## Description (New Behavior)

Adds the **inbound half of the CEO training loop** — a reply channel. The daily CEO report is send-only, so Nathan's answers to pending `[ask]` questions only reach the vault if he tells a live agent in-session; questions stall for months. This playbook gives him a low-friction inbound path from any device: he edits a synced dropbox (`CEO/from-nathan.md`), and `nathan-inbox` routes the entries on the next run, before `morning`.

The design lives in Obsidian (specs don't go in the repo), rev 3 — this PR is the v1 implementation of that spec.

**Core invariants (all tested):**
- **Never auto-commit a fuzzy answer.** A candidate bullet gets a bounded LLM proposal `{qid, confidence}`; the qid is validated against the live open-`[ask]` set (a hallucinated qid is discarded). A confident, validated match is *staged* — a frozen record in `CEO/log/proposed-answers.md` plus a `- [ ] [ask] [confirm] …` line written into `Pending.md` (which the morning report already quotes). The question is **not** answered until Nathan replies `ok <nb>`.
- **Commit is idempotent + binding-checked.** `ok <nb>` flips the `[ask]` line to `[done]` and stages the answer to `Profile/_inbox/<host>.md`, but only if the frozen content-hash still matches what was reported (drift → needs-review), and no-ops if the qid is already `[done]` (crash/replay safe).
- **Never silently drop.** Low-confidence, hallucinated qid, expired (7d, injectable clock), drifted, LLM-unavailable → all land in `CEO/needs-review/nathan-inbox.md`.
- **Discretion.** Denylist-flagged bullets are held with content **withheld** (hash only) — never written to proposals/candidates/archive/profile.
- **Immutability.** `dismiss`/`note` against an already-confirmed qid is refused.
- **Watermark** keyed on `(content, occurrence-count)`: stable under mid-list insertion, distinct for intentionally-identical bullets.
- The dropbox is single-writer: the script reads it and **never** writes or clears it.

`ceo cron nathan-inbox` runs it on demand.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-nathan-inbox.test.sh` — expect **All tests passed. (18 tests)**. Suite is mutation-verified (each guard fails when reverted) and green on bash 3.2 and 5.3.
3. `shellcheck -S warning scripts/ceo-nathan-inbox.sh` — clean.
4. Confirm the playbook doc `docs/playbooks/nathan-inbox.md` declares its outputs and frontmatter (`runner: script`, `schedule: "15 3 * * *"`, all 7 days).

## Additional Notes

- Registration is via `ceo playbook scan` on **ML-1 only** (`scope: single`), per `ceo-scan-only-on-ml1` — not run here.
- The bounded LLM proposal step (`CEO_NATHAN_PROPOSE_CMD`, default `ceo llm-propose`) is the only non-deterministic path and is stubbed in tests; the `ceo llm-propose` CLI wiring is a follow-up. Everything else is deterministic, tested bash.
- Out of scope (later subsystems): Capture (auto-detecting recurring instructions) and Enforce (in-session agent supervision).
