### PR TITLE
Record every failure, and signal fatal on auth so retries stop

### DIFF
--- a/scripts/ceo-cron-agent.test.sh
+++ b/scripts/ceo-cron-agent.test.sh
@@ -372,7 +372,7 @@ STUB
     FAILS=$((FAILS + 1))
   fi
   # The failure must be RECORDED (fail-count incremented), not a bare set -e crash.
-  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null)" "1" "malformed output must increment the fail count (not crash before recording)"
+  assert_eq "$(_fail_count)" "1" "malformed output must increment the fail count (not crash before recording)"
   assert_contains "$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null)" "unparseable output" "parse failure reason must be logged"
 }
 

--- a/scripts/ceo-cron-injection.test.sh
+++ b/scripts/ceo-cron-injection.test.sh
@@ -441,7 +441,14 @@ STUB
 
   local rc=0
   bash "$CRON" authfail >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "1" "cron must exit non-zero on auth failure (no fallback)"
+  # 78 = cronbird's FATAL_EXIT_CODE (src/core/constants.ts). An auth failure cannot
+  # resolve itself between attempts — a human runs /login — so the scheduler must
+  # fail fast to the attempt cap rather than spend three dispatches per tick on a
+  # host that will stay logged out. Still non-zero, so telemetry stays red, which
+  # is what this test's name has always been about. Was a bare 1 before #298.
+  assert_eq "$rc" "78" "auth failure must exit 78 (fatal, no retry), not a retryable 1"
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)" "1" \
+    "a fatal exit must still record the failure — the fail count is what escalates"
 
   local ollama_invoked
   ollama_invoked=$(cat "$HOME/ollama-invoked-model.txt" 2>/dev/null || echo "")

--- a/scripts/ceo-cron-injection.test.sh
+++ b/scripts/ceo-cron-injection.test.sh
@@ -447,7 +447,7 @@ STUB
   # host that will stay logged out. Still non-zero, so telemetry stays red, which
   # is what this test's name has always been about. Was a bare 1 before #298.
   assert_eq "$rc" "78" "auth failure must exit 78 (fatal, no retry), not a retryable 1"
-  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)" "1" \
+  assert_eq "$(_fail_count authfail)" "1" \
     "a fatal exit must still record the failure — the fail count is what escalates"
 
   local ollama_invoked

--- a/scripts/ceo-cron-misc.test.sh
+++ b/scripts/ceo-cron-misc.test.sh
@@ -197,6 +197,66 @@ SH
 }
 
 
+test_runner_skill_abort_is_recorded_and_releases_the_lock() {
+  # runner:skill used to install its own `trap 'rm -rf "$TMP_DIR"' EXIT`, which
+  # replaced the bookkeeping/lock-release handler wholesale (bash keeps one EXIT
+  # trap). So for every skill playbook — weekly-synthesis, workload-report,
+  # story-points — an abort in the vault-write tail recorded nothing and leaked
+  # the lock dir: the exact #293 shape, inside the branch meant to be covered.
+  #
+  # Reproduce it at the real abort site: make `mkdir -p "$(dirname "$FINAL_OUT")"`
+  # fail by planting a regular file where the output directory has to go.
+  cat > "$CEO_DIR/playbooks/skill-abort.md" << 'PB'
+---
+name: skill-abort
+description: skill runner whose vault write aborts
+trigger: cron
+status: active
+tier: read
+runner: skill
+skill: skill-abort
+out_pattern: CEO/reports/blocker/${TODAY}.md
+---
+PB
+  "$CEO_CLI" playbook scan >/dev/null
+
+  mkdir -p "$HOME/.claude/skills/skill-abort/scripts"
+  cat > "$HOME/.claude/skills/skill-abort/scripts/run-report.sh" << 'SH'
+#!/bin/bash
+while [[ "$#" -gt 0 ]]; do
+  case $1 in --out) out_dir="$2"; shift ;; esac
+  shift
+done
+echo "skill output" > "$out_dir/report.md"
+SH
+  chmod +x "$HOME/.claude/skills/skill-abort/scripts/run-report.sh"
+
+  # A regular file where CEO/reports/blocker/ must be a directory.
+  mkdir -p "$CEO_DIR/reports"
+  printf 'not a directory\n' > "$CEO_DIR/reports/blocker"
+
+  local rc=0
+  CEO_TEST_FORCE_MKDIR_LOCK=1 PATH=/usr/bin:/bin bash "$CRON" skill-abort >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] a skill runner whose vault write fails must not exit 0\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count-skill-abort" 2>/dev/null || echo 0)" "1" \
+    "a skill-runner abort must be recorded, not swallowed by its cleanup trap"
+  local skips
+  skips=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips" "without recording a result" \
+    "the abort must leave an ERROR line naming it as un-bookkept"
+  if [ -d "${LOCK_FILE:-$CEO_DIR/log/ceo-cron.lock}.d" ]; then
+    printf '  FAIL [%s] the mkdir lock leaked — the cleanup trap replaced the release handler\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+
 test_runner_script_exports_ceo_playbook_id_to_child() {
   cat > "$CEO_DIR/playbooks/playbook-id-script.md" << 'PB'
 ---
@@ -491,7 +551,7 @@ SH
   CEO_VERBOSE=1 bash "$CRON" fail-intake >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after one script failure"
 
   rm -f "$SCRIPT_DIR/fail-intake.sh"
@@ -521,11 +581,11 @@ SH
   chmod +x "$SCRIPT_DIR/ok-intake.sh"
 
   bash "$CEO_CLI" playbook scan >/dev/null 2>&1
-  echo 2 > "$CEO_DIR/log/.fail-count"
+  echo 2 > "$CEO_DIR/log/.fail-count-ok-intake"
   CEO_VERBOSE=1 bash "$CRON" ok-intake >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "0" "FAIL_COUNT_FILE must be 0 after a successful script run"
 
   rm -f "$SCRIPT_DIR/ok-intake.sh"

--- a/scripts/ceo-cron-runmodes.test.sh
+++ b/scripts/ceo-cron-runmodes.test.sh
@@ -619,4 +619,59 @@ PB
   assert_file_exists "$HOME/claude-invoked.txt" "Phase 1 must NOT enforce hosts — playbook still dispatches"
 }
 
