### PR TITLE
feat(ollama-agent): committed task registry + close ungated delegation bypass

### DIFF
--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -32,7 +32,30 @@ apply, gated before any model call); `--scores` points at a model-matrix `scores
 
 ## Governance (registry + delegation gate)
 
-A registered task (`--registry reg.json --task-name <name>`) is gated **before any model call**:
+The canonical registry ships at [`ollama-agent/registry.json`](registry.json). It
+intentionally ships **empty** (no delegable entries): enabling a task that pins a
+local model in a delegable tier is gated behind the delegation spike ([#255](https://github.com/nhangen/claude-ceo/issues/255))
+and blast-radius routing policy ([#254](https://github.com/nhangen/claude-ceo/issues/254)).
+A CI guard (`test_committed_registry_enables_no_delegable_tier`) fails if a delegable
+entry is added here instead of through that gated work.
+
+Entry shape (`tasks.<name>`):
+
+```jsonc
+{
+  "runner": "ollama",          // required; only "ollama" is a known runner
+  "model": "gpt-oss:20b",      // required; the local model to run
+  "tier": "deterministic",     // required; deterministic | low-stakes-write | high-stakes
+  "tools": "*",                // optional; "*" or a list of allowed tool names
+  "rules": true,               // optional; inject relevance-selected rules (default true)
+  "skills": false,             // optional; expose the skill catalog (default false)
+  "min_score": 0.9,            // optional; refuse unless the model earned this on eval_task
+  "eval_task": "think-02",     // required WHEN min_score is set ("*" = cross-task mean)
+  "eval_model": null           // optional; override which model's score is checked
+}
+```
+
+A registered task (`--registry registry.json --task-name <name>`) is gated **before any model call**:
 
 - `tier: high-stakes` is never delegated to a local model (refused, exit 3); only `deterministic`
   and `low-stakes-write` run. Unknown `runner`/`tier` is rejected, never defaulted.

--- a/ollama-agent/README.md
+++ b/ollama-agent/README.md
@@ -19,12 +19,14 @@ Part of the [local-agent bridge epic (#185)](https://github.com/nhangen/claude-c
 
 ```bash
 # requires a running ollama daemon with the model pulled
+# --ungated: an ad-hoc run applies no delegation gate, so it must opt in explicitly
 python ollama-agent/cli.py --task "summarize the README in 3 bullets" \
