### PR TITLE
Send report content over stdin so a verbose run doesn't abort past 128KB

### DIFF
--- a/scripts/ceo-cron-scriptmode-2.test.sh
+++ b/scripts/ceo-cron-scriptmode-2.test.sh
@@ -1128,9 +1128,10 @@ test_pending_drip_oversized_no_questions_leaves_inbox_alone() {
   # explicitly found nothing gets appended anyway. Inbox noise, not data loss.
   _write_pending_drip_registry
   # ~100KB: above the 64KB pipe buffer (so the pre-fix grep really SIGPIPEs) but
-  # below Linux's 128KB per-argument execve limit, which _report passes log_entry
-  # through as argv. At 200KB this test also tripped that unrelated ceiling and
-  # failed on CI while passing on macOS — see the argv issue filed separately.
+  # below Linux's 128KB per-argument execve limit. At 200KB this test also tripped
+  # that unrelated ceiling and failed on CI while passing on macOS. That ceiling is
+  # fixed now (#297 — _report routes content over stdin), and the size stays at
+  # ~100KB deliberately so this test keeps pinning one limit, not two.
   local pad line filler=""
   pad=$(printf 'x%.0s' {1..200})
   for ((line = 0; line < 500; line++)); do filler+="$pad"$'\n'; done
@@ -1158,9 +1159,10 @@ test_pending_drip_oversized_failed_entry_uses_report_not_inbox() {
   # revert, so it is not coverage for this.
   _write_pending_drip_registry
   # ~100KB: above the 64KB pipe buffer (so the pre-fix grep really SIGPIPEs) but
-  # below Linux's 128KB per-argument execve limit, which _report passes log_entry
-  # through as argv. At 200KB this test also tripped that unrelated ceiling and
-  # failed on CI while passing on macOS — see the argv issue filed separately.
+  # below Linux's 128KB per-argument execve limit. At 200KB this test also tripped
+  # that unrelated ceiling and failed on CI while passing on macOS. That ceiling is
+  # fixed now (#297 — _report routes content over stdin), and the size stays at
+  # ~100KB deliberately so this test keeps pinning one limit, not two.
   local pad line filler=""
   pad=$(printf 'x%.0s' {1..200})
   for ((line = 0; line < 500; line++)); do filler+="$pad"$'\n'; done
@@ -1218,6 +1220,85 @@ test_pending_drip_no_relevant_questions_suppresses_inbox() {
     FAILS=$((FAILS + 1))
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+# _report must hand content to ceo-report.sh over stdin, never as a third argv
+# string. Linux caps a single argv at MAX_ARG_STRLEN (131072) regardless of the
+# much larger total ARG_MAX, so a verbose model response made execve fail E2BIG
+# (rc 126) and, under errexit, aborted the playbook after the model had already
+# run — losing the report and skipping _record_failure too (#297).
+#
+# This one is deterministic on every platform: it asserts the *shape* of the
+# call rather than waiting for a limit to be exceeded, so it fails on a revert
+# even on macOS, which has no per-argument limit at all.
+test_report_passes_content_on_stdin_not_argv() {
+  _write_pending_drip_registry
+  # `failed`, not `completed`: for pending-drip a completed entry is routed to
+  # the host inbox, and only the failure path goes through _report. The sibling
+  # oversized test makes the same choice for the same reason.
+  _stub_claude_log_entry "failed" "stdin-routing-sentinel"
+
+  local sandbox; sandbox=$(mktemp -d)
+  cp "$SCRIPT_DIR"/*.sh "$sandbox/" 2>/dev/null
+  cat > "$sandbox/ceo-report.sh" << STUB
+#!/bin/bash
+printf '%s' "\$#" > "$sandbox/argc"
+printf '%s' "\${3:-}" > "$sandbox/arg3"
+cat > "$sandbox/stdin"
+exit 0
+STUB
+  chmod +x "$sandbox/ceo-report.sh"
+
+  # stdin from /dev/null, which is what the daemon and cron actually hand the
+  # script. It also keeps a revert failing cleanly instead of hanging: pre-fix the
+  # content came in on argv and nothing was piped, so the stub's `cat` inherited
+  # the test runner's stdin and blocked until the suite timed out. A hung suite
+  # burns CI's job timeout and reports nothing useful.
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$sandbox/ceo-cron.sh" pending-drip </dev/null >/dev/null 2>&1 || true
+
+  assert_eq "$(cat "$sandbox/argc" 2>/dev/null || echo missing)" "2" \
+    "ceo-report.sh must receive exactly 2 args — content as argv is what breaks past 128KB on Linux"
+  assert_eq "$(cat "$sandbox/arg3" 2>/dev/null || echo missing)" "" \
+    "the third argv must be empty"
+  local piped
+  piped=$(cat "$sandbox/stdin" 2>/dev/null || echo "")
+  assert_contains "$piped" "stdin-routing-sentinel" \
+    "the report content must arrive on stdin"
+  rm -rf "$sandbox"
+}
+
+# The end-to-end half, at the size that actually tripped the ceiling. Honest
+# limitation: this is only a failing test on Linux (CI, ML-1). macOS has no
+# per-argument limit, so it passes there before and after the fix — which is
+# exactly how the bug hid for as long as it did. The stub test above is what
+# guards the invariant on a developer's Mac.
+test_report_survives_a_log_entry_past_the_linux_argv_ceiling() {
+  _write_pending_drip_registry
+  # ~200KB: comfortably past MAX_ARG_STRLEN (131072). The sibling oversized
+  # tests deliberately sit at ~100KB to stay under it, because they pin the
+  # 64KB pipe-buffer invariant and must not conflate the two limits.
+  local pad line filler=""
+  pad=$(printf 'y%.0s' {1..200})
+  for ((line = 0; line < 1000; line++)); do filler+="$pad"$'\n'; done
+  _stub_claude_log_entry "failed" "argv-ceiling-sentinel
+$filler"
+
+  CEO_HOSTNAME=testhost CEO_FORCE=1 bash "$CRON" pending-drip >/dev/null 2>&1 || true
+
+  local report
+  report="$CEO_DIR/reports/$(date +%Y-%m-%d).md"
+  assert_file_exists "$report" "a 200KB log entry must still produce a report"
+  local body
+  body=$(cat "$report" 2>/dev/null || echo "")
+  assert_contains "$body" "argv-ceiling-sentinel" \
+    "the oversized entry's content must reach the report, not be lost to an E2BIG abort"
+
+  # The E2BIG abort at _report happened *before* _record_failure, so a lost
+  # report also meant a silent run: no fail count, so no 3-strike escalation.
+  # This entry self-reports failed, so the bookkeeping lands in the per-trigger
+  # counter and cron-skips.log rather than cron-runs.log.
+  assert_eq "$(_fail_count pending-drip)" "1" \
+    "the failure must be counted — the pre-fix abort skipped bookkeeping entirely"
 }
 
 run_tests

--- a/scripts/ceo-cron.sh
+++ b/scripts/ceo-cron.sh
@@ -206,12 +206,27 @@ _preview() {
 # In dry-run the report (and its Discord side-channel) is folded into the
 # preview file instead of being posted/written, so no path can leak a dry-run
 # to Discord or the report intake.
+# The content goes over stdin, never argv. Linux caps a *single* argv string at
+# MAX_ARG_STRLEN (131072 bytes, 32 pages) independently of the far larger total
+# ARG_MAX, so a verbose model response made execve fail E2BIG — rc 126,
+# "Argument list too long". Under `set -euo pipefail` that aborted the playbook
+# *after* the model had run: the report was never written and `_record_failure`
+# was never reached either, so the run vanished with no error in the report it
+# failed to write. macOS has no per-argument limit, which is why this only ever
+# bit ML-1 and the CI runner. ceo-report.sh has always accepted stdin.
+#
+# A here-string rather than `printf ... |`: bash backs `<<<` with a temp file, so
+# there is no writer process to take SIGPIPE if ceo-report.sh exits before
+# draining stdin. A pipe there would trade this bug for the #296 class, where a
+# short-circuiting consumer kills the producer and pipefail aborts the run.
+# `<<<` appends one newline and `$(cat)` strips trailing newlines, so the content
+# ceo-report.sh sees is byte-identical to what argv delivered.
 _report() {
   if [ "${CEO_DRY_RUN:-}" = "1" ]; then
     _preview "Report (${1}) that would post to Discord / report intake:" "${3:-}"
     return 0
   fi
-  "$SCRIPT_DIR/ceo-report.sh" "$@"
+  "$SCRIPT_DIR/ceo-report.sh" "$1" "$2" <<< "${3:-}"
 }
 
 # Single source of truth for terminal-exit bookkeeping. Every success path calls


### PR DESCRIPTION
Closes #297

## Description (Issue Fixed & New Behavior)

`_report` handed the model's output to `ceo-report.sh` as a third argv string. Linux caps a **single** argv at `MAX_ARG_STRLEN` (131072 bytes, 32 pages) independently of the far larger total `ARG_MAX`, so a verbose enough response made `execve` fail `E2BIG` — rc 126, `Argument list too long`.

Under `set -euo pipefail` that aborted the playbook **after the model had already run**, which is what makes it worse than a lost report:

- the report was never written to `CEO/reports/<date>.md` — the run's entire output is gone
- `_record_failure` at `:514` was never reached either, so there was no fail count and no 3-strike escalation

The run simply disappeared, with no error in the report it failed to write. macOS has no per-argument limit, which is why this only bit ML-1 — the host that owns every single-scope scanner playbook — and the CI runner. The trigger is response verbosity, so it is intermittent rather than permanent: a playbook that occasionally loses everything.

`ceo-report.sh` has accepted stdin since it was written (`echo "content" | ceo-report.sh <type> <trigger>`), and drains it at `:21` *before* the vault check and any early exit. So the fix lands at the single `_report` chokepoint, needs no consumer change, and covers all nine call sites at once.

**A here-string, not a pipe.** bash backs `<<<` with a temp file, so there is no writer process to take `SIGPIPE` if `ceo-report.sh` ever exits before draining stdin. `printf ... |` would trade this bug for the #296 class, where a short-circuiting consumer kills the producer and `pipefail` aborts the run. `<<<` appends one newline and `$(cat)` strips trailing newlines, so what `ceo-report.sh` receives is byte-identical to what argv delivered.

Also audited the sibling call sites: `_report` is the only place potentially-large content crosses an `execve`. `ceo-notify.sh failure "$TRIGGER" "$reason"` passes a bounded one-line reason.

## Testing Procedure

1. Check out this branch, then `bash scripts/ceo-cron-scriptmode-2.test.sh` — expect all 40 to pass.
2. **Confirm the shape test fails on a revert, on any platform.** In `scripts/ceo-cron.sh`, change `"$SCRIPT_DIR/ceo-report.sh" "$1" "$2" <<< "${3:-}"` back to `"$SCRIPT_DIR/ceo-report.sh" "$@"` and re-run. `test_report_passes_content_on_stdin_not_argv` must fail on three named assertions: argc is 3 not 2, the third argv is non-empty, and nothing arrived on stdin. Restore.
3. **Note what step 2 does *not* prove on a Mac.** `test_report_survives_a_log_entry_past_the_linux_argv_ceiling` uses the 200KB entry that actually tripped the ceiling, but macOS has no per-argument limit, so it passes there before and after — exactly how this hid. On Linux (CI, ML-1) it is the one that fails pre-fix. The two tests are a pair on purpose; neither alone is adequate.
4. `shellcheck -S warning scripts/ceo-cron.sh scripts/ceo-cron-scriptmode-2.test.sh` — clean.
5. Full suite: `for f in scripts/*.test.sh; do bash "$f" >/dev/null 2>&1 || echo "FAIL $f"; done`. Only `ceo-git-monitor.test.sh` should fail, identically to untouched `main` — a local `git-identity-gate` hook rejecting that test's `Test User <test@example.com>` fixture commit. It passes in CI, which has no such hook.

## Additional Notes / HelpScout Tickets

- The test invokes `ceo-cron.sh` with stdin from `/dev/null`, matching what the daemon and cron actually provide. That is load-bearing, not cosmetic: without it a revert made the stub's `cat` inherit the test runner's stdin and block until the suite timed out. A hung suite burns CI's 10-minute job timeout and reports nothing useful, so the revert case now fails in three named assertions instead of hanging.
- Updated the stale comment on `test_pending_drip_oversized_failed_entry_uses_report_not_inbox`, which pointed at this ceiling as an open issue and explained why its fixture stays at ~100KB. The size stays — that test pins the 64KB pipe-buffer invariant, and conflating two limits in one fixture is what made the original CI failure confusing.
- Filed #302 while diagnosing an unrelated failure this week: a `runner: script` playbook records only `Script exited N`, with no pointer to the script's own log. Same family — a failure that reports too little to act on — but a separate change.
