### PR TITLE
fix: read CLAUDE_CODE_SESSION_ID for ollama run attribution

### DIFF
--- a/ollama-agent/ollama_agent/ledger.py
+++ b/ollama-agent/ollama_agent/ledger.py
@@ -2,9 +2,9 @@
 
 Each completed run appends one JSON line recording the LOCAL model's token usage
 (ground truth from ollama's eval_count/prompt_eval_count) plus enough context to
-attribute it: the Claude session that spawned it (CLAUDE_SESSION_ID), the model,
-and the run outcome. A downstream consumer (token-scope) reads this by path to
-estimate delegation savings — it never reverse-parses transcripts.
+attribute it: the Claude session that spawned it (CLAUDE_CODE_SESSION_ID), the
+model, and the run outcome. A downstream consumer (token-scope) reads this by
+path to estimate delegation savings — it never reverse-parses transcripts.
 
 The bridge deliberately records only raw counts + model id here; it does NOT
 price the run or compute savings (it has no Claude pricing table and shouldn't
@@ -14,6 +14,16 @@ import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+def session_id():
+    """The Claude session that spawned this run, for attribution downstream.
+
+    Claude Code exports ``CLAUDE_CODE_SESSION_ID`` to the environment of the
+    tool calls it makes (including the Bash call that runs this bridge). The
+    legacy ``CLAUDE_SESSION_ID`` is honored as a fallback for other harnesses /
+    manual runs. Returns None when neither is set (an unattributed run)."""
+    return os.environ.get("CLAUDE_CODE_SESSION_ID") or os.environ.get("CLAUDE_SESSION_ID")
 
 
 def ledger_path():
@@ -35,7 +45,7 @@ def append_run(rec, model, task_name, cwd, now=None, path=None):
     entry = {
         "ts": stamp,
         "run_id": rec.get("run_id"),
-        "session_id": os.environ.get("CLAUDE_SESSION_ID"),
+        "session_id": session_id(),
         "model": model,
         "task_name": task_name,
         "cwd": cwd,

--- a/ollama-agent/tests/test_ledger.py
+++ b/ollama-agent/tests/test_ledger.py
@@ -16,6 +16,7 @@ def _rec(**over):
 
 def test_append_run_writes_expected_fields(tmp_path, monkeypatch):
     p = tmp_path / "runs.jsonl"
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
     monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-xyz")
     out = append_run(_rec(), "mistral-small3.2:24b", "code-fix", "/repo", path=str(p))
     assert out == str(p)
@@ -37,7 +38,26 @@ def test_append_run_is_append_only(tmp_path):
     assert len(p.read_text().strip().splitlines()) == 2
 
 
+def test_session_id_from_claude_code_env(tmp_path, monkeypatch):
+    # Claude Code exports CLAUDE_CODE_SESSION_ID (not CLAUDE_SESSION_ID) to bash
+    # tool calls — this is the var attribution must read.
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sess-code-1")
+    p = tmp_path / "runs.jsonl"
+    append_run(_rec(), "m", "t", "/c", path=str(p))
+    assert json.loads(p.read_text().strip())["session_id"] == "sess-code-1"
+
+
+def test_claude_code_session_id_takes_precedence(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sess-code-1")
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-legacy")
+    p = tmp_path / "runs.jsonl"
+    append_run(_rec(), "m", "t", "/c", path=str(p))
+    assert json.loads(p.read_text().strip())["session_id"] == "sess-code-1"
+
+
 def test_session_id_none_when_env_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
     monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
     p = tmp_path / "runs.jsonl"
     append_run(_rec(), "m", "t", "/c", path=str(p))


### PR DESCRIPTION
## Description (Bug Fix)

The ollama-agent run ledger (added in #264) recorded `session_id` from `CLAUDE_SESSION_ID`, but **Claude Code exports the session id as `CLAUDE_CODE_SESSION_ID`** to the environment of the bash tool calls it makes — including the call that runs this bridge. `CLAUDE_SESSION_ID` was never set, so **every ledger entry recorded `session_id: null`**, and the `token-scope --savings` consumer could never attribute a delegation to a Claude session — the net savings figure was always excluded.

Verified live: with `CLAUDE_CODE_SESSION_ID` present the ledger now captures the real session id (`1e15feb5…`); before the fix, `env | grep CLAUDE` shows `CLAUDE_CODE_SESSION_ID` is set while `CLAUDE_SESSION_ID` is absent.

### Fix
- `ledger.py`: new `session_id()` helper reads `CLAUDE_CODE_SESSION_ID` (what Claude Code sets), falling back to the legacy `CLAUDE_SESSION_ID` for other harnesses / manual runs.
- Docstring updated to name the correct var.

### Tests
- `test_session_id_from_claude_code_env` — primary var captured.
- `test_claude_code_session_id_takes_precedence` — new var wins over legacy.
- `test_session_id_none_when_env_absent` — now clears **both** vars (the prior version cleared only the legacy one, so once the code read `CLAUDE_CODE_SESSION_ID` it would have leaked the real session id from the test-runner's own environment — a false pass).

## Testing Procedure
1. Check out this branch. `cd ollama-agent && python3 -m pytest -q` → 180 pass.
2. Run a delegation with `CLAUDE_CODE_SESSION_ID` set and confirm the ledger line's `session_id` matches it; unset both vars and confirm it's `null`.

## Additional Notes
Unblocks `token-scope --savings` attribution end-to-end. No behavior change for the token counts themselves.