### PR TITLE
Stop truncating consumers failing their producers repo-wide

### DIFF
--- a/hooks/ceo-tier-router.sh
+++ b/hooks/ceo-tier-router.sh
@@ -24,7 +24,13 @@ if [ "$tool_name" != "Task" ] && [ "$tool_name" != "Agent" ]; then
 fi
 
 subagent_type="$(printf '%s' "$input" | jq -r '.tool_input.subagent_type // ""')"
-label="$(printf '%s' "$input" | jq -r '.tool_input.description // .tool_input.prompt // ""' | head -c 200)"
+# Capture, then truncate from a here-string. `jq … | head -c 200` SIGPIPEs jq once
+# the prompt exceeds the pipe buffer, and under `set -euo pipefail` this bare
+# assignment aborts the hook — skipping tier routing for exactly the largest
+# dispatches. `head -c` stays byte-counting for parity with the tier-map labels.
+_label_raw="$(printf '%s' "$input" | jq -r '.tool_input.description // .tool_input.prompt // ""')"
+label="$(head -c 200 <<< "$_label_raw")"
+unset _label_raw
 
 [ -n "$label" ] || exit 0
 

--- a/scripts/blessings-lib.sh
+++ b/scripts/blessings-lib.sh
@@ -32,13 +32,18 @@ ensure_blessings_cache() {
     return 0
   fi
 
-  local picks
-  picks=$(strip_frontmatter "$src" \
+  # Shuffle fully, then take 3 from a here-string. `… | cut -f2- | head -3` SIGPIPEs
+  # cut once the shuffled pool passes the pipe buffer (~400 entries), and pipefail
+  # promotes 141 to this bare assignment — which aborts count-blessings.sh's
+  # cmd_repick *after* it has already rm -f'd the cache, losing it with no output.
+  # ceo-gather.sh's caller happens to survive only because it uses `|| true`.
+  local picks pool
+  pool=$(strip_frontmatter "$src" \
     | { grep '^- ' || true; } \
     | awk 'BEGIN{srand()} {print rand()"\t"$0}' \
     | sort -k1,1n \
-    | cut -f2- \
-    | head -3)
+    | cut -f2-)
+  picks=$(head -3 <<< "$pool")
 
   tmp=$(mktemp "$cache.tmp.XXXXXX")
   {

--- a/scripts/ceo-cron-fallback-classify.test.sh
+++ b/scripts/ceo-cron-fallback-classify.test.sh
@@ -90,4 +90,58 @@ test_badflag_empty_stdout_is_terminal() {
   assert_eq "$(_classify_claude_failure 1 "")" "terminal" "empty stdout + non-zero → terminal"
 }
 
+# --- Oversized bodies: the banner match must survive a body past the pipe buffer ---
+
+# A body large enough that the producer is still writing when `grep -q` exits on
+# its first match — the only condition under which SIGPIPE fires. The banner sits
+# on line 1 so grep short-circuits immediately. ~200KB against a 64KB pipe buffer.
+_oversized_body() {
+  local banner="$1" pad i=0
+  printf '%s\n' "$banner"
+  pad=$(printf 'x%.0s' {1..200})
+  while [ "$i" -lt 1000 ]; do printf '%s\n' "$pad"; i=$((i + 1)); done
+}
+
+# The fixture is load-bearing: below the pipe buffer the pre-fix form works fine
+# and the test would pass against broken code. Assert the old
+# `printf … | grep -q` really does report failure on this exact body.
+_assert_pipe_form_breaks() {
+  local raw="$1" pattern="$2" rc=0
+  ( set -o pipefail; printf '%s' "$raw" | grep -qEi "$pattern" ) || rc=$?
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] fixture no longer breaks the pre-fix `printf | grep -q` form (rc=0), so it proves nothing — it must exceed the pipe buffer\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+}
+
+test_oversized_ratelimit_body_is_still_transient() {
+  local raw
+  raw=$(_oversized_body 'Claude API session limit reached. Please try again later.')
+  _assert_pipe_form_breaks "$raw" 'session limit'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "transient" \
+    "rate-limit banner in a 200KB body → transient (fallback stays armed)"
+}
+
+test_oversized_auth_body_is_still_auth() {
+  local raw
+  raw=$(_oversized_body 'Error: authentication_failed. Please run /login.')
+  _assert_pipe_form_breaks "$raw" 'authentication_failed'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" \
+    "auth banner in a 200KB body → auth, not terminal"
+}
+
+test_oversized_plaintext_body_emits_no_stderr_noise() {
+  # The envelope probes ran `printf … | jq`, and jq bails immediately on non-JSON,
+  # so every large plain-text failure wrote four "printf: write error: Broken pipe"
+  # lines into the cron log. Classification was correct; the log was not.
+  local raw errfile out
+  raw=$(_oversized_body 'some unexpected error we have no pattern for')
+  errfile=$(mktemp)
+  out=$(_classify_claude_failure 1 "$raw" 2>"$errfile")
+  assert_eq "$out" "terminal" "unknown oversized body → terminal (fail-safe)"
+  assert_eq "$(cat "$errfile")" "" "no broken-pipe noise leaks to stderr"
+  rm -f "$errfile"
+}
+
 run_tests

--- a/scripts/ceo-cron-fallback-classify.test.sh
+++ b/scripts/ceo-cron-fallback-classify.test.sh
@@ -104,37 +104,62 @@ _oversized_body() {
 
 # The fixture is load-bearing: below the pipe buffer the pre-fix form works fine
 # and the test would pass against broken code. Assert the old
-# `printf … | grep -q` really does report failure on this exact body.
-_assert_pipe_form_breaks() {
+# `printf … | grep -q` really does report failure on this exact body — AND that it
+# succeeds on a small body carrying the same banner. Both halves are needed: a bare
+# "non-zero" check is also satisfied by grep's rc=1 no-match, which would let a
+# banner that stopped matching masquerade as a working canary. The pair proves the
+# failure is size-dependent, i.e. SIGPIPE.
+#
+# Deliberately NOT asserting rc==141: the signature is platform-dependent. BSD grep
+# and GNU grep on WSL give 141; GNU grep on GitHub's ubuntu runner gives 2 ("write
+# error: Broken pipe"). Pinning 141 cost a CI cycle in #294.
+_pipe_form_rc() {
   local raw="$1" pattern="$2" rc=0
   ( set -o pipefail; printf '%s' "$raw" | grep -qEi "$pattern" ) || rc=$?
+  echo "$rc"
+}
+
+_assert_pipe_form_breaks() {
+  local raw="$1" pattern="$2" banner="$3" big_rc small_rc
+  big_rc=$(_pipe_form_rc "$raw" "$pattern")
+  small_rc=$(_pipe_form_rc "$banner" "$pattern")
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
-  if [ "$rc" -eq 0 ]; then
+  if [ "$big_rc" -eq 0 ]; then
     printf '  FAIL [%s] fixture no longer breaks the pre-fix `printf | grep -q` form (rc=0), so it proves nothing — it must exceed the pipe buffer\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  elif [ "$small_rc" -ne 0 ]; then
+    printf '  FAIL [%s] canary is passing for the wrong reason: the pre-fix form also fails on a SMALL body (rc=%s), so the pattern simply is not matching — not SIGPIPE\n' "$CURRENT_TEST" "$small_rc"
     _record_assertion_fail
   fi
 }
 
 test_oversized_ratelimit_body_is_still_transient() {
-  local raw
-  raw=$(_oversized_body 'Claude API session limit reached. Please try again later.')
-  _assert_pipe_form_breaks "$raw" 'session limit'
+  local banner='Claude API session limit reached. Please try again later.' raw
+  raw=$(_oversized_body "$banner")
+  _assert_pipe_form_breaks "$raw" 'session limit' "$banner"
   assert_eq "$(_classify_claude_failure 1 "$raw")" "transient" \
     "rate-limit banner in a 200KB body → transient (fallback stays armed)"
 }
 
 test_oversized_auth_body_is_still_auth() {
-  local raw
-  raw=$(_oversized_body 'Error: authentication_failed. Please run /login.')
-  _assert_pipe_form_breaks "$raw" 'authentication_failed'
+  local banner='Error: authentication_failed. Please run /login.' raw
+  raw=$(_oversized_body "$banner")
+  _assert_pipe_form_breaks "$raw" 'authentication_failed' "$banner"
   assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" \
     "auth banner in a 200KB body → auth, not terminal"
 }
 
 test_oversized_plaintext_body_emits_no_stderr_noise() {
-  # The envelope probes ran `printf … | jq`, and jq bails immediately on non-JSON,
-  # so every large plain-text failure wrote four "printf: write error: Broken pipe"
-  # lines into the cron log. Classification was correct; the log was not.
+  # The envelope probes ran `printf … | jq`; when jq bails on non-JSON before
+  # draining stdin, the shell writes four "printf: write error: Broken pipe" lines
+  # into the cron log. Classification was correct; the log was not.
+  #
+  # HONEST LIMIT: this test does NOT reliably fail when that fix is reverted. Whether
+  # jq exits before printf finishes writing is a scheduling race — observed firing
+  # repeatedly in one run of this suite and 0/6 times in a direct probe at the same
+  # 200KB. So there is no canary here, unlike the two tests above. What it does pin
+  # deterministically is the classification, and after the fix there is no pipe left
+  # at all, so clean stderr is structural rather than lucky.
   local raw errfile out
   raw=$(_oversized_body 'some unexpected error we have no pattern for')
   errfile=$(mktemp)

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -71,10 +71,14 @@ _classify_claude_failure() {
     # NB: do NOT use `.is_error // empty` — jq's `//` treats the boolean `false`
     # like null, collapsing a genuine `is_error:false` to empty. Read it raw
     # ("false"/"true"/"null"/"" for non-object).
-    is_error=$(printf '%s' "$raw" | jq -r 'if type=="object" then (.is_error) else empty end' 2>/dev/null || true)
-    status=$(printf '%s'  "$raw" | jq -r 'if type=="object" then (.api_error_status // empty) else empty end' 2>/dev/null || true)
-    subtype=$(printf '%s' "$raw" | jq -r 'if type=="object" then (.subtype // empty) else empty end' 2>/dev/null || true)
-    stop=$(printf '%s'    "$raw" | jq -r 'if type=="object" then (.stop_reason // empty) else empty end' 2>/dev/null || true)
+    # Here-strings, not `printf … | jq`: on plain-text (non-JSON) output jq bails
+    # at the first bytes and closes stdin, so a large body SIGPIPEs printf and the
+    # shell writes "printf: write error: Broken pipe" into the cron log on every
+    # plain-text failure. `|| true` still stands — jq exits non-zero on a parse error.
+    is_error=$(jq -r 'if type=="object" then (.is_error) else empty end' <<< "$raw" 2>/dev/null || true)
+    status=$(jq -r 'if type=="object" then (.api_error_status // empty) else empty end' <<< "$raw" 2>/dev/null || true)
+    subtype=$(jq -r 'if type=="object" then (.subtype // empty) else empty end' <<< "$raw" 2>/dev/null || true)
+    stop=$(jq -r 'if type=="object" then (.stop_reason // empty) else empty end' <<< "$raw" 2>/dev/null || true)
   fi
 
   # Parseable success envelope: ok, unless the result was truncated (a partial
@@ -100,11 +104,14 @@ _classify_claude_failure() {
   # No parseable envelope. Exit 0 = success (plain-text plan/exec phases).
   if [ "$rc" -eq 0 ] 2>/dev/null; then echo "ok"; return 0; fi
 
-  # Non-zero exit, non-JSON stdout → last-resort banner match.
-  if printf '%s' "$raw" | grep -qEi 'session limit|hit your limit|rate.?limit|overloaded'; then
+  # Non-zero exit, non-JSON stdout → last-resort banner match. Here-strings, not
+  # `printf … | grep -q`: grep exits on the first match and closes the pipe, so a
+  # body past the pipe buffer SIGPIPEs printf and pipefail reports 141 — a match
+  # read as a no-match, silently disabling the ollama fallback on large responses.
+  if grep -qEi 'session limit|hit your limit|rate.?limit|overloaded' <<< "$raw"; then
     echo "transient"; return 0
   fi
-  if printf '%s' "$raw" | grep -qEi 'authentication_failed|not authenticated|logged out|invalid api key|please run .?/login'; then
+  if grep -qEi 'authentication_failed|not authenticated|logged out|invalid api key|please run .?/login' <<< "$raw"; then
     echo "auth"; return 0
   fi
   echo "terminal"; return 0   # fail-safe: unknown never falls open to fallback

--- a/scripts/ceo-cron-scriptmode-2.test.sh
+++ b/scripts/ceo-cron-scriptmode-2.test.sh
@@ -1116,6 +1116,58 @@ test_pending_drip_failed_entry_uses_report_not_inbox() {
 }
 
 
+test_pending_drip_oversized_no_questions_leaves_inbox_alone() {
+  # ceo-cron.sh:571's `grep -Eiq 'no relevant .*questions?'` gate, at a size that
+  # broke it: the marker is near the top, so grep short-circuits while the producer
+  # is still writing, pipefail reports 141, the `if` reads no-match, and a drip that
+  # explicitly found nothing gets appended anyway. Inbox noise, not data loss.
+  _write_pending_drip_registry
+  local pad line filler=""
+  pad=$(printf 'x%.0s' {1..200})
+  for ((line = 0; line < 1000; line++)); do filler+="$pad"$'\n'; done
+  _stub_claude_log_entry "completed" "No relevant questions for this trigger.
+$filler"
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$CRON" pending-drip >/dev/null 2>&1 || true
+
+  local inbox="$CEO_DIR/inbox/testhost.md"
+  if [ -s "$inbox" ]; then
+    printf '  FAIL [%s] a "no relevant questions" drip must leave the inbox untouched\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+
+test_pending_drip_oversized_failed_entry_uses_report_not_inbox() {
+  # Same invariant as the test above, at a size that breaks the mechanism it used.
+  # `**Status:** failed` sits on line 3, so the pre-fix `printf '%s\n' "$log_entry"
+  # | grep -q` had grep short-circuit almost immediately while the producer was
+  # still writing the body — pipefail then reported 141, the `if` read it as
+  # no-match, and a run that self-reported FAILURE was promoted to success and
+  # appended to Nathan's inbox. The small-body test above passes against that
+  # revert, so it is not coverage for this.
+  _write_pending_drip_registry
+  local pad line filler=""
+  pad=$(printf 'x%.0s' {1..200})
+  for ((line = 0; line < 1000; line++)); do filler+="$pad"$'\n'; done
+  _stub_claude_log_entry "failed" "Something failed
+$filler"
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$CRON" pending-drip >/dev/null 2>&1 || true
+
+  local inbox report
+  inbox="$CEO_DIR/inbox/testhost.md"
+  report="$CEO_DIR/reports/$(date +%Y-%m-%d).md"
+  if [ -s "$inbox" ]; then
+    printf '  FAIL [%s] oversized failed pending-drip must not create inbox task\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  assert_file_exists "$report" "oversized failed pending-drip must use normal report path"
+}
+
+
 test_pending_drip_skips_when_pending_md_empty() {
   _write_pending_drip_registry
   # Setup line 32 + helper line 1885 leave $CEO_DIR/approvals/pending.md

--- a/scripts/ceo-cron-scriptmode-2.test.sh
+++ b/scripts/ceo-cron-scriptmode-2.test.sh
@@ -1122,9 +1122,13 @@ test_pending_drip_oversized_no_questions_leaves_inbox_alone() {
   # is still writing, pipefail reports 141, the `if` reads no-match, and a drip that
   # explicitly found nothing gets appended anyway. Inbox noise, not data loss.
   _write_pending_drip_registry
+  # ~100KB: above the 64KB pipe buffer (so the pre-fix grep really SIGPIPEs) but
+  # below Linux's 128KB per-argument execve limit, which _report passes log_entry
+  # through as argv. At 200KB this test also tripped that unrelated ceiling and
+  # failed on CI while passing on macOS — see the argv issue filed separately.
   local pad line filler=""
   pad=$(printf 'x%.0s' {1..200})
-  for ((line = 0; line < 1000; line++)); do filler+="$pad"$'\n'; done
+  for ((line = 0; line < 500; line++)); do filler+="$pad"$'\n'; done
   _stub_claude_log_entry "completed" "No relevant questions for this trigger.
 $filler"
 
@@ -1148,9 +1152,13 @@ test_pending_drip_oversized_failed_entry_uses_report_not_inbox() {
   # appended to Nathan's inbox. The small-body test above passes against that
   # revert, so it is not coverage for this.
   _write_pending_drip_registry
+  # ~100KB: above the 64KB pipe buffer (so the pre-fix grep really SIGPIPEs) but
+  # below Linux's 128KB per-argument execve limit, which _report passes log_entry
+  # through as argv. At 200KB this test also tripped that unrelated ceiling and
+  # failed on CI while passing on macOS — see the argv issue filed separately.
   local pad line filler=""
   pad=$(printf 'x%.0s' {1..200})
-  for ((line = 0; line < 1000; line++)); do filler+="$pad"$'\n'; done
+  for ((line = 0; line < 500; line++)); do filler+="$pad"$'\n'; done
   _stub_claude_log_entry "failed" "Something failed
 $filler"
 

--- a/scripts/ceo-cron-tier-routing.test.sh
+++ b/scripts/ceo-cron-tier-routing.test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/test-harness.sh"
 source "$SCRIPT_DIR/ceo-tier-lib.sh"
 source "$SCRIPT_DIR/ceo-model-ledger.sh"
@@ -67,6 +68,50 @@ test_disable_flag_skips_tier_map() {
   local model
   CEO_TIER_ROUTER_DISABLE="1" model=$(_resolve_model_for_playbook "find-stale-branches")
   assert_eq "$model" "sonnet" "CEO_TIER_ROUTER_DISABLE skips the tier-map lookup entirely"
+}
+
+# --- The hook itself, run as a process, against a prompt past the pipe buffer ---
+# The simulation above covers ceo-cron.sh's resolution block; these exercise
+# hooks/ceo-tier-router.sh, which runs under `set -euo pipefail` where a
+# SIGPIPEd jq aborts the hook and skips routing for the largest dispatches.
+
+_oversized_task_payload() {
+  local big
+  # ~120KB, opening with "find" so the tier map matches on the first 200 bytes.
+  big=$(printf 'find %.0s' {1..20000})
+  jq -nc --arg p "$big" \
+    '{tool_name:"Task", tool_input:{prompt:$p, subagent_type:"general-purpose"}}'
+}
+
+# Same load-bearing-fixture guard as the classifier suite: prove the pre-fix
+# `jq … | head -c 200` form actually fails on this payload.
+_assert_head_pipe_form_breaks() {
+  local payload="$1" rc=0
+  ( set -o pipefail
+    printf '%s' "$payload" | jq -r '.tool_input.prompt' | head -c 200 >/dev/null
+  ) || rc=$?
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] fixture no longer breaks the pre-fix `jq | head -c` form (rc=0), so it proves nothing — the prompt must exceed the pipe buffer\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+}
+
+test_hook_routes_an_oversized_prompt() {
+  local payload out rc=0
+  payload=$(_oversized_task_payload)
+  _assert_head_pipe_form_breaks "$payload"
+  out=$(printf '%s' "$payload" | "$REPO_ROOT/hooks/ceo-tier-router.sh" 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "hook exits 0 on a prompt past the pipe buffer"
+  assert_contains "$out" '"model":"haiku"' "oversized dispatch is still downgraded to the mapped tier"
+}
+
+test_hook_routes_a_small_prompt() {
+  local payload out rc=0
+  payload=$(jq -nc '{tool_name:"Task", tool_input:{prompt:"find stale branches", subagent_type:"general-purpose"}}')
+  out=$(printf '%s' "$payload" | "$REPO_ROOT/hooks/ceo-tier-router.sh" 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "hook exits 0 on a small prompt"
+  assert_contains "$out" '"model":"haiku"' "small dispatch is downgraded to the mapped tier"
 }
 
 run_tests

--- a/scripts/ceo-cron-tier-routing.test.sh
+++ b/scripts/ceo-cron-tier-routing.test.sh
@@ -77,7 +77,8 @@ test_disable_flag_skips_tier_map() {
 
 _oversized_task_payload() {
   local big
-  # ~120KB, opening with "find" so the tier map matches on the first 200 bytes.
+  # 100,000 bytes (~1.5x the measured 64KB pipe buffer), opening with "find" so the
+  # tier map matches within the first 200 bytes.
   big=$(printf 'find %.0s' {1..20000})
   jq -nc --arg p "$big" \
     '{tool_name:"Task", tool_input:{prompt:$p, subagent_type:"general-purpose"}}'

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -492,7 +492,9 @@ _dispatch_single_output() {
   _v ""
 
   local self_reported_failed=0
-  if printf '%s\n' "$log_entry" | grep -q '^\*\*Status:\*\* failed'; then
+  # Here-string: `grep -q` closes the pipe on the first match, so a log entry past
+  # the pipe buffer would report no-match and let a self-reported failure through.
+  if grep -q '^\*\*Status:\*\* failed' <<< "$log_entry"; then
     self_reported_failed=1
   fi
 
@@ -568,7 +570,7 @@ _append_pending_drip_to_inbox() {
     return 0
   fi
 
-  if printf '%s\n' "$log_entry" | grep -Eiq 'no relevant .*questions?'; then
+  if grep -Eiq 'no relevant .*questions?' <<< "$log_entry"; then
     _v "Pending drip found no relevant questions; inbox unchanged."
     return 0
   fi
@@ -1075,7 +1077,7 @@ preflight_has_ceo_branches() {
   [ -f "$repos_file" ] || return 1
   while IFS= read -r repo_path; do
     repo_path=$(echo "$repo_path" | xargs)
-    [ -d "$repo_path" ] && git -C "$repo_path" branch --list "${BRANCH_PREFIX}*" 2>/dev/null | grep -q . && return 0
+    [ -d "$repo_path" ] && [ -n "$(git -C "$repo_path" branch --list "${BRANCH_PREFIX}*" 2>/dev/null)" ] && return 0
   done < <(grep "^|" "$repos_file" | grep -v "^| Repo\|^|---" | awk -F'|' '{print $3}')
   return 1
 }

--- a/scripts/ceo-disk-monitor.sh
+++ b/scripts/ceo-disk-monitor.sh
@@ -166,9 +166,16 @@ if ! {
       for r in "${REASONS[@]}"; do printf -- '- %s\n' "$r"; done
       printf '\n## Largest dumps\n\n```\n'
       if [ -d "$WSL_CRASHES_PATH" ]; then
-        if ! ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null | head -10; then
+        # Capture then truncate. `ls | head -10` SIGPIPEs ls on a directory with
+        # enough entries, and pipefail made the `if !` read that as a failure —
+        # so the alert printed the 10 dumps AND "(unable to list)" underneath.
+        _dump_listing=$(ls -laSh "$WSL_CRASHES_PATH" 2>/dev/null) || _dump_listing=""
+        if [ -n "$_dump_listing" ]; then
+          head -10 <<< "$_dump_listing"
+        else
           echo "(unable to list)"
         fi
+        unset _dump_listing
       fi
       printf '```\n\n## Resolution\n\nDelete unwanted dumps:\n\n```bash\nrm %s/*.dmp\n```\n' "$WSL_CRASHES_PATH"
     fi

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -81,7 +81,7 @@ _denyfile="$VAULT/Profile/discretion-denylist.txt"
 
 _is_flagged() {
   [ -s "$_DENY_TMP" ] || return 1
-  printf '%s' "$1" | grep -qiFf "$_DENY_TMP"
+  grep -qiFf "$_DENY_TMP" <<< "$1"
 }
 
 # ---------- Pending.md queries + mutations ----------
@@ -131,7 +131,7 @@ _autostamp_qids() {
       # a later `ok` can never close two questions at once (confirm invariant).
       # Distinct text diverges as the sha1 prefix lengthens; byte-identical
       # questions exhaust the 40-char hash, then fall back to an -N suffix.
-      while printf '%s\n' "$used" | grep -qxF "$qid"; do
+      while grep -qxF "$qid" <<< "$used"; do
         n=$((n + 1))
         if [ "$n" -le 40 ]; then qid="q-$(printf '%s' "$base" | cut -c1-"$n")"
         else qid="q-$base-$n"; fi

--- a/scripts/ceo-nathan-inbox.sh
+++ b/scripts/ceo-nathan-inbox.sh
@@ -288,7 +288,10 @@ id from the list. If none apply, reply with exactly: NONE. No other text."
   read -ra pcmd <<< "$PROPOSE_CMD"
   out="$(printf '%s' "$prompt" | "${pcmd[@]}" 2>/dev/null)"; prc=$?
   if [ "$prc" -ne 0 ]; then _needs_review "LLM harness unavailable (exit $prc) — held: $bullet"; return; fi
-  line="$(printf '%s\n' "$out" | sed '/^[[:space:]]*$/d' | head -1)"
+  # First non-blank line, pipe-free: `sed … | head -1` leaves head closing the pipe
+  # on sed, which is the same SIGPIPE shape one level down. awk reads a here-string,
+  # so its `exit` can't break anything. NF==0 for a whitespace-only line.
+  line="$(awk 'NF{print; exit}' <<< "$out")"
   # shellcheck disable=SC2086  # intentional split: fields are qid + confidence
   set -f; set -- $line; set +f   # -f so a * / ? in model output can't glob the cwd
   case "${1:-}" in ""|NONE|none|None) _needs_review "unmatched: $bullet"; return ;; esac

--- a/scripts/count-blessings.test.sh
+++ b/scripts/count-blessings.test.sh
@@ -265,6 +265,67 @@ test_repick_prints_todays_picks() {
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+# A pool past the pipe buffer used to SIGPIPE `cut` in the `… | cut -f2- | head -3`
+# pipeline, and pipefail promoted 141 to a bare assignment in ensure_blessings_cache.
+# cmd_repick rm -f's the cache BEFORE calling it, so errexit aborted mid-way and the
+# cache was simply gone — repick printed nothing, and `show` then exited 0 printing
+# nothing, so the blessings block vanished from the morning report with no error
+# anywhere. Threshold is roughly 400 entries, i.e. reached by accumulation.
+#
+# ceo-gather.sh's caller survived only because it uses `|| true`, which is why a
+# per-caller triage cleared this site. The fix is in the library, not the caller.
+_write_many_blessings() {
+  local count="$1" today i
+  today=$(date +%Y-%m-%d)
+  {
+    printf -- '---\ntype: ea-blessings\nupdated: %s\n---\n\n' "$today"
+    for ((i = 0; i < count; i++)); do
+      printf -- '- blessing %04d %s\n' "$i" "$(printf 'y%.0s' {1..200})"
+    done
+  } > "$CEO_DIR/blessings.md"
+}
+
+# The fixture must exceed the pipe buffer or the pre-fix pipeline works fine and the
+# test passes against broken code. Prove it size-dependently: the pre-fix shape must
+# fail on this pool and succeed on a 3-entry one. Not asserting 141 — the signature
+# differs across platforms (2 on GitHub's ubuntu runner).
+_pool_pipe_rc() {
+  local n="$1" rc=0
+  ( set -o pipefail
+    local i
+    for ((i = 0; i < n; i++)); do printf -- '- b %04d %s\n' "$i" "$(printf 'y%.0s' {1..200})"; done \
+      | cut -f2- | head -3 >/dev/null
+  ) || rc=$?
+  echo "$rc"
+}
+
+test_repick_survives_oversized_blessings_file() {
+  local big_rc small_rc
+  big_rc=$(_pool_pipe_rc 700)
+  small_rc=$(_pool_pipe_rc 3)
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  if [ "$big_rc" -eq 0 ]; then
+    printf '  FAIL [%s] fixture no longer breaks the pre-fix `cut | head -3` form (rc=0), so it proves nothing\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  elif [ "$small_rc" -ne 0 ]; then
+    printf '  FAIL [%s] canary passing for the wrong reason: pre-fix form fails on a SMALL pool too (rc=%s)\n' "$CURRENT_TEST" "$small_rc"
+    _record_assertion_fail
+  fi
+
+  _write_many_blessings 700
+  local out rc=0
+  out=$(bash "$CLI" repick 2>/dev/null) || rc=$?
+  assert_eq "$rc" "0" "repick must not abort on a large blessings file"
+  assert_file_exists "$CEO_DIR/cache/blessings-today.md" \
+    "repick must leave the cache it deleted — losing it silently drops blessings from the report"
+  assert_contains "$out" "Repicked" "repick must still print its confirmation"
+
+  local picks
+  picks=$(grep -c '^- ' "$CEO_DIR/cache/blessings-today.md" 2>/dev/null || echo 0)
+  assert_eq "$picks" "3" "cache must hold exactly 3 picks"
+}
+
+
 test_repick_forces_regeneration() {
   bash "$CLI" add "a" >/dev/null
   bash "$CLI" add "b" >/dev/null


### PR DESCRIPTION
Closes #295

## Description (Issue Fixed & New Behavior)

Follow-up to #293/#294. That PR fixed the truncation-SIGPIPE class in `ceo-gather.sh`; a repo-wide sweep found the same shape in four more files. The invariant is unchanged: under `set -euo pipefail`, a consumer that closes the pipe early SIGPIPEs its producer and `pipefail` promotes 141 to the pipeline's status. What that *does* depends entirely on the caller — abort, misclassification, or log noise.

**Real abort.** `hooks/ceo-tier-router.sh:27` ran `jq … | head -c 200` as a bare assignment under `set -euo pipefail`. A Task prompt past the pipe buffer (a pasted diff, a file dump) exited the hook 141, so tier routing was skipped for exactly the dispatches where downgrading matters most. Now captures, then truncates from a here-string.

**False negatives.** An `if` condition is errexit-exempt, so these never aborted — a match simply read as a no-match:

- `ceo-cron-lib.sh:104,107` — a genuine session-limit response fell through to `terminal`, and `_route_claude_failure` never failed over to ollama. Fails safe in direction, but disables the fallback precisely when Claude returned a large body.
- `ceo-cron.sh:495` — a self-reported failed run passed the `**Status:** failed` gate and got appended to the inbox.
- `ceo-cron.sh:571` — a "no relevant questions" drip was appended anyway.
- `ceo-cron.sh:1078`, `ceo-nathan-inbox.sh:84,134` — small producers today, no observed failure; converted for uniformity. `:84` is the discretion deny-list check, where a false negative is a leak rather than a nuisance.

**Log noise, not in #295 — the new tests surfaced it.** `ceo-cron-lib.sh:74-77` ran the four envelope probes as `printf … | jq`. jq bails at the first bytes of non-JSON, so every large plain-text failure wrote four `printf: write error: Broken pipe` lines into the cron log. Classification was correct; the log wasn't.

Item 3 of #295 — `ceo-schedulerd` records each run's exit code and nothing reads it — is deliberately **not** here. It needs a retry/escalation policy, not a one-line fix, and it is the reason #293 ran dead for two days. #295 stays open for it.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-cron-fallback-classify.test.sh` → 16 tests pass, **and no `Broken pipe` lines on stderr** (before this change, the oversized cases printed four per call).
3. `bash scripts/ceo-cron-tier-routing.test.sh` → 6 tests pass, including two that pipe a real payload into `hooks/ceo-tier-router.sh` as a process.
4. Revert-check the hook: restore `label="$(printf '%s' "$input" | jq -r '…' | head -c 200)"` at `hooks/ceo-tier-router.sh:27` and re-run step 3. Expect `test_hook_routes_an_oversized_prompt` to fail with `got: 141, want: 0`.
5. Revert-check the classifier: restore `printf '%s' "$raw" | grep -qEi 'session limit|…'` at `ceo-cron-lib.sh:104` and re-run step 2. Expect `got: terminal, want: transient`.
6. `shellcheck -S warning` on all six changed files → clean.

Both new fixtures carry #294's canary, which asserts the pre-fix pipeline form still fails on that exact payload. Delete the canary's guard and shrink the fixture below the ~64KB pipe buffer and the tests pass against broken code — that is how the first attempt in #294 went wrong, so the guard is not decoration.

## Additional Notes / HelpScout Tickets

Verified on this host (macOS, bash 3.2 + BSD grep): the two directly-affected suites, every suite that consumes the changed functions (`ceo-cron-scriptmode-2`, `ceo-gather-truncation`, `ceo-nathan-inbox`, `ceo-cron-lib`, `ceo-cron-misc`, `ceo-cron-runmodes`), and shellcheck — all green. The exit-code *value* differs by platform (BSD grep and GNU grep on WSL give 141; GitHub's ubuntu runner gives 2, which cost a CI cycle in #294), so the canary asserts non-zero rather than a specific signature. The hook assertion checks `rc == 0`, which is platform-independent.

ML-1 was fast-forwarded to `9f1d743` in the same session; all three of its enabled playbooks now dry-run `exit=0`, each having exited `141` before.