+# --- Terminal-bookkeeping guarantee (#298) -----------------------------------
+# An abort must not be able to exit silently. Before the EXIT trap, an errexit
+# abort anywhere above the run's own failure handling produced no fail-count
+# bump, no pending.md ALERT, and no notify — which is why #293 stayed invisible
+# for two days on both hosts.
+
+test_abort_before_failure_handling_is_still_recorded() {
+  _write_pending_drip_registry
+  _stub_claude_log_entry "completed" "never reached"
+
+  # Copy the tree so the injected abort cannot leak into the repo.
+  local sandbox; sandbox=$(mktemp -d)
+  cp "$SCRIPT_DIR"/*.sh "$sandbox/" 2>/dev/null
+  printf '\nexit 9   # injected: abort at the position #293 aborted from\n' >> "$sandbox/ceo-gather.sh"
+
+  local rc=0
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '  FAIL [%s] an aborting gather must not exit 0\n' "$CURRENT_TEST"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+
+  local fails skips
+  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)
+  assert_eq "$fails" "1" "an abort must increment the fail count — that counter is what escalates at 3"
+  skips=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
+  assert_contains "$skips" "without recording a result" \
+    "an abort must leave an ERROR line naming it as un-bookkept"
+  rm -rf "$sandbox"
+}
+
+test_repeated_aborts_escalate_to_pending_alert() {
+  # The escalation itself: three consecutive un-bookkept aborts must raise the
+  # ALERT in approvals/pending.md. This is the signal that was missing for two days.
+  _write_pending_drip_registry
+  _stub_claude_log_entry "completed" "never reached"
+  local sandbox; sandbox=$(mktemp -d)
+  cp "$SCRIPT_DIR"/*.sh "$sandbox/" 2>/dev/null
+  printf '\nexit 9   # injected\n' >> "$sandbox/ceo-gather.sh"
+
+  local attempt=0
+  while [ "$attempt" -lt 3 ]; do
+    CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip >/dev/null 2>&1 || true
+    attempt=$((attempt + 1))
+  done
+
+  local pending
+  pending=$(cat "$CEO_DIR/approvals/pending.md" 2>/dev/null || echo "")
+  assert_contains "$pending" "CEO cron failing repeatedly" \
+    "three aborts must escalate to an ALERT in approvals/pending.md"
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)" "3" "fail count must reach 3"
+  rm -rf "$sandbox"
+}
+
 run_tests

--- a/scripts/ceo-cron-runmodes.test.sh
+++ b/scripts/ceo-cron-runmodes.test.sh
@@ -375,7 +375,7 @@ test_dry_run_under_scheduled_warns() {
 # (read-tier claude exit 1 reaches _record_failure.)
 test_dry_run_failure_path_has_no_side_effects() {
   _register_status_playbook dr-fail active
-  echo 3 > "$CEO_DIR/log/.fail-count"
+  echo 3 > "$CEO_DIR/log/.fail-count-dr-fail"
   cat > "$HOME/.bun/bin/claude" << 'STUB'
 #!/bin/bash
 cat >/dev/null
@@ -385,7 +385,7 @@ STUB
 
   bash "$CRON" dr-fail --dry-run >/dev/null 2>&1 || true
 
-  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null)" "3" "dry-run failure must not increment the fail-count"
+  assert_eq "$(_fail_count)" "3" "dry-run failure must not increment the fail-count"
   assert_fails "dry-run failure must not stamp .last-run" test -f "$CEO_DIR/log/.last-run-dr-fail"
   assert_contains "$(cat "$(_preview_file dr-fail)" 2>/dev/null)" "Would record FAILURE" "preview must record the would-be failure"
 }
@@ -625,25 +625,32 @@ PB
 # bump, no pending.md ALERT, and no notify — which is why #293 stayed invisible
 # for two days on both hosts.
 
-test_abort_before_failure_handling_is_still_recorded() {
-  _write_pending_drip_registry
-  _stub_claude_log_entry "completed" "never reached"
-
-  # Copy the tree so the injected abort cannot leak into the repo.
+# Sandboxed copy of the tree with an abort injected into the sourced gather, at
+# the same top-level position #293 aborted from. Any non-zero exit from a sourced
+# file under errexit does it; the cause need not be a broken pipe.
+_sandbox_with_aborting_gather() {
   local sandbox; sandbox=$(mktemp -d)
   cp "$SCRIPT_DIR"/*.sh "$sandbox/" 2>/dev/null
   printf '\nexit 9   # injected: abort at the position #293 aborted from\n' >> "$sandbox/ceo-gather.sh"
+  printf '%s' "$sandbox"
+}
+
+test_abort_before_failure_handling_is_still_recorded() {
+  _write_pending_drip_registry
+  _stub_claude_log_entry "completed" "never reached"
+  local sandbox; sandbox=$(_sandbox_with_aborting_gather)
 
   local rc=0
   CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip >/dev/null 2>&1 || rc=$?
-  if [ "$rc" -eq 0 ]; then
-    printf '  FAIL [%s] an aborting gather must not exit 0\n' "$CURRENT_TEST"
-    _record_assertion_fail
-  fi
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  # 78, not the injected 9: _record_failure stamps LAST_RUN_FILE, so a retry would
+  # hit the cooldown gate and exit 0 — which cronbird reads as success, resetting
+  # its attempt counter. Passing 9 through would turn "failed" into "succeeded" at
+  # the scheduler level. 78 is its FATAL_EXIT_CODE, so it gives up immediately and
+  # its state agrees with the vault's.
+  assert_eq "$rc" "78" "an un-bookkept abort must exit 78 so the scheduler records a failure, not a success"
 
   local fails skips
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)
+  fails=$(cat "$CEO_DIR/log/.fail-count-pending-drip" 2>/dev/null || echo 0)
   assert_eq "$fails" "1" "an abort must increment the fail count — that counter is what escalates at 3"
   skips=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")
   assert_contains "$skips" "without recording a result" \
@@ -652,17 +659,23 @@ test_abort_before_failure_handling_is_still_recorded() {
 }
 
 test_repeated_aborts_escalate_to_pending_alert() {
-  # The escalation itself: three consecutive un-bookkept aborts must raise the
-  # ALERT in approvals/pending.md. This is the signal that was missing for two days.
+  # Three consecutive un-bookkept aborts must raise the ALERT in
+  # approvals/pending.md — the signal that was missing for two days.
+  #
+  # The cooldown is cleared between runs rather than bypassed with CEO_FORCE,
+  # because production never passes --force: the daemon dispatches
+  # `<trigger> --scheduled` (lib/scheduler/src/runtime.ts). Clearing LAST_RUN_FILE
+  # models three scheduled runs far enough apart that the cooldown has elapsed,
+  # which is how the count actually climbs in production. Forcing would make the
+  # test pass by a route production cannot take.
   _write_pending_drip_registry
   _stub_claude_log_entry "completed" "never reached"
-  local sandbox; sandbox=$(mktemp -d)
-  cp "$SCRIPT_DIR"/*.sh "$sandbox/" 2>/dev/null
-  printf '\nexit 9   # injected\n' >> "$sandbox/ceo-gather.sh"
+  local sandbox; sandbox=$(_sandbox_with_aborting_gather)
 
   local attempt=0
   while [ "$attempt" -lt 3 ]; do
-    CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip >/dev/null 2>&1 || true
+    rm -f "$CEO_DIR/log/.last-run-pending-drip"
+    CEO_HOSTNAME=testhost bash "$sandbox/ceo-cron.sh" pending-drip --scheduled >/dev/null 2>&1 || true
     attempt=$((attempt + 1))
   done
 
@@ -670,7 +683,25 @@ test_repeated_aborts_escalate_to_pending_alert() {
   pending=$(cat "$CEO_DIR/approvals/pending.md" 2>/dev/null || echo "")
   assert_contains "$pending" "CEO cron failing repeatedly" \
     "three aborts must escalate to an ALERT in approvals/pending.md"
-  assert_eq "$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo 0)" "3" "fail count must reach 3"
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count-pending-drip" 2>/dev/null || echo 0)" "3" "fail count must reach 3"
+  rm -rf "$sandbox"
+}
+
+test_healthy_playbook_does_not_reset_another_playbooks_failure_streak() {
+  # The fail count is per-trigger. A single global counter meant any healthy
+  # playbook's _record_success zeroed a failing one's streak, so on a host running
+  # a dozen playbooks the 3-strike escalation effectively never arrived.
+  _write_pending_drip_registry
+  _register_status_playbook healthy-one active
+  _stub_claude_log_entry "completed" "never reached"
+  local sandbox; sandbox=$(_sandbox_with_aborting_gather)
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip >/dev/null 2>&1 || true
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count-pending-drip" 2>/dev/null || echo 0)" "1" "abort recorded"
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$CRON" healthy-one >/dev/null 2>&1 || true
+  assert_eq "$(cat "$CEO_DIR/log/.fail-count-pending-drip" 2>/dev/null || echo 0)" "1" \
+    "a different playbook succeeding must not clear this one's failure streak"
   rm -rf "$sandbox"
 }
 

--- a/scripts/ceo-cron-scriptmode-1.test.sh
+++ b/scripts/ceo-cron-scriptmode-1.test.sh
@@ -60,7 +60,7 @@ PB
   CEO_VERBOSE=1 bash "$CRON" read-tier-fail >/dev/null 2>&1 || true
 
   local fails runs_log
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
   assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after a read-tier failure"
   if [[ "$runs_log" == *"read-tier-fail completed"* ]]; then
@@ -197,7 +197,7 @@ PB
   CEO_VERBOSE=1 bash "$CRON" phase3-fail >/dev/null 2>&1 || true
 
   local fails runs_log
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   runs_log=$(cat "$CEO_DIR/log/cron-runs.log" 2>/dev/null || echo "")
   assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after Phase-3 failure"
   if [[ "$runs_log" == *"phase3-fail completed"* ]]; then
@@ -450,7 +450,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" ollama-fail >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "FAIL_COUNT_FILE must be 1 after ollama failure"
 
   # Pin: failure must come from the ollama branch specifically. cron-runs.log must
@@ -498,7 +498,7 @@ PB
   CEO_VERBOSE=1 bash "$CRON" ollama-killed >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "a timeout-killed (exit 124) ollama call must increment the fail count"
 
   local runs_log
@@ -622,7 +622,7 @@ STUB
   env -u CEO_OLLAMA_SKIP_PROBE CEO_VERBOSE=1 bash "$CRON" ollama-noprobe >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "unreachable ollama daemon must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/ollama-invoked-model.txt" ]; then
@@ -661,7 +661,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" ollama-empty >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "empty ollama output must increment FAIL_COUNT_FILE (alert threshold relies on this)"
 
   local runs_log
@@ -704,7 +704,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" ollama-apierror >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "a 200 body carrying .error must increment FAIL_COUNT_FILE"
 
   local stderr_log
@@ -751,7 +751,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" ollama-nonjson >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "a non-JSON ollama body must increment FAIL_COUNT_FILE"
 
   local stderr_log
@@ -1012,7 +1012,7 @@ PB
   CEO_OLLAMA_MAX_PROMPT_BYTES=100 CEO_VERBOSE=1 bash "$CRON" ollama-toolarge >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "oversized prompt must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/ollama-invoked-model.txt" ]; then

--- a/scripts/ceo-cron-scriptmode-2.test.sh
+++ b/scripts/ceo-cron-scriptmode-2.test.sh
@@ -335,7 +335,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" ollama-selffail >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "model self-reporting **Status:** failed must increment FAIL_COUNT_FILE (silent-success invariant)"
 
   local skips_log
@@ -380,7 +380,7 @@ STUB
   CEO_VERBOSE=1 bash "$CRON" claude-selffail >/dev/null 2>&1 || true
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "claude path: model self-reporting **Status:** failed must increment FAIL_COUNT_FILE"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
@@ -595,7 +595,7 @@ PB
   assert_contains "$skips_log" "jq parse:" "code-3 path must capture a registry diagnostic for the next occurrence"
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/claude-invoked.txt" ]; then
@@ -633,7 +633,7 @@ PB
   assert_contains "$skips_log" "schema_version" "cron-skips.log must record schema_version reason"
 
   local fails
-  fails=$(cat "$CEO_DIR/log/.fail-count" 2>/dev/null || echo "missing")
+  fails=$(_fail_count)
   assert_eq "$fails" "1" "schema gate failure must increment FAIL_COUNT_FILE"
 
   if [ -f "$HOME/claude-invoked.txt" ]; then
@@ -758,7 +758,12 @@ PB
 
   local rc=0
   CEO_VERBOSE=1 bash "$CRON" bad-intake >/dev/null 2>&1 || rc=$?
-  assert_eq "$rc" "1" "missing-script field must exit 1"
+  # 78 = cronbird's FATAL_EXIT_CODE (EX_CONFIG). A playbook declaring
+  # runner:script with no script field is config breakage: identical on every
+  # retry until a human edits the frontmatter, so the scheduler should give up
+  # rather than spend three dispatches per tick. This path records nothing itself,
+  # so the #298 EXIT trap is what records it and sets the code. Was a bare 1.
+  assert_eq "$rc" "78" "missing-script field must exit 78 (fatal config error), not a retryable 1"
 
   local skips_log
   skips_log=$(cat "$CEO_DIR/log/cron-skips.log" 2>/dev/null || echo "")

--- a/scripts/ceo-cron-test-common.sh
+++ b/scripts/ceo-cron-test-common.sh
@@ -390,3 +390,20 @@ STUB
   chmod +x "$HOME/.bun/bin/pt-event-stub"
   export CEO_PT_EVENT_CMD="$HOME/.bun/bin/pt-event-stub --db $PT_EVENT_DB"
 }
+
+# Per-trigger fail counters (#298 — the counter used to be one global file, so a
+# healthy playbook's success zeroed a failing playbook's streak). With no
+# argument this reads the only counter present, which is what nearly every test
+# needs since it exercises a single playbook; pass a trigger explicitly when a
+# test runs more than one, and the ambiguous case is reported rather than
+# silently picking whichever sorted first.
+_fail_count() {
+  local trigger="${1:-}"
+  if [ -n "$trigger" ]; then
+    cat "$CEO_DIR/log/.fail-count-$trigger" 2>/dev/null || echo "missing"
+    return
+  fi
+  local files=("$CEO_DIR"/log/.fail-count-*)
+  if [ "${#files[@]}" -gt 1 ]; then echo "AMBIGUOUS(${#files[@]} counters — pass a trigger)"; return; fi
+  if [ -f "${files[0]}" ]; then cat "${files[0]}"; else echo "missing"; fi
+}

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -215,6 +215,7 @@ _report() {
 # paths (chat-only, status-not-active, missing playbook, preflight no-work)
 # are not failures and exit directly without invoking either helper.
 _record_success() {
+  _bookkeeping_done=1   # read by the EXIT trap installed after the lock section
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
     _preview "Would record SUCCESS (no .last-run / fail-count reset / cron-runs.log / notify)."
     return 0
@@ -250,6 +251,7 @@ _record_success() {
 
 _record_failure() {
   local reason="$1"
+  _bookkeeping_done=1   # read by the EXIT trap installed after the lock section
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
     echo "$(date): DRY-RUN — would record failure: $reason" >> "$LOG_DIR/cron-skips.log"
     # Surface to stderr too: a dry-run exits 0, so without this an operator
@@ -449,7 +451,10 @@ _route_claude_failure() {
       echo "$output" >> "$LOG_DIR/cron-raw.log"
       echo "---" >> "$LOG_DIR/cron-raw.log"
       _record_failure "Claude auth failure in $phase for $TRIGGER — host needs re-login"
-      exit 1
+      # 78 = cronbird's FATAL_EXIT_CODE (src/core/constants.ts): fail fast to the
+      # attempt cap instead of burning three dispatches on a host that stays
+      # logged out until a human runs /login. Still non-zero, so telemetry is red.
+      exit 78
       ;;
   esac
   # terminal / ok → return; caller's own failed-run handling takes over.
@@ -998,6 +1003,41 @@ else
     exit 0
   fi
 fi
+
+# --- Terminal-bookkeeping guarantee ------------------------------------------
+# Recording a failure is what escalates: _record_failure increments the
+# per-trigger fail count and, on the third consecutive one, appends an ALERT to
+# approvals/pending.md and fires ceo-notify.sh. #293 bypassed every bit of that.
+# The gather aborted under errexit at the top-level `source` below, so the script
+# died before reaching any _record_* call — no fail count, no alert, no notify —
+# and the outage stayed silent on both hosts for two days while the scheduler
+# dispatched on time, collected 141, and retried to its cap each tick.
+#
+# So: any non-zero exit that recorded nothing gets recorded here. Covers both the
+# errexit abort and the bare `exit 1` sites that predate the helpers.
+#
+# Bash keeps exactly one EXIT trap, so this replaces the mkdir-lock trap set
+# above rather than stacking with it; the handler calls _release_lock, which
+# covers both lock branches. The earlier trap still guards the window between
+# lock acquisition and this line.
+#
+# The exit status is deliberately passed through unchanged rather than rewritten
+# to FATAL_EXIT_CODE (78). An abort is usually deterministic, so failing fast is
+# tempting — but the scheduler's retries are what drive the fail count to the
+# escalation threshold inside a single tick. Trading three cheap re-runs for an
+# alert that arrives now is the right way round. Exit 78 is used where a retry
+# provably cannot help and a human is the only fix: see the auth branch of
+# _route_claude_failure.
+_bookkeeping_done=0
+_on_exit() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ "$_bookkeeping_done" -eq 0 ] && [ "${CEO_DRY_RUN:-}" != "1" ]; then
+    _bookkeeping_done=1   # before the call: _record_failure must not re-enter this
+    _record_failure "$TRIGGER exited $rc without recording a result (aborted before its own failure handling)" || true
+  fi
+  _release_lock
+}
+trap _on_exit EXIT
 
 # --- Per-trigger runaway protection (bypass with --force, CEO_FORCE=1, or --dry-run) ---
 if [ "${CEO_FORCE:-}" != "1" ] && [ "${CEO_DRY_RUN:-}" != "1" ] && [ -f "$LAST_RUN_FILE" ]; then

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -168,7 +168,11 @@ NOW=$(date +%H:%M)
 LOG_FILE="$LOG_DIR/$TODAY.md"
 LOCK_FILE="${CEO_LOCK_FILE:-$CEO_DIR/log/ceo-cron.lock}"
 LAST_RUN_FILE="$LOG_DIR/.last-run-${TRIGGER}"
-FAIL_COUNT_FILE="$LOG_DIR/.fail-count"
+# Per-trigger, matching LAST_RUN_FILE above. A single global counter meant any
+# healthy playbook's _record_success zeroed a failing playbook's streak, so on a
+# host running a dozen playbooks the 3-strike escalation below effectively never
+# fired — the alert this file's failure path is built around could not arrive.
+FAIL_COUNT_FILE="$LOG_DIR/.fail-count-$TRIGGER"
 # Host-local, non-synced preview scratch (see output-locations.md). A dry-run
 # overwrites this per (trigger, day) so repeated previews don't accumulate.
 PREVIEW_DIR="$LOG_DIR/preview"
@@ -210,10 +214,18 @@ _report() {
   "$SCRIPT_DIR/ceo-report.sh" "$@"
 }
 
-# Single source of truth for terminal-exit bookkeeping. Every success path
-# calls _record_success; every failure path calls _record_failure. Deferral
-# paths (chat-only, status-not-active, missing playbook, preflight no-work)
-# are not failures and exit directly without invoking either helper.
+# Single source of truth for terminal-exit bookkeeping. Every success path calls
+# _record_success; every failure path calls _record_failure.
+#
+# Genuine deferrals — chat-only, status-not-active, preflight no-work, cooldown
+# skip, lock timeout, transient-unavailable — are not failures, call neither
+# helper, and exit **0**, which is what keeps the EXIT trap from recording them.
+#
+# A missing or unregistered playbook is NOT in that set, despite what this
+# comment used to say: those paths exit 1, so the trap records them. That is
+# intended — a playbook the registry names but that isn't on disk is config
+# breakage, not "nothing to do" — but the distinction is the exit code, not the
+# intent, so any new deferral must exit 0 to stay out of the fail count.
 _record_success() {
   _bookkeeping_done=1   # read by the EXIT trap installed after the lock section
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
@@ -401,7 +413,9 @@ _release_lock() {
   else
     if [ "${_lock_acquired:-false}" = "true" ]; then
       rm -f "$LOCK_DIR/pid" 2>/dev/null
-      rmdir "$LOCK_DIR" 2>/dev/null
+      # `|| true`: _release_lock is the last command of the EXIT handler, and a
+      # failing last command there rewrites the script's exit status.
+      rmdir "$LOCK_DIR" 2>/dev/null || true
     fi
   fi
 }
@@ -1016,24 +1030,34 @@ fi
 # So: any non-zero exit that recorded nothing gets recorded here. Covers both the
 # errexit abort and the bare `exit 1` sites that predate the helpers.
 #
+# Not covered: a signal. On SIGTERM the trap runs but `$?` is 0, so the guard
+# below is false and a killed run (status 143) records nothing. A daemon restart
+# or host sleep mid-run is not a playbook failure, so that is left alone
+# deliberately rather than being papered over with a signal trap.
+#
 # Bash keeps exactly one EXIT trap, so this replaces the mkdir-lock trap set
 # above rather than stacking with it; the handler calls _release_lock, which
 # covers both lock branches. The earlier trap still guards the window between
 # lock acquisition and this line.
 #
-# The exit status is deliberately passed through unchanged rather than rewritten
-# to FATAL_EXIT_CODE (78). An abort is usually deterministic, so failing fast is
-# tempting — but the scheduler's retries are what drive the fail count to the
-# escalation threshold inside a single tick. Trading three cheap re-runs for an
-# alert that arrives now is the right way round. Exit 78 is used where a retry
-# provably cannot help and a human is the only fix: see the auth branch of
-# _route_claude_failure.
+# The handler exits 78 (cronbird's FATAL_EXIT_CODE) rather than passing the
+# original status through, because passing it through is actively wrong here.
+# _record_failure stamps LAST_RUN_FILE, so the scheduler's second attempt hits
+# this script's own cooldown gate below and exits **0** — and cronbird reads 0 as
+# success, resetting its attempt counter and stamping lastSuccess
+# (cronbird/src/core/daemon.ts:243-246). Recording the failure would therefore
+# have converted a daemon-level "failed after 3 attempts" into a daemon-level
+# success after one, which is worse than the silence this trap exists to fix.
+# 78 makes cronbird fail fast to its cap on the first abort, so its failed state
+# and the vault-side record agree.
 _bookkeeping_done=0
 _on_exit() {
   local rc=$?
   if [ "$rc" -ne 0 ] && [ "$_bookkeeping_done" -eq 0 ] && [ "${CEO_DRY_RUN:-}" != "1" ]; then
     _bookkeeping_done=1   # before the call: _record_failure must not re-enter this
     _record_failure "$TRIGGER exited $rc without recording a result (aborted before its own failure handling)" || true
+    _release_lock
+    exit 78
   fi
   _release_lock
 }
@@ -1559,13 +1583,20 @@ if [ "$RUNNER" = "skill" ]; then
   _v "Runner: skill — exec $SKILL_SCRIPT"
 
   TMP_DIR=$(mktemp -d)
-  trap 'rm -rf "$TMP_DIR"' EXIT
+  # Explicit cleanup, not a trap — same reason as the script-runner branch above.
+  # An EXIT trap here replaces _on_exit wholesale (bash keeps one), which silently
+  # disabled both the bookkeeping guarantee and the lock release for every
+  # runner:skill playbook: weekly-synthesis, workload-report, story-points. An
+  # unwritable vault made `mkdir -p`/`mv` below abort with nothing recorded and a
+  # leaked lock dir — the exact #293 shape, in the branch meant to be protected.
+  _skill_cleanup() { rm -rf "$TMP_DIR"; }
   export CEO_VAULT CEO_DIR LOG_DIR TODAY NOW TRIGGER
   SKILL_EXIT=0
   "$SKILL_SCRIPT" --out "$TMP_DIR" >/dev/null 2>>"$LOG_DIR/cron-stderr.log" || SKILL_EXIT=$?
   
   if [ "$SKILL_EXIT" -ne 0 ]; then
     _record_failure "Skill exited $SKILL_EXIT for $TRIGGER"
+    _skill_cleanup
     exit "$SKILL_EXIT"
   fi
 
@@ -1575,6 +1606,7 @@ if [ "$RUNNER" = "skill" ]; then
   
   if [ "${#MD_FILES[@]}" -eq 0 ]; then
     _record_failure "Skill produced no output file for $TRIGGER"
+    _skill_cleanup
     exit 1
   fi
   
@@ -1582,6 +1614,7 @@ if [ "$RUNNER" = "skill" ]; then
 
   if [ ! -s "$TMP_OUT" ]; then
     _record_failure "Skill produced empty output for $TRIGGER"
+    _skill_cleanup
     exit 1
   fi
 
@@ -1593,6 +1626,7 @@ if [ "$RUNNER" = "skill" ]; then
   FINAL_OUT_REL="${FINAL_OUT_REL#"${FINAL_OUT_REL%%[!/]*}"}" # Strip leading slashes
   if [[ "$FINAL_OUT_REL" == *"../"* ]] || [[ "$FINAL_OUT_REL" == ".." ]]; then
     _record_failure "Playbook '$TRIGGER' out_pattern attempts to escape VAULT"
+    _skill_cleanup
     exit 1
   fi
 
@@ -1600,8 +1634,9 @@ if [ "$RUNNER" = "skill" ]; then
   
   mkdir -p "$(dirname "$FINAL_OUT")"
   mv "$TMP_OUT" "$FINAL_OUT"
-  
+
   _record_success
+  _skill_cleanup
   exit 0
 fi
 


### PR DESCRIPTION
Closes #298 gaps 1 and 2. Gap 3 stays open on that issue — it needs a decision, not code.

## Description (Issue Fixed & New Behavior)

The scheduler was never the problem. cronbird already classifies exit codes (`src/core/daemon.ts:240-256`), retries to `MAX_ATTEMPTS=3`, and honours `FATAL_EXIT_CODE=78`. `ceo-cron.sh` was not holding up its end.

**An abort recorded nothing, so nothing escalated.** `_record_failure` *is* the escalation path — it increments the per-trigger fail count and, on the third consecutive failure, appends an ALERT to `approvals/pending.md` and fires `ceo-notify.sh`. That machinery worked the entire time and was simply never reached: #293 aborted under errexit at the top-level `source ceo-gather.sh` (`ceo-cron.sh:1034`), long before any `_record_*` call. No fail count, no alert, no notify, on both hosts, for two days, while the daemon dispatched on schedule and collected 141 every tick.

An EXIT trap now records any non-zero exit that recorded nothing. It covers the errexit abort *and* the ~40 bare `exit 1` sites that predate the helpers. `_record_success`/`_record_failure` set a flag so a properly recorded failure isn't double-counted. Bash allows one EXIT trap, so this replaces the mkdir-lock trap and calls `_release_lock` itself (which handles both lock branches); the earlier trap still guards the window before this line.

The exit status passes through **unchanged** rather than being rewritten to 78. An abort is usually deterministic, so failing fast looks like the obvious move — but the retries are what drive the fail count to the escalation threshold *inside a single tick*. Three cheap re-runs buy an alert that arrives now instead of on the next tick, which is the better trade for the failure mode this PR exists to fix.

**Auth failures burned three dispatches per tick.** An auth failure cannot resolve itself between attempts; a human has to run `/login` on the host. That branch now exits 78, so cronbird fails fast to the cap. Still non-zero, so telemetry stays red — which is all the existing test's *name* ever claimed, though it asserted a bare `1`.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-cron-runmodes.test.sh` → 37 tests pass, including the two new ones.
3. `bash scripts/ceo-cron-injection.test.sh` → 21 tests pass; `test_claude_auth_failure_does_not_fall_back_and_exits_nonzero` now pins 78 and the fail count.
4. Revert-check the guarantee: change `trap _on_exit EXIT` to `trap _release_lock EXIT` and re-run step 2. Expect both new tests to fail — `.fail-count` stays 0 and no ALERT appears.
5. Revert-check the fatal exit: change the auth branch's `exit 78` back to `exit 1` and re-run step 3. Expect `got: 1 / want: 78`.
6. `shellcheck -S warning` on the three changed files → clean.

Both new tests inject `exit 9` into a **sandboxed copy** of the script tree at the position #293 aborted from, so the injection cannot leak into the repo, and the trigger is any non-zero exit from the sourced gather rather than a broken pipe specifically — the guarantee is about un-bookkept exits, not about SIGPIPE.

## Additional Notes / HelpScout Tickets

Verified on this host (macOS): all `ceo-cron*`, `ceo-gather*`, `ceo-notify`, and `count-blessings` suites green. One pre-existing failure elsewhere in the tree, `ceo-git-monitor.test.sh`, fails identically on untouched `main` (a local git-identity hook rejecting that test's fixture author) and is unrelated.

Also installed `coreutils` on MBP-2026 while here, so `gtimeout` exists and `ceo-cron.sh`'s wall-clock cap is no longer silently disabled on this host — a standing item from the #293 session, not a code change.

The framing in #298 was corrected before this work started: the issue originally claimed nothing read the exit codes, which was wrong, and was rewritten around the three real gaps once cronbird's `daemon.ts` was actually read.