### PR TITLE
Fix #253: drive-to-green mode for the ollama-agent (--verify-cmd)

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -50,6 +50,9 @@ def main(argv=None):
     p.add_argument("--temperature", type=float, default=0.7)
     p.add_argument("--num-ctx", type=int, default=16384)
     p.add_argument("--turn-cap", type=int, default=8)
+    p.add_argument("--verify-cmd", default=None,
+                   help="Shell command that gates completion: the agent keeps "
+                        "iterating until it exits 0 (drive-to-green). Runs in --cwd.")
     p.add_argument("--shell-timeout", type=int, default=30)
     p.add_argument("--rules-dir", default="~/.claude/rules",
                    help="Directory of rule .md files to select from.")
@@ -186,7 +189,7 @@ def main(argv=None):
     transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
     try:
         rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap,
-                        run_id=a.run_id)
+                        run_id=a.run_id, verify_cmd=a.verify_cmd)
     except RuntimeError as e:
         print(f"agent failed: {e}", file=sys.stderr)
         return 1
@@ -200,7 +203,7 @@ def main(argv=None):
         print(json.dumps(rec, indent=2))
     else:
         final = rec["transcript"][-1]
-        print(f"completed={rec['completed']} turns={rec['turns']} "
+        print(f"completed={rec['completed']} verified={rec['verified']} turns={rec['turns']} "
               f"calls={len(rec['calls'])} unknown={rec['unknown_calls']}")
         print("--- final message ---")
         print(final.get("content", "(no content)"))

--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -54,7 +54,8 @@ def _tool_calls_from_content(content):
     return calls
 
 
-def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
+def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
+              verify_cmd=None):
     """Run one task to completion (a turn with no tool calls) or the turn cap.
 
     Returns a record: completed, turns, the full transcript, and the toolbox's
@@ -64,11 +65,19 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
     `run_id` is an optional caller-minted identifier echoed back in the record so
     a downstream ingestion pass can dedup this run's findings (the bridge itself
     does not mint one — a standalone run leaves it None). Additive.
+
+    `verify_cmd` is an optional shell command that gates completion: when the
+    model stops (a turn with no tool calls), the command runs in the toolbox's
+    cwd and the stop is accepted only if it exits 0. A non-zero exit feeds the
+    failure back and the loop continues, so the run drives to a green gate rather
+    than to the model's own say-so. `verified` is None when no gate is configured,
+    else the last check's pass/fail; the turn cap still bounds the loop.
     """
     messages = [{"role": "system", "content": system},
                 {"role": "user", "content": task}]
     transcript = list(messages)
     completed = False
+    verified = None
     turns = 0
     while turns < turn_cap:
         turns += 1
@@ -82,6 +91,22 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
             # model answered in prose.
             calls = _tool_calls_from_content(msg.get("content"))
         if not calls:
+            if verify_cmd:
+                res = json.loads(toolbox.run_shell(verify_cmd))
+                if res.get("returncode") == 0:
+                    verified = True
+                    completed = True
+                    break
+                verified = False
+                feedback = {"role": "user", "content": (
+                    "Verification command `%s` is not passing yet (returncode=%s). "
+                    "Fix the remaining failures and keep going — do not stop until "
+                    "it exits 0.\nstdout:\n%s\nstderr:\n%s" % (
+                        verify_cmd, res.get("returncode"),
+                        res.get("stdout", ""), res.get("stderr", "")))}
+                transcript.append(feedback)
+                messages.append(feedback)
+                continue
             completed = True
             break
         for c in calls:
