### PR TITLE
Recognize an expired OAuth session as an auth failure, not a terminal one

### DIFF
--- a/scripts/ceo-cron-fallback-classify.test.sh
+++ b/scripts/ceo-cron-fallback-classify.test.sh
@@ -111,6 +111,15 @@ test_result_text_does_not_hijack_a_successful_envelope() {
     "is_error false wins over auth-shaped .result text"
 }
 
+test_envelope_without_is_error_key_does_not_become_auth() {
+  # jq gives "null" for a missing is_error, so a check written as "not false" would
+  # accept this and exit 78 on a phase that succeeded. The .result read requires
+  # is_error to be literally true for that reason.
+  local raw='{"result":"the OAuth session expired handling was refactored"}'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "ok" \
+    "an exit-0 envelope with no is_error key must not classify as auth on .result prose"
+}
+
 test_plaintext_plan_success_is_ok() {
   # Plan/exec phases emit plain text (no --output-format json); exit 0 = success.
   local raw='ACTION: 1 | read | check inbox | n/a'

--- a/scripts/ceo-cron-fallback-classify.test.sh
+++ b/scripts/ceo-cron-fallback-classify.test.sh
@@ -72,6 +72,45 @@ test_auth_banner_non_json_is_auth() {
   assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" "auth banner → auth"
 }
 
+# The two shapes observed on ML-1 2026-08-13, verbatim from cron-raw.log. Both
+# were classified `terminal`, so no re-auth escalation fired and cronbird retried
+# three times per playbook — the exact outcome ff05940's fatal-on-auth signal
+# exists to prevent.
+
+test_oauth_expired_envelope_is_auth() {
+  # The single-call envelope names auth in `.result` and nowhere else:
+  # api_error_status is null, and subtype is the string "success" even though
+  # is_error is true. Reading only the status/subtype keys yields terminal.
+  local raw='{"is_error":true,"stop_reason":"stop_sequence","total_cost_usd":0,"terminal_reason":"api_error","api_error_status":null,"subtype":"success","result":"Failed to authenticate: OAuth session expired and could not be refreshed","type":"result"}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" \
+    "OAuth-expired envelope → auth (auth text lives in .result)"
+}
+
+test_oauth_expired_plaintext_is_auth() {
+  # Plan/exec phases emit this bare, with no envelope. The pre-fix banner regex
+  # matched `authentication_failed|not authenticated|logged out|invalid api key|
+  # please run /login` — none of which appear in what Claude Code actually prints.
+  local raw='Failed to authenticate: OAuth session expired and could not be refreshed'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "auth" \
+    "OAuth-expired plain text → auth"
+}
+
+test_envelope_subtype_success_with_error_still_not_ok() {
+  # Guard the trap that made the envelope look healthy: subtype "success" beside
+  # is_error true must never read as ok, whatever .result says.
+  local raw='{"is_error":true,"subtype":"success","api_error_status":null,"result":"something else entirely"}'
+  assert_eq "$(_classify_claude_failure 1 "$raw")" "terminal" \
+    "is_error true with subtype success → terminal, never ok"
+}
+
+test_result_text_does_not_hijack_a_successful_envelope() {
+  # A *successful* run whose report happens to discuss authentication must stay
+  # ok — the new .result read must not outrank is_error:false.
+  local raw='{"is_error":false,"subtype":"success","result":"Reviewed the OAuth session expired handling in ceo-cron-lib.sh"}'
+  assert_eq "$(_classify_claude_failure 0 "$raw")" "ok" \
+    "is_error false wins over auth-shaped .result text"
+}
+
 test_plaintext_plan_success_is_ok() {
   # Plan/exec phases emit plain text (no --output-format json); exit 0 = success.
   local raw='ACTION: 1 | read | check inbox | n/a'

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -115,9 +115,15 @@ _classify_claude_failure() {
   # Structured error whose only auth signal is the .result prose. Checked against
   # the same pattern as the plain-text tier below, so the two paths cannot drift
   # apart — which is how the envelope path missed a message the banner tier would
-  # also have missed. Reached only when is_error is not "false", so a successful
-  # run whose report merely discusses authentication is unaffected.
-  if [ -n "$result" ] && _looks_like_auth_failure "$result"; then
+  # also have missed.
+  #
+  # `is_error = true` is required rather than merely "not false". An envelope with
+  # no is_error key at all yields the string "null" here, so "not false" would let
+  # an exit-0 object whose report happens to discuss authentication — "the session
+  # expired handling was refactored" — classify as auth and exit 78. No current
+  # caller emits that shape (single-call always passes --output-format json), but
+  # the guard costs one condition and removes the class.
+  if [ "$is_error" = "true" ] && [ -n "$result" ] && _looks_like_auth_failure "$result"; then
     echo "auth"; return 0
   fi
   # Structured error, is_error true, but no usable status → unknown-but-real.

--- a/scripts/ceo-cron-lib.sh
+++ b/scripts/ceo-cron-lib.sh
@@ -43,6 +43,19 @@ ceo_morning_raw_digest() {
   [ -n "${DAILY_NOTE_TOP3:-}" ] && { echo "Top 3:"; echo "${DAILY_NOTE_TOP3}"; }
 }
 
+# _looks_like_auth_failure <text> — true when the text names an authentication
+# failure. One pattern, called from both of _classify_claude_failure's tiers, so
+# the envelope path and the plain-text path cannot recognize different sets of
+# messages. `failed to authenticate` and the OAuth clause are what Claude Code
+# actually prints for an expired session; the older, narrower list matched none
+# of it, so morning and reconcile were classified terminal on ML-1 2026-08-13 —
+# no re-auth escalation, and three retries each instead of a fatal stop.
+# Here-string, not a pipe: grep closes the pipe on its first match, which SIGPIPEs
+# a large body and turns a match into a no-match under pipefail.
+_looks_like_auth_failure() {
+  grep -qEi 'authentication_failed|failed to authenticate|not authenticated|logged out|invalid api key|please run .?/login|oauth[^.]{0,40}(expired|refresh)|session expired|could not be refreshed' <<< "${1:-}"
+}
+
 # _classify_claude_failure <exit_code> <raw_stdout> — decide how a `claude
 # --print` invocation ended, so the caller can route it. Prints exactly one of:
 #   ok        succeeded (complete result)
@@ -63,7 +76,7 @@ ceo_morning_raw_digest() {
 # banner tier without it. Pure — no globals, no I/O.
 _classify_claude_failure() {
   local rc="${1:-1}" raw="${2:-}"
-  local is_error="" status="" subtype="" stop=""
+  local is_error="" status="" subtype="" stop="" result=""
   if command -v jq >/dev/null 2>&1; then
     # NB: do NOT use `.is_error // empty` — jq's `//` treats the boolean `false`
     # like null, collapsing a genuine `is_error:false` to empty. Read it raw
@@ -76,6 +89,10 @@ _classify_claude_failure() {
     status=$(jq -r 'if type=="object" then (.api_error_status // empty) else empty end' <<< "$raw" 2>/dev/null || true)
     subtype=$(jq -r 'if type=="object" then (.subtype // empty) else empty end' <<< "$raw" 2>/dev/null || true)
     stop=$(jq -r 'if type=="object" then (.stop_reason // empty) else empty end' <<< "$raw" 2>/dev/null || true)
+    # `.result` carries the human-readable cause, and for an expired OAuth session
+    # it is the ONLY place auth is named: api_error_status comes back null and
+    # subtype reads "success" beside is_error true (observed ML-1 2026-08-13).
+    result=$(jq -r 'if type=="object" then (.result // empty) else empty end' <<< "$raw" 2>/dev/null || true)
   fi
 
   # Parseable success envelope: ok, unless the result was truncated (a partial
@@ -95,6 +112,14 @@ _classify_claude_failure() {
   case "$subtype" in
     *auth*|*login*|*credential*) echo "auth"; return 0 ;;
   esac
+  # Structured error whose only auth signal is the .result prose. Checked against
+  # the same pattern as the plain-text tier below, so the two paths cannot drift
+  # apart — which is how the envelope path missed a message the banner tier would
+  # also have missed. Reached only when is_error is not "false", so a successful
+  # run whose report merely discusses authentication is unaffected.
+  if [ -n "$result" ] && _looks_like_auth_failure "$result"; then
+    echo "auth"; return 0
+  fi
   # Structured error, is_error true, but no usable status → unknown-but-real.
   [ "$is_error" = "true" ] && { echo "terminal"; return 0; }
 
@@ -108,7 +133,7 @@ _classify_claude_failure() {
   if grep -qEi 'session limit|hit your limit|rate.?limit|overloaded' <<< "$raw"; then
     echo "transient"; return 0
   fi
-  if grep -qEi 'authentication_failed|not authenticated|logged out|invalid api key|please run .?/login' <<< "$raw"; then
+  if _looks_like_auth_failure "$raw"; then
     echo "auth"; return 0
   fi
   echo "terminal"; return 0   # fail-safe: unknown never falls open to fallback


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

ML-1 lost its Claude OAuth session overnight. `morning` failed three times (03:20–03:22) and `reconcile` three times (07:50–07:52), every one with the same cause:

```
Failed to authenticate: OAuth session expired and could not be refreshed
```

`_classify_claude_failure` returned `terminal` for all six, on both of its tiers. `terminal` is the branch that does none of the things this failure needs — `auth` (`scripts/ceo-cron.sh:473-486`) is the one that reports *"automation is down until re-auth. Fix: ssh to this host, run `claude`, then /login"*, calls `_record_failure`, and exits 78, cronbird's fatal code that caps the attempts.

So three things went wrong at once: the alert named no cause and no remedy, `.fail-count-morning` and `.fail-count-reconcile` both stayed at `0` after three failures each, and each playbook burned three dispatches against a host that could not possibly succeed. The retry half is exactly what `ff05940` ("signal fatal on auth so retries stop") was added to prevent — the signal was right, the classification never reached it.

Each tier missed it for its own reason.

**The single-call envelope names auth only in `.result`.** The classifier read `api_error_status` (`null` here), `subtype` (the string `"success"`, sitting beside `is_error: true`) and `stop_reason` — none of which mention auth — then fell through to the `is_error` catch-all. Verbatim from `cron-raw.log`:

```json
{"is_error":true,"terminal_reason":"api_error","api_error_status":null,
 "subtype":"success",
 "result":"Failed to authenticate: OAuth session expired and could not be refreshed"}
```

**The plain-text tier**, which plan and exec phases hit, matched `authentication_failed|not authenticated|logged out|invalid api key|please run /login`. None of those strings appear in what Claude Code actually prints.

Both tiers now call one `_looks_like_auth_failure` helper. That is the structural half of the fix: the two paths could previously recognize different sets of messages, which is how the envelope path missed a string the banner tier would also have missed. One pattern, one place to widen.

The `.result` read is placed after the `is_error: false` success check, so a successful run whose report merely *discusses* authentication stays `ok`.

**This does not re-authenticate ML-1.** That needs a human on that host: `claude`, then `/login`. Until then every `runner: claude` playbook there keeps failing — it will now say so and stop retrying.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-cron-fallback-classify.test.sh` — 20 pass. Four are new:
   - the OAuth envelope above → `auth` (verbatim payload from `cron-raw.log`)
   - the bare OAuth line → `auth` (the plan/exec shape)
   - `is_error: true` with `subtype: "success"` → `terminal`, never `ok` — guards the trap that made the envelope look healthy
   - `is_error: false` with auth-shaped `.result` prose → `ok`, so the new read cannot hijack a successful run
3. Confirm the fix is load-bearing: delete the `.result` branch from `_classify_claude_failure` and re-run — the envelope case fails (`got: terminal, want: auth`). Restore, and it is green again.
4. `bash scripts/ceo-cron-lib.test.sh scripts/ceo-cron-inputs.test.sh scripts/ceo-cron-morning-fallback.test.sh scripts/ceo-cron-injection.test.sh scripts/morning-playbook.test.sh` — all pass.
5. `shellcheck -S warning scripts/ceo-cron-lib.sh scripts/ceo-cron-fallback-classify.test.sh` — clean.

Environment: **local shell test suites** on MBP-2026. The production path (a real expired session routing through `exit 78`) has not been re-exercised — that needs the failure to recur on ML-1 after this lands.

## Additional Notes

Found while investigating the six failure notifications from ML-1, not from a test. Worth noting for the next reader: `.fail-count-*` reading `0` after repeated failures is a symptom of misclassification rather than of the counter being broken — the counter is only written on the branches that call `_record_failure`.
