### PR TITLE
Fix #173: notify only on real work via a fired/noop outcome channel

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -1396,12 +1396,17 @@ if [ "$RUNNER" = "script" ]; then
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER CEO_RUNNER_OUTCOME_FILE
   SCRIPT_EXIT=0
   "$SCRIPT_FULL" >>"$LOG_DIR/cron-stdout.log" 2>>"$LOG_DIR/cron-stderr.log" || SCRIPT_EXIT=$?
+  # Explicit cleanup (not a trap): an EXIT trap here would clobber the lock-release
+  # trap set earlier at the top of the run. rm before each exit instead so the
+  # per-tick outcome tmp file doesn't leak.
   if [ "$SCRIPT_EXIT" -ne 0 ]; then
     _v "FAILED (exit: $SCRIPT_EXIT)"
     _record_failure "Script exited $SCRIPT_EXIT for $TRIGGER"
+    rm -f "$CEO_RUNNER_OUTCOME_FILE"
     exit "$SCRIPT_EXIT"
   fi
   _record_success
+  rm -f "$CEO_RUNNER_OUTCOME_FILE"
   exit 0
 fi
 

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -224,9 +224,20 @@ _record_success() {
   # ticket-triage-autopilot (every 30m, silent-by-design v2 cache adapter) would
   # otherwise flood the notify webhook when notify_events="all".
   case "$TRIGGER" in
-    disk-monitor|ticket-triage-autopilot) SUCCESS_NOTIFY=0 ;;
+    disk-monitor) SUCCESS_NOTIFY=0 ;;
     *) SUCCESS_NOTIFY=1 ;;
   esac
+  # A script-runner playbook may signal its outcome via CEO_RUNNER_OUTCOME_FILE
+  # so a heartbeat tick that did no work stays silent while a tick that did real
+  # work still notifies (#173): "fired" => notify, "noop" => silent. Absent or
+  # any other value leaves the per-trigger default above. This is the general
+  # mechanism that retires per-playbook hardcodes like the disk-monitor case.
+  if [ -n "${CEO_RUNNER_OUTCOME_FILE:-}" ] && [ -f "$CEO_RUNNER_OUTCOME_FILE" ]; then
+    case "$(cat "$CEO_RUNNER_OUTCOME_FILE" 2>/dev/null)" in
+      fired) SUCCESS_NOTIFY=1 ;;
+      noop)  SUCCESS_NOTIFY=0 ;;
+    esac
+  fi
   if [ "$SUCCESS_NOTIFY" = "1" ] && [ -x "$SCRIPT_DIR/ceo-notify.sh" ]; then
     "$SCRIPT_DIR/ceo-notify.sh" success "$TRIGGER" >/dev/null 2>&1 || \
       echo "$(date): WARN — ceo-notify.sh success exited non-zero for $TRIGGER" >> "$LOG_DIR/cron-skips.log"
@@ -1379,7 +1390,10 @@ if [ "$RUNNER" = "script" ]; then
     exit 0
   fi
   _v "Runner: script — exec $SCRIPT_PATH"
