### PR TITLE
docs(playbooks): flag workload-report non-functional (ZenHub retired)

### DIFF
--- a/docs/playbooks/workload-report.md
+++ b/docs/playbooks/workload-report.md
@@ -14,6 +14,13 @@ requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]
 
 # Workload Report
 
+> ⚠ **Non-functional since 2026-06-29.** This playbook reads from ZenHub (see
+> `requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]`), which was retired that day.
+> The underlying skill was **not** migrated to GitHub Projects (unlike
+> `story-points`), so it produces no usable report. The frontmatter still says
+> `status: active`; retire the playbook or migrate the skill to GitHub Projects
+> before relying on it again.
+
 Skill-backed playbook. The dispatcher invokes the `workload-report` skill directly via `runner: skill` — no LLM call.
 
 ## What it does


### PR DESCRIPTION
#none

## Description

Found during a repo-wide docs audit. The `workload-report` playbook doc presented it as a working, active playbook, but the underlying skill reads from ZenHub — retired 2026-06-29 — and was never migrated to GitHub Projects (unlike `story-points`, which was). So the playbook produces no usable report.

Adds a status note to the doc. The frontmatter (`status: active`, `requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]`) is **left unchanged** — flipping it is an operational retire-or-migrate decision, not a doc fix, so it's surfaced in the note for a human to action.

## Testing Procedure

1. Check out this branch.
2. Open `docs/playbooks/workload-report.md` → the non-functional status note renders at the top of the body.

## Additional Notes

Companion to nhangen/llm-tools#129, which flags the same skill's SKILL.md and fixes a related ZenHub credential reference in that repo's README. Recommended follow-up (separate from this doc PR): retire this playbook or migrate the skill to GitHub Projects.