### PR TITLE
Adopt cronbird #9 loop: track dispatch completions and unpin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         # (update CRONBIRD_REF, adapt src/main.ts, re-run) when adopting new
         # cronbird features.
         env:
-          CRONBIRD_REF: 1a715f76ba61a12975d8a4ca8683e67be4d76f01
+          CRONBIRD_REF: 7b8f35ebb2b8b7f534cd105438b2b2601f2a2763
         run: |
           git clone --filter=blob:none https://github.com/nhangen/cronbird.git "${GITHUB_WORKSPACE}/../cronbird"
           git -C "${GITHUB_WORKSPACE}/../cronbird" checkout --quiet "$CRONBIRD_REF"

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -40,10 +40,12 @@ import {
   doneDir,
   enabledPath,
   heartbeatPath,
+  isSafeSegment,
   registryPath,
   resolveFixedLookbackMs,
   resolveHost,
   runningDir,
+  runningMarker,
   swarmPath,
   syncedHeartbeatPath,
 } from "@/runtime";
@@ -122,6 +124,7 @@ function readStateDir(dir: string): Record<string, string> {
   if (!existsSync(dir)) return {};
   const out: Record<string, string> = {};
   for (const name of readdirSync(dir)) {
+    if (!isSafeSegment(name)) continue; // defensive: never read a name we'd refuse to write
     try {
       out[name] = readFileSync(`${dir}/${name}`, "utf8");
     } catch {
@@ -129,6 +132,16 @@ function readStateDir(dir: string): Record<string, string> {
     }
   }
   return out;
+}
+
+/** Is a process alive? `kill(pid, 0)` probes without signalling; ESRCH ⇒ gone. */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function main(): Promise<void> {
@@ -186,6 +199,12 @@ async function main(): Promise<void> {
       // Swallow + log so one bad dispatch can't crash-loop the daemon; the
       // guard is already persisted, so this playbook is simply skipped this
       // minute and fires again at its next slot.
+      // A job name is used as a run-state filename; refuse anything that isn't a
+      // single safe path segment rather than write outside the run-state dir.
+      if (!isSafeSegment(name)) {
+        log(`refusing to dispatch unsafe job name: ${JSON.stringify(name)}`);
+        return;
+      }
       const startedTs = Date.now();
       const runMarker = `${runDir}/${name}`;
       const clearRunning = () => {
@@ -197,7 +216,7 @@ async function main(): Promise<void> {
       };
       try {
         // Mark in-flight BEFORE spawn so a completion can never race ahead of it.
-        writeFileSync(runMarker, String(startedTs));
+        writeFileSync(runMarker, runningMarker(startedTs));
         const proc = Bun.spawn(cfg.dispatchArgv(name), {
           env: { ...process.env, CEO_VAULT: vault },
           stdout: "ignore",
@@ -205,6 +224,10 @@ async function main(): Promise<void> {
           stdin: "ignore",
         });
         proc.unref();
+        // Rewrite with the PID now that it's known, so a crashed daemon's orphaned
+        // marker is dropped by liveness (dead PID) instead of stalling the queue
+        // for RUN_STATE_STALE_MS.
+        writeFileSync(runMarker, runningMarker(startedTs, proc.pid));
         log(`dispatched ${name}`);
         // Record completion so cronbird's queue advances (the MAX_CONCURRENT=1
         // gate drains the next job only once this one is observed done). Runs on
@@ -250,7 +273,7 @@ async function main(): Promise<void> {
     // the loop observes completions and drains the queue instead of stranding
     // every job behind the first (which would silently drop same-minute
     // collisions like morning + morning-brief at 03:20).
-    readCompletions: () => buildCompletions(readStateDir(runDir), readStateDir(dDir), Date.now()),
+    readCompletions: () => buildCompletions(readStateDir(runDir), readStateDir(dDir), Date.now(), { isAlive: pidAlive }),
   };
 
   log(`started — host=${host} vault=${vault} registry=${regPath}`);

--- a/lib/scheduler/src/main.ts
+++ b/lib/scheduler/src/main.ts
@@ -13,7 +13,7 @@
  * Schedules evaluate in the host's local timezone (the matcher is created with
  * no timezone, matching `new Date()`); registry schedules carry no per-entry tz.
  */
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import {
   createMatcher,
@@ -34,12 +34,16 @@ import { parseRegistry } from "@/registry";
 import { parseEnabled } from "@/enabled";
 import { parseSwarm } from "@/swarm";
 import {
+  buildCompletions,
+  completionRecord,
   dispatchArgv,
+  doneDir,
   enabledPath,
   heartbeatPath,
   registryPath,
   resolveFixedLookbackMs,
   resolveHost,
+  runningDir,
   swarmPath,
   syncedHeartbeatPath,
 } from "@/runtime";
@@ -108,6 +112,25 @@ function readIfExists(path: string): string {
   return existsSync(path) ? readFileSync(path, "utf8") : "";
 }
 
+/**
+ * Read every file in a run-state dir as {basename: contents}; {} when the dir is
+ * absent. A file that vanishes between listing and read (a completion cleared its
+ * running marker mid-scan) is skipped — fail-safe, matching cronbird's torn-read
+ * contract for `readCompletions`.
+ */
+function readStateDir(dir: string): Record<string, string> {
+  if (!existsSync(dir)) return {};
+  const out: Record<string, string> = {};
+  for (const name of readdirSync(dir)) {
+    try {
+      out[name] = readFileSync(`${dir}/${name}`, "utf8");
+    } catch {
+      // entry removed between readdir and read — treat as absent
+    }
+  }
+  return out;
+}
+
 async function main(): Promise<void> {
   const vault = requireEnv("CEO_VAULT");
   const home = requireEnv("HOME");
@@ -115,6 +138,12 @@ async function main(): Promise<void> {
 
   const { registryPath: regPath, heartbeatPath: hbPath, swarmPath: swPath, syncedHeartbeatPath: syncedHbPath, host } = cfg;
   const enPath = enabledPath(home);
+  // Dispatch-completion state (cronbird #9 queue): the dispatch wrapper below
+  // writes running/done here; readCompletions reassembles it each tick.
+  const runDir = runningDir(home);
+  const dDir = doneDir(home);
+  mkdirSync(runDir, { recursive: true });
+  mkdirSync(dDir, { recursive: true });
 
   let running = true;
   let wakeEarly: (() => void) | null = null;
@@ -157,7 +186,18 @@ async function main(): Promise<void> {
       // Swallow + log so one bad dispatch can't crash-loop the daemon; the
       // guard is already persisted, so this playbook is simply skipped this
       // minute and fires again at its next slot.
+      const startedTs = Date.now();
+      const runMarker = `${runDir}/${name}`;
+      const clearRunning = () => {
+        try {
+          rmSync(runMarker, { force: true });
+        } catch {
+          // already gone
+        }
+      };
       try {
+        // Mark in-flight BEFORE spawn so a completion can never race ahead of it.
+        writeFileSync(runMarker, String(startedTs));
         const proc = Bun.spawn(cfg.dispatchArgv(name), {
           env: { ...process.env, CEO_VAULT: vault },
           stdout: "ignore",
@@ -166,7 +206,23 @@ async function main(): Promise<void> {
         });
         proc.unref();
         log(`dispatched ${name}`);
+        // Record completion so cronbird's queue advances (the MAX_CONCURRENT=1
+        // gate drains the next job only once this one is observed done). Runs on
+        // the daemon's own event loop, so it never races readCompletions.
+        void proc.exited
+          .then((exitCode) => {
+            writeFileSync(`${dDir}/${name}`, JSON.stringify(completionRecord(startedTs, Date.now(), exitCode)));
+            clearRunning();
+          })
+          .catch((err) => {
+            // Exit tracking itself failed: record a failure and clear the marker
+            // so an unobservable run can never wedge the queue.
+            writeFileSync(`${dDir}/${name}`, JSON.stringify(completionRecord(startedTs, Date.now(), 1)));
+            clearRunning();
+            log(`completion tracking failed for ${name}: ${err instanceof Error ? err.message : String(err)}`);
+          });
       } catch (err) {
+        clearRunning(); // spawn failed at start — don't leave a phantom in-flight marker
         log(`dispatch failed for ${name}: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
@@ -183,6 +239,18 @@ async function main(): Promise<void> {
     maxSleepMs: MAX_SLEEP_MS,
     resolveLookback,
     shouldContinue: () => running,
+    // cronbird #9 queue inputs. CEO wires no priority / dependency / cooldown
+    // source yet, so these are the documented defaults: all-equal FIFO ordering,
+    // no upstreams (the dependency gate is a no-op), no cooldown. Wiring real
+    // resolvers from registry metadata is a later, deliberate step.
+    priority: () => 0,
+    dependencies: () => [],
+    cooldownSeconds: () => 0,
+    // Real run-state read — the dispatch wrapper above writes running/done, so
+    // the loop observes completions and drains the queue instead of stranding
+    // every job behind the first (which would silently drop same-minute
+    // collisions like morning + morning-brief at 03:20).
+    readCompletions: () => buildCompletions(readStateDir(runDir), readStateDir(dDir), Date.now()),
   };
 
   log(`started — host=${host} vault=${vault} registry=${regPath}`);

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -108,10 +108,39 @@ export function doneDir(home: string): string {
  */
 export const RUN_STATE_STALE_MS = 3_600_000; // 1 hour
 
-/** Parse a `running/<name>` body (epoch-ms startedTs); null on garbage/torn. */
-export function parseRunningEntry(raw: string): number | null {
-  const n = Number(raw.trim());
-  return Number.isFinite(n) && n > 0 ? n : null;
+/** A parsed `running/<name>` marker: when it started, and the child PID if known. */
+export interface RunningMarker {
+  startedTs: number;
+  /** null during the brief pre-spawn window before the PID is known. */
+  pid: number | null;
+}
+
+/**
+ * Serialize a running marker. Written as `startedTs` before spawn (PID unknown),
+ * rewritten as `startedTs pid` once the child exists so a crashed daemon's
+ * orphaned marker can be dropped by liveness rather than waiting out the stale
+ * window.
+ */
+export function runningMarker(startedTs: number, pid?: number | null): string {
+  return pid != null && pid > 0 ? `${startedTs} ${pid}` : String(startedTs);
+}
+
+/** Parse a `running/<name>` body (`startedTs` or `startedTs pid`); null on garbage/torn. */
+export function parseRunningEntry(raw: string): RunningMarker | null {
+  const parts = raw.trim().split(/\s+/);
+  const startedTs = Number(parts[0]);
+  if (!Number.isFinite(startedTs) || startedTs <= 0) return null;
+  const pidNum = parts.length > 1 ? Number(parts[1]) : NaN;
+  return { startedTs, pid: Number.isInteger(pidNum) && pidNum > 0 ? pidNum : null };
+}
+
+/**
+ * A job name is used directly as a run-state filename, so it must be a single
+ * safe path segment — no `/`, no `.`/`..`. Live registry names are kebab slugs;
+ * this guards the path-escape surface if a future name isn't.
+ */
+export function isSafeSegment(name: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(name) && name !== "." && name !== "..";
 }
 
 /** Parse+validate a `done/<name>` body (CompletionRecord JSON); null on garbage/torn. */
@@ -152,12 +181,23 @@ export function buildCompletions(
   runningRaw: Record<string, string>,
   doneRaw: Record<string, string>,
   now: number,
-  staleMs = RUN_STATE_STALE_MS,
+  opts: { staleMs?: number; isAlive?: (pid: number) => boolean } = {},
 ): { running: Record<string, number>; done: Record<string, CompletionRecord> } {
+  const staleMs = opts.staleMs ?? RUN_STATE_STALE_MS;
+  const isAlive = opts.isAlive;
   const running: Record<string, number> = {};
   for (const [name, raw] of Object.entries(runningRaw)) {
-    const ts = parseRunningEntry(raw);
-    if (ts !== null && !isStaleRunning(ts, now, staleMs)) running[name] = ts;
+    const m = parseRunningEntry(raw);
+    if (m === null) continue;
+    // With a known PID and a liveness probe: a live child is genuinely in-flight
+    // (keep it, even past the stale window — respects MAX_CONCURRENT=1 for a long
+    // job); a dead PID is a crash orphan, dropped immediately (no 1h stall).
+    if (m.pid !== null && isAlive) {
+      if (isAlive(m.pid)) running[name] = m.startedTs;
+      continue;
+    }
+    // No PID yet (pre-spawn window) or no probe → fall back to the time guard.
+    if (!isStaleRunning(m.startedTs, now, staleMs)) running[name] = m.startedTs;
   }
   const done: Record<string, CompletionRecord> = {};
   for (const [name, raw] of Object.entries(doneRaw)) {

--- a/lib/scheduler/src/runtime.ts
+++ b/lib/scheduler/src/runtime.ts
@@ -2,6 +2,7 @@
  * Real-environment helpers for ceo-schedulerd, kept pure so they are unit-tested
  * without touching the filesystem. `main.ts` composes them with Bun's spawn/fs.
  */
+import type { CompletionRecord } from "cronbird/core";
 
 /**
  * How long without a heartbeat before `ceo doctor` reports the daemon stale.
@@ -68,4 +69,100 @@ export function resolveHost(env: { CEO_HOSTNAME?: string }, osHost: string): str
  */
 export function dispatchArgv(cronBin: string, name: string): string[] {
   return [cronBin, name, "--scheduled"];
+}
+
+// --- Dispatch-completion state (cronbird #9 `readCompletions` contract) --------
+//
+// cronbird's post-#9 loop dispatches through a queue capped at MAX_CONCURRENT
+// and advances only when a job's completion is observed via `readCompletions()`.
+// The daemon's `dispatch` is fire-and-forget, so without a wrapper writing run
+// state the loop sees "nothing ever completes" and strands every job queued
+// behind the first — silently dropping the loser of any same-minute collision
+// (e.g. morning + morning-brief at 03:20). This layer is that wrapper: the
+// dispatch glue in main.ts writes `running/<name>` (body: startedTs epoch-ms)
+// before spawn and, on exit, `done/<name>` (body: CompletionRecord JSON) while
+// clearing the running marker. `readCompletions` reassembles both dirs.
+//
+// One writer/reader (the daemon's single event loop) → no cross-process torn
+// reads; plain writeFileSync is safe, no temp-rename needed. `done/` holds one
+// file per job (overwritten each completion), so it stays bounded to the job set.
+
+/** Root for the dispatch-completion state dirs, host-local under `~/.ceo`. */
+export function runStateDir(home: string): string {
+  return `${home}/.ceo/schedulerd/run-state`;
+}
+/** In-flight run markers: `running/<name>` body = startedTs (epoch-ms). */
+export function runningDir(home: string): string {
+  return `${runStateDir(home)}/running`;
+}
+/** Last-completion records: `done/<name>` body = CompletionRecord JSON. */
+export function doneDir(home: string): string {
+  return `${runStateDir(home)}/done`;
+}
+
+/**
+ * A `running/<name>` marker older than this is ignored: a daemon crash mid-run
+ * orphans the child (its exit handler dies with the daemon), leaving a marker
+ * that would otherwise wedge the MAX_CONCURRENT=1 queue forever. Comfortably
+ * longer than any real playbook run.
+ */
+export const RUN_STATE_STALE_MS = 3_600_000; // 1 hour
+
+/** Parse a `running/<name>` body (epoch-ms startedTs); null on garbage/torn. */
+export function parseRunningEntry(raw: string): number | null {
+  const n = Number(raw.trim());
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** Parse+validate a `done/<name>` body (CompletionRecord JSON); null on garbage/torn. */
+export function parseDoneEntry(raw: string): CompletionRecord | null {
+  try {
+    const v = JSON.parse(raw) as Partial<CompletionRecord>;
+    if (
+      typeof v?.ts === "number" &&
+      typeof v?.exitCode === "number" &&
+      typeof v?.durationMs === "number"
+    ) {
+      return { ts: v.ts, exitCode: v.exitCode, durationMs: v.durationMs };
+    }
+  } catch {
+    // torn/partial write — treat as absent, matching cronbird's fail-safe read contract
+  }
+  return null;
+}
+
+/** True when an in-flight marker is old enough to be a crash orphan, not a live run. */
+export function isStaleRunning(startedTs: number, now: number, staleMs = RUN_STATE_STALE_MS): boolean {
+  return now - startedTs > staleMs;
+}
+
+/** Build the CompletionRecord written to `done/<name>` when a dispatched run exits. */
+export function completionRecord(startedTs: number, endedTs: number, exitCode: number): CompletionRecord {
+  return { ts: endedTs, exitCode, durationMs: Math.max(0, endedTs - startedTs) };
+}
+
+/**
+ * Reassemble the `readCompletions()` shape from raw dir contents (name → file
+ * body). Pure so the stale-filter and torn-read handling are unit-tested without
+ * fs; main.ts reads the dirs and passes the maps in. Stale/garbage running
+ * markers and unparseable done records are dropped (fail-safe: an unreadable
+ * entry means "not running" / "no completion", never a wrong gate).
+ */
+export function buildCompletions(
+  runningRaw: Record<string, string>,
+  doneRaw: Record<string, string>,
+  now: number,
+  staleMs = RUN_STATE_STALE_MS,
+): { running: Record<string, number>; done: Record<string, CompletionRecord> } {
+  const running: Record<string, number> = {};
+  for (const [name, raw] of Object.entries(runningRaw)) {
+    const ts = parseRunningEntry(raw);
+    if (ts !== null && !isStaleRunning(ts, now, staleMs)) running[name] = ts;
+  }
+  const done: Record<string, CompletionRecord> = {};
+  for (const [name, raw] of Object.entries(doneRaw)) {
+    const rec = parseDoneEntry(raw);
+    if (rec !== null) done[name] = rec;
+  }
+  return { running, done };
 }

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildCompletions,
   CATCHUP_LOOKBACK_CAP_MS,
   CATCHUP_LOOKBACK_FLOOR_MS,
+  completionRecord,
   dispatchArgv,
+  doneDir,
   enabledPath,
   HEARTBEAT_STALE_MS,
   heartbeatPath,
+  isStaleRunning,
   MAX_SLEEP_MS,
+  parseDoneEntry,
+  parseRunningEntry,
   registryPath,
   resolveFixedLookbackMs,
   resolveHost,
+  RUN_STATE_STALE_MS,
+  runningDir,
+  runStateDir,
   swarmPath,
   syncedHeartbeatPath,
 } from "@/runtime";
@@ -63,6 +72,81 @@ describe("catch-up look-back bounds (#157)", () => {
     expect(CATCHUP_LOOKBACK_FLOOR_MS).toBe(3_600_000); // 1h
     expect(CATCHUP_LOOKBACK_CAP_MS).toBe(21_600_000); // 6h
     expect(CATCHUP_LOOKBACK_FLOOR_MS).toBeLessThan(CATCHUP_LOOKBACK_CAP_MS);
+  });
+});
+
+describe("dispatch-completion state paths", () => {
+  test("run-state dirs are host-local under ~/.ceo/schedulerd", () => {
+    expect(runStateDir("/home/me")).toBe("/home/me/.ceo/schedulerd/run-state");
+    expect(runningDir("/home/me")).toBe("/home/me/.ceo/schedulerd/run-state/running");
+    expect(doneDir("/home/me")).toBe("/home/me/.ceo/schedulerd/run-state/done");
+  });
+});
+
+describe("parseRunningEntry (startedTs marker body)", () => {
+  test("parses a positive epoch-ms integer", () => {
+    expect(parseRunningEntry("1700000000000")).toBe(1_700_000_000_000);
+    expect(parseRunningEntry("  1700000000000\n")).toBe(1_700_000_000_000);
+  });
+  test("garbage / zero / negative / empty → null (fail-safe)", () => {
+    expect(parseRunningEntry("abc")).toBeNull();
+    expect(parseRunningEntry("0")).toBeNull();
+    expect(parseRunningEntry("-5")).toBeNull();
+    expect(parseRunningEntry("")).toBeNull();
+  });
+});
+
+describe("parseDoneEntry (CompletionRecord body)", () => {
+  test("parses a valid record", () => {
+    expect(parseDoneEntry('{"ts":100,"exitCode":0,"durationMs":42}')).toEqual({ ts: 100, exitCode: 0, durationMs: 42 });
+  });
+  test("torn JSON or missing/typewrong fields → null", () => {
+    expect(parseDoneEntry('{"ts":100,"exitCode":0')).toBeNull(); // truncated write
+    expect(parseDoneEntry('{"ts":100,"exitCode":0}')).toBeNull(); // missing durationMs
+    expect(parseDoneEntry('{"ts":"x","exitCode":0,"durationMs":1}')).toBeNull(); // wrong type
+    expect(parseDoneEntry("")).toBeNull();
+  });
+});
+
+describe("isStaleRunning (crash-orphan guard)", () => {
+  test("a marker within the window is live", () => {
+    expect(isStaleRunning(1_000, 1_000 + RUN_STATE_STALE_MS, RUN_STATE_STALE_MS)).toBe(false);
+  });
+  test("a marker older than the window is a stale orphan", () => {
+    expect(isStaleRunning(1_000, 1_000 + RUN_STATE_STALE_MS + 1, RUN_STATE_STALE_MS)).toBe(true);
+  });
+});
+
+describe("completionRecord", () => {
+  test("records exit code and clamps duration to >= 0", () => {
+    expect(completionRecord(100, 142, 0)).toEqual({ ts: 142, exitCode: 0, durationMs: 42 });
+    expect(completionRecord(200, 100, 1).durationMs).toBe(0); // clock skew never yields negative
+  });
+});
+
+describe("buildCompletions (readCompletions reassembly)", () => {
+  const NOW = 10_000_000;
+  test("assembles valid running + done entries", () => {
+    const out = buildCompletions(
+      { morning: String(NOW - 1000) },
+      { "morning-brief": '{"ts":123,"exitCode":0,"durationMs":5}' },
+      NOW,
+    );
+    expect(out.running).toEqual({ morning: NOW - 1000 });
+    expect(out.done).toEqual({ "morning-brief": { ts: 123, exitCode: 0, durationMs: 5 } });
+  });
+  test("drops a stale running marker so a crash orphan cannot wedge the MAX_CONCURRENT=1 queue", () => {
+    const out = buildCompletions(
+      { stuck: String(NOW - RUN_STATE_STALE_MS - 1), live: String(NOW - 1) },
+      {},
+      NOW,
+    );
+    expect(out.running).toEqual({ live: NOW - 1 }); // stuck dropped
+  });
+  test("drops garbage/torn entries on both sides (fail-safe)", () => {
+    const out = buildCompletions({ bad: "nope" }, { torn: '{"ts":1' }, NOW);
+    expect(out.running).toEqual({});
+    expect(out.done).toEqual({});
   });
 });
 

--- a/lib/scheduler/tests/runtime.test.ts
+++ b/lib/scheduler/tests/runtime.test.ts
@@ -9,6 +9,7 @@ import {
   enabledPath,
   HEARTBEAT_STALE_MS,
   heartbeatPath,
+  isSafeSegment,
   isStaleRunning,
   MAX_SLEEP_MS,
   parseDoneEntry,
@@ -18,6 +19,7 @@ import {
   resolveHost,
   RUN_STATE_STALE_MS,
   runningDir,
+  runningMarker,
   runStateDir,
   swarmPath,
   syncedHeartbeatPath,
@@ -83,16 +85,49 @@ describe("dispatch-completion state paths", () => {
   });
 });
 
-describe("parseRunningEntry (startedTs marker body)", () => {
-  test("parses a positive epoch-ms integer", () => {
-    expect(parseRunningEntry("1700000000000")).toBe(1_700_000_000_000);
-    expect(parseRunningEntry("  1700000000000\n")).toBe(1_700_000_000_000);
+describe("parseRunningEntry (startedTs [pid] marker body)", () => {
+  test("parses startedTs with no PID (pre-spawn window)", () => {
+    expect(parseRunningEntry("1700000000000")).toEqual({ startedTs: 1_700_000_000_000, pid: null });
+    expect(parseRunningEntry("  1700000000000\n")).toEqual({ startedTs: 1_700_000_000_000, pid: null });
   });
-  test("garbage / zero / negative / empty → null (fail-safe)", () => {
+  test("parses startedTs + PID", () => {
+    expect(parseRunningEntry("1700000000000 4242")).toEqual({ startedTs: 1_700_000_000_000, pid: 4242 });
+  });
+  test("a garbage PID degrades to no-PID (falls back to the time guard), startedTs still honored", () => {
+    expect(parseRunningEntry("1700000000000 abc")).toEqual({ startedTs: 1_700_000_000_000, pid: null });
+  });
+  test("garbage / zero / negative / empty startedTs → null (fail-safe)", () => {
     expect(parseRunningEntry("abc")).toBeNull();
     expect(parseRunningEntry("0")).toBeNull();
     expect(parseRunningEntry("-5")).toBeNull();
     expect(parseRunningEntry("")).toBeNull();
+  });
+});
+
+describe("runningMarker (serialize)", () => {
+  test("startedTs only when PID is absent", () => {
+    expect(runningMarker(100)).toBe("100");
+    expect(runningMarker(100, null)).toBe("100");
+  });
+  test("startedTs + PID when known", () => {
+    expect(runningMarker(100, 4242)).toBe("100 4242");
+  });
+  test("round-trips through parseRunningEntry", () => {
+    expect(parseRunningEntry(runningMarker(100, 4242))).toEqual({ startedTs: 100, pid: 4242 });
+  });
+});
+
+describe("isSafeSegment (filename guard)", () => {
+  test("accepts kebab/underscore/dot slugs", () => {
+    expect(isSafeSegment("morning-brief")).toBe(true);
+    expect(isSafeSegment("ticket_triage.v2")).toBe(true);
+  });
+  test("rejects path separators and traversal", () => {
+    expect(isSafeSegment("a/b")).toBe(false);
+    expect(isSafeSegment("..")).toBe(false);
+    expect(isSafeSegment(".")).toBe(false);
+    expect(isSafeSegment("../etc")).toBe(false);
+    expect(isSafeSegment("")).toBe(false);
   });
 });
 
@@ -147,6 +182,28 @@ describe("buildCompletions (readCompletions reassembly)", () => {
     const out = buildCompletions({ bad: "nope" }, { torn: '{"ts":1' }, NOW);
     expect(out.running).toEqual({});
     expect(out.done).toEqual({});
+  });
+  test("with a PID + liveness probe: a dead PID is dropped immediately, a live PID is kept even past the stale window", () => {
+    const alive = new Set([4242]);
+    const out = buildCompletions(
+      {
+        crashed: runningMarker(NOW - 1, 9999), // recent but PID gone → crash orphan
+        longRun: runningMarker(NOW - RUN_STATE_STALE_MS - 5, 4242), // older than stale but alive → real in-flight
+      },
+      {},
+      NOW,
+      { isAlive: (pid) => alive.has(pid) },
+    );
+    expect(out.running).toEqual({ longRun: NOW - RUN_STATE_STALE_MS - 5 });
+  });
+  test("without a PID (pre-spawn window), falls back to the time guard", () => {
+    const out = buildCompletions(
+      { preSpawn: runningMarker(NOW - 1) },
+      {},
+      NOW,
+      { isAlive: () => false }, // probe present but marker has no PID → time guard applies
+    );
+    expect(out.running).toEqual({ preSpawn: NOW - 1 });
   });
 });
 


### PR DESCRIPTION
Closes #288
Closes #289

Unpins the scheduler from pre-#9 cronbird now that cronbird #22 is merged, by giving the daemon what the #9 loop needs to advance its queue.

## Description

cronbird #9 rewrote the daemon loop to dispatch through a priority queue capped at `MAX_CONCURRENT=1`, advancing only when a job's completion is observed via `readCompletions()`. Our `dispatch` was fire-and-forget with no completion signal, so under the new loop every job would strand queued behind the first, and the loser of any same-minute collision would be **silently dropped** once its slot aged past the catch-up window. Real collisions exist today: `morning` + `morning-brief` at 03:20 weekdays, and `ticket-triage-autopilot` (`*/30`) against `git-monitor` / `pending-drip` / `disk-monitor` / `value-tracker` / `llm-tools-align` at `:00`/`:30`. That is why CI was pinned to `1a715f7` (pre-#9).

This PR supplies the missing piece — a dispatch-completion layer — and unpins.

- **Completion state (`runtime.ts`):** `running/<name>` (body: startedTs) and `done/<name>` (body: `CompletionRecord` JSON) under `~/.ceo/schedulerd/run-state`. Pure, unit-tested `parseRunningEntry` / `parseDoneEntry` / `buildCompletions` handle torn/garbage reads fail-safe. A crash-orphaned `running` marker older than `RUN_STATE_STALE_MS` (1h) is ignored so it can't wedge the `MAX_CONCURRENT=1` queue forever.
- **Dispatch wrapper (`main.ts`):** write the running marker before spawn; on `proc.exited`, write the done record and clear the marker. Runs on the daemon's own event loop, so it never races `readCompletions` (single writer/reader → no torn reads, no temp-rename needed).
- **The four #9 deps:** real `readCompletions`, plus `priority`/`dependencies`/`cooldownSeconds` as documented defaults (all-equal FIFO, no upstreams, no cooldown).
- **Unpin:** `CRONBIRD_REF` `1a715f7` → `7b8f35e` (cronbird #22 merge).

### Behavior change

Colliding jobs now run **one-at-a-time as each completes** instead of racing in parallel. No drops. For CEO's heavy `claude -p` playbooks this is also gentler (no stacked concurrent sessions). Wiring real priority/dependency/cooldown from registry metadata is a later, deliberate step.

## Testing Procedure

1. Check out this branch; `cd lib/scheduler && bun install` (resolves `file:../../../cronbird`; ensure the sibling cronbird clone is at `7b8f35e` or later).
2. `bun run typecheck` — passes against post-#9 cronbird (resolves the shipped `cronbird/core` `.d.ts`, does not recompile cronbird source).
3. `bun test` — **47 pass, 0 fail**, including new coverage for `buildCompletions` (valid assembly, stale-marker drop, torn/garbage fail-safe), `parseRunningEntry`/`parseDoneEntry`, `isStaleRunning`, `completionRecord`, and the run-state path helpers.
4. CI clones cronbird at the new `CRONBIRD_REF` and runs the same typecheck + test.

## Additional Notes

Closes the loop opened by cronbird #21/#22. Follow-up (separate): adopt the actual priority-chain features by wiring `priority`/`dependencies`/`cooldownSeconds` from registry metadata, if/when CEO wants dependency-ordered dispatch.