### PR TITLE
token-intake: capture credits and escalate a week over the cap

### DIFF
--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -66,6 +66,11 @@ when the week is over cap **and** above the worst *full* week in the 8-week wind
 Truncated weeks hold only part of their spend, so counting them would understate
 the bar.
 
+When the window contains no full week at all — a fresh host, or `--since` too
+short — there is no bar to clear, so the alert falls back to plain "over cap". That
+fires at most once for that week and only when genuinely over, which is the right
+trade for a host with no history to compare against.
+
 The metric is `--credits`'s projection when it has one and spend-so-far otherwise.
 The report suppresses its projection until a fifth of the week has elapsed, so a
 Monday-morning cron run judges what has actually been spent rather than

--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -1,6 +1,6 @@
 ---
 name: token-intake
-description: Daily RTK + token-scope spend intake — drops one inbox item linking to today's report
+description: Daily RTK + token-scope spend intake — drops one inbox item linking to today's report, and escalates a week tracking over the credit cap
 trigger: cron
 schedule: "45 8 * * 1-5"
 preflight: none
@@ -18,20 +18,53 @@ Shell-only playbook. The dispatcher invokes `scripts/ceo-token-intake.sh` direct
 
 ## What it does
 
-Captures four command outputs into `CEO/reports/token/<TODAY>.md`:
+Captures command outputs into `CEO/reports/token/<TODAY>-<HOST>.md`:
 
 - `rtk gain` — global RTK savings
-- `rtk gain -p` — RTK savings scoped to current project
-- `rtk cc-economics` — ccusage spend vs RTK savings
+- `npx ccusage monthly` — Claude Code monthly spend
 - `token-scope --since 1d` — Claude Code spend for the last 24h
+- `token-scope --credits --since 8w` — weekly credits against the plan cap
+- **credit cap check** — reads `--credits --json` and names where the week stands
+- **auth health** — flags a host that ran sessions but produced no successful turns
 
