### PR TITLE
feat(nathan-inbox): match via the installed claude harness, not a wrapper

### DIFF
--- a/docs/playbooks/nathan-inbox.md
+++ b/docs/playbooks/nathan-inbox.md
@@ -102,12 +102,14 @@ supervision) are later subsystems. Design lives in Obsidian, not the repo.
 
 ## Documented gaps
 
-- The bounded LLM proposal (`CEO_NATHAN_PROPOSE_CMD`, default `ceo llm-propose`)
-  is the only non-deterministic step. If it fails or is unavailable, candidates
-  fall through to needs-review — no silent loss. Every other path is
-  deterministic bash and unit-tested. The `ceo llm-propose` CLI itself is not yet
-  implemented (follow-up); until then set `CEO_NATHAN_PROPOSE_CMD` to a working
-  proposer or every candidate lands in needs-review.
+- The match is the only non-deterministic step. It uses the **installed Claude
+  Code harness** directly — headless `claude -p` (override with
+  `CEO_NATHAN_PROPOSE_CMD`, default `claude -p --model $CEO_MODEL`) — not a
+  wrapper or a spawned CEO subprocess. The harness returns one line
+  `<qid> <confidence>` (or `NONE`); the ingest validates the qid against the open
+  set and applies the confidence floor. If the harness fails/unavailable, the
+  candidate falls through to needs-review — no silent loss. Every other path is
+  deterministic bash and unit-tested.
 - **No lock:** a cron run racing a manual `ceo cron nathan-inbox` could read the
   seen-set before either appends and double-propose one bullet. `scope: single`
   on one scheduler makes this rare; a `flock` guard is a follow-up.

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -32,7 +32,11 @@ HOST="${CEO_HOSTNAME:-$(hostname -s)}"
 
 DROPBOX="${CEO_NATHAN_DROPBOX:-$CEO_DIR/from-nathan.md}"
 PENDING="${CEO_PENDING_FILE:-$VAULT/Pending.md}"
-PROPOSE_CMD="${CEO_NATHAN_PROPOSE_CMD:-ceo llm-propose}"
+# The matcher is the installed Claude Code harness, headless: `claude -p`. No
+# wrapper, no subprocess dressing — the harness IS the model. CEO_NATHAN_PROPOSE_CMD
+# overrides the command (tests point it at a stub).
+PROPOSE_MODEL="${CEO_MODEL:-sonnet}"
+PROPOSE_CMD="${CEO_NATHAN_PROPOSE_CMD:-claude -p --model $PROPOSE_MODEL}"
 CONF_MIN="${CEO_NATHAN_CONFIDENCE_MIN:-0.6}"
 EXPIRY_DAYS="${CEO_NATHAN_EXPIRY_DAYS:-7}"
 
@@ -212,20 +216,34 @@ handle_correct() {  # nb action(note|dismiss)
 }
 
 handle_candidate() {  # bullet
-  local bullet="$1" out qid conf nb hash q prc
+  local bullet="$1" out prc line qid conf nb hash q prompt
   local -a pcmd
   if _is_flagged "$bullet"; then
     _needs_review "discretion-flagged candidate held (content withheld) — hash $(_hash "$bullet")"
     return
   fi
-  # PROPOSE_CMD may be multi-word (the default is "ceo llm-propose"): split into
-  # argv so bash does not try to exec a single binary with an embedded space.
+  # Ask the harness which open question this bullet answers. It returns one line
+  # "<qid> <confidence>" (or NONE). qid-legitimacy and the confidence floor are
+  # validated below — the harness is not trusted to enforce them.
+  prompt="Match this note to at most one of the open questions it answers.
+
+NOTE:
+$bullet
+
+OPEN QUESTIONS (id<TAB>text):
+$OPEN_Q_LIST
+
+Reply with ONE line: the question id, a space, your confidence 0.0-1.0, using an
+id from the list. If none apply, reply with exactly: NONE. No other text."
+  # PROPOSE_CMD is multi-word (`claude -p --model …`): split into argv.
   read -ra pcmd <<< "$PROPOSE_CMD"
-  out="$(printf '%s' "$OPEN_Q_LIST" | "${pcmd[@]}" "$bullet" 2>/dev/null)"; prc=$?
-  if [ "$prc" -ne 0 ]; then _needs_review "LLM proposer unavailable (exit $prc) — held: $bullet"; return; fi
-  qid="$(printf '%s' "$out" | head -1 | cut -f1)"
-  conf="$(printf '%s' "$out" | head -1 | cut -f2)"
-  if [ -z "$qid" ]; then _needs_review "unmatched: $bullet"; return; fi
+  out="$(printf '%s' "$prompt" | "${pcmd[@]}" 2>/dev/null)"; prc=$?
+  if [ "$prc" -ne 0 ]; then _needs_review "LLM harness unavailable (exit $prc) — held: $bullet"; return; fi
+  line="$(printf '%s\n' "$out" | sed '/^[[:space:]]*$/d' | head -1)"
+  # shellcheck disable=SC2086  # intentional split: fields are qid + confidence
+  set -- $line
+  case "${1:-}" in ""|NONE|none|None) _needs_review "unmatched: $bullet"; return ;; esac
+  qid="$1"; conf="${2:-0}"
   if ! _qid_is_open "$qid"; then _needs_review "proposed qid ($qid) not an open question — held: $bullet"; return; fi
   if ! awk -v c="$conf" -v m="$CONF_MIN" 'BEGIN{exit !((c+0) >= (m+0))}'; then
     _needs_review "low-confidence ($conf) match — held: $bullet"; return

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -241,7 +241,7 @@ id from the list. If none apply, reply with exactly: NONE. No other text."
   if [ "$prc" -ne 0 ]; then _needs_review "LLM harness unavailable (exit $prc) — held: $bullet"; return; fi
   line="$(printf '%s\n' "$out" | sed '/^[[:space:]]*$/d' | head -1)"
   # shellcheck disable=SC2086  # intentional split: fields are qid + confidence
