### PR TITLE
Ignore tmp/ and generated eval output so a mis-staged add cannot commit them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,17 @@ next-steps.txt
 # Python bytecode (ollama-agent package)
 __pycache__/
 *.pyc
+.pytest_cache/
+
+# Scratch: cron stdout and hand-run report output land here and can carry
+# production data, so a mis-staged `git add` must not be able to commit them.
+tmp/
+
+# Generated model output. This covers every eval dir without each needing the
+# hand-placed `*` + `!.gitignore` sentinel that evals/ollama-agent-poc/out/ has.
+#
+# Contents, not the directory: git cannot re-include anything beneath an excluded
+# directory, so the `evals/*/out/` form would shadow that tracked sentinel — and
+# any future one — instead of leaving it visible. repo-hygiene.test.sh pins the
+# distinction, since the two spellings read as equivalent.
+evals/*/out/*

--- a/scripts/repo-hygiene.test.sh
+++ b/scripts/repo-hygiene.test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Tests that this repo's .gitignore actually ignores the paths that must never
+# reach a commit.
+#
+# Asserted against `git check-ignore` rather than by grepping .gitignore for the
+# pattern text, because a pattern's presence is not the property that matters —
+# whether git ignores the path is, and the two diverge (a later negation, a
+# nested .gitignore, a pattern that anchors differently than it reads). Reverting
+# any of the .gitignore lines these cover turns the matching case red.
+#
+# tmp/ holds cron stdout and hand-run report output that can carry production
+# data (no-commit-tmp-logs). evals/*/out/ is generated model output. A single
+# mis-staged `git add` nearly committed both on 2026-08-13 (#313).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+# check-ignore needs a path git can decide on, not a path that happens to exist,
+# so these are all hypothetical files under the ignored dirs. --no-index keeps a
+# tracked path from short-circuiting the answer.
+_is_ignored() {
+  git -C "$REPO_ROOT" check-ignore -q --no-index "$1" && echo yes || echo no
+}
+
+test_tmp_dir_is_ignored() {
+  assert_eq "$(_is_ignored tmp/cron-full.out)" "yes" "tmp/ cron stdout is ignored"
+  assert_eq "$(_is_ignored tmp/scratch.md)" "yes" "tmp/ scratch markdown is ignored"
+}
+
+test_eval_output_dirs_are_ignored() {
+  assert_eq "$(_is_ignored evals/ollama-matrix/out/think-01--m.txt)" "yes" \
+    "generated eval output is ignored"
+  assert_eq "$(_is_ignored evals/some-future-eval/out/x.txt)" "yes" \
+    "the rule covers eval dirs that do not exist yet"
+}
+
+test_pytest_cache_is_ignored() {
+  assert_eq "$(_is_ignored .pytest_cache/CACHEDIR.TAG)" "yes" \
+    "root pytest cache is ignored"
+  assert_eq "$(_is_ignored ollama-agent/.pytest_cache/v/cache/lastfailed)" "yes" \
+    "nested pytest cache is ignored"
+}
+
+# The evals/*/out/ rule must not swallow the tracked sentinel that already lives
+# in one of those dirs, or a `git status` there stops reporting a real change to
+# a file this repo tracks.
+test_tracked_sentinel_is_not_ignored() {
+  assert_eq "$(_is_ignored evals/ollama-agent-poc/out/.gitignore)" "no" \
+    "the tracked out/.gitignore sentinel stays visible"
+}
+
+# Guard the inverse: an over-broad pattern that ignored the source tree would
+# make every assertion above pass while quietly hiding real work.
+test_source_paths_are_not_ignored() {
+  assert_eq "$(_is_ignored scripts/ceo)" "no" "the CLI is not ignored"
+  assert_eq "$(_is_ignored evals/ollama-agent-poc/eval.py)" "no" \
+    "eval source next to an ignored out/ is not ignored"
+  assert_eq "$(_is_ignored docs/playbooks/morning-scan.md)" "no" \
+    "playbook docs are not ignored"
+}
+
+run_tests

--- a/scripts/repo-hygiene.test.sh
+++ b/scripts/repo-hygiene.test.sh
@@ -22,8 +22,29 @@ source "$SCRIPT_DIR/test-harness.sh"
 # check-ignore needs a path git can decide on, not a path that happens to exist,
 # so these are all hypothetical files under the ignored dirs. --no-index keeps a
 # tracked path from short-circuiting the answer.
