### PR TITLE
Stop host-local runtime state from syncing between hosts

### DIFF
--- a/scripts/ceo-stignore-coverage.test.sh
+++ b/scripts/ceo-stignore-coverage.test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Every host-local runtime file the scripts write under CEO/log must be excluded
+# from Syncthing by syncthing/shared.stignore.
+#
+# #299 renamed the single `.fail-count` to `.fail-count-<trigger>` and the
+# stignore kept the bare name, which silently stopped matching. All nine
+# per-trigger counters then synced between hosts, reintroducing the very bug
+# #299 fixed — a healthy playbook zeroing a failing one's streak — except across
+# hosts instead of across triggers, plus Syncthing conflict copies on concurrent
+# writes. Nothing failed; both hosts just agreed on a wrong number.
+#
+# So the check derives the file list from the source rather than restating it: a
+# state file added or renamed later is picked up here automatically, which is the
+# only version of this test that survives the next rename.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test-harness.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STIGNORE="$REPO_ROOT/syncthing/shared.stignore"
+
+# Dotfile paths written under $LOG_DIR / $CEO_DIR/log by any non-test script.
+# A trailing "-" in the captured name means the source interpolated a trigger or
+# similar suffix, so the example path substitutes a concrete one.
+_discover_state_files() {
+  local f
+  for f in "$SCRIPT_DIR"/*.sh; do
+    case "$f" in
+      *.test.sh|*test-common.sh|*test-harness.sh|*debug-*) continue ;;
+    esac
+    awk 'match($0, /\$(LOG_DIR|CEO_DIR\/log)"?\/\.[a-z-]+/) {
+      m = substr($0, RSTART, RLENGTH)
+      sub(/^\$(LOG_DIR|CEO_DIR\/log)"?\//, "", m)
+      print m
+    }' "$f"
+  done | sort -u
+}
+
+# Does any stignore pattern glob-match this vault-relative path?
+_is_ignored() {
+  local path="$1" line
+  while IFS= read -r line; do
+    case "$line" in ''|'//'*|'#'*) continue ;; esac
+    # shellcheck disable=SC2254  # the pattern is data — glob expansion is the point
+    case "$path" in $line) return 0 ;; esac
+  done < "$STIGNORE"
+  return 1
+}
+
+test_stignore_covers_every_host_local_log_file() {
+  local name example found=0
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    found=$((found + 1))
+    example="$name"
+    case "$name" in *-) example="${name}example" ;; esac
+    if _is_ignored "CEO/log/$example"; then
+      assert_eq "ignored" "ignored" "CEO/log/$example is excluded from sync"
+    else
+      assert_eq "NOT-ignored" "ignored" \
+        "CEO/log/$example is host-local state but no shared.stignore pattern matches it"
+    fi
+  done < <(_discover_state_files)
+
+  # A discovery step that silently finds nothing would make every assertion above
+  # vacuous and this test permanently green.
+  if [ "$found" -lt 4 ]; then
+    printf '  FAIL [%s] discovery found only %d state files; the awk pattern has drifted from the source\n' \
+      "${CURRENT_TEST:-stignore}" "$found"
+    _record_assertion_fail
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_bare_fail_count_pattern_would_not_cover_the_per_trigger_counters() {
+  # Pins the specific regression: assert the pre-fix pattern really was the
+  # problem, so this file documents a demonstrated failure rather than a theory.
+  local path="CEO/log/.fail-count-morning"
+  local bare="CEO/log/.fail-count"
+  # shellcheck disable=SC2254
+  case "$path" in $bare) assert_eq "matched" "no-match" \
+      "the bare pattern must NOT match a per-trigger counter — if it does, this test is meaningless" ;;
+    *) assert_eq "no-match" "no-match" "the bare .fail-count pattern does not match .fail-count-<trigger>" ;;
+  esac
+  if _is_ignored "$path"; then
+    assert_eq "ignored" "ignored" "the current stignore does cover .fail-count-<trigger>"
+  else
+    assert_eq "NOT-ignored" "ignored" "the current stignore must cover .fail-count-<trigger>"
+  fi
+}
+
+test_stignore_file_exists_and_is_readable() {
+  assert_file_exists "$STIGNORE" "syncthing/shared.stignore must exist for this check to mean anything"
+}
+
+run_tests

--- a/syncthing/shared.stignore
+++ b/syncthing/shared.stignore
@@ -29,7 +29,15 @@ node_modules
 CEO/log/.last-run-*
 CEO/log/.retry-*.json
 CEO/log/.config-hash
-CEO/log/.fail-count
+// Trailing * is load-bearing: #299 renamed the single .fail-count to
+// .fail-count-<trigger>, and the bare pattern silently stopped matching, so
+// every per-trigger counter synced between hosts. That reintroduced the exact
+// bug #299 fixed — one host's healthy run zeroing another's failure streak —
+// one level up. ceo-stignore-coverage.test.sh now enforces the coverage.
+CEO/log/.fail-count*
+CEO/log/.last-scan
+CEO/log/.from-nathan-seen
+CEO/log/.nathan-nb-counter
 // --dry-run preview output is host-local scratch (see ceo-cron.sh --dry-run)
 CEO/log/preview/
 // registry.json is host-local — it now lives at ~/.ceo/registry.json (each host


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

#299 renamed the single `CEO/log/.fail-count` to `.fail-count-<trigger>`. `syncthing/shared.stignore` kept matching the old bare name, so the pattern silently stopped matching and **all nine per-trigger counters have been syncing between MBP-2026 and ML-1 ever since.**

That reintroduces the exact bug #299 set out to fix, one level up. #299's point was that a single global counter let any healthy playbook zero a failing one's streak, so the 3-strike escalation never arrived. Per-trigger counters fixed that per host — and then synced, so now a healthy playbook on *one host* zeroes a failing playbook's streak on *the other*. Concurrent writes from two hosts also invite Syncthing conflict copies on a file whose whole content is one integer.

Nothing failed, which is why it went unnoticed for a week. Both hosts simply agreed on a wrong number: `.fail-count-llm-tools-align` read `3` on MBP-2026 for a failure that only ever happened on ML-1. I found it while reading counters on both hosts and noticing all nine matched byte-for-byte, including one that couldn't have.

Auditing the rest of `CEO/log` turned up three more host-local files that were never covered at all: `.last-scan` (morning-scan's marker), `.from-nathan-seen` and `.nathan-nb-counter` (both `ceo-nathan-inbox.sh`). They don't exist on either host yet — the playbooks that write them aren't currently enabled — so this closes the gap before it produces the same silent agreement.

**The test derives the file list from the source instead of restating it.** A hand-maintained list of state files would have passed this exact rename, since the list and the stignore would both have said `.fail-count` and agreed with each other while disagreeing with the code. `_discover_state_files` greps `$LOG_DIR/.<name>` out of every non-test script, so a file added or renamed later is checked automatically.

It also fails when discovery finds fewer than four files. Without that, an awk pattern that drifts from the source yields an empty loop, every assertion becomes vacuous, and the test goes permanently green — which is the same class of failure as the bug itself.

## Testing Procedure

1. Check out this branch, then `bash scripts/ceo-stignore-coverage.test.sh` — expect 3 tests passing.
2. **Confirm it catches the regression.** Edit `syncthing/shared.stignore`: change `CEO/log/.fail-count*` back to `CEO/log/.fail-count`, and delete the `.last-scan`, `.from-nathan-seen`, and `.nathan-nb-counter` lines. Re-run. Expect 5 failures naming each gap separately:
   - `CEO/log/.fail-count-example is host-local state but no shared.stignore pattern matches it`
   - the same for `.from-nathan-seen`, `.last-scan`, `.nathan-nb-counter`
   - plus `the current stignore must cover .fail-count-<trigger>`
   Restore the file.
3. **Confirm the vacuity guard works.** Break the awk regex in `_discover_state_files` (e.g. change `LOG_DIR` to `LOG_DIRX`) and re-run. It must fail with `discovery found only 0 state files; the awk pattern has drifted from the source`, not pass. Restore.
4. `shellcheck -S warning scripts/ceo-stignore-coverage.test.sh` — clean.
5. Sanity-check the live symptom on your own hosts: `for f in <vault>/CEO/log/.fail-count-*; do echo "$(basename "$f")=$(cat "$f")"; done` on both. Before this change they match byte-for-byte; after Syncthing picks up the new ignore they diverge independently.

## Additional Notes / HelpScout Tickets

- **Existing synced counters are deliberately left in place.** Adding a stignore pattern stops future syncing but does not delete what is already there, and the values self-heal: the next successful run on each host resets its own counter via `_record_success`. Deleting them by hand would also mean touching the vault on two machines for no benefit.
- The `*` on `CEO/log/.fail-count*` covers both the legacy bare name (still present on both hosts) and the per-trigger form, so no host is left with an unignored leftover.
- Found while sweeping outstanding work rather than from a report. Sibling of #302 in kind: the failure mode is a signal that looks fine and is wrong, not an error anybody sees.
