### PR TITLE
ceo-cron: classify Claude failures (transient→ollama, auth→loud fail) (#280)

### DIFF
--- a/scripts/ceo-cron-fallback-classify.test.sh
+++ b/scripts/ceo-cron-fallback-classify.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Unit tests for _classify_claude_failure (ceo-cron-lib.sh).
+# Pure function: given (exit_code, raw_stdout) it prints one of
+# transient|auth|terminal|ok. No CLI, no I/O — crafted envelopes only.
+#
+# Each test must fail if the classifier is reverted to the old stdout
+# substring grep (`session limit|hit your limit`).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-harness.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/ceo-cron-lib.sh"
+
+# --- Primary signal: the --output-format json envelope (single-call path) ---
+
+test_transient_5xx_envelope_no_ratelimit_text() {
+  # 503, is_error true, and NO "session limit" text — the old grep classified
+  # this as ok (no match) and never fell back. New code reads api_error_status.
+  local raw='{"type":"result","is_error":true,"subtype":"error_during_execution","api_error_status":503}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "transient" "503 envelope → transient"
+}
+
+test_transient_429_envelope() {
+  local raw='{"is_error":true,"api_error_status":429}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "transient" "429 → transient"
+}
+
+test_auth_401_envelope() {
+  local raw='{"is_error":true,"subtype":"error","api_error_status":401}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" "401 → auth"
+}
+
+test_auth_403_envelope() {
+  local raw='{"is_error":true,"api_error_status":403}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" "403 → auth"
+}
+
+test_other_4xx_envelope_is_terminal() {
+  local raw='{"is_error":true,"api_error_status":400}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "terminal" "400 → terminal"
+}
+
+test_success_envelope_is_ok() {
+  local raw='{"type":"result","is_error":false,"subtype":"success","stop_reason":"end_turn","result":"done"}'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "ok" "success envelope → ok"
+}
+
+test_truncated_output_exit0_is_not_ok() {
+  # is_error false but stop_reason max_tokens → degraded, must not pass as ok.
+  local raw='{"is_error":false,"subtype":"success","stop_reason":"max_tokens","result":"partial"}'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "terminal" "truncated (max_tokens) → terminal, not ok"
+}
+
+test_success_result_mentions_session_limit_is_still_ok() {
+  # The self-referential false positive the old grep had: the model's OUTPUT
+  # discusses "session limit" but the run succeeded. Must be ok, not transient.
+  local raw='{"is_error":false,"subtype":"success","stop_reason":"end_turn","result":"The session limit banner means you hit your limit."}'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "ok" "success mentioning 'session limit' → ok"
+}
+
+# --- Fallback tier: non-JSON banners (plan/exec plain-text phases) ---
+
+test_ratelimit_banner_non_json_is_transient() {
+  # Regression guard: the one case the old code got right must still work.
+  local raw='Claude API session limit reached. Please try again later.'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "transient" "rate-limit banner → transient"
+}
+
+test_auth_banner_non_json_is_auth() {
+  local raw='Error: authentication_failed. Please run /login.'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" "auth banner → auth"
+}
+
+test_plaintext_plan_success_is_ok() {
+  # Plan/exec phases emit plain text (no --output-format json); exit 0 = success.
+  local raw='ACTION: 1 | read | check inbox | n/a'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "ok" "plain-text plan success → ok"
+}
+
+# --- Fail-safe: unknown failures default to terminal, never fall open ---
+
+test_unknown_nonzero_exit_defaults_terminal() {
+  local raw='some unexpected error we have no pattern for'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "terminal" "unknown failure → terminal (fail-safe)"
+}
+
+test_badflag_empty_stdout_is_terminal() {
+  # Bad flag: exit 1, stderr carries the message, stdout empty.
+  assert_eq "$(_classify_claude_failure 1 "")" "terminal" "empty stdout + non-zero → terminal"
+}
+
+run_tests

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -45,3 +45,67 @@ ceo_morning_raw_digest() {
   [ -n "$rev" ] && { echo "Needs review:"; echo "$rev"; }
   [ -n "${DAILY_NOTE_TOP3:-}" ] && { echo "Top 3:"; echo "${DAILY_NOTE_TOP3}"; }
 }
+
+# _classify_claude_failure <exit_code> <raw_stdout> — decide how a `claude
+# --print` invocation ended, so the caller can route it. Prints exactly one of:
+#   ok        succeeded (complete result)
+#   transient availability/throttle failure (5xx, 429, network) — safe to fall
+#             back to a local model
+#   auth      authentication failure — NEVER fall back (a local-model report
+#             would re-mute the logged-out alarm); fail loud + escalate
+#   terminal  logic/invocation error, truncated output, or an unrecognized
+#             failure — fail loud, no fallback, no retry (fail-safe default)
+#
+# Primary signal is the `--output-format json` envelope (single-call path, the
+# only path that falls back): `is_error`, `api_error_status` (HTTP status),
+# `stop_reason`. Plan/exec phases emit plain text (no envelope) and never fall
+# back, so for them we only distinguish ok vs a best-effort banner match — the
+# legacy `session limit` substring survives ONLY as this last-resort tier, never
+# as the primary key. Never exits non-zero; unknown → terminal (fail-safe, not
+# fail-open-to-fallback). Requires jq for the envelope path; degrades to the
+# banner tier without it. Pure — no globals, no I/O.
+_classify_claude_failure() {
+  local rc="${1:-1}" raw="${2:-}"
+  local is_error="" status="" subtype="" stop=""
+  if command -v jq >/dev/null 2>&1; then
+    # NB: do NOT use `.is_error // empty` — jq's `//` treats the boolean `false`
+    # like null, collapsing a genuine `is_error:false` to empty. Read it raw
+    # ("false"/"true"/"null"/"" for non-object).
+    is_error=$(printf '%s' "$raw" | jq -r 'if type=="object" then (.is_error) else empty end' 2>/dev/null || true)
+    status=$(printf '%s'  "$raw" | jq -r 'if type=="object" then (.api_error_status // empty) else empty end' 2>/dev/null || true)
+    subtype=$(printf '%s' "$raw" | jq -r 'if type=="object" then (.subtype // empty) else empty end' 2>/dev/null || true)
+    stop=$(printf '%s'    "$raw" | jq -r 'if type=="object" then (.stop_reason // empty) else empty end' 2>/dev/null || true)
+  fi
+
+  # Parseable success envelope: ok, unless the result was truncated (a partial
+  # report must not pass as healthy — the exit-0 silent-degradation case).
+  if [ "$is_error" = "false" ]; then
+    [ "$stop" = "max_tokens" ] && { echo "terminal"; return 0; }
+    echo "ok"; return 0
+  fi
+
+  # Parseable error envelope with an HTTP status → route by status class.
+  case "$status" in
+    429|5[0-9][0-9]) echo "transient"; return 0 ;;
+    401|403)         echo "auth";      return 0 ;;
+    4[0-9][0-9])     echo "terminal";  return 0 ;;
+  esac
+  # Structured error whose subtype names auth (status absent/unmapped).
+  case "$subtype" in
+    *auth*|*login*|*credential*) echo "auth"; return 0 ;;
+  esac
+  # Structured error, is_error true, but no usable status → unknown-but-real.
+  [ "$is_error" = "true" ] && { echo "terminal"; return 0; }
+
+  # No parseable envelope. Exit 0 = success (plain-text plan/exec phases).
+  if [ "$rc" -eq 0 ] 2>/dev/null; then echo "ok"; return 0; fi
+
+  # Non-zero exit, non-JSON stdout → last-resort banner match.
+  if printf '%s' "$raw" | grep -qEi 'session limit|hit your limit|rate.?limit|overloaded'; then
+    echo "transient"; return 0
+  fi
+  if printf '%s' "$raw" | grep -qEi 'authentication_failed|not authenticated|logged out|invalid api key|please run .?/login'; then
+    echo "auth"; return 0
+  fi
+  echo "terminal"; return 0   # fail-safe: unknown never falls open to fallback
+}

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -404,28 +404,55 @@ _release_lock() {
   fi
 }
 
