### PR TITLE
Make doctor detect stignore drift, and stop it truncating silently

### DIFF
--- a/scripts/ceo
+++ b/scripts/ceo
@@ -127,6 +127,39 @@ _doctor_stale_grace() {
   echo $(( 4 * 86400 ))
 }
 
+# Compare the vault's live .stignore against the repo's syncthing/shared.stignore.
+#
+# Deployment is a documented manual copy (README: "copy syncthing/shared.stignore
+# to ~/Documents/Obsidian/.stignore"), with nothing verifying it happened. It
+# drifted for four months on one host and was never done at all on the other, so
+# every host-local runtime file — per-trigger fail counters, dry-run previews,
+# the host-local registry — synced between machines. Nothing errored; the hosts
+# just silently shared state they are each supposed to own.
+#
+# Prints a "✗ ..." line per missing pattern and a trailing "MISSING=<n>" summary.
+# An absent repo file yields MISSING=0: this check is about deployment drift, and
+# a repo we cannot read is not evidence of it.
+_doctor_check_stignore() {
+  local repo_file="$1" live_file="$2"
+  if [ ! -f "$repo_file" ]; then echo "MISSING=0"; return 0; fi
+  if [ ! -f "$live_file" ]; then
+    echo "✗ no .stignore at the vault root — every host-local CEO/log file is syncing between hosts"
+    echo "  fix: cp $repo_file $live_file"
+    echo "MISSING=1"
+    return 0
+  fi
+  local missing=0 pattern
+  while IFS= read -r pattern; do
+    case "$pattern" in ''|'//'*|'#'*) continue ;; esac
+    if ! grep -qxF -- "$pattern" "$live_file"; then
+      echo "✗ .stignore is missing '$pattern' — that path is syncing between hosts"
+      missing=$((missing + 1))
+    fi
+  done < "$repo_file"
+  [ "$missing" -gt 0 ] && echo "  fix: cp $repo_file $live_file"
+  echo "MISSING=$missing"
+}
+
 # Detect scheduled playbooks that silently stopped RUNNING or stopped DELIVERING
 # to Discord. Prints a "✗ ..." line per stale playbook and a trailing
 # "FRESH=<n> STALE=<n>" summary line. Absent signal files (never-run / never-