@@ -101,6 +126,7 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
             messages.append(tool_msg)
     return {
         "completed": completed,
+        "verified": verified,
         "turns": turns,
         "run_id": run_id,
         "transcript": transcript,

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -166,6 +166,49 @@ def test_loop_dispatches_tools_then_finishes(tmp_path):
     assert rec["unknown_calls"] == []
 
 
+def test_verify_cmd_none_is_prior_behavior(tmp_path):
+    # No verify gate: the model stopping (no tool calls) completes immediately,
+    # and `verified` is None (feature not engaged).
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, verify_cmd=None)
+    assert rec["completed"] is True
+    assert rec["turns"] == 1
+    assert rec["verified"] is None
+
+
+def test_verify_cmd_passing_accepts_the_stop(tmp_path):
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, verify_cmd="true")
+    assert rec["completed"] is True
+    assert rec["verified"] is True
+    assert rec["turns"] == 1
+
+
+def test_verify_cmd_keeps_going_until_green(tmp_path):
+    # The model tries to stop every turn, but the verify command fails the first
+    # time and passes the second. The loop must NOT accept the first stop — it
+    # re-prompts and only completes once verification is green.
+    counter = tmp_path / "cnt"
+    verify = f"n=$(cat {counter} 2>/dev/null || echo 0); n=$((n+1)); echo $n > {counter}; [ $n -ge 2 ]"
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("fix it", "sys", transport, ToolBox(cwd=tmp_path), TOOLS,
+                    turn_cap=8, verify_cmd=verify)
+    assert rec["completed"] is True
+    assert rec["verified"] is True
+    assert rec["turns"] == 2
+
+
+def test_verify_cmd_never_green_ends_unverified_at_cap(tmp_path):
+    # Verify never passes: the run exhausts the cap and reports verified False,
+    # completed False — a caller must see it did NOT reach green.
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("fix it", "sys", transport, ToolBox(cwd=tmp_path), TOOLS,
+                    turn_cap=3, verify_cmd="false")
+    assert rec["verified"] is False
+    assert rec["completed"] is False
+    assert rec["turns"] == 3
+
+
 def test_run_id_echoed_in_record(tmp_path):
     transport = _script({"role": "assistant", "content": "done"})
     rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, run_id="run-abc")

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -23,11 +23,13 @@ def _stub(monkeypatch, captured):
     # run_agent receives so the test can assert what rule text was injected.
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: (lambda m, t: {"role": "assistant", "content": "ok"}))
 
-    def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
+    def fake_run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
+                       verify_cmd=None):
         captured["system"] = system
         captured["tools"] = tools
         captured["run_id"] = run_id
-        return {"completed": True, "turns": 1, "run_id": run_id,
+        captured["verify_cmd"] = verify_cmd
+        return {"completed": True, "verified": None, "turns": 1, "run_id": run_id,
                 "transcript": [{"role": "assistant", "content": "done"}],
                 "calls": [], "unknown_calls": []}
     monkeypatch.setattr(cli, "run_agent", fake_run_agent)
@@ -58,7 +60,7 @@ def test_cli_human_output_prints_summary_and_final_message(tmp_path, monkeypatch
     rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "completed=True turns=1 calls=0 unknown=[]" in out
+    assert "completed=True verified=None turns=1 calls=0 unknown=[]" in out
     assert "--- final message ---" in out and "done" in out
 
 
@@ -146,7 +148,8 @@ def test_cli_rules_loaded_hash_no_match_distinct_from_none(tmp_path, monkeypatch
 def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
 
-    def boom(task, system, transport, toolbox, tools, turn_cap=8, run_id=None):
+    def boom(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
+             verify_cmd=None):
         raise RuntimeError("ollama unreachable")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", boom)


### PR DESCRIPTION
Closes #253. Sub-issue of #252.

## Description (New Behavior)

The agent loop treated "the model stopped calling tools" as completion — the model's own say-so, not a passing gate. `run_agent` now takes an optional `verify_cmd`: when the model stops, the command runs in the toolbox `cwd` and the stop is accepted **only** if it exits 0. A non-zero exit feeds the failure (returncode + stdout/stderr) back into the conversation and the loop continues until green or the turn cap. The record gains `verified` (`None` = no gate configured, else the last check's pass/fail). Exposed as `cli.py --verify-cmd`; the human summary prints `verified=`.

**Why:** lets a delegated coding task run **unattended to a passing test suite**, so the PM reviews once at the end instead of babysitting each round — the "self-iterate-to-green" lever from #252. Full-file `write_file` is unchanged (robust at 24B); no patch tool (that's gated by the #255 spike).

## Testing Procedure

1. Check out this branch; `cd ollama-agent`.
2. `python3 -m pytest -q` → `165 passed`.
3. New agent tests: `verify_cmd` None = prior behavior; passing accepts the stop; **fail-then-green keeps going** (turns==2); never-green ends `verified=False, completed=False` at the cap; cli propagation.
4. Live smoke (needs ollama + a local model):
   `python3 cli.py --model mistral-small3.2:24b --cwd $(mktemp -d) --no-rules --no-skills --turn-cap 6 --verify-cmd '[ "$(cat answer.txt)" = "42" ]' --task 'write 42 to answer.txt' --json` → `completed True verified True`.

## Additional Notes

Claude-authored (agent's own loop = infra). `scheduler` CI check is pre-existing red on `main`, unrelated.