### PR TITLE
chore(playbooks): disable workload-report (ZenHub retired, never migrated)

### DIFF
--- a/docs/playbooks/workload-report.md
+++ b/docs/playbooks/workload-report.md
@@ -5,7 +5,7 @@ trigger: cron
 schedule: "0 7 * * 1,3"
 preflight: none
 tier: read
-status: active
+status: disabled
 runner: skill
 skill: workload-report
 out_pattern: CEO/reports/workload/${TODAY}-${HOSTNAME}.md
@@ -17,9 +17,12 @@ requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]
 > ⚠ **Non-functional since 2026-06-29.** This playbook reads from ZenHub (see
 > `requires: [ZENHUB_TOKEN, ZENHUB_WORKSPACE_ID]`), which was retired that day.
 > The underlying skill was **not** migrated to GitHub Projects (unlike
-> `story-points`), so it produces no usable report. The frontmatter still says
-> `status: active`; retire the playbook or migrate the skill to GitHub Projects
-> before relying on it again.
+> `story-points`), so it produces no usable report. **Disabled 2026-07-08**
+> (`status: disabled`) so the scheduler stops firing a job that can only fail.
+> To restore it, migrate the skill to GitHub Projects (mirror `story-points`'s
+> `ghp-estimates.js` pattern) and flip `status` back to `active`. Applying the
+> disable requires `ceo playbook scan` **on ML-1** (per `ceo-scan-only-on-ml1`);
+> until then the installed scheduler line lingers on hosts that already scanned.
 
 Skill-backed playbook. The dispatcher invokes the `workload-report` skill directly via `runner: skill` — no LLM call.
 


### PR DESCRIPTION
#none

## Description

The `workload-report` playbook (Mon/Wed 07:00, `runner: skill`) invokes a skill that reads from ZenHub. ZenHub was retired 2026-06-29 and the skill was never ported to GitHub Projects (unlike `story-points`), so every scheduled fire can only fail or emit an empty report.

Sets `status: active → disabled`. Per `docs/playbooks/SCHEMA.md`, a `disabled` playbook is skipped by the scheduler and its previously-installed cron/scheduler line is **removed on the next scan**. Also updates the doc note to record the disable + the restore path.

## Testing Procedure

1. Check out this branch; open `docs/playbooks/workload-report.md`.
2. Confirm frontmatter `status: disabled` and the updated status note.

## Additional Notes

- **Applying this requires `ceo playbook scan` on ML-1** (per `ceo-scan-only-on-ml1` — never scan on the MacBook). Until ML-1 rescans, the installed scheduler line lingers on hosts that already scanned; the `disabled` status stops it firing on the next scheduled invocation regardless (scheduler enforces `active`-only).
- To restore: migrate the skill to GitHub Projects (mirror `story-points`' `ghp-estimates.js`) and flip `status` back to `active`.
- Companion to the earlier doc-note PR #262 and the repo-wide docs audit.