### PR TITLE
Guard the CEO_VAULT FATAL desktop notification against test/automated runs

### DIFF
--- a/scripts/ceo-config.sh
+++ b/scripts/ceo-config.sh
@@ -180,10 +180,28 @@ ceo_require_vault() {
     # Sentinel file alongside the notification channels so observability sees
     # the escalation even if osascript (locked session) and logger both fail.
     : > "$HOME/.claude/ceo-fatal-alerted" 2>/dev/null || true
-    if command -v osascript &>/dev/null; then
-      osascript -e 'display notification "CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." with title "Claude CEO FATAL"' &>/dev/null || true
-    else
-      logger "Claude CEO FATAL: CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." 2>/dev/null || true
+    # Durable diagnostic. A dispatched cron tick's stderr is discarded by the
+    # daemon, so the macOS popup is otherwise the ONLY trace of this failure and
+    # there is nothing to diagnose after the fact. Record the resolution context
+    # to a CEO_VAULT-independent log (the vault is what failed to resolve): which
+    # HOME/USER the failing tick ran under and whether ~/.ceo/config was visible
+    # there — the two things that pinpoint a wrong-HOME cron/launchd env.
+    printf '%s FATAL CEO_VAULT unresolved after %d ticks — HOME=%s USER=%s config=%s env_CEO_VAULT=%s\n' \
+      "$(date '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null || date)" "$fails" "$HOME" "${USER:-?}" \
+      "$([ -f "$(ceo_config_path)" ] && echo present || echo MISSING)" \
+      "${CEO_VAULT:+set}" >> "$HOME/.claude/ceo-fatal.log" 2>/dev/null || true
+    # Desktop notification is user-facing and must NOT fire from the test suite
+    # or any automated/non-interactive run — the escalation test drives the
+    # counter to 3, which would otherwise pop a real "Claude CEO FATAL" macOS
+    # notification on the developer's machine. Tests set CEO_NO_DESKTOP_NOTIFY=1;
+    # real cron ticks leave it unset and still alert. The durable log + sentinel
+    # above are unconditional so observability survives the suppressed popup.
+    if [ -z "${CEO_NO_DESKTOP_NOTIFY:-}" ]; then
+      if command -v osascript &>/dev/null; then
+        osascript -e 'display notification "CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." with title "Claude CEO FATAL"' &>/dev/null || true
+      else
+        logger "Claude CEO FATAL: CEO_VAULT unresolved for 3+ cron ticks. Run ceo setup." 2>/dev/null || true
+      fi
     fi
   fi
   exit 1

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -719,7 +719,6 @@ STUB
   done
   got=$([ -f "$marker" ] && echo fired || echo none)
   assert_eq "$got" "fired" "unguarded escalation must reach the notification path"
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
 test_pr_sources_path_uses_home() {

--- a/scripts/ceo-config.test.sh
+++ b/scripts/ceo-config.test.sh
@@ -659,7 +659,7 @@ test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback() {
   local counter_file="$TEST_HOME/.claude/ceo-cron-config-fails"
   local fails_value
   for _i in 1 2 3; do
-    env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 PATH="$PATH" bash -c "
+    env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 CEO_NO_DESKTOP_NOTIFY=1 PATH="$PATH" bash -c "
       set -uo pipefail
       source '$LIB'
       ceo_require_vault
@@ -676,6 +676,49 @@ test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback() {
   " >/dev/null 2>&1 || true
   fails_value=$(cat "$counter_file" 2>/dev/null || echo missing)
   assert_eq "$fails_value" "1" "corrupted counter must reset to 1 on next failure"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_fatal_escalation_desktop_notify_guarded() {
+  # The FATAL escalation (fails >= 3) pops a real macOS notification via
+  # osascript. It must be suppressed under CEO_NO_DESKTOP_NOTIFY=1 so the test
+  # suite (which drives the counter to 3) never fires a real popup, while the
+  # durable log still records. A stub osascript captures invocation + validates
+  # argv (stub-cli-argv-validation).
+  local bindir="$TEST_HOME/stubbin"; mkdir -p "$bindir"
+  cat > "$bindir/osascript" <<'STUB'
+#!/bin/bash
+case "$*" in
+  *"display notification"*"Claude CEO FATAL"*) echo fired >> "$OSA_MARKER" ;;
+  *) echo "osascript stub: unexpected argv: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$bindir/osascript"
+  local marker="$TEST_HOME/osa-fired"
+  local fatal_log="$TEST_HOME/.claude/ceo-fatal.log"
+  local counter="$TEST_HOME/.claude/ceo-cron-config-fails"
+  local got
+
+  # Phase 1 — guarded: 3 fails with CEO_NO_DESKTOP_NOTIFY=1 → stub must NOT fire.
+  rm -f "$counter" "$marker" "$fatal_log" 2>/dev/null || true
+  for _i in 1 2 3; do
+    env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 CEO_NO_DESKTOP_NOTIFY=1 \
+      OSA_MARKER="$marker" PATH="$bindir:$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_require_vault" >/dev/null 2>&1 || true
+  done
+  got=$([ -f "$marker" ] && echo fired || echo none)
+  assert_eq "$got" "none" "guarded escalation must NOT fire the desktop notification"
+  assert_file_exists "$fatal_log" "durable FATAL log must be written even when the popup is suppressed"
+  assert_contains "$(cat "$fatal_log" 2>/dev/null)" "CEO_VAULT unresolved after 3 ticks" "fatal log records tick count"
+
+  # Phase 2 — unguarded: 3 fails, no guard → stub MUST fire (guard is load-bearing;
+  # reverting the guard makes Phase 1 fail).
+  rm -f "$counter" "$marker" 2>/dev/null || true
+  for _i in 1 2 3; do
+    env -i HOME="$TEST_HOME" CEO_VAULT="" CEO_TEST_FORCE_MKDIR_LOCK=1 \
+      OSA_MARKER="$marker" PATH="$bindir:$PATH" bash -c "set -uo pipefail; source '$LIB'; ceo_require_vault" >/dev/null 2>&1 || true
+  done
+  got=$([ -f "$marker" ] && echo fired || echo none)
+  assert_eq "$got" "fired" "unguarded escalation must reach the notification path"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 


### PR DESCRIPTION
Closes #none

## Description
`ceo_require_vault` (`scripts/ceo-config.sh`) fires a real macOS "Claude CEO FATAL" notification via `osascript` once the config-fail counter reaches 3. There was **no guard**, so the escalation test (`test_require_vault_increments_fail_counter_atomically_with_mkdir_fallback`, which drives the counter to 3 against a real PATH) pops a real notification every time it runs — the source of spurious "CEO_VAULT unresolved for 3+ cron ticks" popups with no matching production scheduler failure. Confirmed via the macOS notification DB: the fires cluster in ×3 bursts within one second (a test loop signature), not the once-per-crossing pattern a real cron tick produces; and the live scheduler is ruled out (the daemon passes `CEO_VAULT`, so it resolves via bypass and never escalates).

Changes:
- Gate the `osascript`/`logger` desktop notification behind `CEO_NO_DESKTOP_NOTIFY` (set by tests). Real cron ticks leave it unset and still alert.
- Record the failure context (`HOME`/`USER`/config-visibility/env-`CEO_VAULT`) to a durable, `CEO_VAULT`-independent `$HOME/.claude/ceo-fatal.log`, since the daemon discards dispatched-tick stderr and the popup was otherwise the only trace of a genuine failure.

## Testing Procedure
1. `bash scripts/ceo-config.test.sh` → `All tests passed. (70 tests)`, and **no macOS notification appears** (previously it did).
2. New `test_fatal_escalation_desktop_notify_guarded` uses a stub `osascript` to assert: under `CEO_NO_DESKTOP_NOTIFY=1` the notification is suppressed while the durable log still records; without the guard the notification path is reached (fail-on-revert).
3. `shellcheck --severity=warning scripts/ceo-config.sh scripts/ceo-config.test.sh` → clean.

## Additional Notes
Does not change production alerting — a real cron tick that cannot resolve `CEO_VAULT` still notifies. A stale second checkout at `~/ML-AI/claude/ceo` (pre-merge, unguarded) will keep firing on test runs until updated past this change.