-  set -- $line
+  set -f; set -- $line; set +f   # -f so a * / ? in model output can't glob the cwd
   case "${1:-}" in ""|NONE|none|None) _needs_review "unmatched: $bullet"; return ;; esac
   qid="$1"; conf="${2:-0}"
   if ! _qid_is_open "$qid"; then _needs_review "proposed qid ($qid) not an open question — held: $bullet"; return; fi

--- a/scripts/ceo-nathan-inbox.test.sh
+++ b/scripts/ceo-nathan-inbox.test.sh
@@ -155,7 +155,30 @@ test_llm_unavailable_candidate_to_needs_review_note_still_works() {
   PROPOSE_FAIL=1 run_ingest
 
   assert_contains "$(NEEDS_REVIEW)" "a candidate answer" "candidate falls through when LLM is down"
+  # Pin the exit-code route specifically: a failed harness call must be recorded as
+  # "harness unavailable", NOT silently collapsed into the empty-output "unmatched"
+  # path (which would pass even if the prc-check were reverted).
+  assert_contains "$(NEEDS_REVIEW)" "harness unavailable" "a non-zero harness exit is routed as unavailable, not unmatched"
   assert_contains "$(CANDIDATES)" "deterministic note" "deterministic note path works without the LLM"
+}
+
+test_none_token_is_treated_as_no_match() {
+  # The prompt instructs the harness to reply NONE when nothing matches; that must
+  # route to needs-review as unmatched (not fall through to qid-validation).
+  write_pending "- [ ] [ask] (qid: q-1) top goal"
+  write_dropbox "- an unrelated musing"
+  # Point the proposer at a stub that emits the literal NONE token.
+  CEO_NATHAN_PROPOSE_CMD="$TEST_HOME/stubs/none-stub.sh"
+  cat > "$TEST_HOME/stubs/none-stub.sh" <<'S'
+#!/bin/bash
+cat >/dev/null; printf 'NONE\n'
+S
+  chmod +x "$TEST_HOME/stubs/none-stub.sh"
+  run_ingest
+
+  assert_contains     "$(NEEDS_REVIEW)" "unmatched" "NONE is treated as no-match (unmatched), not a bad qid"
+  assert_not_contains "$(NEEDS_REVIEW)" "proposed qid (NONE)" "NONE must not reach qid-validation"
+  assert_not_contains "$(PROPOSALS)"    "an unrelated musing" "NONE stages no proposal"
 }
 
 test_unconfirmed_proposal_relisted_not_committed() {
@@ -299,7 +322,7 @@ test_nothing_dropped_no_match() {
 
 # --- regression tests from the mini-panel review of PR #248 ---
 
-# Finding A: a multi-word proposer command (production default is "ceo llm-propose")
+# Finding A: a multi-word proposer command (production default is "claude -p --model …")
 # must be invoked as argv, not sought as one binary with an embedded space.
 test_multiword_proposer_command_is_invoked() {
   export CEO_NATHAN_PROPOSE_CMD="bash $TEST_HOME/stubs/propose-stub.sh"


### PR DESCRIPTION
## Description

Makes `nathan-inbox`'s propose step call the **installed Claude Code harness** directly — headless `claude -p --model $CEO_MODEL` (overridable via `CEO_NATHAN_PROPOSE_CMD` for tests) — instead of the bespoke `ceo llm-propose` subprocess wrapper.

The wrapper was a reflex carried over from the ollama-agent harness (#247), where wrapping + parsing an external model subprocess is the correct shape because local models are unreliable and need a driver. That shape doesn't belong here: Claude Code **is** the harness, so there's nothing to spawn or defensively parse. The prompt is assembled inline in the ingest; the harness returns one `<qid> <confidence>` line (or `NONE`), and the ingest validates qid-legitimacy + the confidence floor exactly as before.

Net: removes a parallel model-invocation layer. No new script, no `ceo` dispatcher change.

## Testing
1. Check out this branch.
2. `bash scripts/ceo-nathan-inbox.test.sh` → **All tests passed. (23 tests)**, green on bash 3.2 and 5.3.
3. `shellcheck -S warning scripts/ceo-nathan-inbox.sh` → clean.

## Notes
Confidence floor + qid validation are unchanged (already tested). The only non-deterministic step is the single harness call; on failure the candidate falls through to needs-review (no silent loss).