+# Reports yes / no / error — three outcomes, not two. `check-ignore -q` exits 1 for
+# "not ignored" and 2 for "git could not answer" (a malformed .gitignore, a bad
+# repo). Collapsing both to "no" would make every negative assertion below pass for
+# the wrong reason at exactly the moment the pattern file is broken.
 _is_ignored() {
-  git -C "$REPO_ROOT" check-ignore -q --no-index "$1" && echo yes || echo no
+  local rc=0
+  git -C "$REPO_ROOT" check-ignore -q --no-index "$1" 2>/dev/null || rc=$?
+  case "$rc" in
+    0) echo yes ;;
+    1) echo no ;;
+    *) echo "error(rc=$rc)" ;;
+  esac
+}
+
+# The reason _is_ignored has three outcomes rather than two. If a git failure read as
+# "not ignored", every negative assertion in this file would pass at exactly the
+# moment git can no longer answer — the shape this file exists to avoid.
+test_a_git_failure_is_not_reported_as_not_ignored() {
+  local got
+  got=$(_is_ignored "")
+  assert_contains "$got" "error" \
+    "a path git cannot resolve must report error, not a confident 'no'"
+  assert_not_contains "$got" "no" "and must not be mistaken for 'not ignored'"
 }
 
 test_tmp_dir_is_ignored() {


### PR DESCRIPTION
Closes #313

## Description (Issue Fixed & New Behavior)

`tmp/` holds cron stdout and hand-run report output that can carry production data, and `evals/*/out/` is 139 files of generated model output. Neither was ignored, so the only thing between a widened `git add` and a commit was somebody reading `git diff --cached --name-only`. That is what caught it on 2026-08-13, when an rtk-proxied `git add -u` staged 149 files from 11 modified and swept both trees in. The proxy half is fixed in nhangen/llm-tools#383; this is the other half — the same mistake becomes harmless rather than merely caught.

`.pytest_cache/` goes in with them. `no-commit-test-artifacts` already forbids committing it and nothing here enforced that.

One thing worth knowing before reading the diff: the eval rule excludes the directory's **contents** (`evals/*/out/*`), not the directory. Git cannot re-include a path beneath an excluded directory, so the `evals/*/out/` spelling shadows the tracked `evals/ollama-agent-poc/out/.gitignore` sentinel instead of leaving it visible. The two forms read as equivalent and the difference only shows up as a tracked file quietly going invisible, so `scripts/repo-hygiene.test.sh` pins it.

Also includes that new test. It asserts through `git check-ignore --no-index` rather than grepping `.gitignore` for pattern text — a pattern being present is not the property that matters, and the two diverge once a negation or a nested `.gitignore` is involved. It carries inverse assertions as well (`scripts/`, `docs/`, and eval source next to an ignored `out/` all stay visible), so an over-broad rule that hid the source tree fails rather than making every other assertion pass. CI picks it up through the existing `scripts/*.test.sh` glob.

A `!evals/*/out/.gitignore` negation was in the first draft and came back out: mutation-testing showed it guarded nothing, because the nested sentinel's own `!.gitignore` already re-includes it.

## Testing Procedure

1. Check out this branch and run `bash scripts/repo-hygiene.test.sh` — 5 tests pass.
2. Delete the `tmp/` line from `.gitignore` and re-run. Two assertions fail. Same for `.pytest_cache/` and for `evals/*/out/*`.
3. Change `evals/*/out/*` to `evals/*/out/` and re-run — `test_tracked_sentinel_is_not_ignored` fails, which is the trap described above.
4. Confirm nothing tracked became invisible: `git ls-files | git check-ignore --stdin --no-index` prints nothing.
5. `git status` in a checkout that has a populated `tmp/` and `evals/ollama-matrix/out/` shows neither.

## Additional Notes / HelpScout Tickets

Sibling to nhangen/llm-tools#383 (the `command git add` convention and the `stage-with-unwrapped-git` rule). `evals/ollama-matrix/tier2` and `tier3` are still untracked and may be prompt inputs worth committing — deliberately out of scope.
