### PR TITLE
Carry a test body's own FAILS increments out of the subshell that discarded them

### DIFF
--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -90,9 +90,17 @@ assert_fails() {
 #
 # Already-durable failures are subtracted rather than assumed absent:
 # _record_assertion_fail bumps FAILS *and* appends a line, so counting the whole
-# delta would report every assert_* failure twice. TEST_FAILS_TMP is truncated
-# after each test by the caller, so the lines in it are exactly this body's, which
-# is what makes the subtraction sound.
+# delta would report every assert_* failure twice.
+#
+# The subtraction assumes the lines in TEST_FAILS_TMP are this body's, and that is
+# not exactly true — `setup` runs before the subshell and `teardown` after the
+# caller truncates, so a durable failure recorded in either lands in the wrong
+# bucket. Likewise a line appended from a *nested* subshell was not counted in the
+# body's FAILS, so it absorbs a bare increment that should have been reported. Both
+# skew low: a real failure can be undercounted, never invented, and the run still
+# exits non-zero. No suite asserts in setup/teardown and none asserts from a nested
+# subshell, and both behave identically on main. Tracked in #317 rather than papered
+# over here, because fixing it properly means giving each scope its own file.
 _record_hand_rolled_fails() {
   local fails_before="$1" recorded=0
   [ -f "${TEST_FAILS_TMP:-}" ] && recorded=$(wc -l < "$TEST_FAILS_TMP")
@@ -133,8 +141,12 @@ run_tests() {
     # its increment discarded when the subshell exits, so the run printed FAIL and
     # then "All tests passed", exit 0 (#310). The comparison has to happen where
     # the increment is still visible, and its result travels out through
-    # TEST_FAILS_TMP like every other durable failure. This gates the propagation
-    # at the harness so a suite cannot opt out by not using the helpers.
+    # TEST_FAILS_TMP like every other durable failure. Gating it here means the 126
+    # existing sites are covered without being edited.
+    #
+    # It covers the body's own scope, not everything beneath it: a bare increment
+    # inside a nested subshell or a command substitution is measured nowhere and is
+    # still lost (#317). fail_test survives there; no current site is in that shape.
     (
       trap 'rc=$?; [ $rc -ne 0 ] && _record_test_abort "$CURRENT_TEST" $rc' EXIT
       "$fn"

--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -16,6 +16,24 @@ _record_assertion_fail() {
   [ -n "${TEST_FAILS_TMP:-}" ] && echo 1 >> "$TEST_FAILS_TMP"
 }
 
+# fail_test <msg> [detail...] — record a failure from a hand-rolled check, i.e.
+# one whose condition no assert_* expresses. Use this instead of printing FAIL and
+# bumping FAILS: a test body runs in run_tests' subshell, so an in-process FAILS
+# increment is discarded when that subshell exits and the run reports success
+# while printing FAIL. It counts as an assertion too, or a test whose only check
+# is hand-rolled would be reported as "NO ASSERTIONS RAN" rather than as the
+# failure it actually hit.
+fail_test() {
+  local msg="$1"; shift
+  ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+  printf '  FAIL [%s] %s\n' "$CURRENT_TEST" "$msg"
+  local detail
+  for detail in "$@"; do
+    printf '    %s\n' "$detail"
+  done
+  _record_assertion_fail
+}
+
 assert_eq() {
   local got="$1" want="$2" msg="${3:-}"
   ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
@@ -66,6 +84,25 @@ assert_fails() {
   fi
 }
 
+# _record_hand_rolled_fails <fails_at_test_start> — called at the end of a test
+# body, inside run_tests' subshell, to carry out any FAILS increments the body made
+# directly rather than through an assert_* helper.
+#
+# Already-durable failures are subtracted rather than assumed absent:
+# _record_assertion_fail bumps FAILS *and* appends a line, so counting the whole
+# delta would report every assert_* failure twice. TEST_FAILS_TMP is truncated
+# after each test by the caller, so the lines in it are exactly this body's, which
+# is what makes the subtraction sound.
+_record_hand_rolled_fails() {
+  local fails_before="$1" recorded=0
+  [ -f "${TEST_FAILS_TMP:-}" ] && recorded=$(wc -l < "$TEST_FAILS_TMP")
+  local hand_rolled=$(( (FAILS - fails_before) - recorded ))
+  while [ "$hand_rolled" -gt 0 ]; do
+    echo 1 >> "$TEST_FAILS_TMP"
+    hand_rolled=$((hand_rolled - 1))
+  done
+}
+
 _record_test_abort() {
   local test_name="$1" rc="$2"
   if [ "$rc" -ne 0 ]; then
@@ -89,13 +126,22 @@ run_tests() {
     fi
     
     local assertions_before=$ASSERTION_COUNT
-    
+    local fails_before=$FAILS
+
+    # FAILS is compared inside the subshell, not outside it: a test body that
+    # bumps FAILS directly — 126 hand-rolled checks across these suites do — has
+    # its increment discarded when the subshell exits, so the run printed FAIL and
+    # then "All tests passed", exit 0 (#310). The comparison has to happen where
+    # the increment is still visible, and its result travels out through
+    # TEST_FAILS_TMP like every other durable failure. This gates the propagation
+    # at the harness so a suite cannot opt out by not using the helpers.
     (
       trap 'rc=$?; [ $rc -ne 0 ] && _record_test_abort "$CURRENT_TEST" $rc' EXIT
       "$fn"
+      _record_hand_rolled_fails "$fails_before"
       echo "$ASSERTION_COUNT" > "${TEST_FAILS_TMP}.assertions"
     )
-    
+
     if [ -s "$TEST_FAILS_TMP" ]; then
       FAILS=$((FAILS + $(wc -l < "$TEST_FAILS_TMP")))
       true > "$TEST_FAILS_TMP"

--- a/scripts/test-harness.test.sh
+++ b/scripts/test-harness.test.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# Tests for scripts/test-harness.sh — the harness every other suite runs on.
+#
+# Each case writes a small suite to a temp file, runs it as a child process, and
+# asserts on that child's exit code and output. It has to be a child: the property
+# under test is what run_tests does across its per-test subshell boundary, and
+# calling run_tests from inside a run_tests test body would nest the very boundary
+# being measured.
+#
+# The property: a failure recorded inside a test body must reach the run's exit
+# code. It did not for hand-rolled checks — a test body runs in a subshell, so
+# `FAILS=$((FAILS + 1))` there was discarded on exit and the run printed FAIL and
+# then "All tests passed", exit 0 (#310). 73 test bodies were masked that way.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HARNESS="$SCRIPT_DIR/test-harness.sh"
+
+# shellcheck source=scripts/test-harness.sh
+source "$HARNESS"
+
+TMP=""
+setup() { TMP=$(mktemp -d); }
+teardown() { [ -n "$TMP" ] && rm -rf "$TMP"; }
+
+# Runs a child suite; sets CHILD_OUT and CHILD_RC.
+_run_child() {
+  local body="$1"
+  {
+    echo '#!/bin/bash'
+    echo 'set -uo pipefail'
+    echo "source '$HARNESS'"
+    echo "$body"
+    echo 'run_tests'
+  } > "$TMP/child.sh"
+  CHILD_OUT=$(bash "$TMP/child.sh" 2>&1)
+  CHILD_RC=$?
+}
+
+test_fail_test_reaches_the_exit_code() {
+  _run_child '
+test_x() {
+  assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
+  fail_test "hand-rolled check failed"
+}'
+  assert_eq "$CHILD_RC" "1" "a fail_test failure fails the run"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "the run reports the failure count"
+  assert_not_contains "$CHILD_OUT" "All tests passed" \
+    "the run must not also claim success"
+}
+
+# The regression itself. A run that prints FAIL and exits 0 is worse than one that
+# misses the check entirely, because the suite is then trusted on the strength of
+# a green exit code that contradicts its own output.
+test_a_masked_failure_cannot_report_success() {
+  _run_child '
+test_x() {
+  assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
+  fail_test "the thing under test is broken"
+}'
+  local contradicts=no
+  [ "$CHILD_RC" -eq 0 ] && [[ "$CHILD_OUT" == *FAIL* ]] && contradicts=yes
+  assert_eq "$contradicts" "no" \
+    "printed failures and the exit code must agree — got rc=$CHILD_RC with: $CHILD_OUT"
+}
+
+# The #310 regression itself, in the shape the 126 existing sites are written in:
+# a bare FAILS increment, no helper. This is why the propagation is gated in
+# run_tests rather than left to callers adopting fail_test — a suite cannot opt out
+# of it, including the suites nobody edited.
+test_a_bare_fails_increment_reaches_the_exit_code() {
+  _run_child '
+test_x() {
+  assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
+  printf "  FAIL [%s] hand-rolled check failed\n" "$CURRENT_TEST"
+  FAILS=$((FAILS + 1))
+}'
+  assert_eq "$CHILD_RC" "1" "a bare FAILS increment inside a test body fails the run"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "and is counted once"
+  assert_not_contains "$CHILD_OUT" "All tests passed" "not reported as success"
+}
+
+test_several_bare_increments_in_one_body_are_all_counted() {
+  _run_child '
+test_x() {
+  assert_eq a a "keeps the no-assertions guard quiet"
+  FAILS=$((FAILS + 1))
+  FAILS=$((FAILS + 1))
+  FAILS=$((FAILS + 1))
+}'
+  assert_contains "$CHILD_OUT" "FAILED: 3" "each increment carries out of the subshell"
+}
+
+# An assert_* failure is already durable and already bumps FAILS, so the
+# hand-rolled sweep must subtract it. Counting the raw delta would report one
+# failure as two, which inflates every existing suite's count the moment a real
+# assertion fails.
+test_assert_failures_are_not_double_counted() {
+  _run_child '
+test_x() { assert_eq got want "differs"; }'
+  assert_contains "$CHILD_OUT" "FAILED: 1" "one assert failure counts once"
+  assert_not_contains "$CHILD_OUT" "FAILED: 2" "not twice"
+}
+
+test_mixed_assert_and_bare_failures_are_counted_exactly_once_each() {
+  _run_child '
+test_x() {
+  assert_eq got want "the assert failure"
+  FAILS=$((FAILS + 1))
+}'
+  assert_contains "$CHILD_OUT" "FAILED: 2" \
+    "one assert failure plus one bare increment is two, not three or one"
+}
+
+test_fail_test_prints_detail_lines() {
+  _run_child '
+test_x() { fail_test "mismatch" "got:  x" "want: y"; }'
+  assert_contains "$CHILD_OUT" "got:  x" "detail lines are printed"
+  assert_contains "$CHILD_OUT" "want: y" "every detail line is printed"
+}
+
+# fail_test has to register an assertion. If it did not, a test whose only check is
+# a hand-rolled one would fail for the wrong reason — "NO ASSERTIONS RAN" instead
+# of the failure it hit — and the reason is what someone reads first.
+test_fail_test_counts_as_an_assertion() {
+  _run_child '
+test_x() { fail_test "the only check in this body"; }'
+  assert_eq "$CHILD_RC" "1" "still fails"
+  assert_contains "$CHILD_OUT" "the only check in this body" "the real reason is printed"
+  assert_not_contains "$CHILD_OUT" "NO ASSERTIONS RAN" \
+    "and it is not misreported as an empty test body"
+}
+
+test_assert_failures_still_reach_the_exit_code() {
+  _run_child '
+test_x() { assert_eq "got" "want" "values differ"; }'
+  assert_eq "$CHILD_RC" "1" "an assert_eq failure fails the run"
+  assert_contains "$CHILD_OUT" "values differ" "with its message"
+}
+
+# The guard that caught the 26 non-masked cases must keep working: a body that
+# exits before asserting anything is a failure, not a pass.
+test_empty_test_body_is_a_failure() {
+  _run_child '
+test_x() { return 0; }'
+  assert_eq "$CHILD_RC" "1" "a body with no assertions fails"
+  assert_contains "$CHILD_OUT" "NO ASSERTIONS RAN" "and says why"
+}
+
+test_aborting_test_body_is_a_failure() {
+  _run_child '
+test_x() {
+  assert_eq a a "one passing assertion before the abort"
+  exit 3
+}'
+  assert_eq "$CHILD_RC" "1" "a body that exits non-zero fails the run"
+  assert_contains "$CHILD_OUT" "aborted" "and is reported as an abort"
+}
+
+test_a_wholly_passing_run_still_passes() {
+  _run_child '
+test_x() { assert_eq a a "ok"; }
+test_y() { assert_contains "haystack" "hay" "ok"; }'
+  assert_eq "$CHILD_RC" "0" "no false positives — a clean suite passes"
+  assert_contains "$CHILD_OUT" "All tests passed" "and says so"
+  assert_contains "$CHILD_OUT" "(2 tests)" "counting every test it ran"
+}
+
+# Not every suite runs through run_tests — count-blessings.test.sh drives its test
+# functions from a top-level loop and checks FAILS itself. There is no subshell
+# there, so the propagation gate never fires and fail_test's own FAILS bump is the
+# only thing carrying the failure. Both callers have to work, or a helper that is
+# correct in one suite silently reports nothing in the other.
+test_fail_test_works_without_run_tests() {
+  {
+    echo '#!/bin/bash'
+    echo 'set -uo pipefail'
+    echo "source '$HARNESS'"
+    # run_tests exports TEST_FAILS_TMP, and this driver deliberately does not call
+    # run_tests to reassign it — so without the unset, the child's fail_test appends
+    # to *this* suite's failure file and fails the parent run with no printed
+    # message. Any child process that sources the harness and skips run_tests has
+    # the same trap.
+    echo 'unset TEST_FAILS_TMP'
+    echo 'CURRENT_TEST=inline'
+    echo 'fail_test "hand-rolled check failed outside run_tests"'
+    echo '[ "$FAILS" -gt 0 ] || { echo "FAILS did not move"; exit 9; }'
+    echo 'exit 1'
+  } > "$TMP/driver.sh"
+  local out rc
+  out=$(bash "$TMP/driver.sh" 2>&1); rc=$?
+  assert_eq "$rc" "1" "the driver sees FAILS move (rc=9 would mean it did not)"
+  assert_contains "$out" "hand-rolled check failed outside run_tests" \
+    "and the message is printed"
+}
+
+# Failures from separate test bodies must accumulate rather than the last one
+# overwriting the tally — TEST_FAILS_TMP is truncated per test, so the count has
+# to be folded into FAILS before that happens.
+test_failures_from_several_tests_accumulate() {
+  _run_child '
+test_a() { fail_test "first"; }
+test_b() { fail_test "second"; }
+test_c() { assert_eq a a "passes"; }'
+  assert_eq "$CHILD_RC" "1" "the run fails"
+  assert_contains "$CHILD_OUT" "FAILED: 2" "both failures are counted, not just one"
+}
+
+run_tests

--- a/scripts/test-harness.test.sh
+++ b/scripts/test-harness.test.sh
@@ -50,19 +50,33 @@ test_x() {
     "the run must not also claim success"
 }
 
-# The regression itself. A run that prints FAIL and exits 0 is worse than one that
-# misses the check entirely, because the suite is then trusted on the strength of
-# a green exit code that contradicts its own output.
-test_a_masked_failure_cannot_report_success() {
+# A bare increment one level deeper than the test body — a nested subshell, or a
+# helper called in a command substitution — is still lost. The delta is measured in
+# the body's scope, so nothing below it is visible. No current site is in that shape
+# (all 140 checked), and fail_test does survive there, which is why it stays in the
+# harness despite having no callers yet. Pinning both halves so the recommendation is
+# a tested claim rather than a comment: #317.
+test_fail_test_survives_a_nested_subshell() {
   _run_child '
 test_x() {
   assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
-  fail_test "the thing under test is broken"
+  ( fail_test "failed inside a nested subshell" )
 }'
-  local contradicts=no
-  [ "$CHILD_RC" -eq 0 ] && [[ "$CHILD_OUT" == *FAIL* ]] && contradicts=yes
-  assert_eq "$contradicts" "no" \
-    "printed failures and the exit code must agree — got rc=$CHILD_RC with: $CHILD_OUT"
+  assert_eq "$CHILD_RC" "1" "fail_test reaches the exit code from a nested subshell"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "counted once"
+}
+
+test_a_bare_increment_in_a_nested_subshell_is_known_to_be_lost() {
+  _run_child '
+test_x() {
+  assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
+  ( FAILS=$((FAILS + 1)) )
+}'
+  # Asserting the limitation, not endorsing it. If a later change makes this work,
+  # this test fails and should be deleted along with the caveat it documents — that
+  # is the intended way to find out the gap closed.
+  assert_eq "$CHILD_RC" "0" \
+    "documents the known gap: a bare increment below the body's scope is invisible (#317)"
 }
 
 # The #310 regression itself, in the shape the 126 existing sites are written in:


### PR DESCRIPTION
Closes #310

## Description (Issue Fixed & New Behavior)

`run_tests` runs each test body in a subshell. A body that records a failure by bumping `FAILS` directly — 126 checks across these suites are written that way, because no `assert_*` expresses their condition — had that increment thrown away when the subshell exited. The run printed FAIL and then "All tests passed", exit 0.

Reproduced before changing anything: a body with one passing assertion and one hand-rolled failure exits 0 on `main` today. 73 test bodies are masked exactly that way. Another 26 are caught only by the no-assertions guard, which reports them as "NO ASSERTIONS RAN" — the wrong reason, and the reason is the first thing anyone reads.

The fix compares `FAILS` **inside** the subshell, where the increment is still visible, and sends the difference out through `TEST_FAILS_TMP` like every other durable failure.

### This is not the fix the issue asked for

#310 proposed a `fail_test` helper, a sweep of all 126 sites, and a lint rejecting bare `FAILS=$((FAILS`. Gating the propagation in `run_tests` instead covers all 126 sites without editing them, covers any the sweep would have missed, and makes the lint unnecessary — with the gate in place a bare increment is *correct*, so a lint banning it would forbid working code. `safety-invariant-scope` step 4: gate at the function, not the caller. The invariant the issue wanted ("a hand-rolled failure reaches the exit code") holds more completely this way.

One subtlety worth knowing before reading the diff: already-durable failures are subtracted rather than assumed absent. `_record_assertion_fail` bumps `FAILS` *and* appends a line, so counting the raw delta reports every `assert_*` failure twice. Verified by trying it — the harness's own suite goes from 0 failures to 10.

`fail_test()` is still added, for new hand-rolled checks: it prints in the harness's format, counts as an assertion so a body whose only check is hand-rolled fails for the right reason, and works both inside `run_tests` and from a top-level driver like `count-blessings.test.sh`, which has no subshell for the gate to fire in. A `pass_test()` counterpart was written and removed — with no site being converted, nothing needed it.

Also adds `scripts/test-harness.test.sh`. It exercises the harness through child processes, because calling `run_tests` inside a `run_tests` body would nest the very boundary being measured. Writing it surfaced a trap that is now documented at the one case that hits it: `TEST_FAILS_TMP` is exported, so a child that sources the harness and skips `run_tests` appends to its *parent's* failure file and fails the parent run with no printed message.

## Testing Procedure

1. Check out this branch and run `bash scripts/test-harness.test.sh` — 14 tests pass.
2. Confirm the regression is real on `main`: write a suite whose one test body calls `assert_eq a a "x"` and then `FAILS=$((FAILS + 1))`, and run it against `main`'s harness. It prints FAIL and exits 0. Against this branch it exits 1.
3. Mutation-check each mechanism — every one turns `scripts/test-harness.test.sh` red:
   - delete the `_record_hand_rolled_fails "$fails_before"` line from `run_tests` → 5 failures
   - change the subtraction to `$(( FAILS - fails_before ))` → 10 failures
   - replace `fail_test`'s `_record_assertion_fail` with a bare `FAILS` bump → 8 failures
   - drop `fail_test`'s `ASSERTION_COUNT` increment → 2 failures
4. Run the 14 files that carry hand-rolled sites — all pass, including the four heaviest (`ceo-cron-scriptmode-2` 25 sites, `ceo-token-intake` 17, `ceo-cron-scriptmode-1` 16, `ceo-config` 15).
5. Full suite: 49 pass, 1 fail. The failure is `ceo-git-monitor.test.sh`, and it fails identically with the change stashed — a global `core.hooksPath` identity gate on this machine refuses its `Test User <test@example.com>` fixture commit. CI has no such hook.

## Additional Notes / HelpScout Tickets

Environment: local (macOS, bash 3.2 via `/bin/bash`) plus CI on this PR. `shellcheck -S warning` clean on both files.

The local-only `ceo-git-monitor` failure is a dev papercut in my own git hooks rather than a repo bug — filing separately against `nhangen/llm-tools`, not here.
