### PR TITLE
ollama-agent: capture local token usage + run ledger

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -16,6 +16,7 @@ from ollama_agent import (ToolBox, TOOLS, USE_SKILL_TOOL, MCPClient, RegistryErr
                           StdioMCPTransport, compose_system, filter_tools, gate,
                           load_registry, load_scores, load_skill_index, mcp_tools_to_ollama,
                           ollama_transport, render_catalog, run_agent)
+from ollama_agent.ledger import append_run
 
 DEFAULT_SYSTEM = (
     "You are a local engineering agent operating inside a single working directory. "
@@ -213,6 +214,14 @@ def main(argv=None):
             mcp_transport.close()
 
     rec["rules_loaded_hash"] = rules_loaded_hash
+    rec["model"] = a.model
+
+    # Record the local model's token usage to the ledger so a consumer can
+    # attribute/estimate delegation savings. Best-effort: a ledger write failure
+    # warns but never fails the run.
+    led = append_run(rec, a.model, a.task_name, a.cwd)
+    if led is None:
+        print("warning: could not write ollama-agent ledger (run unaffected)", file=sys.stderr)
 
     if a.json:
         print(json.dumps(rec, indent=2))
@@ -220,6 +229,7 @@ def main(argv=None):
         final = rec["transcript"][-1]
         print(f"completed={rec['completed']} verified={rec['verified']} turns={rec['turns']} "
               f"calls={len(rec['calls'])} unknown={rec['unknown_calls']}")
+        print(f"ollama tokens: in={rec['ollama_input_tokens']} out={rec['ollama_output_tokens']}")
         print("--- final message ---")
         print(final.get("content", "(no content)"))
     return 0

--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -79,9 +79,13 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
     completed = False
     verified = None
     turns = 0
+    ollama_input_tokens = 0
+    ollama_output_tokens = 0
     while turns < turn_cap:
         turns += 1
-        msg = transport(messages, tools)
+        msg, usage = transport(messages, tools)
+        ollama_input_tokens += usage.get("input", 0)
+        ollama_output_tokens += usage.get("output", 0)
         transcript.append(msg)
         messages.append(msg)
         calls = msg.get("tool_calls") or []
@@ -129,6 +133,8 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
         "verified": verified,
         "turns": turns,
         "run_id": run_id,
+        "ollama_input_tokens": ollama_input_tokens,
+        "ollama_output_tokens": ollama_output_tokens,
         "transcript": transcript,
         "calls": toolbox.calls,
         "unknown_calls": toolbox.unknown_calls,

--- a/ollama-agent/ollama_agent/ledger.py
+++ b/ollama-agent/ollama_agent/ledger.py
@@ -50,5 +50,8 @@ def append_run(rec, model, task_name, cwd, now=None, path=None):
         with open(p, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
         return str(p)
-    except OSError:
+    except Exception:
+        # Best-effort telemetry must never fail an otherwise-successful run, so
+        # this swallows any error (I/O, or a non-serializable field slipping in),
+        # honoring the "never raises" contract above.
         return None

--- a/ollama-agent/ollama_agent/ledger.py
+++ b/ollama-agent/ollama_agent/ledger.py
@@ -1,0 +1,54 @@
+"""Append-only ledger of ollama-agent runs.
+
+Each completed run appends one JSON line recording the LOCAL model's token usage
+(ground truth from ollama's eval_count/prompt_eval_count) plus enough context to
+attribute it: the Claude session that spawned it (CLAUDE_SESSION_ID), the model,
+and the run outcome. A downstream consumer (token-scope) reads this by path to
+estimate delegation savings — it never reverse-parses transcripts.
+
+The bridge deliberately records only raw counts + model id here; it does NOT
+price the run or compute savings (it has no Claude pricing table and shouldn't
+guess). Valuation lives in the consumer.
+"""
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def ledger_path():
+    """Resolve the ledger file. OLLAMA_AGENT_LEDGER overrides (tests, custom
+    setups); otherwise XDG state dir, falling back to ~/.local/state."""
+    override = os.environ.get("OLLAMA_AGENT_LEDGER")
+    if override:
+        return Path(override)
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "ollama-agent" / "runs.jsonl"
+
+
+def append_run(rec, model, task_name, cwd, now=None, path=None):
+    """Append one run to the ledger. Best-effort: a write failure returns None
+    (and never raises) so ledger I/O can't fail an otherwise-successful run.
+    Returns the path written on success."""
+    p = Path(path) if path is not None else ledger_path()
+    stamp = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    entry = {
+        "ts": stamp,
+        "run_id": rec.get("run_id"),
+        "session_id": os.environ.get("CLAUDE_SESSION_ID"),
+        "model": model,
+        "task_name": task_name,
+        "cwd": cwd,
+        "ollama_input_tokens": rec.get("ollama_input_tokens", 0),
+        "ollama_output_tokens": rec.get("ollama_output_tokens", 0),
+        "turns": rec.get("turns"),
+        "completed": rec.get("completed"),
+        "verified": rec.get("verified"),
+    }
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return str(p)
+    except OSError:
+        return None

--- a/ollama-agent/ollama_agent/transport.py
+++ b/ollama-agent/ollama_agent/transport.py
@@ -13,6 +13,10 @@ DEFAULT_HOST = "127.0.0.1:11434"
 
 
 def parse_chat_response(status, body):
+    """Return (message, usage). `usage` carries ollama's own token counts —
+    prompt_eval_count (input) and eval_count (output) — so a caller can attribute
+    local-model spend. Both default to 0 when the daemon omits them (older builds
+    or an interrupted stream), never None, so downstream sums stay numeric."""
     if status != 200:
         raise RuntimeError(f"ollama HTTP {status}: {body[:200]}")
     data = json.loads(body)
@@ -20,11 +24,15 @@ def parse_chat_response(status, body):
         raise RuntimeError(f"ollama error: {data['error']}")
     if "message" not in data:
         raise RuntimeError(f"ollama 200 with no message: {body[:200]}")
-    return data["message"]
+    usage = {
+        "input": int(data.get("prompt_eval_count") or 0),
+        "output": int(data.get("eval_count") or 0),
+    }
+    return data["message"], usage
 
 
 def ollama_transport(model, host=DEFAULT_HOST, temperature=0.7, num_ctx=16384, timeout=600):
-    """Return a transport(messages, tools) -> assistant message dict.
+    """Return a transport(messages, tools) -> (assistant message dict, usage dict).
 
     Raises RuntimeError on any non-success response and re-raises URLError
     (daemon down) so the caller sees a failure rather than a silent hang.

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -146,11 +146,32 @@ def test_normalize_args(raw, expected):
 # --- loop ---
 
 def _script(*responses):
+    """Build a transport from scripted responses. Each response is either a plain
+    assistant-message dict (paired with zero usage) or a (message, usage) tuple to
+    exercise token accounting. Transport returns (message, usage), matching the
+    real contract."""
     seq = iter(responses)
     last = responses[-1]
     def transport(messages, tools):
-        return next(seq, last)
+        r = next(seq, last)
+        if isinstance(r, tuple):
+            return r
+        return r, {"input": 0, "output": 0}
     return transport
+
+
+def test_records_ollama_token_usage_across_turns(tmp_path):
+    # Ground-truth local-model spend: eval_count/prompt_eval_count summed over
+    # every turn of the run (this is the data the savings estimate reads).
+    transport = _script(
+        ({"role": "assistant", "tool_calls": [
+            {"function": {"name": "write_file", "arguments": {"path": "f.txt", "content": "hi"}}}]},
+         {"input": 30, "output": 300}),
+        ({"role": "assistant", "content": "done"}, {"input": 15, "output": 150}),
+    )
+    rec = run_agent("write", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, turn_cap=8)
+    assert rec["ollama_input_tokens"] == 45
+    assert rec["ollama_output_tokens"] == 450
 
 
 def test_loop_dispatches_tools_then_finishes(tmp_path):
@@ -345,9 +366,12 @@ class _FakeResp:
 def test_transport_success(monkeypatch):
     import ollama_agent.transport as t
     monkeypatch.setattr(t.urllib.request, "urlopen",
-                        lambda req, timeout: _FakeResp(200, json.dumps({"message": {"role": "assistant", "content": "ok"}})))
-    msg = t.ollama_transport("m")([{"role": "user", "content": "hi"}], [])
+                        lambda req, timeout: _FakeResp(200, json.dumps({
+                            "message": {"role": "assistant", "content": "ok"},
+                            "prompt_eval_count": 7, "eval_count": 11})))
+    msg, usage = t.ollama_transport("m")([{"role": "user", "content": "hi"}], [])
     assert msg["content"] == "ok"
+    assert usage == {"input": 7, "output": 11}
 
 
 def test_transport_httperror_routes_through_success_parser(monkeypatch):
@@ -374,8 +398,19 @@ def test_transport_urlerror_raises_unreachable(monkeypatch):
 # --- transport success check ---
 
 def test_parse_chat_response_ok():
-    assert parse_chat_response(200, json.dumps({"message": {"role": "assistant", "content": "hi"}})) \
-        == {"role": "assistant", "content": "hi"}
+    msg, usage = parse_chat_response(200, json.dumps({
+        "message": {"role": "assistant", "content": "hi"},
+        "prompt_eval_count": 12, "eval_count": 34}))
+    assert msg == {"role": "assistant", "content": "hi"}
+    assert usage == {"input": 12, "output": 34}
+
+
+def test_parse_chat_response_usage_defaults_zero_when_absent():
+    # Older ollama builds / interrupted streams may omit the counts — default to
+    # 0 (numeric), never None, so downstream sums don't break.
+    msg, usage = parse_chat_response(200, json.dumps({
+        "message": {"role": "assistant", "content": "hi"}}))
+    assert usage == {"input": 0, "output": 0}
 
 
 def test_parse_chat_response_non_200_raises():

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -30,9 +30,14 @@ def _stub(monkeypatch, captured):
         captured["run_id"] = run_id
         captured["verify_cmd"] = verify_cmd
         return {"completed": True, "verified": None, "turns": 1, "run_id": run_id,
+                "ollama_input_tokens": 40, "ollama_output_tokens": 400,
                 "transcript": [{"role": "assistant", "content": "done"}],
                 "calls": [], "unknown_calls": []}
     monkeypatch.setattr(cli, "run_agent", fake_run_agent)
+    # Neutralize the ledger write so cli tests never touch the real state dir;
+    # capture the args instead for the tests that assert on them.
+    monkeypatch.setattr(cli, "append_run",
+                        lambda rec, model, task_name, cwd: captured.setdefault("ledger", (model, task_name, cwd)) or "/dev/null/ledger")
 
 
 def _tool_names(tools):

--- a/ollama-agent/tests/test_ledger.py
+++ b/ollama-agent/tests/test_ledger.py
@@ -1,0 +1,73 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ollama_agent.ledger import append_run, ledger_path  # noqa: E402
+
+
+def _rec(**over):
+    base = {"run_id": "r1", "ollama_input_tokens": 45, "ollama_output_tokens": 450,
+            "turns": 2, "completed": True, "verified": None}
+    base.update(over)
+    return base
+
+
+def test_append_run_writes_expected_fields(tmp_path, monkeypatch):
+    p = tmp_path / "runs.jsonl"
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-xyz")
+    out = append_run(_rec(), "mistral-small3.2:24b", "code-fix", "/repo", path=str(p))
+    assert out == str(p)
+    line = json.loads(p.read_text().strip())
+    assert line["model"] == "mistral-small3.2:24b"
+    assert line["task_name"] == "code-fix"
+    assert line["cwd"] == "/repo"
+    assert line["ollama_input_tokens"] == 45
+    assert line["ollama_output_tokens"] == 450
+    assert line["session_id"] == "sess-xyz"
+    assert line["run_id"] == "r1"
+    assert line["ts"].endswith("Z")
+
+
+def test_append_run_is_append_only(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    append_run(_rec(), "m", "t", "/c", path=str(p))
+    append_run(_rec(), "m", "t", "/c", path=str(p))
+    assert len(p.read_text().strip().splitlines()) == 2
+
+
+def test_session_id_none_when_env_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    p = tmp_path / "runs.jsonl"
+    append_run(_rec(), "m", "t", "/c", path=str(p))
+    assert json.loads(p.read_text().strip())["session_id"] is None
+
+
+def test_missing_token_counts_default_zero(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    append_run({"run_id": "r"}, "m", "t", "/c", path=str(p))  # no token keys
+    line = json.loads(p.read_text().strip())
+    assert line["ollama_input_tokens"] == 0
+    assert line["ollama_output_tokens"] == 0
+
+
+def test_append_run_failure_returns_none(tmp_path):
+    # Parent path is a FILE, so mkdir(parents=True) raises OSError → best-effort
+    # returns None, never raises (ledger I/O can't fail a run).
+    blocker = tmp_path / "afile"
+    blocker.write_text("x")
+    out = append_run(_rec(), "m", "t", "/c", path=str(blocker / "nested" / "runs.jsonl"))
+    assert out is None
+
+
+def test_ledger_path_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom.jsonl"
+    monkeypatch.setenv("OLLAMA_AGENT_LEDGER", str(target))
+    assert ledger_path() == target
+
+
+def test_ledger_path_uses_xdg_state(monkeypatch, tmp_path):
+    monkeypatch.delenv("OLLAMA_AGENT_LEDGER", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    assert ledger_path() == tmp_path / "ollama-agent" / "runs.jsonl"


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

First half of the delegation-savings estimate (#252): the bridge needs to record how many tokens the **local** model actually used, because that's the ground truth a savings estimate is built from. Today the bridge throws those counts away — `transport.parse_chat_response` returned only the assistant message and dropped ollama's `prompt_eval_count`/`eval_count`.

Changes (all in `ollama-agent/`):
- **`transport.py`** — `parse_chat_response` now returns `(message, usage)` where `usage = {input: prompt_eval_count, output: eval_count}` (both default to `0`, never `None`, when the daemon omits them).
- **`agent.py`** — `run_agent` unpacks the tuple, sums usage across every turn, and adds `ollama_input_tokens` / `ollama_output_tokens` to the run record.
- **`ledger.py`** (new) — `append_run()` writes one JSON line per run to `$XDG_STATE_HOME/ollama-agent/runs.jsonl` (override: `OLLAMA_AGENT_LEDGER`): `ts, run_id, session_id (CLAUDE_SESSION_ID), model, task_name, cwd, ollama_input_tokens, ollama_output_tokens, turns, completed, verified`. Best-effort — a write failure warns but never fails a run.
- **`cli.py`** — records `model`, calls `append_run`, and prints an `ollama tokens: in=… out=…` summary line.

**Deliberately no pricing/savings math here.** The bridge records raw counts + model id only; valuation (and net-savings vs the Claude PM overhead) lives in the consumer (token-scope), which has the Claude pricing table and the session's billed spend. This split was the auditor's call — the bridge shouldn't guess Claude rates.

## Testing Procedure
1. `cd ollama-agent && python3 -m pytest -q` → 178 pass (adds usage-capture, token-accumulation, and 7 ledger tests; updates the transport-contract stubs).
2. Contract check: the only `transport()` consumers are `run_agent` and `cli.py` — both updated; `ceo-cron.sh` reads only additive-safe fields (`.completed/.model/.run_id/.turns/.calls/.unknown`).
3. Live (optional, needs ollama): `python3 cli.py --ungated --task "list files" --model mistral-small3.2:24b --cwd /some/repo` → stderr shows `ollama tokens: in=… out=…`; `cat $XDG_STATE_HOME/ollama-agent/runs.jsonl` shows the appended run line.

## Additional Notes
The token-scope consumer (reads this ledger → estimates net delegation savings valued at current Claude prices) is a follow-up PR on nhangen/token-scope. Pricing table there was just refreshed (token-scope#13).