-Then idempotently appends one line to `CEO/inbox.md`:
+Then idempotently appends one line to `CEO/inbox/<HOST>.md` (per-host, so two
+Syncthing peers can't race on the same path):
 
 ```
-- [ ] Review daily token report [[CEO/reports/token/<TODAY>]]
+- [ ] Review daily token report [[CEO/reports/token/<TODAY>-<HOST>]]
 ```
 
-The chat-triggered `inbox` playbook picks the line up next time `ceo chat inbox` runs.
+## Declared outputs
+
+- `CEO/reports/token/{TODAY}-{HOST}.md` — the report
+- `CEO/inbox/{HOST}.md` — the review line, plus up to two escalations below
+
+## Escalations
+
+Two conditions get their own inbox item, because they are actionable rather than
+informational:
+
+| Condition | Marker keyed on | Re-alerts when |
+|---|---|---|
+| Week is over (or projected over) the credit cap | the ISO week | a **new** week goes over |
+| Host produced no successful Claude turns in 48h | the host | the prior alert was checked off |
+
+Both dedupe on the **unchecked** marker, so a condition that persists doesn't
+re-append daily but a genuine state transition does alert. This is the
+`ceo-automated-writers-are-playbooks` rule in practice — the disk-monitor
+incident appended 64 identical hourly alerts because it had no such gate.
+
+**Why credits and not dollars.** The plan's cap is denominated in credits, so a
+dollar total can't answer "am I over?". `--credits` reports weighted tokens per
+ISO week against the cap; the alert carries the ratio and names the lever, which
+is context size per turn — cache reads and writes are ~90% of a weighted week,
+so shorter sessions and `/clear` move the number and shorter answers don't.
+
+**A token-scope too old to have `--credits`** is escalated as its own inbox item
+naming `/plugin update`, and the credits capture is skipped rather than attempted.
+`capture` treats a non-zero exit as a run failure, so attempting it would redden
+cron telemetry every morning for something only the user can fix — training them
+to ignore the failure channel.
 
 ## Install
 

--- a/docs/playbooks/token-intake.md
+++ b/docs/playbooks/token-intake.md
@@ -46,25 +46,49 @@ informational:
 
 | Condition | Marker keyed on | Re-alerts when |
 |---|---|---|
-| Week is over (or projected over) the credit cap | the ISO week | a **new** week goes over |
+| Week is over cap **and worse than the worst full week in the window** | the ISO week | a **new** week beats the baseline |
 | Host produced no successful Claude turns in 48h | the host | the prior alert was checked off |
 
-Both dedupe on the **unchecked** marker, so a condition that persists doesn't
-re-append daily but a genuine state transition does alert. This is the
-`ceo-automated-writers-are-playbooks` rule in practice — the disk-monitor
-incident appended 64 identical hourly alerts because it had no such gate.
+The auth marker keys on the host, so a re-alert after check-off *is* the state
+transition. The cap marker already keys on the ISO week, so it dedupes regardless
+of checkbox state — checking it off must not make the same week report twice.
+
+Neither escalation carries the report wikilink. The daily review line is counted
+*by* wikilink to prove it appends exactly once, so a second line carrying the same
+link would break that invariant every week the alert fired.
+
+## Why the cap alert has a baseline
+
+A bare "over cap" trigger is useless on a host that is chronically over — it
+reports the baseline back as news every week, which is the nag
+`ceo-automated-writers-are-playbooks` exists to prevent. So the alert fires only
+when the week is over cap **and** above the worst *full* week in the 8-week window.
+Truncated weeks hold only part of their spend, so counting them would understate
+the bar.
+
+The metric is `--credits`'s projection when it has one and spend-so-far otherwise.
+The report suppresses its projection until a fifth of the week has elapsed, so a
+Monday-morning cron run judges what has actually been spent rather than
+extrapolating from a few hours.
 
 **Why credits and not dollars.** The plan's cap is denominated in credits, so a
-dollar total can't answer "am I over?". `--credits` reports weighted tokens per
-ISO week against the cap; the alert carries the ratio and names the lever, which
-is context size per turn — cache reads and writes are ~90% of a weighted week,
-so shorter sessions and `/clear` move the number and shorter answers don't.
+dollar total can't answer "am I over?". The alert names the lever: cache reads and
+writes are ~90% of a weighted week, so shorter sessions and `/clear` move the
+number and shorter answers don't.
 
-**A token-scope too old to have `--credits`** is escalated as its own inbox item
-naming `/plugin update`, and the credits capture is skipped rather than attempted.
-`capture` treats a non-zero exit as a run failure, so attempting it would redden
-cron telemetry every morning for something only the user can fix — training them
-to ignore the failure channel.
+## Failure modes it distinguishes
+
+| Situation | What happens |
+|---|---|
+| `token-scope` missing from PATH entirely | the `--since 1d` capture fails, run exits non-zero — a real failure |
+| `token-scope` present but predates `--credits` | credits capture skipped, one inbox item naming `/plugin update`, run exits **0** |
+| `--credits --json` returns an unexpected shape | reported as a contract error, not as "no data" |
+| `weekly_cap` is 0 or missing | refused rather than printed as "0M cap" |
+| no started week in the window | reported as such; a future-dated week (clock skew) is never judged |
+
+The stale-plugin case deliberately does not fail the run: `capture` treats a
+non-zero exit as a run failure, and reddening cron every morning for something
+only a `/plugin update` fixes trains the reader to ignore the failure channel.
 
 ## Install
 

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # ceo-token-intake.sh — Daily RTK + token-scope spend intake.
-# Captures four command outputs to CEO/reports/token/<TODAY>-<host>.md and
+# Captures command outputs to CEO/reports/token/<TODAY>-<host>.md and
 # idempotently appends one inbox line to CEO/inbox/<host>.md linking to it.
+# Also escalates a distinct inbox item when the week is tracking over the plan's
+# credit cap — the one number in the report that is actionable rather than
+# informational, and the reason the report exists at all.
 # Per-host filenames keep two Syncthing peers from racing on the same path.
 # The chat-triggered inbox playbook surfaces the line via `ceo chat inbox`.
 #
@@ -136,12 +139,102 @@ if [ "${TS_CMD[0]}" = "token-scope" ]; then
 fi
 unset _ts_resolved _ts_runtime _ts_path
 
+# check_credit_cap — the actionable half of this report.
+#
+# A dollar total cannot say whether the week is over the plan allowance, because
+# the plan is metered in credits. `token-scope --credits --json` reports weighted
+# tokens per ISO week against that cap; this reads the week in progress and, when
+# it is over (or projected over), escalates ONE inbox item.
+#
+# Escalation is keyed on the ISO week, deduped on the UNCHECKED marker: a week
+# that is still over tomorrow does not re-append, but a NEW week going over does
+# alert. That is a state transition, not a signal generator — the distinction
+# ceo-automated-writers-are-playbooks exists to enforce, and the disk-monitor
+# incident (64 identical hourly alerts) is what happens without it.
+#
+# Never fails the run: a stale plugin cache without --credits is reported as its
+# own actionable item, not as red cron telemetry, because the fix is a /plugin
+# update the user performs, not a broken job.
+CAP_ALERT=""
+CAP_ALERT_KEY=""
+
+# Probed once, before the report is written. A build without --credits must not
+# reach `capture` at all: capture treats a non-zero exit as a run failure, so an
+# out-of-date plugin cache would redden cron telemetry every morning when the
+# actual fix is a `/plugin update` the user performs. That belongs in the inbox
+# as an actionable item, not in the failure channel.
+TS_HAS_CREDITS=0
+if "${TS_CMD[@]}" --help 2>/dev/null | grep -q -- '--credits'; then
+  TS_HAS_CREDITS=1
+else
+  CAP_ALERT="token-scope in the plugin cache predates \`--credits\`, so this report cannot say whether the week is over the credit cap. Fix: run \`/plugin update\` in Claude Code."
+  CAP_ALERT_KEY="stale-plugin"
+fi
+
+check_credit_cap() {
+  if [ "$TS_HAS_CREDITS" -ne 1 ]; then
+    printf 'SKIP: this token-scope build has no --credits (plugin cache predates it); escalated to the inbox.\n'
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'SKIP: jq not on PATH; cannot read the credits report without guessing.\n'
+    return 0
+  fi
+
+  local json
+  if ! json=$("${TS_CMD[@]}" --credits --since 8w --json 2>/dev/null); then
+    printf 'SKIP: token-scope --credits exited non-zero.\n'
+    return 0
+  fi
+
+  # The week in progress: partial, and started on or before now. Reading the last
+  # row instead would pick a future-dated week if a synced host's clock is skewed.
+  local row
+  row=$(printf '%s' "$json" | jq -c '
+    (.meta.weekly_cap // 0) as $cap
+    | [ .weeks[] | select(.partial == true) ] | last
+    | select(. != null)
+    | { week: .weekStart,
+        credits: .credits,
+        ratio: (.projectedCapRatio // .capRatio),
+        projected: (.projectedCapRatio != null),
+        cap: $cap }' 2>/dev/null) || row=""
+  if [ -z "$row" ] || [ "$row" = "null" ]; then
+    printf 'No week in progress in the last 8w — nothing to compare against the cap.\n'
+    return 0
+  fi
+
+  local week ratio projected credits cap
+  week=$(printf '%s' "$row" | jq -r '.week')
+  ratio=$(printf '%s' "$row" | jq -r '.ratio')
+  projected=$(printf '%s' "$row" | jq -r '.projected')
+  credits=$(printf '%s' "$row" | jq -r '(.credits / 1000000) | (. * 10 | round) / 10')
+  cap=$(printf '%s' "$row" | jq -r '(.cap / 1000000) | (. * 10 | round) / 10')
+
+  local over
+  over=$(printf '%s' "$row" | jq -r 'if (.ratio // 0) > 1 then "yes" else "no" end')
+  local shape="so far"
+  [ "$projected" = "true" ] && shape="projected"
+
+  printf 'week %s: %sM credits %s vs %sM cap (%sx)\n' "$week" "$credits" "$shape" "$cap" "$ratio"
+  if [ "$over" = "yes" ]; then
+    CAP_ALERT="Week of $week is ${ratio}x the ${cap}M credit cap (${credits}M $shape). Cache reads and writes are ~90% of a weighted week, so the lever is context size per turn — shorter sessions and /clear, not shorter answers."
+    CAP_ALERT_KEY="$week"
+    printf 'WARN: over cap\n'
+  fi
+  return 0
+}
+
 if ! {
   printf -- '---\ndate: %s\ntype: ceo-token-intake\n---\n\n' "$TODAY"
   printf '# Token Report — %s\n' "$TODAY"
   capture "RTK — global savings" rtk gain
   capture "ccusage — Claude Code monthly" npx --yes ccusage@latest monthly
   capture "token-scope — last 24h" "${TS_CMD[@]}" --since 1d
+  if [ "$TS_HAS_CREDITS" -eq 1 ]; then
+    capture "token-scope — credits vs weekly cap" "${TS_CMD[@]}" --credits --since 8w
+  fi
+  capture "credit cap check" check_credit_cap
   capture "auth health" check_auth_health
 } > "$REPORT_FILE"; then
   echo "ERROR: failed to write $REPORT_FILE" >&2
@@ -170,6 +263,17 @@ if [ -n "$AUTH_ALERT" ]; then
   AUTH_LINE="- [ ] ⚠️ $AUTH_MARKER in 48h — likely logged out; ssh in and run \`claude\` then /login ($WIKILINK)"
   if ! grep -qF -- "- [ ] ⚠️ $AUTH_MARKER" "$INBOX_FILE"; then
     printf '%s\n' "$AUTH_LINE" >> "$INBOX_FILE"
+  fi
+fi
+
+# Escalate an over-cap week (or a plugin too old to tell) as its own item.
+# The marker carries the week, so a still-over week does not re-append tomorrow
+# but a new week going over does alert.
+if [ -n "$CAP_ALERT" ]; then
+  CAP_MARKER="Credit cap ($CAP_ALERT_KEY) on $HOST"
+  CAP_LINE="- [ ] ⚠️ $CAP_MARKER — $CAP_ALERT ($WIKILINK)"
+  if ! grep -qF -- "- [ ] ⚠️ $CAP_MARKER" "$INBOX_FILE"; then
+    printf '%s\n' "$CAP_LINE" >> "$INBOX_FILE"
   fi
 fi
 

--- a/scripts/ceo-token-intake.sh
+++ b/scripts/ceo-token-intake.sh
@@ -164,7 +164,12 @@ CAP_ALERT_KEY=""
 # actual fix is a `/plugin update` the user performs. That belongs in the inbox
 # as an actionable item, not in the failure channel.
 TS_HAS_CREDITS=0
-if "${TS_CMD[@]}" --help 2>/dev/null | grep -q -- '--credits'; then
+if ! command -v "${TS_CMD[0]}" >/dev/null 2>&1; then
+  # A missing binary is a genuine run failure — the `--since 1d` capture below
+  # will record it and exit non-zero. Telling the user to run `/plugin update`
+  # for something that isn't installed would be wrong advice on top of red cron.
+  :
+elif "${TS_CMD[@]}" --help 2>/dev/null | grep -q -- '--credits'; then
   TS_HAS_CREDITS=1
 else
   CAP_ALERT="token-scope in the plugin cache predates \`--credits\`, so this report cannot say whether the week is over the credit cap. Fix: run \`/plugin update\` in Claude Code."
@@ -173,7 +178,7 @@ fi
 
 check_credit_cap() {
   if [ "$TS_HAS_CREDITS" -ne 1 ]; then
-    printf 'SKIP: this token-scope build has no --credits (plugin cache predates it); escalated to the inbox.\n'
+    printf 'SKIP: no token-scope with --credits available; see the inbox if this is a stale plugin.\n'
     return 0
   fi
   if ! command -v jq >/dev/null 2>&1; then
@@ -183,44 +188,75 @@ check_credit_cap() {
 
   local json
   if ! json=$("${TS_CMD[@]}" --credits --since 8w --json 2>/dev/null); then
-    printf 'SKIP: token-scope --credits exited non-zero.\n'
+    printf 'ERROR: token-scope --credits exited non-zero.\n'
+    return 0
+  fi
+  # Distinguish a contract change from an idle week. Routing both to "no data"
+  # would let a renamed field silence this check indefinitely.
+  if ! printf '%s' "$json" | jq -e 'has("weeks") and (.meta | has("weekly_cap"))' >/dev/null 2>&1; then
+    printf 'ERROR: --credits --json is not the expected shape (missing .weeks or .meta.weekly_cap).\n'
     return 0
   fi
 
-  # The week in progress: partial, and started on or before now. Reading the last
-  # row instead would pick a future-dated week if a synced host's clock is skewed.
-  local row
-  row=$(printf '%s' "$json" | jq -c '
-    (.meta.weekly_cap // 0) as $cap
-    | [ .weeks[] | select(.partial == true) ] | last
-    | select(. != null)
-    | { week: .weekStart,
-        credits: .credits,
-        ratio: (.projectedCapRatio // .capRatio),
-        projected: (.projectedCapRatio != null),
-        cap: $cap }' 2>/dev/null) || row=""
-  if [ -z "$row" ] || [ "$row" = "null" ]; then
-    printf 'No week in progress in the last 8w — nothing to compare against the cap.\n'
+  local cap
+  cap=$(printf '%s' "$json" | jq -r '.meta.weekly_cap')
+  if [ -z "$cap" ] || [ "$cap" = "null" ] || [ "$cap" = "0" ]; then
+    printf 'ERROR: weekly_cap is %s — nothing to compare against.\n' "${cap:-empty}"
     return 0
   fi
 
-  local week ratio projected credits cap
-  week=$(printf '%s' "$row" | jq -r '.week')
-  ratio=$(printf '%s' "$row" | jq -r '.ratio')
-  projected=$(printf '%s' "$row" | jq -r '.projected')
-  credits=$(printf '%s' "$row" | jq -r '(.credits / 1000000) | (. * 10 | round) / 10')
-  cap=$(printf '%s' "$row" | jq -r '(.cap / 1000000) | (. * 10 | round) / 10')
+  # The week in progress: partial AND already started. Filtering on `partial`
+  # alone picks a future-dated week when a synced host's clock is skewed, and
+  # because that phantom week is nearly empty it reads as comfortably under cap
+  # — masking a real over-cap week instead of merely mis-reporting one.
+  local today row
+  today=$(date -u +%Y-%m-%d)
+  row=$(printf '%s' "$json" | jq -c --arg today "$today" '
+    [ .weeks[] | select(.partial == true and .weekStart <= $today) ] | last // empty' 2>/dev/null) || row=""
+  if [ -z "$row" ]; then
+    printf 'No started week in progress in the last 8w — nothing to compare against the cap.\n'
+    return 0
+  fi
 
-  local over
-  over=$(printf '%s' "$row" | jq -r 'if (.ratio // 0) > 1 then "yes" else "no" end')
-  local shape="so far"
-  [ "$projected" = "true" ] && shape="projected"
+  # Baseline: the worst FULL week in the window. Truncated weeks hold only part
+  # of their spend, so including them would understate the bar.
+  local baseline
+  baseline=$(printf '%s' "$json" | jq -r '
+    [ .weeks[] | select(.partial != true and .truncated != true) | .capRatio ]
+    | if length == 0 then "" else (max | (. * 100 | round) / 100) end' 2>/dev/null) || baseline=""
 
-  printf 'week %s: %sM credits %s vs %sM cap (%sx)\n' "$week" "$credits" "$shape" "$cap" "$ratio"
-  if [ "$over" = "yes" ]; then
-    CAP_ALERT="Week of $week is ${ratio}x the ${cap}M credit cap (${credits}M $shape). Cache reads and writes are ~90% of a weighted week, so the lever is context size per turn — shorter sessions and /clear, not shorter answers."
+  local week ratio shape credits capm
+  week=$(printf '%s' "$row" | jq -r '.weekStart')
+  # projectedCapRatio is null until a fifth of the week has elapsed, so before
+  # then this falls back to spend-so-far and cannot alert on Monday-morning
+  # arithmetic. Nulls never reach the message.
+  ratio=$(printf '%s' "$row" | jq -r '((.projectedCapRatio // .capRatio) // 0) | (. * 100 | round) / 100')
+  shape=$(printf '%s' "$row" | jq -r 'if .projectedCapRatio != null then "projected" else "so far" end')
+  credits=$(printf '%s' "$row" | jq -r '((.credits // 0) / 1000000) | (. * 10 | round) / 10')
+  capm=$(awk -v c="$cap" 'BEGIN { printf "%.1f", c / 1000000 }')
+
+  printf 'week %s: %sM credits %s vs %sM cap (%sx); worst full week in window: %sx\n' \
+    "$week" "$credits" "$shape" "$capm" "$ratio" "${baseline:-n/a}"
+
+  # Escalate only a week that is BOTH over the cap and worse than the worst full
+  # week in the window. A bare `> 1` on a host that runs 1.5-4.7x every week is a
+  # weekly nag that reports the baseline as news; this fires when the week is
+  # genuinely worse than recent behaviour, which is the only version worth reading.
+  local trip=0
+  if awk -v r="$ratio" 'BEGIN { exit !(r > 1) }'; then
+    if [ -z "$baseline" ]; then
+      trip=1
+    elif awk -v r="$ratio" -v b="$baseline" 'BEGIN { exit !(r > b) }'; then
+      trip=1
+    fi
+  fi
+
+  if [ "$trip" -eq 1 ]; then
+    local vs="no full week in the window to compare against"
+    [ -n "$baseline" ] && vs="worse than the worst full week in the window (${baseline}x)"
+    CAP_ALERT="Week of $week is ${ratio}x the ${capm}M credit cap (${credits}M $shape) — $vs. Cache reads and writes are ~90% of a weighted week, so the lever is context size per turn: shorter sessions and /clear, not shorter answers."
     CAP_ALERT_KEY="$week"
-    printf 'WARN: over cap\n'
+    printf 'WARN: over cap and above baseline\n'
   fi
   return 0
 }
@@ -269,10 +305,18 @@ fi
 # Escalate an over-cap week (or a plugin too old to tell) as its own item.
 # The marker carries the week, so a still-over week does not re-append tomorrow
 # but a new week going over does alert.
+# The marker deliberately omits the report wikilink: the daily review line is
+# counted by wikilink to prove it is appended exactly once, and a second line
+# carrying the same link would break that invariant every week this fires.
+#
+# Dedupe ignores the checkbox state, unlike the auth alert above. The auth marker
+# keys on the host, so a re-alert after check-off IS the transition; this marker
+# already keys on the ISO week, so re-appending after a check-off would tell the
+# user about the same week twice.
 if [ -n "$CAP_ALERT" ]; then
   CAP_MARKER="Credit cap ($CAP_ALERT_KEY) on $HOST"
-  CAP_LINE="- [ ] ⚠️ $CAP_MARKER — $CAP_ALERT ($WIKILINK)"
-  if ! grep -qF -- "- [ ] ⚠️ $CAP_MARKER" "$INBOX_FILE"; then
+  CAP_LINE="- [ ] ⚠️ $CAP_MARKER — $CAP_ALERT"
+  if ! grep -qF -- "$CAP_MARKER" "$INBOX_FILE"; then
     printf '%s\n' "$CAP_LINE" >> "$INBOX_FILE"
   fi
 fi

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -9,6 +9,42 @@ INTAKE="$SCRIPT_DIR/ceo-token-intake.sh"
 
 source "$SCRIPT_DIR/test-harness.sh"
 
+# write_token_scope_stub <credits-json> <supports-credits: yes|no>
+# Rebuilds the token-scope stub. The JSON is what `--credits --json` returns;
+# "no" makes --help omit --credits, simulating a plugin cache older than the
+# report (the case that must NOT redden cron).
+write_token_scope_stub() {
+  local json="$1" supports="$2"
+  mkdir -p "$TEST_HOME/.bun/bin"
+  {
+    printf '#!/bin/bash\n'
+    printf 'set -u\n'
+    printf 'CREDITS_JSON=%q\n' "$json"
+    printf 'SUPPORTS=%q\n' "$supports"
+    cat << 'STUB'
+case "$1" in
+  --help)
+    echo "token-scope — stub"
+    echo "  --since <duration>"
+    [ "$SUPPORTS" = "yes" ] && echo "  --credits               weekly credit consumption vs plan cap"
+    exit 0 ;;
+  --version) echo "token-scope 9.9.9-stub"; exit 0 ;;
+  --credits)
+    if [ "$SUPPORTS" != "yes" ]; then
+      echo "unknown flag: --credits" >&2; exit 1
+    fi
+    for a in "$@"; do [ "$a" = "--json" ] && { printf '%s\n' "$CREDITS_JSON"; exit 0; }; done
+    echo "token-scope-stub: credits table"; exit 0 ;;
+  --since)
+    echo "token-scope-stub: $*"; exit 0 ;;
+esac
+echo "token-scope-stub: unexpected argv: $*" >&2
+exit 2
+STUB
+  } > "$TEST_HOME/.bun/bin/token-scope"
+  chmod +x "$TEST_HOME/.bun/bin/token-scope"
+}
+
 setup() {
   TEST_HOME=$(mktemp -d)
   HOME_BACKUP="$HOME"
@@ -24,15 +60,16 @@ setup() {
 #!/bin/bash
 echo "rtk-stub: $*"
 STUB
-  cat > "$TEST_HOME/.bun/bin/token-scope" << 'STUB'
-#!/bin/bash
-echo "token-scope-stub: $*"
-STUB
+  # token-scope stub: pattern-matches argv and exits non-zero on an unexpected
+  # shape (stub-cli-argv-validation). An echo-everything stub would have hidden
+  # the --credits probe entirely, and the script's behaviour now depends on it.
+  # Per-test overrides go through write_token_scope_stub below.
+  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":50000000,"capRatio":0.3,"projectedCapRatio":0.6}]}' "yes"
   cat > "$TEST_HOME/.bun/bin/npx" << 'STUB'
 #!/bin/bash
 echo "npx-stub: $*"
 STUB
-  chmod +x "$TEST_HOME/.bun/bin/rtk" "$TEST_HOME/.bun/bin/token-scope" "$TEST_HOME/.bun/bin/npx"
+  chmod +x "$TEST_HOME/.bun/bin/rtk" "$TEST_HOME/.bun/bin/npx"
 
   # Stage a getent stub so ceo_pin_home_or_warn (via ceo_resolve_real_home)
   # resolves to $TEST_HOME instead of the developer's real ~/. Without this,
@@ -393,6 +430,92 @@ test_auth_alert_when_no_successful_turns_dedupes_and_reappears() {
   bash "$INTAKE" >/dev/null 2>&1
   count=$(grep -c -F "No successful Claude runs on $CEO_HOSTNAME" "$inbox")
   assert_eq "$count" "2" "outage after a prior check-off must re-alert"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+# ─── credit cap escalation ────────────────────────────────────────────────────
+
+test_report_captures_credits_when_supported() {
+  bash "$INTAKE" >/dev/null 2>&1
+  local report
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$report")" "credits vs weekly cap" "report must capture the credits section"
+  assert_contains "$(cat "$report")" "credit cap check" "report must record the cap check"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
+}
+
+test_under_cap_does_not_escalate() {
+  # Default stub: 0.6x projected. A report that escalated while under the cap
+  # would be a signal generator, which is what the disk-monitor incident was.
+  bash "$INTAKE" >/dev/null 2>&1
+  local inbox count
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "Credit cap" "$inbox" || true)
+  assert_eq "$count" "0" "a week under the cap must not escalate"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_over_cap_escalates_once_per_week() {
+  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  bash "$INTAKE" >/dev/null 2>&1
+  local inbox count
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "Credit cap (2026-08-10) on $CEO_HOSTNAME" "$inbox")
+  assert_eq "$count" "1" "an over-cap week must escalate exactly once, not once per run"
+  assert_contains "$(cat "$inbox")" "2.4x" "the alert must carry the projected ratio"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
+}
+
+test_new_over_cap_week_re_alerts() {
+  # Keyed on the ISO week, so a fresh week going over IS a state transition.
+  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-17","partial":true,"credits":300000000,"capRatio":1.9,"projectedCapRatio":2.5}]}' "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local inbox count
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "Credit cap (" "$inbox")
+  assert_eq "$count" "2" "a new week going over cap must re-alert"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_ignores_future_dated_week_when_picking_current() {
+  # A synced host with a skewed clock can stamp a turn into next week. Reading
+  # the last partial row blindly would judge the cap on that phantom week.
+  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local report
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$report")" "week 2026-08-10" "must name the week it judged"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_stale_plugin_escalates_but_does_not_fail_the_run() {
+  # The fix is a /plugin update the user performs. Reddening cron every morning
+  # for a whole quarter would train them to ignore the failure channel.
+  write_token_scope_stub '{}' "no"
+  bash "$INTAKE" >/dev/null 2>&1
+  local rc=$?
+  assert_eq "$rc" "0" "a token-scope without --credits must not fail the run"
+  local inbox
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$inbox")" "Credit cap (stale-plugin)" "stale plugin must escalate as its own item"
+  assert_contains "$(cat "$inbox")" "/plugin update" "the alert must name the fix"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
+}
+
+test_stale_plugin_skips_the_credits_capture() {
+  # capture() records a non-zero exit as a run failure, so the credits capture
+  # must not even be attempted against a build that lacks the flag.
+  write_token_scope_stub '{}' "no"
+  bash "$INTAKE" >/dev/null 2>&1
+  local report
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  if grep -qF "credits vs weekly cap" "$report"; then
+    printf '  FAIL [%s] credits capture must be skipped when unsupported\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -72,10 +72,11 @@ STUB
   # shape (stub-cli-argv-validation). An echo-everything stub would have hidden
   # the --credits probe entirely, and the script's behaviour now depends on it.
   # Per-test overrides go through write_token_scope_stub below.
-  # Default: over cap (1.8x) but BELOW the 2.4x worst full week — the user's real
-  # steady state. A stub that was comfortably under cap hid the fact that the cap
-  # line broke the review-line count invariant every week the alert fired.
-  write_token_scope_stub "$STUB_JSON_BASELINE" "yes"
+  # Default: a week that DOES escalate (3.1x, above the 2.4x worst full week). The
+  # pre-existing inbox invariant tests then run with the alert firing, which is
+  # when they can actually break; with a quiet default they passed for years
+  # without ever exercising the path that appends a second line.
+  write_token_scope_stub "$STUB_JSON_WORSE" "yes"
   cat > "$TEST_HOME/.bun/bin/npx" << 'STUB'
 #!/bin/bash
 echo "npx-stub: $*"
@@ -459,6 +460,7 @@ test_over_cap_but_not_worse_than_baseline_does_not_escalate() {
   # The user is over cap EVERY week (1.5-4.7x). A bare `> 1` trigger would report
   # his own baseline back to him weekly, which is the nag
   # ceo-automated-writers-are-playbooks exists to prevent.
+  write_token_scope_stub "$STUB_JSON_BASELINE" "yes"
   bash "$INTAKE" >/dev/null 2>&1
   local inbox count
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
@@ -468,7 +470,6 @@ test_over_cap_but_not_worse_than_baseline_does_not_escalate() {
 }
 
 test_worse_than_baseline_escalates_once_per_week() {
-  write_token_scope_stub "$STUB_JSON_WORSE" "yes"
   bash "$INTAKE" >/dev/null 2>&1
   bash "$INTAKE" >/dev/null 2>&1
   local inbox count

--- a/scripts/ceo-token-intake.test.sh
+++ b/scripts/ceo-token-intake.test.sh
@@ -9,6 +9,14 @@ INTAKE="$SCRIPT_DIR/ceo-token-intake.sh"
 
 source "$SCRIPT_DIR/test-harness.sh"
 
+# Shared stub payloads. capRatio/projectedCapRatio are what the script reads;
+# `partial` and `truncated` decide which weeks form the baseline.
+STUB_WEEK_FULL='{"weekStart":"2026-08-03","partial":false,"truncated":false,"credits":400000000,"capRatio":2.4,"projectedCapRatio":null}'
+# 1.8x now, under the 2.4x baseline -> over cap but NOT worse than recent behaviour
+STUB_JSON_BASELINE="{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$STUB_WEEK_FULL,{\"weekStart\":\"2026-08-10\",\"partial\":true,\"truncated\":false,\"credits\":300000000,\"capRatio\":1.5,\"projectedCapRatio\":1.8}]}"
+# 3.1x projected, above the 2.4x baseline -> a genuinely worse week
+STUB_JSON_WORSE="{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$STUB_WEEK_FULL,{\"weekStart\":\"2026-08-10\",\"partial\":true,\"truncated\":false,\"credits\":520000000,\"capRatio\":2.6,\"projectedCapRatio\":3.1}]}"
+
 # write_token_scope_stub <credits-json> <supports-credits: yes|no>
 # Rebuilds the token-scope stub. The JSON is what `--credits --json` returns;
 # "no" makes --help omit --credits, simulating a plugin cache older than the
@@ -64,7 +72,10 @@ STUB
   # shape (stub-cli-argv-validation). An echo-everything stub would have hidden
   # the --credits probe entirely, and the script's behaviour now depends on it.
   # Per-test overrides go through write_token_scope_stub below.
-  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":50000000,"capRatio":0.3,"projectedCapRatio":0.6}]}' "yes"
+  # Default: over cap (1.8x) but BELOW the 2.4x worst full week — the user's real
+  # steady state. A stub that was comfortably under cap hid the fact that the cap
+  # line broke the review-line count invariant every week the alert fired.
+  write_token_scope_stub "$STUB_JSON_BASELINE" "yes"
   cat > "$TEST_HOME/.bun/bin/npx" << 'STUB'
 #!/bin/bash
 echo "npx-stub: $*"
@@ -440,60 +451,143 @@ test_report_captures_credits_when_supported() {
   local report
   report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
   assert_contains "$(cat "$report")" "credits vs weekly cap" "report must capture the credits section"
-  assert_contains "$(cat "$report")" "credit cap check" "report must record the cap check"
+  assert_contains "$(cat "$report")" "worst full week in window" "cap check must state the baseline it compared against"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
 }
 
-test_under_cap_does_not_escalate() {
-  # Default stub: 0.6x projected. A report that escalated while under the cap
-  # would be a signal generator, which is what the disk-monitor incident was.
+test_over_cap_but_not_worse_than_baseline_does_not_escalate() {
+  # The user is over cap EVERY week (1.5-4.7x). A bare `> 1` trigger would report
+  # his own baseline back to him weekly, which is the nag
+  # ceo-automated-writers-are-playbooks exists to prevent.
   bash "$INTAKE" >/dev/null 2>&1
   local inbox count
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
   count=$(grep -c -F "Credit cap" "$inbox" || true)
-  assert_eq "$count" "0" "a week under the cap must not escalate"
+  assert_eq "$count" "0" "a week over cap but within recent behaviour must not escalate"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_over_cap_escalates_once_per_week() {
-  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+test_worse_than_baseline_escalates_once_per_week() {
+  write_token_scope_stub "$STUB_JSON_WORSE" "yes"
   bash "$INTAKE" >/dev/null 2>&1
   bash "$INTAKE" >/dev/null 2>&1
   local inbox count
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
   count=$(grep -c -F "Credit cap (2026-08-10) on $CEO_HOSTNAME" "$inbox")
-  assert_eq "$count" "1" "an over-cap week must escalate exactly once, not once per run"
-  assert_contains "$(cat "$inbox")" "2.4x" "the alert must carry the projected ratio"
-  ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
+  assert_eq "$count" "1" "a worse-than-baseline week must escalate exactly once, not once per run"
+  assert_contains "$(cat "$inbox")" "3.1x" "the alert must carry the projected ratio"
+  assert_contains "$(cat "$inbox")" "2.4x" "the alert must name the baseline it beat"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
 }
 
-test_new_over_cap_week_re_alerts() {
-  # Keyed on the ISO week, so a fresh week going over IS a state transition.
-  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+test_cap_line_does_not_carry_the_report_wikilink() {
+  # The daily review line is counted BY wikilink to prove it appends once. A cap
+  # line carrying the same link broke that invariant every week it fired, and the
+  # suite only passed because the old default stub was under cap.
+  write_token_scope_stub "$STUB_JSON_WORSE" "yes"
   bash "$INTAKE" >/dev/null 2>&1
-  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-17","partial":true,"credits":300000000,"capRatio":1.9,"projectedCapRatio":2.5}]}' "yes"
+  local today inbox count
+  today=$(date +%Y-%m-%d)
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  count=$(grep -c -F "[[CEO/reports/token/$today-$CEO_HOSTNAME]]" "$inbox")
+  assert_eq "$count" "1" "only the review line may carry the report wikilink"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_checked_off_cap_alert_does_not_re_append_same_week() {
+  # Unlike the auth alert (keyed on host, where a re-alert IS the transition),
+  # this marker already keys on the ISO week, so re-appending after a check-off
+  # would report the same week twice.
+  write_token_scope_stub "$STUB_JSON_WORSE" "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local inbox count
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  sed -i.bak "s|- \[ \] ⚠️ \(Credit cap\)|- [x] ⚠️ \1|" "$inbox"; rm -f "$inbox.bak"
+  bash "$INTAKE" >/dev/null 2>&1
+  count=$(grep -c -F "Credit cap (2026-08-10) on $CEO_HOSTNAME" "$inbox")
+  assert_eq "$count" "1" "a checked-off cap alert must not re-append for the same week"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_new_worse_week_re_alerts() {
+  # Both weeks must be in the PAST, or the date filter correctly refuses to judge
+  # them and there is nothing to re-alert about. (Learned the hard way: the first
+  # version of this test used a next-week date and failed for that reason.)
+  local base='{"weekStart":"2026-07-27","partial":false,"truncated":false,"credits":400000000,"capRatio":2.4,"projectedCapRatio":null}'
+  local worse='"partial":true,"truncated":false,"credits":520000000,"capRatio":2.6,"projectedCapRatio":3.1'
+  write_token_scope_stub "{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$base,{\"weekStart\":\"2026-08-03\",$worse}]}" "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  write_token_scope_stub "{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$base,{\"weekStart\":\"2026-08-10\",$worse}]}" "yes"
   bash "$INTAKE" >/dev/null 2>&1
   local inbox count
   inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
   count=$(grep -c -F "Credit cap (" "$inbox")
-  assert_eq "$count" "2" "a new week going over cap must re-alert"
+  assert_eq "$count" "2" "a new week beating the baseline must re-alert"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
-test_ignores_future_dated_week_when_picking_current() {
-  # A synced host with a skewed clock can stamp a turn into next week. Reading
-  # the last partial row blindly would judge the cap on that phantom week.
-  write_token_scope_stub '{"meta":{"weekly_cap":166700000},"weeks":[{"weekStart":"2026-08-10","partial":true,"credits":300000000,"capRatio":1.8,"projectedCapRatio":2.4}]}' "yes"
+test_future_dated_week_is_not_judged_and_cannot_mask_a_real_one() {
+  # Clock skew on a synced host can stamp a turn into next week. Picking the last
+  # partial row blindly judges that nearly-empty phantom week, reads it as
+  # comfortably under cap, and SILENCES a real over-cap alert.
+  local json
+  json="{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$STUB_WEEK_FULL,{\"weekStart\":\"2026-08-10\",\"partial\":true,\"truncated\":false,\"credits\":520000000,\"capRatio\":2.6,\"projectedCapRatio\":3.1},{\"weekStart\":\"2099-01-05\",\"partial\":true,\"truncated\":false,\"credits\":300,\"capRatio\":0.000002,\"projectedCapRatio\":0.000002}]}"
+  write_token_scope_stub "$json" "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local report inbox
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$report")" "week 2026-08-10" "must judge the started week, not the future-dated one"
+  assert_contains "$(cat "$inbox")" "Credit cap (2026-08-10)" "the phantom week must not mask a real alert"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
+}
+
+test_projection_absent_falls_back_to_spend_so_far() {
+  # --credits returns projectedCapRatio null until a fifth of the week elapses,
+  # so a Monday-morning run must judge on spend-so-far, not extrapolate noise.
+  local json
+  json="{\"meta\":{\"weekly_cap\":166700000},\"weeks\":[$STUB_WEEK_FULL,{\"weekStart\":\"2026-08-10\",\"partial\":true,\"truncated\":false,\"credits\":30000000,\"capRatio\":0.18,\"projectedCapRatio\":null}]}"
+  write_token_scope_stub "$json" "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local report inbox count
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$report")" "0.18x" "must report spend-so-far when no projection exists"
+  if grep -q "nullx" "$report"; then
+    printf '  FAIL [%s] a null ratio must never reach the report text\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  count=$(grep -c -F "Credit cap" "$inbox" || true)
+  assert_eq "$count" "0" "an early-week run under cap must not escalate"
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 3))
+}
+
+test_malformed_credits_json_is_reported_as_a_contract_error() {
+  # A renamed field must not read as "no data" — that would silence this check
+  # indefinitely and look like an idle week.
+  write_token_scope_stub '{"unexpected":true}' "yes"
   bash "$INTAKE" >/dev/null 2>&1
   local report
   report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
-  assert_contains "$(cat "$report")" "week 2026-08-10" "must name the week it judged"
+  assert_contains "$(cat "$report")" "not the expected shape" "a contract change must be named, not swallowed"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
 }
 
+test_zero_weekly_cap_is_refused() {
+  write_token_scope_stub '{"meta":{"weekly_cap":0},"weeks":[{"weekStart":"2026-08-10","partial":true,"truncated":false,"credits":1,"capRatio":9,"projectedCapRatio":9}]}' "yes"
+  bash "$INTAKE" >/dev/null 2>&1
+  local report inbox
+  report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  assert_contains "$(cat "$report")" "nothing to compare against" "a zero cap must be refused, not printed as 0M"
+  if grep -q -F "0M credit cap" "$inbox"; then
+    printf '  FAIL [%s] must not escalate against a zero cap\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 2))
+}
+
 test_stale_plugin_escalates_but_does_not_fail_the_run() {
-  # The fix is a /plugin update the user performs. Reddening cron every morning
-  # for a whole quarter would train them to ignore the failure channel.
   write_token_scope_stub '{}' "no"
   bash "$INTAKE" >/dev/null 2>&1
   local rc=$?
@@ -506,14 +600,26 @@ test_stale_plugin_escalates_but_does_not_fail_the_run() {
 }
 
 test_stale_plugin_skips_the_credits_capture() {
-  # capture() records a non-zero exit as a run failure, so the credits capture
-  # must not even be attempted against a build that lacks the flag.
   write_token_scope_stub '{}' "no"
   bash "$INTAKE" >/dev/null 2>&1
   local report
   report="$CEO_DIR/reports/token/$(date +%Y-%m-%d)-$CEO_HOSTNAME.md"
   if grep -qF "credits vs weekly cap" "$report"; then
     printf '  FAIL [%s] credits capture must be skipped when unsupported\n' "$CURRENT_TEST"
+    FAILS=$((FAILS + 1))
+  fi
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+}
+
+test_missing_binary_is_not_misdiagnosed_as_a_stale_plugin() {
+  # A command-not-found token-scope yields empty --help, which the first cut read
+  # as "old plugin" — telling the user to /plugin update something not installed.
+  rm -f "$TEST_HOME/.bun/bin/token-scope"
+  bash "$INTAKE" >/dev/null 2>&1
+  local inbox
+  inbox="$CEO_DIR/inbox/$CEO_HOSTNAME.md"
+  if [ -f "$inbox" ] && grep -q -F "Credit cap (stale-plugin)" "$inbox"; then
+    printf '  FAIL [%s] a missing binary must not be reported as a stale plugin\n' "$CURRENT_TEST"
     FAILS=$((FAILS + 1))
   fi
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The daily token report captured dollars and RTK savings — neither of which answers the only question the plan actually asks. The cap is denominated in **credits**, so "$459 yesterday" can't tell you whether the week is over. `token-scope --credits` (nhangen/token-scope#22) answers it, so the report reads it.

**Two additions:**

1. The report captures `token-scope --credits --since 8w` for the record.
2. A new `credit cap check` step reads `--credits --json`, states where the week in progress stands, and escalates **one** inbox item when the week is over cap **and worse than the worst full week in the 8-week window**. The alert carries both numbers and names the lever: cache reads + writes are ~90% of a weighted week, so what moves it is context size per turn — shorter sessions and `/clear`, not shorter answers.

**Why a baseline and not just "over cap".** You are over cap *every* week (1.5–4.7x). A bare `> 1` trigger fires once per ISO week forever — technically a state transition, functionally the weekly nag `ceo-automated-writers-are-playbooks` exists to prevent, reporting your own baseline back as news. Gating on "worse than the worst full week in the window" makes it fire when something actually changed. Truncated weeks hold only part of their spend, so they're excluded from the baseline or they'd understate the bar.

**Escalation is a state machine, not a signal generator.** The marker is keyed on the ISO week and dedupes on the *unchecked* marker, so a week that's still over tomorrow doesn't re-append, while a **new** week going over does alert. That distinction is the point of `ceo-automated-writers-are-playbooks` — the disk-monitor incident appended 64 identical hourly alerts for want of it. Tests cover both directions.

**It picks the week in progress carefully:** the last partial row that has *already started*, not simply the last partial row. A synced host with a skewed clock can stamp a turn into next week; judging that phantom week doesn't merely mis-report — because it's nearly empty it reads as comfortably under cap and **silences a real over-cap alert.**

**A `token-scope` predating `--credits` does not fail the run.** The probe happens once, before the report, and the credits capture is *skipped* rather than attempted — `capture` records a non-zero exit as a run failure, so attempting it would redden cron telemetry every morning for something only a `/plugin update` fixes, training the reader to ignore the failure channel. It escalates as its own actionable inbox item instead.

### Second commit — what the audit caught

An adversarial audit found the first commit asserted three things it did not do. Fixed in `7eecc92`:

- **The date filter did not exist.** The comment, the doc, and this PR body all described `select(.partial == true and .weekStart <= $today)`; the jq was `select(.partial == true) | last`. So a future-dated week *was* judged — and being nearly empty it read as under cap and would have silenced a genuine alert. The test that named this behavior was vacuous: its fixture had one week and no future-dated row, so it passed with the filter absent, which it was. Both are fixed, and the test now carries a 2099 row alongside a real over-cap week.
- **The escalation broke a pre-existing invariant.** The cap line carried the report wikilink, and the daily review line is counted *by* wikilink to prove it appends exactly once. Three existing tests passed only because the default stub was under cap so the alert never fired; with the stub set to your real condition they failed. The cap line no longer carries the link, the default stub is now over cap, and those three tests bind for the right reason.
- **The trigger was unfixed, not fixed** — `> 1` on a chronically-over host. Now gated on the baseline, as described above.

Four smaller ones, each with a test: a checked-off cap alert re-appended the next day (the marker keys on the week, so dedupe now ignores the checkbox — unlike the auth alert, where a re-alert after check-off *is* the transition); a `token-scope` missing from PATH produced empty `--help`, was read as "old plugin", and advised `/plugin update` for something not installed while `capture` failed anyway and reddened cron; malformed or renamed JSON exited jq non-zero and was reported as "no week in progress", so a contract change would have silenced the check indefinitely; and a missing `weekly_cap` printed `1.8x the 0M credit cap` while a null ratio printed `nullx`.

**12 assertions fail when `ceo-token-intake.sh` is reverted** — including the three pre-existing invariant tests, which is the evidence they now bind.

## Testing Procedure

1. `bash scripts/ceo-token-intake.test.sh` — 28 tests pass (13 new).
2. Confirm the tests are load-bearing: `git stash push scripts/ceo-token-intake.sh && bash scripts/ceo-token-intake.test.sh` → **12 assertions fail**; `git stash pop` to restore.
3. `bash -n scripts/ceo-token-intake.sh` — clean.
4. Live run against the real vault: `CEO_HOSTNAME=$(hostname -s) bash scripts/ceo-token-intake.sh; echo $?` → exits **0**, and because this host's plugin cache is still on 1.3.2 the report reads:
   ```
   ## credit cap check
   SKIP: this token-scope build has no --credits (plugin cache predates it); escalated to the inbox.
   ```
   with one inbox item: `- [ ] ⚠️ Credit cap (stale-plugin) on MBP-2026 — … Fix: run /plugin update in Claude Code.` That's the stale-plugin path proven end to end on real data, not a fixture.
5. After `/plugin update`, re-run and confirm the `credits vs weekly cap` section appears and the cap check names the week and ratio.

New tests: credits captured when supported; no escalation while under cap; over-cap escalates exactly once across two runs; a new week re-alerts; the judged week is named (guards the future-dated-week case); stale plugin escalates without failing the run; stale plugin skips the credits capture entirely.

**The token-scope test stub now pattern-matches argv** and exits non-zero on an unexpected shape, per `stub-cli-argv-validation`. The previous echo-everything stub would have hidden the `--credits` probe completely, and the script's behaviour now depends on it.

## Additional Notes

The playbook doc was stale in three ways before this: it listed `rtk gain -p` and `rtk cc-economics`, which the script hasn't run for some time, and named `CEO/inbox.md` when the script writes the per-host shadow `CEO/inbox/<HOST>.md`. Rewritten against what the script actually does, with declared outputs and both escalations stated in a table.

The `description` in the playbook frontmatter changed, so `~/.ceo/registry.json` will show the old text until `ceo playbook scan` runs on each host. Cosmetic — the dispatcher keys on `name`, `scope`, and `script`, none of which moved.

Worked in a worktree: the main clone is on `nh/chore/retire-am-playbooks` for #307, which another session owns.
