### PR TITLE
fix(gather): stop truncation SIGPIPE aborting every scheduled playbook

### DIFF
--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -733,10 +733,17 @@ END_LOG_ENTRY"
   local failed_chunks=0
   for i in $(seq 1 "$n_chunks"); do
     offset=$(( (i - 1) * chunk_budget ))
-    # Two pipe-free steps, not `tail … | head -c`: head closing the pipe SIGPIPEs
-    # tail on every chunk but the last, which pipefail turns into an aborted scan
-    # (#293). Byte-exact on purpose — these offsets come from `wc -c`, so slicing
-    # with ${SCAN_BLOCK:offset:len} would misalign chunks on multibyte content.
+    # Two pipe-free steps, not `tail … | head -c`. head closing the pipe SIGPIPEs
+    # tail on every chunk but the last, so the pipeline's status is 141 under
+    # pipefail. That does NOT abort today: the sole caller is
+    # `OLLAMA_OUT=$(_ollama_chunked_scan …) || OLLAMA_EXIT=$?`, and a command
+    # substitution on the left of `||` has errexit suppressed, so the 141 was
+    # discarded and `piece` still received its full budget of bytes. This is
+    # therefore hardening, not a live bug fix — but the same construct in a bare
+    # assignment is exactly what killed every playbook in #293, and it would abort
+    # here the moment that caller loses its `||`. Byte-exact on purpose: the offsets
+    # come from `wc -c`, so ${SCAN_BLOCK:offset:len} would misalign chunk
+    # boundaries on multibyte content.
     piece=$(tail -c "+$((offset + 1))" <<< "$SCAN_BLOCK")
     piece=$(head -c "$chunk_budget" <<< "$piece")
     [ -z "$(printf '%s' "$piece" | tr -d '[:space:]')" ] && continue
@@ -793,8 +800,10 @@ ${partial_findings}"
     _v "  Synthesis prompt too large ($synth_bytes bytes) — truncating findings"
     local avail=$(( CEO_OLLAMA_MAX_PROMPT_BYTES - base_bytes - 512 ))
     # Here-string, not `printf … | head -c`. This branch runs only when the findings
-    # exceed the cap — exactly when head closes early and SIGPIPEs the producer, so
-    # under pipefail the truncation aborted the run it was meant to rescue (#293).
+    # exceed the cap — exactly when head closes early and SIGPIPEs the producer. Same
+    # standing as the chunk site above: errexit is suppressed at this function's
+    # caller, so the 141 was discarded rather than aborting. Hardening against the
+    # #293 construct, not a live fix.
     partial_findings=$(head -c "$avail" <<< "$partial_findings")
     synth_prompt="${base_prompt}
 PRE-SUMMARIZED VAULT FINDINGS (truncated):

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -733,7 +733,12 @@ END_LOG_ENTRY"
   local failed_chunks=0
   for i in $(seq 1 "$n_chunks"); do
     offset=$(( (i - 1) * chunk_budget ))
-    piece=$(printf '%s' "$SCAN_BLOCK" | tail -c "+$((offset + 1))" | head -c "$chunk_budget")
+    # Two pipe-free steps, not `tail … | head -c`: head closing the pipe SIGPIPEs
+    # tail on every chunk but the last, which pipefail turns into an aborted scan
+    # (#293). Byte-exact on purpose — these offsets come from `wc -c`, so slicing
+    # with ${SCAN_BLOCK:offset:len} would misalign chunks on multibyte content.
+    piece=$(tail -c "+$((offset + 1))" <<< "$SCAN_BLOCK")
+    piece=$(head -c "$chunk_budget" <<< "$piece")
     [ -z "$(printf '%s' "$piece" | tr -d '[:space:]')" ] && continue
 
     chunk_prompt="Extract actionable findings from this vault data fragment for a morning scan. Output a concise bullet list only — no preamble or commentary.
@@ -787,7 +792,10 @@ ${partial_findings}"
   if [ "$synth_bytes" -gt "$CEO_OLLAMA_MAX_PROMPT_BYTES" ]; then
     _v "  Synthesis prompt too large ($synth_bytes bytes) — truncating findings"
     local avail=$(( CEO_OLLAMA_MAX_PROMPT_BYTES - base_bytes - 512 ))
-    partial_findings=$(printf '%s' "$partial_findings" | head -c "$avail")
+    # Here-string, not `printf … | head -c`. This branch runs only when the findings
+    # exceed the cap — exactly when head closes early and SIGPIPEs the producer, so
+    # under pipefail the truncation aborted the run it was meant to rescue (#293).
+    partial_findings=$(head -c "$avail" <<< "$partial_findings")
     synth_prompt="${base_prompt}
 PRE-SUMMARIZED VAULT FINDINGS (truncated):
 ${partial_findings}"