@@ -516,12 +549,27 @@ cmd_doctor() {
   # daemon dying; this catches one playbook wedged or gated while the daemon lives.
   local _fresh_out _fr_stale
   _fresh_out=$(_doctor_check_freshness "${CEO_REGISTRY_FILE:-$HOME/.ceo/registry.json}" "$CEO_DIR/log")
-  printf '%s\n' "$_fresh_out" | grep '^✗' | sed 's/^/  /'
+  # `|| true`: under `set -e` a non-matching grep exits 1 and aborts cmd_doctor
+  # before it prints its Result line — so doctor silently truncated on exactly
+  # the healthy hosts where there was nothing to report.
+  printf '%s\n' "$_fresh_out" | grep '^✗' | sed 's/^/  /' || true
   _fr_stale=$(printf '%s\n' "$_fresh_out" | sed -n 's/.*STALE=\([0-9]*\).*/\1/p' | tail -1)
   if [ "${_fr_stale:-0}" -gt 0 ]; then
     fail=$(( fail + _fr_stale ))
   else
     echo "  ✓ playbook freshness: no scheduled playbook has silently stopped running or delivering"
+    ok=$(( ok + 1 ))
+  fi
+
+  local _sti_out _sti_missing _sti_repo
+  _sti_repo="${CEO_STIGNORE_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/syncthing/shared.stignore}"
+  _sti_out=$(_doctor_check_stignore "$_sti_repo" "$CEO_VAULT/.stignore")
+  printf '%s\n' "$_sti_out" | grep -E '^(✗|  fix:)' | sed 's/^/  /' || true
+  _sti_missing=$(printf '%s\n' "$_sti_out" | sed -n 's/^MISSING=\([0-9]*\)$/\1/p' | tail -1)
+  if [ "${_sti_missing:-0}" -gt 0 ]; then
+    warn=$(( warn + 1 ))
+  else
+    echo "  ✓ .stignore matches the repo: host-local runtime state is not syncing"
     ok=$(( ok + 1 ))
   fi
 

--- a/scripts/ceo-doctor-freshness.test.sh
+++ b/scripts/ceo-doctor-freshness.test.sh
@@ -98,4 +98,73 @@ test_absent_signal_file_not_flagged() {
   assert_contains "$out" "STALE=0" "a never-run playbook (no signal file) is pending, not stale"
 }
 
+# --- _doctor_check_stignore -------------------------------------------------
+# Deployment of syncthing/shared.stignore is a manual copy with nothing verifying
+# it. It drifted four months on one host and was never done on the other, so
+# host-local state (per-trigger fail counters, dry-run previews, the host-local
+# registry) synced between machines with no error anywhere.
+
+_sti_files() {
+  REPO_STI="$TMP/shared.stignore"
+  LIVE_STI="$TMP/vault/.stignore"
+  mkdir -p "$TMP/vault"
+  cat > "$REPO_STI" <<'STI'
+// a comment, which must not be treated as a pattern
+CEO/log/.fail-count*
+CEO/log/preview/
+CEO/registry.json
+STI
+}
+
+test_stignore_flags_a_pattern_missing_from_the_live_file() {
+  _sti_files
+  printf '%s\n' 'CEO/log/.fail-count*' 'CEO/registry.json' > "$LIVE_STI"
+  local out; out=$(_doctor_check_stignore "$REPO_STI" "$LIVE_STI")
+  assert_contains "$out" "MISSING=1" "one absent pattern must be counted"
+  assert_contains "$out" "CEO/log/preview/" "the missing pattern must be named"
+  assert_contains "$out" "fix: cp" "the fix line must give the copy command"
+}
+
+test_stignore_clean_when_live_matches_repo() {
+  _sti_files
+  grep -v '^//' "$REPO_STI" > "$LIVE_STI"
+  local out; out=$(_doctor_check_stignore "$REPO_STI" "$LIVE_STI")
+  assert_contains "$out" "MISSING=0" "a live file carrying every pattern is clean"
+}
+
+test_stignore_absent_live_file_is_the_loudest_case() {
+  # ML-1 had no .stignore at all, which is worse than drift: every host-local
+  # file syncs. It must not be reported as merely "0 missing".
+  _sti_files
+  rm -f "$LIVE_STI"
+  local out; out=$(_doctor_check_stignore "$REPO_STI" "$LIVE_STI")
+  assert_contains "$out" "MISSING=1" "an absent .stignore must be flagged, not treated as clean"
+  assert_contains "$out" "no .stignore at the vault root" "the message must say the file is absent"
+}
+
+test_stignore_comments_are_not_treated_as_patterns() {
+  # A '//' line is a Syncthing comment. Counting it as a missing pattern would
+  # make the check permanently dirty and train the reader to ignore it.
+  _sti_files
+  grep -v '^//' "$REPO_STI" > "$LIVE_STI"
+  local out; out=$(_doctor_check_stignore "$REPO_STI" "$LIVE_STI")
+  assert_contains "$out" "MISSING=0" "comment lines must not count as patterns"
+}
+
+test_stignore_absent_repo_file_is_not_reported_as_drift() {
+  _sti_files
+  local out; out=$(_doctor_check_stignore "$TMP/does-not-exist" "$LIVE_STI")
+  assert_contains "$out" "MISSING=0" "an unreadable repo file is not evidence of drift"
+}
+
+test_stignore_matches_whole_lines_not_substrings() {
+  # 'CEO/registry.json' must not be satisfied by a live line that merely contains
+  # it as a substring, or a narrower live pattern would mask a missing broader one.
+  _sti_files
+  printf '%s\n' 'CEO/log/.fail-count*' 'CEO/log/preview/' 'x-CEO/registry.json-y' > "$LIVE_STI"
+  local out; out=$(_doctor_check_stignore "$REPO_STI" "$LIVE_STI")
+  assert_contains "$out" "MISSING=1" "a substring match must not satisfy a pattern"
+  assert_contains "$out" "CEO/registry.json" "the unsatisfied pattern must be named"
+}
+
 run_tests

--- a/scripts/ceo-doctor.test.sh
+++ b/scripts/ceo-doctor.test.sh
@@ -462,4 +462,42 @@ test_doctor_clamps_future_schedulerd_heartbeat_to_alive() {
   assert_not_contains "$output" "(heartbeat -" "future-dated heartbeat age must not be negative"
 }
 
+# doctor must always reach its Result line. Both the freshness and .stignore
+# blocks pipe through `grep`, and under `set -euo pipefail` a non-matching grep
+# exits 1 and aborts cmd_doctor mid-run — so the report silently truncated on
+# exactly the hosts where there was nothing to report, and the operator saw a
+# short output with no Result summary and no clue it was incomplete.
+test_doctor_prints_its_result_line_when_nothing_is_stale() {
+  # A clean host: no runs logged, so the freshness check finds nothing stale and
+  # its grep matches nothing. Pre-fix this aborted before "Result:".
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "Result:" \
+    "doctor must print its Result summary even when every grep-driven check matches nothing"
+}
+
+test_doctor_reports_the_stignore_check() {
+  # A vault with no .stignore is the ML-1 case: every host-local CEO/log file
+  # syncs between hosts. doctor must say so rather than stay silent.
+  rm -f "$CEO_VAULT/.stignore"
+  local output
+  output=$("$CEO_BIN" doctor 2>&1 || true)
+  assert_contains "$output" "Result:" "doctor must still complete with a missing .stignore"
+  assert_contains "$output" ".stignore" "doctor must mention .stignore either way"
+}
+
+test_doctor_stignore_clean_when_live_file_matches_repo() {
+  local repo_sti
+  repo_sti="$(cd "$(dirname "$CEO_BIN")/.." && pwd)/syncthing/shared.stignore"
+  if [ -f "$repo_sti" ]; then
+    grep -vE '^\s*(//|#|$)' "$repo_sti" > "$CEO_VAULT/.stignore"
+    local output
+    output=$("$CEO_BIN" doctor 2>&1 || true)
+    assert_contains "$output" "host-local runtime state is not syncing" \
+      "a deployed .stignore must read as clean"
+  else
+    assert_eq "skip" "skip" "repo shared.stignore not reachable from the test bin path"
+  fi
+}
+
 run_tests


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

Two bugs, both found by running `ceo doctor` end-to-end rather than trusting the unit tests around it.

### 1. stignore deployment drift was undetectable

`shared.stignore` reaches a host by a documented manual copy — README: *"copy `syncthing/shared.stignore` to `~/Documents/Obsidian/.stignore`"* — with nothing verifying it happened. In practice:

- **MBP-2026's copy was dated April 15**, four months stale
- **ML-1 had no `.stignore` at all**

So every host-local runtime file was syncing between the two machines: the per-trigger fail counters (#304), dry-run previews under `CEO/log/preview/`, and `CEO/registry.json` — which was made host-local in D1 *precisely because* two hosts scanning a shared copy conflict. Nothing errored. Both hosts silently agreed on state each is supposed to own separately. #304 fixed the pattern in the repo; this makes the repo→host gap visible, which is the half that actually let it persist.

`_doctor_check_stignore` names each missing pattern, prints the `cp` command, and counts as a warning (not a failure — it is a deployment gap, not a broken host).

Design choices worth flagging, each with a test:
- **Whole-line match, not substring.** Otherwise a narrower live pattern masks a missing broader one.
- **An absent live file is its own louder case**, not "0 missing" — that was the worse of the two real states, and reporting it as clean would have been the same silence again.
- **An unreadable repo file reports clean.** This checks deployment drift; a repo we cannot read is not evidence of it.
- **`//` comments are not patterns.** Counting them would make the check permanently dirty and train the reader to ignore it.

### 2. `ceo doctor` was aborting before its own Result line

Both the freshness and stignore blocks pipe through `grep`, and under `set -euo pipefail` a non-matching `grep` exits 1 and kills `cmd_doctor` mid-run. The report truncated on **exactly the hosts where there was nothing to report** — the operator saw a short output with no `Result:` summary and no indication it was incomplete.

The freshness one has been latent since it was written; adding a second grep-driven check made it fire on this host, which is how it surfaced. Both are now `|| true`.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-doctor-freshness.test.sh` — 16 pass (6 new, covering the missing-pattern, clean, absent-live-file, comments, absent-repo-file, and substring cases).
3. `bash scripts/ceo-doctor.test.sh` — 23 pass (3 new, driving the real binary).
4. **Confirm the truncation fix is real coverage.** Remove either `|| true` from `scripts/ceo` (lines 555 and 567) and re-run step 3. `test_doctor_prints_its_result_line_when_nothing_is_stale` must fail, and its captured output stops one line short of `Result:`. Restore.
5. **Confirm the check works on real data**, not just fixtures — this is the part fixtures can't prove:
   ```bash
   bash -c 'export CEO_LIB_ONLY=1; set +u; source scripts/ceo; set +e +u; unset CEO_LIB_ONLY;
     _doctor_check_stignore syncthing/shared.stignore "$HOME/Documents/Obsidian/.stignore"'
   ```
   Expect `MISSING=0` against a deployed file. Point it at a stale copy (mine is at `.stignore.bak-2026-08-12`) and expect six named gaps: `.fail-count*`, `.last-scan`, `.from-nathan-seen`, `.nathan-nb-counter`, `preview/`, `registry.json`.
6. `bash scripts/ceo doctor` — completes and prints `Result:` with a `✓ .stignore matches the repo` line.
7. `shellcheck -S warning scripts/ceo scripts/ceo-doctor.test.sh scripts/ceo-doctor-freshness.test.sh` — clean.
8. Full suite: only `ceo-git-monitor.test.sh` fails, identically to untouched `main` (local `git-identity-gate` hook vs its `Test User <test@example.com>` fixture commit; absent in CI).

## Additional Notes / HelpScout Tickets

- **Both hosts have been deployed already** — the correct `shared.stignore` is now at each vault root, with the previous MBP file kept at `.stignore.bak-2026-08-12`. This PR is what stops it drifting again, not what fixes the current state.
- The repo path is resolved from `BASH_SOURCE` and overridable via `CEO_STIGNORE_REPO`, so an installed `ceo` on a host whose checkout lives elsewhere can still be pointed at the right file.
- `ceo doctor` also currently reports 6 Syncthing conflict files at the vault root, all `.ffs_lock`/`.ffs_db` from a *different* sync tool. Unrelated to this change and left alone.
- Follows #304 (the pattern) and #303. Sibling of #302 in kind: a signal that looks fine and is wrong.
