### PR TITLE
Update story-points playbook for consolidated org project 80

### DIFF
--- a/docs/playbooks/story-points.md
+++ b/docs/playbooks/story-points.md
@@ -35,8 +35,10 @@ manual captures live). Built as a CEO playbook rather than a hand-rolled cron so
 `requires: [GH_PROJECT_TOKEN]` — ceo-cron sources `~/.config/ceo/credentials.env` and the
 `requires:` credential gate (distinct from the `preflight:` function, which is `none`)
 aborts the run with a non-zero exit before exec if it is unset. `GH_PROJECT_TOKEN` must
-carry the `project` scope: story points are read from the org GitHub Projects boards
-(projects 72–75), not ZenHub.
+carry the `project` scope: story points are read from the single org GitHub Projects
+board (project 80), not ZenHub. Points live in project 80's numeric **Estimate** field
+(there is no "Story Points" field on 80). Project 80 covers OptinMonster, TrustPulse, and
+Beacon; Comment Converter is no longer tracked here.
 
 GitHub PR/issue auth uses a separate `GITHUB_TOKEN`, resolved by the skill from env or
 `gh auth token -u nhangenam` (awesomemotive org access). **`GITHUB_TOKEN` is not in
@@ -67,9 +69,12 @@ lives in llm-tools at `home/.claude/skills/story-points/`; ML-1 must have that p
 
 ## ZenHub → GitHub Projects migration (complete)
 
-The ZenHub cutover is done: the bundled `analyzer/` reads story points from the org
-GitHub Projects boards (projects 72–75) via `ghp-estimates.js`. The playbook contract is
-unchanged apart from `requires:` (now `GH_PROJECT_TOKEN` instead of the ZenHub vars).
+The ZenHub cutover is done, and the former per-product boards (projects 72–75) have since
+been consolidated into a single org board, **project 80**. The bundled `analyzer/` reads
+story points from project 80's numeric **Estimate** field via `ghp-estimates.js` — there
+is no "Story Points" field on 80. Project 80 covers OptinMonster, TrustPulse, and Beacon;
+Comment Converter is dropped. The playbook contract is unchanged apart from `requires:`
+(now `GH_PROJECT_TOKEN` instead of the ZenHub vars).
 Before the next `ceo playbook scan` on ML-1, add `GH_PROJECT_TOKEN` (project scope) to
 ML-1's `~/.config/ceo/credentials.env` or the `requires:` credential gate will fail the run.
 


### PR DESCRIPTION
Closes #267

## Description
AwesomeMotive retired ZenHub and consolidated the per-product GitHub Projects boards (OptinMonster 72, TrustPulse 73, Comment Converter 74, Beacon 75) into a single org project 80. This updates the `docs/playbooks/story-points.md` playbook doc to match.

- References to "projects 72–75" replaced with the single org project 80.
- Points now read from project 80's numeric **Estimate** field (there is no "Story Points" field on 80).
- Comment Converter is dropped; project 80 covers OptinMonster, TrustPulse, and Beacon.
- Schedule, runner, credentials, and outputs are unchanged.

Docs-only change.

## Testing Procedure
1. Check out this branch.
2. Read `docs/playbooks/story-points.md`.
3. Confirm no remaining references to boards 72/73/74/75 and that the Credentials and migration sections describe project 80 + the Estimate field.