-_check_rate_limit() {
-  local output="$1"
-  local phase="$2"
-  if printf '%s\n' "$output" | grep -qEi "session limit|hit your limit"; then
-    if [ "$phase" = "single-call" ] && [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" != "1" ]; then
-      _v "Claude rate-limited! Falling back to ollama..."
-      echo "$(date) [$TRIGGER] Rate-limited (Claude). Falling back to ollama." >> "$LOG_DIR/cron-skips.log"
-      export CEO_CRON_OLLAMA_FALLBACK=1
-      _release_lock
-      exec bash "$SCRIPT_DIR/ceo-cron.sh" "$TRIGGER"
-    fi
+# _route_claude_failure <exit_code> <raw_stdout> <phase> — called when a
+# `claude --print` invocation exited non-zero. Classifies the failure via
+# _classify_claude_failure (ceo-cron-lib.sh) and handles the two classes that
+# need special routing:
+#   transient — availability/throttle (5xx, 429, rate-limit, network). On the
+#               single-call path, fall back to ollama once; on plan/exec (or if
+#               already on the fallback run) record the run skipped and exit 0.
+#   auth      — NEVER fall back: an ollama report would re-mute the exact
+#               logged-out alarm. Record a failed run with a re-auth escalation
+#               and exit non-zero so cron telemetry goes red.
+# For `terminal` (and the can't-happen `ok`) it returns, letting the caller's
+# own failed-run handling take over — that path already records failed + exits.
+_route_claude_failure() {
+  local rc="$1" output="$2" phase="$3"
+  local class; class="$(_classify_claude_failure "$rc" "$output")"
 
-    _v "SKIPPED (rate-limited in $phase)"
-    _report action "$TRIGGER" "**Status:** skipped: rate-limited
+  case "$class" in
+    transient)
+      if [ "$phase" = "single-call" ] && [ "${CEO_CRON_OLLAMA_FALLBACK:-0}" != "1" ]; then
+        _v "Claude unavailable (transient)! Falling back to ollama..."
+        echo "$(date) [$TRIGGER] Transient failure (Claude). Falling back to ollama." >> "$LOG_DIR/cron-skips.log"
+        export CEO_CRON_OLLAMA_FALLBACK=1
+        _release_lock
+        exec bash "$SCRIPT_DIR/ceo-cron.sh" "$TRIGGER"
+      fi
+      _v "SKIPPED (transient failure in $phase)"
+      _report action "$TRIGGER" "**Status:** skipped: unavailable
 **Playbook:** $PLAYBOOK_REL
-**Note:** Claude API session limit reached. Raw output saved to cron-raw.log."
-    echo "$(date) [$TRIGGER] Rate-limited ($phase):" >> "$LOG_DIR/cron-skips.log"
-    echo "$(date) [$TRIGGER] $phase output:" >> "$LOG_DIR/cron-raw.log"
-    echo "$output" >> "$LOG_DIR/cron-raw.log"
-    echo "---" >> "$LOG_DIR/cron-raw.log"
-    exit 0
-  fi
+**Note:** Claude API transiently unavailable (rate-limit / 5xx / network) in $phase. Raw output saved to cron-raw.log."
+      echo "$(date) [$TRIGGER] Transient ($phase):" >> "$LOG_DIR/cron-skips.log"
+      echo "$(date) [$TRIGGER] $phase output:" >> "$LOG_DIR/cron-raw.log"
+      echo "$output" >> "$LOG_DIR/cron-raw.log"
+      echo "---" >> "$LOG_DIR/cron-raw.log"
+      exit 0
+      ;;
+    auth)
+      _v "AUTH FAILURE in $phase — not falling back (would mask a logged-out host)"
+      _report action "$TRIGGER" "**Status:** failed: auth
+**Playbook:** $PLAYBOOK_REL
+**Note:** Claude authentication failed in $phase — automation is down until re-auth. Fix: ssh to this host, run \`claude\`, then /login. Raw output saved to cron-raw.log."
+      echo "$(date) [$TRIGGER] AUTH FAILURE ($phase):" >> "$LOG_DIR/cron-skips.log"
+      echo "$(date) [$TRIGGER] $phase output:" >> "$LOG_DIR/cron-raw.log"
+      echo "$output" >> "$LOG_DIR/cron-raw.log"
+      echo "---" >> "$LOG_DIR/cron-raw.log"
+      _record_failure "Claude auth failure in $phase for $TRIGGER — host needs re-login"
+      exit 1
+      ;;
+  esac
+  # terminal / ok → return; caller's own failed-run handling takes over.
 }
 
 # Single source of truth for routing read-tier model output. Both runner
@@ -1856,7 +1883,7 @@ END_LOG_ENTRY"
     # stdout before the CLI can emit its JSON envelope), so check the raw
     # stdout here, not the jq-parsed .result (which would be empty on
     # non-JSON input and silently defeat rate-limit detection).
-    _check_rate_limit "$SINGLE_RAW" "single-call"
+    _route_claude_failure "$SINGLE_EXIT" "$SINGLE_RAW" "single-call"
     _v "FAILED (exit: $SINGLE_EXIT)"
     _report action "$TRIGGER" "**Status:** failed
 **Playbook:** $PLAYBOOK_REL
@@ -1937,7 +1964,7 @@ PLAN_OUTPUT=$(cd "$VAULT" && echo "$PLAN_PROMPT" | CLAUDE_MEM_INTERNAL=1 $(_with
   --model "$MODEL" --disallowedTools "Bash,Write,Edit" 2>"$LOG_DIR/cron-stderr.log") || PLAN_EXIT=$?
 
 if [ $PLAN_EXIT -ne 0 ]; then
-  _check_rate_limit "$PLAN_OUTPUT" "plan"
+  _route_claude_failure "$PLAN_EXIT" "$PLAN_OUTPUT" "plan"
   _v "Phase 1 FAILED (exit: $PLAN_EXIT)"
   echo "$(date) [$TRIGGER] Plan output:" >> "$LOG_DIR/cron-raw.log"
   echo "$PLAN_OUTPUT" >> "$LOG_DIR/cron-raw.log"
@@ -2044,7 +2071,7 @@ END_LOG_ENTRY"
 
   _v "Phase 3 done (exit: $EXEC_EXIT)"
   if [ $EXEC_EXIT -ne 0 ]; then
-    _check_rate_limit "$EXEC_OUTPUT" "exec"
+    _route_claude_failure "$EXEC_EXIT" "$EXEC_OUTPUT" "exec"
     _v "FAILED — raw output saved to cron-raw.log"
     _report action "$TRIGGER" "**Status:** failed
 **Playbook:** $PLAYBOOK_REL

--- a/scripts/ceo-cron.test.sh
+++ b/scripts/ceo-cron.test.sh
@@ -3313,6 +3313,47 @@ STUB
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_claude_auth_failure_does_not_fall_back_and_exits_nonzero() {
+  # Auth failure must NOT fall back to ollama (a local-model report would
+  # re-mute the logged-out alarm). Fails if the auth path is reverted to
+  # fall-open: then rc would be 0 and ollama would be invoked.
+  cat > "$CEO_DIR/playbooks/authfail.md" << 'PB'
+---
+name: authfail
+description: auth failure
+trigger: cron
+schedule: "0 9 * * *"
+preflight: none
+tier: read
+status: active
+---
+# noop
+PB
+  bash "$CEO_CLI" playbook scan >/dev/null 2>&1
+
+  # single-call uses --output-format json; stub emits an auth-error envelope.
+  cat > "$TEST_HOME/.bun/bin/claude" << 'STUB'
+#!/bin/bash
+echo '{"type":"result","is_error":true,"subtype":"error","api_error_status":401,"result":""}'
+exit 1
+STUB
+  chmod +x "$TEST_HOME/.bun/bin/claude"
+  rm -f "$HOME/ollama-invoked-model.txt"
+
+  local rc=0
+  bash "$CRON" authfail >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "1" "cron must exit non-zero on auth failure (no fallback)"
+
+  local ollama_invoked
+  ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")
+  assert_eq "$ollama_invoked" "" "ollama must NOT be invoked on auth failure"
+
+  local skip_log
+  skip_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skip_log" "AUTH FAILURE" "cron-skips.log must record the auth failure"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
 test_ceo_cron_skips_read_tier_on_failed_gather() {
   cat > "$CEO_DIR/playbooks/morning-brief.md" << 'PB'
 ---


### PR DESCRIPTION
Closes #280

## Description

Replaces `ceo-cron.sh`'s only Claude→Ollama fallback — a `grep -qEi "session limit|hit your limit"` on stdout — with an error classifier keyed on the `claude --print --output-format json` envelope.

**`_classify_claude_failure` (ceo-cron-lib.sh, pure/unit-tested)** reads `is_error`, `api_error_status`, `stop_reason` and returns `ok | transient | auth | terminal`:
- **transient** — `api_error_status` 5xx/429 (or, for the plain-text plan/exec phases with no envelope, a rate-limit banner). Safe to fall back to a local model.
- **auth** — 401/403 / auth subtype / auth banner. **Never falls back** — an Ollama report would re-mute the exact logged-out alarm; a 6-day silent ML-1 outage motivated this.
- **terminal** — other 4xx, truncated output (`stop_reason: max_tokens`), or any unrecognized failure (fail-safe default, never fail-open-to-fallback).

**`_route_claude_failure` (ceo-cron.sh)** replaces `_check_rate_limit` at all three call sites (single-call, plan, exec): transient falls back (single-call) or skips (plan/exec); auth records a failed run with a re-auth escalation and exits non-zero; terminal defers to the existing failed-run handling.

Task 0 (probing the live CLI envelope) is captured in the design spec; the exact `subtype`/`api_error_status` values for a real auth-failure and rate-limit are pinned to a `warning`-level TODO in the spec (capture in the wild / from ML-1 `cron-raw.log`). Ollama *writing* enablement is explicitly out of scope (gated behind #254/#255).

## Testing Procedure

1. Check out this branch.
2. `cd scripts && bash ceo-cron-fallback-classify.test.sh` — 13 unit tests: envelope classes, banner fallback, truncation, the "output mentions 'session limit' but exit 0 → ok" false-positive guard, fail-safe default.
3. `TEST_FILTER=claude_ bash ceo-cron.test.sh` — integration: rate-limit still falls back to ollama (glm4); the new `test_claude_auth_failure_does_not_fall_back_and_exits_nonzero` confirms auth exits non-zero and never invokes ollama.
4. `bash ceo-cron.test.sh` — full suite green.
5. `shellcheck --severity=warning scripts/ceo-cron.sh scripts/ceo-cron-lib.sh scripts/*.test.sh` — clean (zero new findings vs master).

## Additional Notes

Design spec lives in the vault (`Projects/Development/nhangen/claude-ceo/specs/2026-07-15-…-design.md`), not the repo, per convention. Independently audited before implementation.