-  --model gpt-oss:20b --cwd /path/to/repo
+  --model gpt-oss:20b --cwd /path/to/repo --ungated
 ```
 
 Flags: `--model`, `--cwd` (the directory tools operate in), `--host`, `--temperature`,
-`--num-ctx`, `--turn-cap`, `--shell-timeout`, `--json` (full record), `--system` (override the system prompt).
+`--num-ctx`, `--turn-cap`, `--shell-timeout`, `--json` (full record), `--system` (override the system prompt),
+`--ungated` (opt into an ad-hoc, ungated run — required unless `--task-name` selects a gated registered task).
 
 Governance flags: `--registry` + `--task-name` run a registered task (its model/tier/tools/rules
 apply, gated before any model call); `--scores` points at a model-matrix `scores.tsv` for the

--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -78,7 +78,22 @@ def main(argv=None):
                    help="Caller-minted run identifier, echoed in the record so a "
                         "downstream ingestion pass can dedup this run's findings.")
     p.add_argument("--json", action="store_true", help="Print the full record as JSON.")
+    p.add_argument("--ungated", action="store_true",
+                   help="Explicitly opt into an ad-hoc, ungated run (no registered "
+                        "task, no delegation gate). Without it, a run must select a "
+                        "registered task via --task-name.")
     a = p.parse_args(argv)
+
+    # The delegation gate (tier + min_score) only fires for a registered task
+    # (--task-name). A bare --task otherwise runs whatever --model says, ungated —
+    # making the gate theater for ad-hoc use. Require an explicit --ungated opt-in
+    # so the bypass is no longer the silent default. The cron bridge always passes
+    # --task-name (ceo-cron.sh) and is unaffected.
+    if not a.task_name and not a.ungated:
+        print("REFUSED: an ad-hoc run requires --ungated (it applies no delegation "
+              "gate). Use --task-name <name> --registry <path> to run a gated, "
+              "registered task instead.", file=sys.stderr)
+        return 2
 
     # Governance: a registered task is gated before any model call. A non-delegable
     # tier (high-stakes) or unknown runner/tier is refused here — never run.

--- a/ollama-agent/registry.json
+++ b/ollama-agent/registry.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Canonical ollama-agent task registry. Intentionally ships with NO delegable entries: enabling a task that pins a local model in a delegable tier (deterministic/low-stakes-write) is gated behind the delegation spike (#255) and blast-radius routing policy (#254). Add entries there, not here, until the spike clears its go/no-go. Entry shape: tasks.<name> = {runner, model, tier, tools?, rules?, skills?, min_score?, eval_task?, eval_model?}. A min_score requires eval_task (use \"*\" for the cross-task mean). See ollama-agent/README.md.",
+  "tasks": {}
+}

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -245,7 +245,7 @@ def test_cli_registered_deterministic_task_applies_model_and_runs(tmp_path, monk
                                        "tier": "deterministic", "tools": ["run_shell", "git"]})
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--ungated", "--task", "do triage", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "do triage", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "triage"])
     assert rc == 0
     assert _tool_names(captured["tools"]) == {"run_shell", "git"}   # restricted to allowlist
@@ -261,7 +261,7 @@ def test_cli_high_stakes_task_is_rejected_before_any_run(tmp_path, monkeypatch, 
         raise AssertionError("run_agent must not be called for a rejected task")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", must_not_run)
-    rc = cli.main(["--ungated", "--task", "pay the invoice", "--cwd", str(tmp_path),
+    rc = cli.main(["--task", "pay the invoice", "--cwd", str(tmp_path),
                    "--registry", reg, "--task-name", "payout"])
     assert rc == 3
     assert "REJECTED task 'payout'" in capsys.readouterr().err
@@ -296,7 +296,7 @@ def test_cli_registry_tool_typo_is_warned_not_silent(tmp_path, monkeypatch, caps
                                  "tools": ["read-file", "git"]})  # 'read-file' is a typo
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
     assert _tool_names(captured["tools"]) == {"git"}   # only the valid name survives
@@ -311,7 +311,7 @@ def test_cli_registry_rules_skills_propagation(tmp_path, monkeypatch, capsys):
     # rules-dir/skills-dir point at fixtures, but the spec forces them off
     rules = _fixture_rules(tmp_path)
     skills = _fixture_skills(tmp_path)
-    rc = cli.main(["--ungated", "--task", "stage the tmp log files", "--cwd", str(tmp_path),
+    rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--skills-dir", str(skills),
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
@@ -332,7 +332,7 @@ def test_cli_min_score_missing_scores_file_rejects(tmp_path, monkeypatch, capsys
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t",
                    "--scores", str(tmp_path / "nope.tsv")])
     assert rc == 3
@@ -353,7 +353,7 @@ def test_cli_min_score_default_scores_path_resolves(tmp_path, monkeypatch):
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
 
@@ -366,7 +366,7 @@ def test_cli_min_score_default_scores_absent_rejects(tmp_path, monkeypatch, caps
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 3
     assert "eval scores file not found" in capsys.readouterr().err
@@ -378,7 +378,7 @@ def test_cli_min_score_below_threshold_rejects(tmp_path, monkeypatch, capsys):
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t", "--scores", sc])
     assert rc == 3
     assert "below min_score" in capsys.readouterr().err
@@ -391,7 +391,7 @@ def test_cli_min_score_passing_with_stale_scores_warns_but_runs(tmp_path, monkey
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t", "--scores", sc])
     assert rc == 0
     assert "stale" in capsys.readouterr().err   # warned, but did not refuse

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_cli_injects_matching_rule(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--no-skills"])
     assert rc == 0
     assert "no-commit-tmp-logs" in captured["system"]
@@ -57,7 +57,7 @@ def test_cli_human_output_prints_summary_and_final_message(tmp_path, monkeypatch
     # covers the `--json` branch; this covers its human-readable counterpart.
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
+    rc = cli.main(["--ungated", "--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
     assert rc == 0
     out = capsys.readouterr().out
     assert "completed=True verified=None turns=1 calls=0 unknown=[]" in out
@@ -68,7 +68,7 @@ def test_cli_threads_run_id_into_record(tmp_path, monkeypatch, capsys):
     import json
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--run-id", "run-xyz", "--json"])
     assert rc == 0
     assert captured["run_id"] == "run-xyz"
@@ -78,14 +78,14 @@ def test_cli_threads_run_id_into_record(tmp_path, monkeypatch, capsys):
 def test_cli_run_id_defaults_none(tmp_path, monkeypatch, capsys):
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
+    rc = cli.main(["--ungated", "--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
     assert rc == 0
     assert captured["run_id"] is None
 
 
 def test_cli_rules_loaded_hash_none_when_rules_off(tmp_path, monkeypatch, capsys):
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills", "--json"])
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills", "--json"])
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["rules_loaded_hash"] == "none"
 
@@ -96,7 +96,7 @@ def test_cli_rules_loaded_hash_stable_and_content_sensitive(tmp_path, monkeypatc
     # selected rule's body changes — otherwise it can't attribute a behavior shift.
     rules = _fixture_rules(tmp_path)
     args = ["--task", "stage the tmp log files for a commit", "--cwd", str(tmp_path),
-            "--rules-dir", str(rules), "--no-skills", "--json"]
+            "--rules-dir", str(rules), "--no-skills", "--json", "--ungated"]
 
     _stub(monkeypatch, {})
     cli.main(args); h1 = json.loads(capsys.readouterr().out)["rules_loaded_hash"]
@@ -116,7 +116,7 @@ def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "stage the tmp log files", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--no-rules", "--no-skills"])
     assert rc == 0
     assert "no-commit-tmp-logs" not in captured["system"]
@@ -126,7 +126,7 @@ def test_cli_no_rules_skips_injection(tmp_path, monkeypatch, capsys):
 def test_cli_no_match_reports_zero(tmp_path, monkeypatch, capsys):
     rules = _fixture_rules(tmp_path)
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "paint the fence blue", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "paint the fence blue", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--no-skills"])
     assert rc == 0
     err = capsys.readouterr().err
@@ -139,7 +139,7 @@ def test_cli_rules_loaded_hash_no_match_distinct_from_none(tmp_path, monkeypatch
     # rules-off run. Revert the `else: "no-match"` branch and this reads "none".
     rules = _fixture_rules(tmp_path)
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "paint the fence blue", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "paint the fence blue", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--no-skills", "--json"])
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["rules_loaded_hash"] == "no-match"
@@ -153,7 +153,7 @@ def test_cli_transport_failure_returns_1(tmp_path, monkeypatch, capsys):
         raise RuntimeError("ollama unreachable")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", boom)
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--rules-dir", str(rules), "--no-rules", "--no-skills"])
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--rules-dir", str(rules), "--no-rules", "--no-skills"])
     assert rc == 1
     assert "agent failed" in capsys.readouterr().err
 
@@ -169,7 +169,7 @@ def test_cli_injects_skill_catalog_and_use_skill_tool(tmp_path, monkeypatch, cap
     skills = _fixture_skills(tmp_path)
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do a thing", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "do a thing", "--cwd", str(tmp_path),
                    "--no-rules", "--skills-dir", str(skills)])
     assert rc == 0
     assert "obsidian-save" in captured["system"] and "use_skill" in captured["system"]
@@ -181,7 +181,7 @@ def test_cli_no_skills_suppresses_catalog_and_tool(tmp_path, monkeypatch, capsys
     skills = _fixture_skills(tmp_path)
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do a thing", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "do a thing", "--cwd", str(tmp_path),
                    "--no-rules", "--skills-dir", str(skills), "--no-skills"])
     assert rc == 0
     assert "obsidian-save" not in captured["system"]
@@ -215,7 +215,7 @@ def test_cli_mcp_bridges_tools_and_closes_transport(tmp_path, monkeypatch, capsy
     captured, closed = {}, {"v": False}
     _stub(monkeypatch, captured)
     _stub_mcp(monkeypatch, closed)
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--mcp", "fake-server arg"])
     assert rc == 0
     assert "mcp__echo" in _tool_names(captured["tools"])
@@ -227,7 +227,7 @@ def test_cli_mcp_bridge_failure_returns_1_and_closes(tmp_path, monkeypatch, caps
     closed = {"v": False}
     _stub(monkeypatch, {})
     _stub_mcp(monkeypatch, closed, init_raises=True)
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--mcp", "broken-server"])
     assert rc == 1
     assert "mcp bridge failed for 'broken-server'" in capsys.readouterr().err
@@ -245,7 +245,7 @@ def test_cli_registered_deterministic_task_applies_model_and_runs(tmp_path, monk
                                        "tier": "deterministic", "tools": ["run_shell", "git"]})
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "do triage", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "do triage", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "triage"])
     assert rc == 0
     assert _tool_names(captured["tools"]) == {"run_shell", "git"}   # restricted to allowlist
@@ -261,7 +261,7 @@ def test_cli_high_stakes_task_is_rejected_before_any_run(tmp_path, monkeypatch, 
         raise AssertionError("run_agent must not be called for a rejected task")
     monkeypatch.setattr(cli, "ollama_transport", lambda *a, **k: None)
     monkeypatch.setattr(cli, "run_agent", must_not_run)
-    rc = cli.main(["--task", "pay the invoice", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "pay the invoice", "--cwd", str(tmp_path),
                    "--registry", reg, "--task-name", "payout"])
     assert rc == 3
     assert "REJECTED task 'payout'" in capsys.readouterr().err
@@ -296,7 +296,7 @@ def test_cli_registry_tool_typo_is_warned_not_silent(tmp_path, monkeypatch, caps
                                  "tools": ["read-file", "git"]})  # 'read-file' is a typo
     captured = {}
     _stub(monkeypatch, captured)
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
     assert _tool_names(captured["tools"]) == {"git"}   # only the valid name survives
@@ -311,7 +311,7 @@ def test_cli_registry_rules_skills_propagation(tmp_path, monkeypatch, capsys):
     # rules-dir/skills-dir point at fixtures, but the spec forces them off
     rules = _fixture_rules(tmp_path)
     skills = _fixture_skills(tmp_path)
-    rc = cli.main(["--task", "stage the tmp log files", "--cwd", str(tmp_path),
+    rc = cli.main(["--ungated", "--task", "stage the tmp log files", "--cwd", str(tmp_path),
                    "--rules-dir", str(rules), "--skills-dir", str(skills),
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
@@ -332,7 +332,7 @@ def test_cli_min_score_missing_scores_file_rejects(tmp_path, monkeypatch, capsys
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t",
                    "--scores", str(tmp_path / "nope.tsv")])
     assert rc == 3
@@ -353,7 +353,7 @@ def test_cli_min_score_default_scores_path_resolves(tmp_path, monkeypatch):
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 0
 
@@ -366,7 +366,7 @@ def test_cli_min_score_default_scores_absent_rejects(tmp_path, monkeypatch, caps
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t"])
     assert rc == 3
     assert "eval scores file not found" in capsys.readouterr().err
@@ -378,7 +378,7 @@ def test_cli_min_score_below_threshold_rejects(tmp_path, monkeypatch, capsys):
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t", "--scores", sc])
     assert rc == 3
     assert "below min_score" in capsys.readouterr().err
@@ -391,7 +391,7 @@ def test_cli_min_score_passing_with_stale_scores_warns_but_runs(tmp_path, monkey
                                  "tier": "deterministic", "min_score": 0.8,
                                  "eval_task": "think-02"})
     _stub(monkeypatch, {})
-    rc = cli.main(["--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
+    rc = cli.main(["--ungated", "--task", "x", "--cwd", str(tmp_path), "--no-rules", "--no-skills",
                    "--registry", reg, "--task-name", "t", "--scores", sc])
     assert rc == 0
     assert "stale" in capsys.readouterr().err   # warned, but did not refuse
@@ -406,3 +406,23 @@ def test_warn_if_stale_scores_branches(capsys):
     fresh = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     cli._warn_if_stale_scores(fresh, 30)
     assert capsys.readouterr().err == ""                          # fresh → silent
+
+
+def test_cli_bare_task_without_ungated_refuses(tmp_path, monkeypatch, capsys):
+    # The delegation-gate bypass is no longer the silent default: a bare --task
+    # (no --task-name, no --ungated) refuses BEFORE any model call.
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills"])
+    assert rc == 2
+    assert "REFUSED" in capsys.readouterr().err
+    assert "system" not in captured   # run_agent never reached
+
+
+def test_cli_ungated_opt_in_runs(tmp_path, monkeypatch, capsys):
+    # With the explicit opt-in, the ad-hoc run proceeds as before.
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills", "--ungated"])
+    assert rc == 0
+    assert "system" in captured       # run_agent reached

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -6,9 +6,13 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from ollama_agent.registry import (  # noqa: E402
-    RegistryError, TaskSpec, filter_tools, gate, load_registry,
+    DELEGABLE_TIERS, RegistryError, TaskSpec, filter_tools, gate, load_registry,
     load_scores, normalize_model, score_for,
 )
+
+# The committed canonical registry (ollama-agent/registry.json), resolved off the
+# same parents[1] that sys.path is anchored to above.
+COMMITTED_REGISTRY = Path(__file__).resolve().parents[1] / "registry.json"
 
 SCORES_TSV = (
     "# generated_at=2026-06-26T00:00:00Z\n"
@@ -266,3 +270,23 @@ def test_gate_min_score_zero_is_a_real_threshold():
                     min_score=0.0, eval_task="think-99")
     ok2, _ = gate(miss, _scored())
     assert not ok2
+
+
+def test_committed_registry_parses():
+    # The shipped canonical registry must load without error, so a malformed
+    # hand-edit fails CI here rather than at first cron dispatch.
+    specs = load_registry(str(COMMITTED_REGISTRY))
+    assert isinstance(specs, dict)
+
+
+def test_committed_registry_enables_no_delegable_tier():
+    # Governance guard: the committed registry ships the *mechanism*, not the
+    # bet. Enabling a task that pins a local model in a delegable tier is gated
+    # behind the delegation spike (#255) + routing policy (#254) and belongs in
+    # that work, not here. This fails the moment such an entry is added to
+    # registry.json, forcing the decision back through the gated issue.
+    specs = load_registry(str(COMMITTED_REGISTRY))
+    delegable = {name: s.tier for name, s in specs.items() if s.tier in DELEGABLE_TIERS}
+    assert not delegable, (
+        f"committed registry enables delegable tier(s): {delegable} — "
+        "delegable pins are gated behind #255/#254, add them there")

--- a/ollama-agent/tests/test_registry.py
+++ b/ollama-agent/tests/test_registry.py
@@ -272,11 +272,14 @@ def test_gate_min_score_zero_is_a_real_threshold():
     assert not ok2
 
 
-def test_committed_registry_parses():
-    # The shipped canonical registry must load without error, so a malformed
-    # hand-edit fails CI here rather than at first cron dispatch.
+def test_committed_registry_ships_empty():
+    # The shipped canonical registry must load without error AND be empty: it is
+    # governance scaffolding, not a place to register tasks. Asserting == {} (not
+    # just "is a dict") also catches a stray high-stakes entry, which the
+    # delegable-tier guard below would let slip. A malformed hand-edit fails here
+    # (load_registry raises) rather than at first cron dispatch.
     specs = load_registry(str(COMMITTED_REGISTRY))
-    assert isinstance(specs, dict)
+    assert specs == {}
 
 
 def test_committed_registry_enables_no_delegable_tier():


### PR DESCRIPTION
Closes #257
Closes #259

## Description

Two related pieces of the ollama-agent delegation-governance story. The gate code (`registry.py` + the CLI wiring) already shipped in #190/#200; what was missing was a canonical registry to load and a non-bypassable default.

**1. Committed task registry (#257).** Adds `ollama-agent/registry.json` as the canonical registry the CLI loads. It ships **empty by design**: enabling a task that pins a local model in a *delegable* tier (deterministic / low-stakes-write) is the payoff bet gated behind the delegation spike (#255) and blast-radius routing policy (#254), so it does not belong here yet. A CI guard (`test_committed_registry_enables_no_delegable_tier`) fails the moment a delegable entry is added to `registry.json`, forcing that decision back through the gated work. The README documents the entry shape and the empty-by-design rationale.

**2. Close the ungated ad-hoc bypass (#259).** A bare `--task` (no `--task-name`) ran ungated against whatever `--model` was passed — the tier/`min_score` gate only fires for a registered task, so it was theater for ad-hoc use. Now an ad-hoc run must opt in explicitly with `--ungated`; without it (and without a registered `--task-name`) the run refuses (exit 2) **before any model call**. The cron bridge (`scripts/ceo-cron.sh`) always passes `--task-name` and is unaffected.

Both are sub-issues under #252 (the delegation token-positivity epic); this PR ships only the governance-neutral mechanism, not the delegation bet.

## Testing Procedure

1. Check out this branch.
2. `cd ollama-agent && python3 -m pytest -q` — 169 pass (this is exactly what CI's `test` job runs).
3. Verify the registry guard: it asserts the committed `registry.json` parses and enables no delegable tier. Add a delegable entry to `registry.json` and re-run — `test_committed_registry_enables_no_delegable_tier` fails as intended.
4. Verify the bypass close:
   - `python3 ollama-agent/cli.py --task "x" --cwd . --no-rules --no-skills` -> refuses with `REFUSED: an ad-hoc run requires --ungated`, exit 2, no model call.
   - Same command with `--ungated` appended -> proceeds (needs a running ollama daemon).
   - `--task-name <name> --registry <path>` (the cron path) is unchanged.

## Additional Notes

- **Pre-existing red on `main` is unrelated.** The `scheduler` CI job fails on `main` (a `tsc --noEmit` / cronbird TypeScript error). This PR touches only ollama-agent Python + `registry.json` + README; the `test` job (which runs the ollama-agent suite) is green. The inherited `scheduler` red is not from this diff.
- The `eval_task` for any future delegable pin must be representative of the *delegated work* (the model-matrix grades deterministic reasoning, not code authorship) — called out in #258, and it's #254's decision.
