### PR TITLE
Auto-stamp qids onto un-tagged Pending.md [ask] lines

### DIFF
--- a/docs/playbooks/nathan-inbox.md
+++ b/docs/playbooks/nathan-inbox.md
@@ -61,13 +61,17 @@ binding-checked: the `ok` commits only if the frozen `(nb → qid, content-hash)
 still matches what was reported. Unconfirmed proposals expire to needs-review
 after `CEO_NATHAN_EXPIRY_DAYS` (default 7).
 
-## qid prerequisite
+## qid (auto-stamped)
 
-Every `Pending.md [ask]` line must carry an explicit `qid:` token, e.g.
-`- [ ] [ask] (qid: q-2026-07-06-01) top goal this quarter`. An `[ask]` line
-**without** a qid is not matchable → the un-tagged question is surfaced in
-needs-review rather than guessed at. Authoring qids on new questions is a
-one-line convention in whatever writes `Pending.md`.
+Every matchable `Pending.md [ask]` line carries a `qid:` token, e.g.
+`- [ ] [ask] (qid: q-80ffff) what is my top goal this quarter`. **Nobody mints
+these by hand** — not Nathan (who never edits `Pending.md`), not the authoring
+agent. Before building the open-question map each run, the ingest auto-stamps
+`(qid: q-<6-char sha1 of the question text>)` onto any open `[ask]` line missing
+one. The stamp is idempotent, stable (same text → same id), and skips `[confirm]`
+lines and already-tagged lines. Local hash only — no LLM egress, no discretion
+concern. A question authored without a qid is therefore matchable on the next
+run, not lost to needs-review.
 
 ## Outputs
 

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -108,6 +108,30 @@ _pending_rewrite() {  # reads an awk program on $1, atomically rewrites Pending
   if awk "$prog" "$PENDING" > "$tmp"; then mv "$tmp" "$PENDING"; else rm -f "$tmp"; return 1; fi
 }
 
+# Auto-stamp a stable qid onto any open [ask] line lacking one, so nobody — not
+# Nathan (who never edits this file), not the authoring agent — ever hand-mints
+# an id. qid = q-<6-char sha1 of the question text>: reproducible and unique
+# among the currently-open set (all matching keys on it). Idempotent; [confirm]
+# lines and already-tagged lines pass through untouched. Local hash only, no LLM
+# egress, so no discretion concern. Runs before the open-question map is built.
+_autostamp_qids() {
+  [ -f "$PENDING" ] || return 0
+  local tmp line qtext qid changed=0
+  local ask_re='^- \[ \] \[ask\]'
+  tmp="$(mktemp)" || { echo "ERROR: mktemp for qid autostamp" >&2; return 1; }
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ $line =~ $ask_re ]] && [[ $line != *'(qid:'* ]] && [[ $line != *'[confirm]'* ]]; then
+      qtext="$(printf '%s' "$line" | sed -E 's/^- \[ \] \[ask\][[:space:]]*//')"
+      qid="q-$(_hash "$qtext" | cut -c1-6)"
+      printf -- '- [ ] [ask] (qid: %s) %s\n' "$qid" "$qtext" >> "$tmp"
+      changed=1
+    else
+      printf '%s\n' "$line" >> "$tmp"
+    fi
+  done < "$PENDING"
+  if [ "$changed" = 1 ]; then mv "$tmp" "$PENDING"; else rm -f "$tmp"; fi
+}
+
 _append_confirm_line() {  # nb qid hash bullet question
   local nb="$1" qid="$2" hash="$3" bullet="$4" q="$5"
   printf -- '- [ ] [ask] [confirm] "%s" → answers "%s"? Reply `ok %s` <!-- nathan-inbox nb:%s qid:%s h:%s -->\n' \
@@ -269,6 +293,9 @@ for _c in "${DROPBOX%.md}".sync-conflict-*.md "${DROPBOX}".sync-conflict-*; do
   _needs_review "sync conflict on $(basename "$DROPBOX") — reconcile $_c into the primary, then delete the copy"
   _seen_add "$_key"
 done
+
+# ---------- 1.5 auto-stamp qids onto any un-tagged open [ask] lines ----------
+_autostamp_qids
 
 # ---------- 2. open-question map (for the LLM proposer + confirm-line text) ----------
 OPEN_Q_LIST="$(grep '^- \[ \] \[ask\]' "$PENDING" 2>/dev/null | grep -v '\[confirm\]' \

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -116,13 +116,28 @@ _pending_rewrite() {  # reads an awk program on $1, atomically rewrites Pending
 # egress, so no discretion concern. Runs before the open-question map is built.
 _autostamp_qids() {
   [ -f "$PENDING" ] || return 0
-  local tmp line qtext qid changed=0
+  local tmp line qtext base qid n used changed=0
   local ask_re='^- \[ \] \[ask\]'
   tmp="$(mktemp)" || { echo "ERROR: mktemp for qid autostamp" >&2; return 1; }
+  # qids already present in the file — never reuse. (Uniqueness is only required
+  # among currently-open questions, but seeding from every token is safe.)
+  used="$(grep -oE '\(qid: [^)]+\)' "$PENDING" 2>/dev/null | sed -E 's/^\(qid: (.+)\)$/\1/')"
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ask_re ]] && [[ $line != *'(qid:'* ]] && [[ $line != *'[confirm]'* ]]; then
       qtext="$(printf '%s' "$line" | sed -E 's/^- \[ \] \[ask\][[:space:]]*//')"
-      qid="q-$(_hash "$qtext" | cut -c1-6)"
+      base="$(_hash "$qtext")"
+      n=6; qid="q-$(printf '%s' "$base" | cut -c1-6)"
+      # Guarantee the minted qid is unique among open + already-assigned qids, so
+      # a later `ok` can never close two questions at once (confirm invariant).
+      # Distinct text diverges as the sha1 prefix lengthens; byte-identical
+      # questions exhaust the 40-char hash, then fall back to an -N suffix.
+      while printf '%s\n' "$used" | grep -qxF "$qid"; do
+        n=$((n + 1))
+        if [ "$n" -le 40 ]; then qid="q-$(printf '%s' "$base" | cut -c1-"$n")"
+        else qid="q-$base-$n"; fi
+      done
+      used="$used
+$qid"
       printf -- '- [ ] [ask] (qid: %s) %s\n' "$qid" "$qtext" >> "$tmp"
       changed=1
     else

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -144,7 +144,17 @@ $qid"
       printf '%s\n' "$line" >> "$tmp"
     fi
   done < "$PENDING"
-  if [ "$changed" = 1 ]; then mv "$tmp" "$PENDING"; else rm -f "$tmp"; fi
+  if [ "$changed" != 1 ]; then rm -f "$tmp"; return 0; fi
+  # Integrity guard: stamping is 1 line in → 1 line out, so the record counts
+  # must match. A mismatch means a mid-loop write failed (e.g. disk full) — do
+  # NOT clobber Pending.md with a truncated file.
+  if [ "$(awk 'END{print NR}' "$tmp")" = "$(awk 'END{print NR}' "$PENDING")" ]; then
+    mv "$tmp" "$PENDING"
+  else
+    rm -f "$tmp"
+    echo "ERROR: qid autostamp line-count mismatch; Pending.md left unchanged" >&2
+    return 1
+  fi
 }
 
 _append_confirm_line() {  # nb qid hash bullet question

--- a/scripts/ceo-nathan-inbox.test.sh
+++ b/scripts/ceo-nathan-inbox.test.sh
@@ -422,6 +422,17 @@ test_autostamp_leaves_existing_qid_untouched() {
   assert_eq "$(PENDING | grep -o '(qid:' | wc -l | tr -d ' ')" "1" "no second qid added to an already-tagged line"
 }
 
+test_autostamp_disambiguates_identical_questions() {
+  # Two byte-identical open [ask] lines hash to the same value → must NOT share a
+  # qid, or a single `ok` would silently close both (confirm-before-commit invariant).
+  write_pending "- [ ] [ask] same question text" "- [ ] [ask] same question text"
+  write_dropbox
+  run_ingest
+  assert_eq "$(PENDING | grep -c '^- \[ \] \[ask\] (qid: q-')" "2" "both identical [ask] lines are stamped"
+  assert_eq "$(PENDING | grep -oE '\(qid: [^)]+\)' | sort -u | wc -l | tr -d ' ')" "2" \
+    "identical questions get DISTINCT qids — no collision, no silent double-close"
+}
+
 test_autostamp_skips_confirm_lines() {
   local confirm='- [ ] [ask] [confirm] "b" → answers "q"? Reply `ok nb-1` <!-- nathan-inbox nb:nb-1 qid:q-1 h:abc -->'
   write_pending "- [ ] [ask] (qid: q-1) real question" "$confirm"

--- a/scripts/ceo-nathan-inbox.test.sh
+++ b/scripts/ceo-nathan-inbox.test.sh
@@ -396,4 +396,38 @@ test_sync_conflict_surfaced_once() {
   assert_eq "$(NEEDS_REVIEW | grep -c 'sync conflict')" "1" "a sync conflict is surfaced once, not every run"
 }
 
+test_bare_ask_line_gets_qid_autostamped() {
+  write_pending "- [ ] [ask] what is my top goal this quarter"
+  write_dropbox
+  run_ingest
+  assert_eq "$(PENDING | grep -c '^- \[ \] \[ask\] (qid: q-[0-9a-f]\{6\}) what is my top goal this quarter$')" "1" \
+    "a bare [ask] line is auto-stamped with a q-<6hex> qid (nobody hand-mints)"
+}
+
+test_autostamp_is_idempotent_and_stable() {
+  write_pending "- [ ] [ask] what is my top goal this quarter"
+  write_dropbox
+  run_ingest
+  local after1; after1="$(PENDING)"
+  run_ingest
+  assert_eq "$(PENDING)" "$after1" "second run does not re-stamp (idempotent + stable id)"
+  assert_eq "$(PENDING | grep -o '(qid:' | wc -l | tr -d ' ')" "1" "exactly one qid token — no double-stamp"
+}
+
+test_autostamp_leaves_existing_qid_untouched() {
+  write_pending "- [ ] [ask] (qid: q-custom) what is my top goal"
+  write_dropbox
+  run_ingest
+  assert_contains "$(PENDING)" "(qid: q-custom)" "an existing qid is never overwritten"
+  assert_eq "$(PENDING | grep -o '(qid:' | wc -l | tr -d ' ')" "1" "no second qid added to an already-tagged line"
+}
+
+test_autostamp_skips_confirm_lines() {
+  local confirm='- [ ] [ask] [confirm] "b" → answers "q"? Reply `ok nb-1` <!-- nathan-inbox nb:nb-1 qid:q-1 h:abc -->'
+  write_pending "- [ ] [ask] (qid: q-1) real question" "$confirm"
+  write_dropbox
+  run_ingest
+  assert_contains "$(PENDING)" "$confirm" "a [confirm] line passes through unchanged — never auto-stamped"
+}
+
 run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The `nathan-inbox` reply channel matches Nathan's freeform replies to open `Pending.md` questions by a `(qid: …)` token on each `[ask]` line. The token was expected to be authored by hand (a documented `shasum` one-liner). That convention was misdirected: **Nathan never edits `Pending.md`** (the CEO authors the questions), and the authoring agents can't be assumed to add a qid — so an un-tagged question was silently unmatchable and any reply to it routed to needs-review.

This moves qid minting into the code. A new `_autostamp_qids` step runs before the open-question map is built each run: it scans `Pending.md` for open `[ask]` lines lacking a qid and stamps `(qid: q-<6-char sha1 of the question text>)` onto each.

- **Idempotent + stable** — same question text → same id; a second run makes no change.
- **Scoped** — `[confirm]` lines and already-tagged lines pass through untouched.
- **Safe** — local hash only, no LLM egress, no discretion concern.
- Result: nobody mints an id by hand; a question authored without a qid is matchable on the next run instead of lost.

Also updates the playbook doc's `## qid` section (was "hand-mint via shasum" → "auto-stamped").

## Testing Procedure

1. Check out this branch.
2. Run the suite on both shells (the script must stay bash-3.2 portable):
   - `/bin/bash scripts/ceo-nathan-inbox.test.sh` → `All tests passed. (28 tests)`
   - `/opt/homebrew/bin/bash scripts/ceo-nathan-inbox.test.sh` → same
3. `shellcheck scripts/ceo-nathan-inbox.sh` → exit 0 (only pre-existing info notes).
4. The 4 new tests: bare `[ask]` line gets `q-<6hex>` stamped; idempotent + single token on re-run; existing qid untouched; `[confirm]` line passes through unchanged.

## Additional Notes / HelpScout Tickets

Follow-up to the reply-channel activation (#248/#249). Personal repo. The stamp fires the next time an `[ask]` question lands in `Pending.md`; no open questions exist today, so it's a no-op until then.