-  export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
+  # Outcome channel (#173): a script may write "fired"/"noop" here to tell
+  # _record_success whether this tick did real work worth a success notify.
+  CEO_RUNNER_OUTCOME_FILE="$(mktemp)"
+  export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER CEO_RUNNER_OUTCOME_FILE
   SCRIPT_EXIT=0
   "$SCRIPT_FULL" >>"$LOG_DIR/cron-stdout.log" 2>>"$LOG_DIR/cron-stderr.log" || SCRIPT_EXIT=$?
   if [ "$SCRIPT_EXIT" -ne 0 ]; then

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -714,6 +714,62 @@ SH
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+# --- #173: script playbooks signal fired/noop so _record_success notifies only
+# on real work, not on every heartbeat tick. Contract: cron exports
+# CEO_RUNNER_OUTCOME_FILE; a script writes "fired" (notify) or "noop" (silent);
+# absent => the prior per-trigger default. ---
+
+_write_outcome_playbook() {  # $1=trigger  $2=outcome-to-write (empty = write nothing)
+  local trig="$1" outcome="$2"
+  cat > "$CEO_DIR/playbooks/$trig.md" << PB
+---
+name: $trig
+description: outcome-signal test
+trigger: cron
+schedule: "*/30 * * * *"
+preflight: none
+tier: read
+status: active
+runner: script
+script: $trig-test.sh
+---
+PB
+  cat > "$SCRIPT_DIR/$trig-test.sh" << SH
+#!/bin/bash
+[ -n "$outcome" ] && [ -n "\$CEO_RUNNER_OUTCOME_FILE" ] && printf '%s' "$outcome" > "\$CEO_RUNNER_OUTCOME_FILE"
+exit 0
+SH
+  chmod +x "$SCRIPT_DIR/$trig-test.sh"
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+}
+
+test_script_outcome_noop_suppresses_success_notify() {
+  _write_outcome_playbook outcome-noop noop
+  CEO_NOTIFY_DEBUG_LOG="$TEST_HOME/notify-debug.log" bash "$CRON" outcome-noop >/dev/null 2>&1 || true
+  local log; log=$(cat "$TEST_HOME/notify-debug.log" 2>/dev/null || echo "")
+  assert_not_contains "$log" "[success/outcome-noop]" "a noop outcome must suppress the success notify"
+  rm -f "$SCRIPT_DIR/outcome-noop-test.sh"
+}
+
+test_autopilot_fired_outcome_notifies() {
+  # ticket-triage-autopilot is in the blanket hardcode today; a "fired" tick
+  # (real merges → tickets) must still ping once the outcome gate replaces it.
+  _write_outcome_playbook ticket-triage-autopilot fired
+  CEO_NOTIFY_DEBUG_LOG="$TEST_HOME/notify-debug.log" bash "$CRON" ticket-triage-autopilot >/dev/null 2>&1 || true
+  local log; log=$(cat "$TEST_HOME/notify-debug.log" 2>/dev/null || echo "")
+  assert_contains "$log" "[success/ticket-triage-autopilot]" "a fired autopilot tick must send the success notify"
+  rm -f "$SCRIPT_DIR/ticket-triage-autopilot-test.sh"
+}
+
+test_script_without_outcome_keeps_default_notify() {
+  # A plain script that writes no outcome preserves the prior behavior: notify.
+  _write_outcome_playbook outcome-default ""
+  CEO_NOTIFY_DEBUG_LOG="$TEST_HOME/notify-debug.log" bash "$CRON" outcome-default >/dev/null 2>&1 || true
+  local log; log=$(cat "$TEST_HOME/notify-debug.log" 2>/dev/null || echo "")
+  assert_contains "$log" "[success/outcome-default]" "a script writing no outcome must still notify (default preserved)"
+  rm -f "$SCRIPT_DIR/outcome-default-test.sh"
+}
+
 test_read_tier_failure_increments_fail_count() {
   cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash

--- a/scripts/ceo-triage-autopilot.sh
+++ b/scripts/ceo-triage-autopilot.sh
@@ -25,6 +25,11 @@ ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
 ceo_pin_home_or_warn || true
 ceo_augment_path
 
+# Default this tick to a silent "noop" for cron's #173 success-notify gate; a
+# real firing tick upgrades it to "fired" below. Set early so every exit path
+# (including the skill-not-found bail) leaves a correct outcome.
+[ -n "${CEO_RUNNER_OUTCOME_FILE:-}" ] && printf 'noop' > "$CEO_RUNNER_OUTCOME_FILE"
+
 : "${HOME:?HOME must be set before ceo-triage-autopilot}"
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
@@ -152,6 +157,8 @@ if [ "$CONSEC_FAILS" -ge "$MAX_FAILS" ]; then
 fi
 
 if [ "$EVENTS_TOTAL" -gt 0 ]; then STATUS="firing"; else STATUS="clear"; fi
+# A firing tick did real work (new merges escalated) — tell cron to notify (#173).
+[ -n "${CEO_RUNNER_OUTCOME_FILE:-}" ] && [ "$STATUS" = "firing" ] && printf 'fired' > "$CEO_RUNNER_OUTCOME_FILE"
 # SINCE resets only on a real transition into firing.
 if [ "$STATUS" = "firing" ] && [ "$PRIOR_STATUS" = "firing" ] && [ -n "$PRIOR_SINCE" ]; then
   SINCE="$PRIOR_SINCE"; else SINCE="$NOW"; fi

--- a/scripts/ceo-triage-autopilot.test.sh
+++ b/scripts/ceo-triage-autopilot.test.sh
@@ -52,13 +52,18 @@ print(json.dumps({"owner": args[0], "events": ev, "unknown": [], "since": None})
 PY
 
 # --- 1. Transition fires once; real consume means run 2 is silent ---
+# CEO_RUNNER_OUTCOME_FILE is the #173 channel: a firing tick writes "fired"
+# (cron notifies), a clear tick writes "noop" (silent). Assert both.
+export CEO_RUNNER_OUTCOME_FILE="$WORK/outcome"
 export STUB_CURRENT="nhangen/a#2"
 bash "$SCRIPT" >/dev/null 2>&1 || fail "run 1 exited non-zero"
 [ "$(grep -cF 'triage-surface:nhangen/a#2' "$INBOX" 2>/dev/null || echo 0)" -eq 1 ] || fail "run 1: expected 1 inbox line"
 grep -q '^status: firing' "$STATE" || fail "run 1: not firing"
+[ "$(cat "$CEO_RUNNER_OUTCOME_FILE" 2>/dev/null)" = "fired" ] || fail "run 1 (firing) must write 'fired' outcome (#173)"
 bash "$SCRIPT" >/dev/null 2>&1 || fail "run 2 exited non-zero"
 [ "$(grep -cF 'triage-surface:nhangen/a#2' "$INBOX" 2>/dev/null || echo 0)" -eq 1 ] || fail "run 2: duplicate line"
 grep -q '^status: clear' "$STATE" || fail "run 2: not clear (real consume should have emptied events)"
+[ "$(cat "$CEO_RUNNER_OUTCOME_FILE" 2>/dev/null)" = "noop" ] || fail "run 2 (clear) must write 'noop' outcome (#173)"
 
 # --- 2. Append failure must NOT consume the transition (catches mark-before-write) ---
 export STUB_CURRENT="nhangen/a#2,nhangen/a#3"   # #3 is new
@@ -90,6 +95,7 @@ rm -f "$STUB_MARK_FILE"; : > "$INBOX"
 export CEO_TRIAGE_SKILL_DIR="$WORK/nonexistent"
 bash "$SCRIPT" >/dev/null 2>&1 || fail "missing-skill run should exit 0"
 grep -q 'last_error: skill_not_found' "$STATE" || fail "missing skill not recorded"
+[ "$(cat "$CEO_RUNNER_OUTCOME_FILE" 2>/dev/null)" = "noop" ] || fail "skill-not-found early exit must leave 'noop' outcome (#173 default covers every exit path)"
 export CEO_TRIAGE_SKILL_DIR="$SKILL"
 
 # --- 6. Unknown-priority (closed set): escalate once ---


### PR DESCRIPTION
Closes #173.

## Description (Bug Fixed & New Behavior)

`ticket-triage-autopilot` polls every 30m; almost every tick is a no-op, yet `_record_success` fired a green "completed" Discord embed on each one (~48/day of "nothing happened"). The prior mitigation (`6807d9c`, 2026-07-01) folded it into the `disk-monitor` blanket hardcode — which over-corrected, silencing **all** its success embeds, including **firing** ticks that did real work (the signal #173 wants kept).

**New behavior — a general outcome channel (not another one-off):**
- The script-runner branch exports `CEO_RUNNER_OUTCOME_FILE`.
- A script writes `fired` (→ notify) or `noop` (→ silent); `_record_success` gates the embed on it. Absent/other ⇒ the prior per-trigger default.
- `ticket-triage-autopilot` defaults each tick to `noop` (set early, so every early-exit path inherits it) and upgrades to `fired` only on a real firing tick.
- Removed `ticket-triage-autopilot` from the hardcode. Net: firing pings, clear heartbeats stay silent, failures notify as before.

Authored Claude-direct: the target is `ceo-cron.sh` (~2000-line shared cron dispatcher = high-blast-radius), not a candidate for local-model full-file-rewrite delegation (see #252/#255).

## Testing Procedure

1. Check out this branch.
2. Fast gate: `TEST_FILTER=outcome bash scripts/ceo-cron.test.sh` → `All tests passed. (3 tests)`, exit 0.
3. Full regression: `bash scripts/ceo-cron.test.sh` → `All tests passed. (175 tests)`, exit 0.
4. `shellcheck scripts/ceo-cron.sh scripts/ceo-triage-autopilot.sh` → clean.
5. The 3 new tests: noop outcome suppresses the embed; a `fired` autopilot tick notifies; a script writing no outcome keeps the default (notify).

## Additional Notes

- Uses `assert_*` (not the raw `FAILS=` pattern) so failures propagate through `run_tests`' per-test subshell — the pre-existing `disk-monitor` suppression test uses the raw pattern and is a silent no-op assertion (out of scope here; worth a follow-up).
- `scheduler` CI check is pre-existing red on `main`, unrelated.