--- a/scripts/ceo-gather-truncation.test.sh
+++ b/scripts/ceo-gather-truncation.test.sh
@@ -52,6 +52,7 @@ teardown() {
 # Source the gather under production's shell options and report the exit status
 # alongside the variable under test and the degradation flag. Anything that trips
 # errexit shows up as a non-zero RC here instead of killing the harness.
+#
 # Run in a SEPARATE bash process, not `( set -euo pipefail … ) || …`. A subshell
 # used as the left operand of `||` has errexit suppressed, so that shape silently
 # reports RC=0 for a run that production would abort — it cannot observe the very
@@ -93,12 +94,19 @@ _write_oversized_pending() {
 
 # The fixture is only meaningful if it actually reproduces the original bug, and
 # the threshold depends on the platform's pipe buffer plus head's read-ahead —
-# neither visible here. So assert the pre-fix form still dies on this exact file,
-# and that it dies of SIGPIPE (141) specifically rather than some other error.
-# Without this, shrinking the fixture silently returns the suite to
+# neither visible here. So assert the pre-fix form still fails on this exact file.
+# Without it, shrinking the fixture silently returns the suite to
 # green-against-broken, which is how the first draft of this test passed.
+#
 # Separate process for the same reason as _run_gather_strict — `( … ) || rc=$?`
 # suppresses errexit and reports a misleading 0.
+#
+# Asserts non-zero rather than a specific code: the failure signature is
+# platform-dependent. macOS/BSD grep and WSL's GNU grep 3.11 die from the signal
+# (141), while the GNU grep on GitHub's ubuntu runner handles it and exits 2 on
+# "write error: Broken pipe". Pinning 141 passed locally and failed CI. Either
+# way the pre-fix form exits non-zero, which is the only thing that matters —
+# that is what errexit turns into an aborted run.
 _assert_fixture_reproduces() {
   local file="$1" rc=0
   bash -c '
@@ -106,12 +114,16 @@ _assert_fixture_reproduces() {
     _naive=$(grep -n "^- \[ \]" "$1" 2>/dev/null | head -20)
     printf "%s" "$_naive" >/dev/null
   ' _ "$file" >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "141" \
-    "fixture must still SIGPIPE the pre-fix \`grep | head\` form, or it proves nothing"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] fixture no longer breaks the pre-fix `grep | head` form (rc=0), so it proves nothing — it must exceed the pipe buffer\n' \
+      "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
 }
 
 # An oversized Pending.md must truncate, not abort. Reverting to
-# `grep … | head -20` makes this fail with RC=141.
+# `grep … | head -20` makes this fail with a non-zero RC (141 or 2, per platform).
 test_oversized_pending_does_not_abort() {
   _write_oversized_pending
   _assert_fixture_reproduces "$CEO_VAULT/Pending.md"

--- a/scripts/ceo-gather-truncation.test.sh
+++ b/scripts/ceo-gather-truncation.test.sh
@@ -5,7 +5,9 @@
 # that is the only mode the bug appears in: a truncating consumer that closes
 # its input early makes the producer die on SIGPIPE, pipefail surfaces 141, and
 # errexit aborts before any playbook work happens. The sibling suite
-# (ceo-gather.test.sh) sources under `set +eu` and cannot observe this.
+# (ceo-gather.test.sh) sources under `set +eu` with no pipefail, so a
+# `grep | head` pipeline there always reports head's 0 — it structurally cannot
+# observe this bug class.
 
 set -euo pipefail
 
@@ -41,61 +43,167 @@ STUB
 teardown() {
   export HOME="$OLD_HOME"
   export PATH="$OLD_PATH"
+  # Restore readability first or the rm fails on the unreadable-file fixture.
+  chmod -R u+rwX "$TMP" 2>/dev/null || true
   unset CEO_VAULT
   rm -rf "$TMP"
 }
 
 # Source the gather under production's shell options and report the exit status
-# alongside the variable under test. Anything that trips errexit shows up as a
-# non-zero RC here.
+# alongside the variable under test and the degradation flag. Anything that trips
+# errexit shows up as a non-zero RC here instead of killing the harness.
+# Run in a SEPARATE bash process, not `( set -euo pipefail … ) || …`. A subshell
+# used as the left operand of `||` has errexit suppressed, so that shape silently
+# reports RC=0 for a run that production would abort — it cannot observe the very
+# bug this suite exists for. A child process also matches production: ceo-cron.sh
+# is its own process with `set -euo pipefail` at the top. Exported env (HOME,
+# CEO_VAULT, PATH) is inherited.
 _run_gather_strict() {
-  local var="$1"
-  ( set -euo pipefail
-    source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1
-    printf 'RC=0|VALUE_LINES=%s\n' "$(printf '%s' "${!var}" | grep -c . || true)"
-  ) || printf 'RC=%s|VALUE_LINES=-\n' "$?"
+  local var="$1" rc=0 out
+  out=$(bash -c '
+    set -euo pipefail
+    source "$1" >/dev/null 2>&1
+    var="$2"
+    printf "RC=0|LINES=%s|DEGRADED=%s|STATUS=%s|FIRST=%s\n" \
+      "$(printf "%s" "${!var}" | grep -c . || true)" \
+      "${FILE_GATHER_DEGRADED:-0}" \
+      "${CEO_GATHER_STATUS:-?}" \
+      "$(printf "%s" "${!var}" | head -1)"
+  ' _ "$SCRIPT_DIR/ceo-gather.sh" "$var" 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'RC=%s|LINES=-|DEGRADED=-|STATUS=-|FIRST=-\n' "$rc"
+  else
+    printf '%s\n' "$out"
+  fi
 }
 
-# A Pending.md far past the 20-line cap must truncate, not abort. Reverting the
-# fix to `grep … | head -20` makes this fail with RC=141.
-#
-# The padding is load-bearing, not decoration. SIGPIPE only fires if the producer
-# is still writing when the consumer closes, so the matched output has to exceed
-# the ~64KB pipe buffer — 500 short lines fit inside it and the bug hides. The
-# real Pending.md that broke production was 952 lines of paragraph-length text.
-test_oversized_pending_does_not_abort() {
+# Write a Pending.md whose matched output is large enough to still be streaming
+# when a truncating consumer closes the pipe. SIGPIPE only fires if the producer
+# is mid-write, so the payload must exceed the ~64KB pipe buffer — 500 short
+# lines fit inside it and the bug hides. Guarded by _assert_fixture_reproduces
+# below rather than trusted.
+_write_oversized_pending() {
   local pad; pad=$(printf 'x%.0s' $(seq 1 300))
-  { for i in $(seq 1 500); do echo "- [ ] [ask] (qid: q-$i) question $i $pad"; done; } \
-    > "$CEO_VAULT/Pending.md"
+  local i
+  : > "$CEO_VAULT/Pending.md"
+  for i in $(seq 1 500); do
+    echo "- [ ] [ask] (qid: q-$i) question $i $pad" >> "$CEO_VAULT/Pending.md"
+  done
+}
+
+# The fixture is only meaningful if it actually reproduces the original bug, and
+# the threshold depends on the platform's pipe buffer plus head's read-ahead —
+# neither visible here. So assert the pre-fix form still dies on this exact file,
+# and that it dies of SIGPIPE (141) specifically rather than some other error.
+# Without this, shrinking the fixture silently returns the suite to
+# green-against-broken, which is how the first draft of this test passed.
+# Separate process for the same reason as _run_gather_strict — `( … ) || rc=$?`
+# suppresses errexit and reports a misleading 0.
+_assert_fixture_reproduces() {
+  local file="$1" rc=0
+  bash -c '
+    set -euo pipefail
+    _naive=$(grep -n "^- \[ \]" "$1" 2>/dev/null | head -20)
+    printf "%s" "$_naive" >/dev/null
+  ' _ "$file" >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "141" \
+    "fixture must still SIGPIPE the pre-fix \`grep | head\` form, or it proves nothing"
+}
+
+# An oversized Pending.md must truncate, not abort. Reverting to
+# `grep … | head -20` makes this fail with RC=141.
+test_oversized_pending_does_not_abort() {
+  _write_oversized_pending
+  _assert_fixture_reproduces "$CEO_VAULT/Pending.md"
 
   local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
-  assert_contains "$out" "RC=0" \
-    "an oversized Pending.md must not abort the gather (#293 — SIGPIPE via head)"
-  assert_contains "$out" "VALUE_LINES=20" \
-    "PENDING_ASK_QUESTIONS must still be capped at 20 lines"
+  assert_contains "$out" "RC=0|LINES=20" \
+    "an oversized Pending.md must truncate to 20 lines, not abort (#293)"
+  # Pin *which* 20. The contract is "top entries only", and a line-count-only
+  # assertion passes just as happily on the last 20. grep -n makes this cheap.
+  assert_contains "$out" "FIRST=1:- [ ] [ask] (qid: q-1)" \
+    "the cap must keep the FIRST 20 matches, not the last"
+  assert_contains "$out" "DEGRADED=0" \
+    "a successful truncation is not a degradation"
 }
 
 # The complement: an under-cap file returns every line and still exits clean, so
-# the fix can't pass by truncating to nothing.
+# the fix cannot pass by truncating to nothing.
 test_small_pending_returns_all_lines() {
   { for i in 1 2 3; do echo "- [ ] [ask] (qid: q-$i) question $i"; done; } \
     > "$CEO_VAULT/Pending.md"
 
   local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
-  assert_contains "$out" "RC=0|VALUE_LINES=3" \
+  assert_contains "$out" "RC=0|LINES=3" \
     "an under-cap Pending.md must return all its lines"
 }
 
-# Same invariant on the sibling site: Profile.md's Active Domains section past
-# the byte cap must truncate rather than abort.
+# grep exits 1 when nothing matches, which pipefail surfaced just as fatally as
+# the SIGPIPE. Empty is a legitimate state — the pending-drip preflight skips on
+# it — so it must not abort. This behavior is load-bearing and was untested.
+test_empty_pending_does_not_abort() {
+  : > "$CEO_VAULT/Pending.md"
+  local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
+  assert_contains "$out" "RC=0|LINES=0" \
+    "an empty Pending.md must skip, not abort (grep rc=1 under pipefail)"
+  assert_contains "$out" "DEGRADED=0" \
+    "legitimately-empty is not a degradation"
+}
+
+# Same path: file has content but no *unchecked* items.
+test_all_checked_pending_does_not_abort() {
+  { for i in 1 2 3; do echo "- [x] [ask] (qid: q-$i) done $i"; done; } \
+    > "$CEO_VAULT/Pending.md"
+  local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
+  assert_contains "$out" "RC=0|LINES=0" \
+    "a fully-checked Pending.md must skip, not abort"
+  assert_contains "$out" "DEGRADED=0" \
+    "no unchecked items is a quiet day, not a failure"
+}
+
+# The distinction a bare `|| true` destroys: an unreadable file yields the same
+# empty string as a file with nothing in it. Tolerating grep's exit 1 must not
+# also tolerate exit 2, or the gather reports "quiet day" on an IO error.
+test_unreadable_pending_marks_degraded() {
+  echo "- [ ] [ask] (qid: q-1) question" > "$CEO_VAULT/Pending.md"
+  chmod 000 "$CEO_VAULT/Pending.md"
+
+  local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
+  chmod 644 "$CEO_VAULT/Pending.md"
+
+  assert_contains "$out" "RC=0" \
+    "an unreadable Pending.md must not abort the gather"
+  assert_contains "$out" "DEGRADED=1" \
+    "an unreadable Pending.md must mark the gather degraded, not read as empty"
+  assert_not_contains "$out" "STATUS=empty" \
+    "an IO error must never be reported as a quiet day (#293 review)"
+}
+
+# Sibling site: Profile.md's Active Domains section past the byte cap must
+# truncate rather than abort. Note GATHER_MAX_FILE is set unconditionally inside
+# the gather, so the cap here is its value (10000), not anything a caller sets.
 test_oversized_active_domains_does_not_abort() {
   { echo "## Active Domains"
     for i in $(seq 1 2000); do echo "- domain $i with padding to exceed the byte cap"; done
     echo "## Next Section"; } > "$CEO_VAULT/Profile.md"
 
-  local out; out=$(GATHER_MAX_FILE=512 _run_gather_strict ACTIVE_DOMAINS_CONTENT)
+  local out; out=$(_run_gather_strict ACTIVE_DOMAINS_CONTENT)
   assert_contains "$out" "RC=0" \
     "an oversized Active Domains section must not abort the gather (#293)"
+  # Without this the test passes with the content empty, so a broken sed pattern
+  # would sail through.
+  assert_contains "$out" "FIRST=## Active Domains" \
+    "the section must actually be captured, not silently emptied"
+}
+
+# The ledger glob: dir present but holding no .md leaves the glob literal, ls
+# exits non-zero, and pipefail + errexit aborted the whole gather — same blast
+# radius as #293, different mechanism.
+test_empty_ledger_dir_does_not_abort() {
+  mkdir -p "$CEO_VAULT/CEO/model"
+  local out; out=$(_run_gather_strict LEDGER_RECENT)
+  assert_contains "$out" "RC=0" \
+    "a model/ dir with no .md files must not abort the gather"
 }
 
 run_tests

--- a/scripts/ceo-gather-truncation.test.sh
+++ b/scripts/ceo-gather-truncation.test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Tests for ceo-gather.sh — truncation must not abort the run (#293).
+#
+# These run the gather under `set -euo pipefail`, matching ceo-cron.sh, because
+# that is the only mode the bug appears in: a truncating consumer that closes
+# its input early makes the producer die on SIGPIPE, pipefail surfaces 141, and
+# errexit aborts before any playbook work happens. The sibling suite
+# (ceo-gather.test.sh) sources under `set +eu` and cannot observe this.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TMP=$(mktemp -d)
+  OLD_HOME="$HOME"
+  OLD_PATH="$PATH"
+  export HOME="$TMP"
+  export CEO_VAULT="$TMP/vault"
+  mkdir -p "$CEO_VAULT/CEO/approvals" "$CEO_VAULT/CEO/log"
+
+  mkdir -p "$TMP/.ceo"
+  cat > "$TMP/.ceo/pr-sources.json" << 'JSON'
+{ "github": { "accounts": [] }, "gitlab": { "usernames": [] } }
+JSON
+
+  # Stub out the network tools so the gather is deterministic and offline. Both
+  # report unauthenticated, which skips their blocks entirely.
+  mkdir -p "$TMP/bin"
+  for _tool in gh glab; do
+    cat > "$TMP/bin/$_tool" << 'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "$TMP/bin/$_tool"
+  done
+  export PATH="$TMP/bin:$PATH"
+}
+
+teardown() {
+  export HOME="$OLD_HOME"
+  export PATH="$OLD_PATH"
+  unset CEO_VAULT
+  rm -rf "$TMP"
+}
+
+# Source the gather under production's shell options and report the exit status
+# alongside the variable under test. Anything that trips errexit shows up as a
+# non-zero RC here.
+_run_gather_strict() {
+  local var="$1"
+  ( set -euo pipefail
+    source "$SCRIPT_DIR/ceo-gather.sh" >/dev/null 2>&1
+    printf 'RC=0|VALUE_LINES=%s\n' "$(printf '%s' "${!var}" | grep -c . || true)"
+  ) || printf 'RC=%s|VALUE_LINES=-\n' "$?"
+}
+
+# A Pending.md far past the 20-line cap must truncate, not abort. Reverting the
+# fix to `grep … | head -20` makes this fail with RC=141.
+#
+# The padding is load-bearing, not decoration. SIGPIPE only fires if the producer
+# is still writing when the consumer closes, so the matched output has to exceed
+# the ~64KB pipe buffer — 500 short lines fit inside it and the bug hides. The
+# real Pending.md that broke production was 952 lines of paragraph-length text.
+test_oversized_pending_does_not_abort() {
+  local pad; pad=$(printf 'x%.0s' $(seq 1 300))
+  { for i in $(seq 1 500); do echo "- [ ] [ask] (qid: q-$i) question $i $pad"; done; } \
+    > "$CEO_VAULT/Pending.md"
+
+  local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
+  assert_contains "$out" "RC=0" \
+    "an oversized Pending.md must not abort the gather (#293 — SIGPIPE via head)"
+  assert_contains "$out" "VALUE_LINES=20" \
+    "PENDING_ASK_QUESTIONS must still be capped at 20 lines"
+}
+
+# The complement: an under-cap file returns every line and still exits clean, so
+# the fix can't pass by truncating to nothing.
+test_small_pending_returns_all_lines() {
+  { for i in 1 2 3; do echo "- [ ] [ask] (qid: q-$i) question $i"; done; } \
+    > "$CEO_VAULT/Pending.md"
+
+  local out; out=$(_run_gather_strict PENDING_ASK_QUESTIONS)
+  assert_contains "$out" "RC=0|VALUE_LINES=3" \
+    "an under-cap Pending.md must return all its lines"
+}
+
+# Same invariant on the sibling site: Profile.md's Active Domains section past
+# the byte cap must truncate rather than abort.
+test_oversized_active_domains_does_not_abort() {
+  { echo "## Active Domains"
+    for i in $(seq 1 2000); do echo "- domain $i with padding to exceed the byte cap"; done
+    echo "## Next Section"; } > "$CEO_VAULT/Profile.md"
+
+  local out; out=$(GATHER_MAX_FILE=512 _run_gather_strict ACTIVE_DOMAINS_CONTENT)
+  assert_contains "$out" "RC=0" \
+    "an oversized Active Domains section must not abort the gather (#293)"
+}
+
+run_tests

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -333,7 +333,12 @@ BRIEFINGS_TRAINING=$(_gather_safe_read "$CEO_DIR/training/briefings.md")
 PROFILE_FILE="$VAULT/Profile.md"
 if [ -f "$PROFILE_FILE" ]; then
 export ACTIVE_DOMAINS_CONTENT
-ACTIVE_DOMAINS_CONTENT=$(sed -n '/^##* *Active Domains/,/^## /p' "$PROFILE_FILE" 2>/dev/null | head -c "$GATHER_MAX_FILE")
+# Capture, then truncate — piping sed into `head -c` SIGPIPEs sed once the section
+# exceeds the cap, which pipefail turns into an aborted run (#293). Here-string
+# rather than ${var:0:n} to keep head's byte semantics; the cap is a byte budget.
+_active_domains_raw=$(sed -n '/^##* *Active Domains/,/^## /p' "$PROFILE_FILE" 2>/dev/null || true)
+ACTIVE_DOMAINS_CONTENT=$(head -c "$GATHER_MAX_FILE" <<< "$_active_domains_raw")
+unset _active_domains_raw
 else
   export ACTIVE_DOMAINS_CONTENT=""
 fi
@@ -345,7 +350,10 @@ fi
 PENDING_FILE="$VAULT/Pending.md"
 if [ -f "$PENDING_FILE" ]; then
 export PENDING_ASK_QUESTIONS
-PENDING_ASK_QUESTIONS=$(grep -n '^- \[ \]' "$PENDING_FILE" 2>/dev/null | head -20)
+# `grep -m 20`, not `grep … | head -20`: head closing the pipe SIGPIPEs grep, and
+# pipefail made that 141 abort every playbook once this file passed 20 items (#293).
+# `|| true` covers grep's exit 1 on no matches — empty is valid, the preflight skips.
+PENDING_ASK_QUESTIONS=$(grep -n -m 20 '^- \[ \]' "$PENDING_FILE" 2>/dev/null || true)
 else
   export PENDING_ASK_QUESTIONS=""
 fi

--- a/scripts/ceo-gather.sh
+++ b/scripts/ceo-gather.sh
@@ -74,6 +74,39 @@ _pr_gather_mark_degraded() {
 $1"
 }
 
+# Same idea for local vault reads. Tolerating a truncation's exit status (#293)
+# must not also tolerate an IO error: an unreadable Pending.md yields the same
+# empty string as a Pending.md with nothing in it, and the status evaluation below
+# would call that "quiet day". This flag keeps the two distinguishable.
+export FILE_GATHER_DEGRADED=0
+export FILE_GATHER_DEGRADED_REASONS=""
+_file_gather_mark_degraded() {
+  FILE_GATHER_DEGRADED=1
+  FILE_GATHER_DEGRADED_REASONS="$FILE_GATHER_DEGRADED_REASONS
+$1"
+}
+
+# _gather_capture_lines <dest-var> <max-lines> <file> <pattern> — matching lines,
+# capped, without the SIGPIPE that `grep … | head -N` earns under pipefail. Caps
+# inside grep so nothing can signal, then splits grep's exit status three ways:
+# 0 matched, 1 legitimately empty (a valid state — the pending-drip preflight
+# skips on it), anything else an IO/tooling error that must not masquerade as
+# empty. Only the third case marks the gather degraded.
+_gather_capture_lines() {
+  local _dest="$1" _max="$2" _file="$3" _pattern="$4"
+  local _out _rc=0 _err _detail=""
+  _err=$(mktemp) || _err=""
+  _out=$(grep -n -m "$_max" "$_pattern" "$_file" 2>"${_err:-/dev/null}") || _rc=$?
+  if [ "$_rc" -gt 1 ]; then
+    [ -n "$_err" ] && _detail=$(head -c 200 "$_err" 2>/dev/null)
+    echo "WARN: grep on $_file failed (rc=$_rc): $_detail" >&2
+    _file_gather_mark_degraded "file-read-failed:$_file:rc=$_rc"
+    _out=""
+  fi
+  [ -n "$_err" ] && rm -f "$_err"
+  printf -v "$_dest" '%s' "$_out"
+}
+
 # Durable channel for jq-failure reasons. The post-processing helpers below run
 # inside `$(...)` command substitution, so a `_pr_gather_mark_degraded` call from
 # there would set PR_GATHER_DEGRADED in a discarded subshell. Failures are
@@ -241,7 +274,18 @@ YESTERDAY_LOG="$LOG_DIR/$YESTERDAY.md"
 if [ -f "$YESTERDAY_LOG" ]; then
   export YESTERDAY_LOG_EXISTS=true
 export YESTERDAY_LOG_SUMMARY
-YESTERDAY_LOG_SUMMARY=$(sed -n '/eod-summary/,/^## /p' "$YESTERDAY_LOG" 2>/dev/null | head -20 || echo "no eod summary")
+# Capture then truncate. The old `sed … | head -20 || echo "no eod summary"` did not
+# abort, which is worse: on SIGPIPE head had already emitted 20 good lines and the
+# fallback got *appended* to them, so the prompt carried 20 real lines contradicted
+# by a "no eod summary" trailer. Reachable when the eod section runs to EOF and the
+# day log exceeds the pipe buffer. (#293)
+_yday_summary_raw=$(sed -n '/eod-summary/,/^## /p' "$YESTERDAY_LOG" 2>/dev/null) || _yday_summary_raw=""
+if [ -n "$_yday_summary_raw" ]; then
+  YESTERDAY_LOG_SUMMARY=$(head -20 <<< "$_yday_summary_raw")
+else
+  YESTERDAY_LOG_SUMMARY="no eod summary"
+fi
+unset _yday_summary_raw
 else
   export YESTERDAY_LOG_EXISTS=false
   export YESTERDAY_LOG_SUMMARY="no log"
@@ -336,7 +380,15 @@ export ACTIVE_DOMAINS_CONTENT
 # Capture, then truncate — piping sed into `head -c` SIGPIPEs sed once the section
 # exceeds the cap, which pipefail turns into an aborted run (#293). Here-string
 # rather than ${var:0:n} to keep head's byte semantics; the cap is a byte budget.
-_active_domains_raw=$(sed -n '/^##* *Active Domains/,/^## /p' "$PROFILE_FILE" 2>/dev/null || true)
+# sed returns 0 when the range simply doesn't match, so a non-zero status here is a
+# real read error and is recorded rather than silently read as "no section".
+_active_domains_rc=0
+_active_domains_raw=$(sed -n '/^##* *Active Domains/,/^## /p' "$PROFILE_FILE" 2>/dev/null) || _active_domains_rc=$?
+if [ "$_active_domains_rc" -ne 0 ]; then
+  echo "WARN: sed on $PROFILE_FILE failed (rc=$_active_domains_rc)" >&2
+  _file_gather_mark_degraded "file-read-failed:$PROFILE_FILE:rc=$_active_domains_rc"
+  _active_domains_raw=""
+fi
 ACTIVE_DOMAINS_CONTENT=$(head -c "$GATHER_MAX_FILE" <<< "$_active_domains_raw")
 unset _active_domains_raw
 else
@@ -350,10 +402,10 @@ fi
 PENDING_FILE="$VAULT/Pending.md"
 if [ -f "$PENDING_FILE" ]; then
 export PENDING_ASK_QUESTIONS
-# `grep -m 20`, not `grep … | head -20`: head closing the pipe SIGPIPEs grep, and
-# pipefail made that 141 abort every playbook once this file passed 20 items (#293).
-# `|| true` covers grep's exit 1 on no matches — empty is valid, the preflight skips.
-PENDING_ASK_QUESTIONS=$(grep -n -m 20 '^- \[ \]' "$PENDING_FILE" 2>/dev/null || true)
+# See _gather_capture_lines: caps inside grep so the truncation can't SIGPIPE (#293),
+# and separates "no unchecked items" from "could not read the file" — a bare `|| true`
+# would report an unreadable Pending.md as a quiet day.
+_gather_capture_lines PENDING_ASK_QUESTIONS 20 "$PENDING_FILE" '^- \[ \]'
 else
   export PENDING_ASK_QUESTIONS=""
 fi
@@ -388,7 +440,11 @@ export LEDGER_PREV_PREDICTED
 LEDGER_PREV_PREDICTED="[]"
 _ledger_dir="$CEO_DIR/model"
 if [ -d "$_ledger_dir" ]; then
-  _latest=$(ls -1 "$_ledger_dir"/*.md 2>/dev/null | sort | tail -1)
+  # `|| true`: with the dir present but holding no .md, bash leaves the glob literal
+  # and ls exits non-zero, which pipefail + errexit turned into an aborted gather —
+  # same blast radius as #293, reachable on a fresh host or after a ledger prune.
+  # 2>/dev/null hides the message, not the status.
+  _latest=$(ls -1 "$_ledger_dir"/*.md 2>/dev/null | sort | tail -1) || true
   if [ -n "$_latest" ]; then
     LEDGER_RECENT=$(tail -40 "$_latest" 2>/dev/null) || LEDGER_RECENT=""
     # Parse the LAST "predicted today:" block's indented bullets into "repo#num" strings.
@@ -422,15 +478,15 @@ _has_data=0
 [ -n "${PENDING_ASK_QUESTIONS:-}" ] && _has_data=1
 
 if [ "$_has_data" -eq 0 ]; then
-  if [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ]; then
+  if [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ] || [ "${FILE_GATHER_DEGRADED:-0}" -eq 1 ]; then
     CEO_GATHER_STATUS="failed"
-    CEO_GATHER_REASONS="All primary data sources empty, and PR gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
+    CEO_GATHER_REASONS="All primary data sources empty, and gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS $FILE_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
   else
     CEO_GATHER_STATUS="empty"
     CEO_GATHER_REASONS="All APIs succeeded, but zero active items found (quiet day)"
   fi
-elif [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ]; then
+elif [ "${PR_GATHER_DEGRADED:-0}" -eq 1 ] || [ "${FILE_GATHER_DEGRADED:-0}" -eq 1 ]; then
   CEO_GATHER_STATUS="partial"
   # Replace newlines with spaces for single-line logging
-  CEO_GATHER_REASONS="PR gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
+  CEO_GATHER_REASONS="gather degraded: $(echo "$PR_GATHER_DEGRADED_REASONS $FILE_GATHER_DEGRADED_REASONS" | tr '\n' ' ')"
 fi


### PR DESCRIPTION
Closes #293

## Description (Issue Fixed & New Behavior)

Every scheduled playbook on MBP-2026 was failing instantly once `Pending.md` passed 20 unchecked items. The daemon burned all three retries and gave up, so nothing had run in two days:

```
[2026-08-10T12:48:00.050Z] ceo-schedulerd: failed token-intake (gave up after 3 attempts)
[2026-08-10T13:33:00.029Z] ceo-schedulerd: failed llm-tools-align (gave up after 3 attempts)
[2026-08-10T10:03:00.054Z] ceo-schedulerd: failed value-tracker (gave up after 3 attempts)
```

`ceo-gather.sh` capped the pending list with `grep -n '^- \[ \]' … | head -20`. `head` closes the pipe, `grep` dies on SIGPIPE, `pipefail` surfaces 141, and `ceo-cron.sh`'s `errexit` aborts before any playbook work happens. The gather is shared preamble, so it killed every playbook regardless of trigger. It stayed latent below 20 items because `grep` finishes before `head` closes.

**The invariant:** a gather step that truncates input to bound cost, or tolerates a legitimately-empty result, must never abort the run.

### Three aborts fixed (all in `ceo-gather.sh`, all verified reproducible)

1. **`:356` — the shipped break.** `grep -m 20` caps inside grep, so the truncation has nothing to signal with.
2. **`:391` — a second abort, no SIGPIPE involved.** `ls -1 "$dir"/*.md | sort | tail -1` with `CEO/model/` present but holding no `.md`: bash leaves the glob literal, `ls` exits non-zero, `pipefail` + `errexit` kill the gather. Same blast radius as the first. Reachable on a fresh host or after a ledger prune; `2>/dev/null` hid the message, not the status.
3. **`:277` — a latent abort *and* a data-corruption bug.** `sed … | head -20 || echo "no eod summary"` did not abort, which is worse: on SIGPIPE `head` had already emitted 20 good lines and the fallback was *appended* to them, so the prompt carried 20 real lines contradicted by a "no eod summary" trailer.

### The `|| true` correction (found in review)

The first commit's `|| true` was **both necessary and too broad**:

- **Necessary** — `grep` exits 1 when `Pending.md` has no unchecked items, and `pipefail` made that as fatal as the SIGPIPE. The old `grep | head` form had this too, so an empty or all-`[x]` `Pending.md` also killed every playbook. Nothing pinned it.
- **Too broad** — `grep` exits 2 on an unreadable file. Swallowing that made the gather report an IO error as `STATUS=empty`, reason *"All APIs succeeded, but zero active items found (quiet day)"*. Actively false: the file could not be read.

`_gather_capture_lines` now splits the status three ways — 0 matched, 1 legitimately empty, ≥2 a read error that warns and sets a new `FILE_GATHER_DEGRADED`. The status evaluation honours the flag, so an unreadable file lands in `failed`/`partial` rather than a false quiet day. Gating it inside a helper stops callers opting out.

### Correction: the two `ceo-cron.sh` sites are hardening, not a fix

The first commit claimed these fixed an aborted scan. **That was wrong, and the comments now say so.** `set -e` is suppressed for a command substitution used as the left operand of `||`, and the only caller is `OLLAMA_OUT=$(_ollama_chunked_scan …) || OLLAMA_EXIT=$?`:

```
# bare assignment in a function, set -euo pipefail
piece=$(printf '%s' "$big" | tail -c +1 | head -c 900)   → exits 141

# same function called as  OUT=$(f) || rc=$?
                                                         → rc=0, piece intact (900 bytes)
```

Verified end to end: a 236KB `SCAN_BLOCK` chunks cleanly with the old piped form in place. So the 141 was discarded and `piece` received its full budget anyway. The rewrites are still worth keeping — the identical construct in a bare assignment is what killed every playbook — but they fix nothing today, and would only matter if that caller lost its `||`.

**No test accompanies them, deliberately.** There is no failure to reproduce: a test asserting exit 0 there passes with the fix reverted. I wrote one, caught that it was vacuous, and deleted it rather than bank false coverage. Severity in this class depends on the *caller*, not the pipeline shape — noted on #295, where `hooks/ceo-tier-router.sh:27` is a bare assignment and therefore a genuine abort.

### Coverage gap this exposed

`ceo-gather.test.sh:67` sources under `set +eu` with no `pipefail`, so a `grep | head` pipeline there always reports head's 0. It **structurally cannot observe this bug class** — which is how 48 green suites sat beside a break that killed every cron.

Two traps hit while writing the new suite, both now guarded in-file:

- **`( set -euo pipefail … ) || rc=$?` cannot see the bug.** A subshell on the left of `||` has errexit suppressed, so that shape reports `RC=0` for a run production aborts. Both helpers now run in a separate `bash` process, matching how `ceo-cron.sh` actually runs.
- **The oversized fixture must exceed the ~64KB pipe buffer**, and the threshold depends on the platform's buffer plus head's read-ahead. My first draft used 500 short lines, fit inside the buffer, and **passed against broken code**. There is now a canary asserting the pre-fix form still dies on the exact fixture, with exit 141 specifically, so shrinking it fails loudly instead of silently.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-gather-truncation.test.sh` → `All tests passed. (7 tests)`.
3. Revert-check the pending site: change `_gather_capture_lines PENDING_ASK_QUESTIONS 20 …` back to `grep -n '^- \[ \]' "$PENDING_FILE" 2>/dev/null | head -20`, re-run → **9 failures**, `RC=141`. Restore.
4. Revert-check the degrade discrimination: use `grep -n -m 20 … || true` instead of the helper, re-run → **exactly 2 failures**, both on `test_unreadable_pending_marks_degraded`, showing `STATUS=empty` on an unreadable file. Restore.
5. Revert-check the ledger glob: drop `|| true` from `:391`, re-run → `RC=1` on `test_empty_ledger_dir_does_not_abort`. Restore.
6. End to end against the real vault: `./scripts/ceo-cron.sh token-intake --scheduled --dry-run; echo $?` → `0`. On `main`: `141`.
7. `shellcheck -S warning scripts/ceo-gather.sh scripts/ceo-cron.sh scripts/ceo-gather-truncation.test.sh` → clean.
8. Full suite as CI runs it: `shopt -s nullglob; tests=(scripts/*.test.sh); printf '%s\n' "${tests[@]}" | xargs -P 4 -I {} bash -c 'bash "$1"' _ {}`.

Local result: 48 suites, one failure — `ceo-git-monitor.test.sh`, which fails identically on unmodified `main`. It is my own global `git-identity-gate` hook rejecting that test's `Test User <test@example.com>` fixture commit; CI's runner has no such hook.

## Additional Notes / HelpScout Tickets

- **#295** — two remaining sites of this class in files outside this PR (`hooks/ceo-tier-router.sh:27`, `scripts/ceo-cron-lib.sh:104,107`), plus the caller-vs-pipeline correction above.
- No `timeout`/`gtimeout` on this host, so `ceo-cron.sh`'s wall-clock cap is silently disabled. Needs `brew install coreutils`. Recorded on #293.
- `Pending.md` is at 952 open items. Entry `q-0ab0ae` is a verified false-premise finding stating eight of the queued `Personal/` deferrals were never actually blocked.

The part worth acting on beyond this PR: `ceo-schedulerd` records each run's exit code (`lib/scheduler/src/main.ts:236`) but nothing reads it — no retry classifier, no escalation. That is why this ran dead for two days while the daemon logged the failure every hour. An alarm on N consecutive non-zero ticks would have caught it on day one, and is worth more than any individual site fix here. Filed as part of #295.
