### PR TITLE
Stop the git-monitor test from writing the developer's global git identity

### DIFF
--- a/scripts/ceo-git-monitor.test.sh
+++ b/scripts/ceo-git-monitor.test.sh
@@ -14,22 +14,40 @@ setup() {
   
   
   export CEO_GIT_DIRS="$TMP/repos"
-  mkdir -p "$TMP/repos"
+  mkdir -p "$TMP/repos" "$TMP/hooks-none"
   
-  git config --global user.email "test@example.com"
-  git config --global user.name "Test User"
+  # Per-process, not `git config --global`. The global form wrote a placeholder
+  # identity into the developer's own ~/.gitconfig and left it there — teardown
+  # never restored it, and on a machine whose repos inherit the global identity
+  # that byline then lands on real commits (nhangen/llm-tools#397).
+  export GIT_AUTHOR_NAME="Test User" GIT_AUTHOR_EMAIL="test@example.com"
+  export GIT_COMMITTER_NAME="Test User" GIT_COMMITTER_EMAIL="test@example.com"
 }
 
 teardown() {
   rm -rf "$TMP"
   unset CEO_VAULT CEO_DIR CEO_GIT_DIRS
+  unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+}
+
+# A fixture repo, with hooks pointed at an empty dir of its own. A machine with a
+# global `core.hooksPath` identity gate installed refuses a placeholder committer,
+# which is correct for a repo you might push and wrong for one that lives inside
+# `mktemp -d` for the length of one assertion. Opting out here — explicitly, in
+# the throwaway repo — beats teaching the gate to guess which repos are real.
+# The empty hooks dir lives outside the repo: inside it, it is one stray file away
+# from making a "clean worktree" fixture dirty and quietly inverting an assertion.
+init_fixture_repo() {
+  local dir="$1"
+  git -C "$dir" init -q
+  git -C "$dir" config core.hooksPath "$TMP/hooks-none"
 }
 
 test_git_monitor_clean_state() {
   local repo_dir="$TMP/repos/clean-repo"
   mkdir -p "$repo_dir"
   cd "$repo_dir"
-  git init -q
+  init_fixture_repo "$repo_dir"
   echo "test" > README.md
   git add README.md
   git commit -q -m "Initial commit"
@@ -48,7 +66,7 @@ test_git_monitor_dirty_worktree() {
   local repo_dir="$TMP/repos/dirty-repo"
   mkdir -p "$repo_dir"
   cd "$repo_dir"
-  git init -q
+  init_fixture_repo "$repo_dir"
   echo "test" > README.md
   git add README.md
   git commit -q -m "Initial commit"


### PR DESCRIPTION
Closes #none

Refs nhangen/llm-tools#397

## Description (Issue Fixed & New Behavior)

`ceo-git-monitor.test.sh`'s `setup()` ran `git config --global user.email "test@example.com"` and `user.name "Test User"`. Global, not local, and `test-harness.sh` has no `HOME` sandbox, so it edited the developer's own `~/.gitconfig`. `teardown()` never put it back.

That block is a placeholder on this machine right now. `git log --all` in `nhangen/llm-tools` shows 44 commits carrying `Test User <test@example.com>` as both author and committer, 42 of them on `main`, dated 2026-05-30 through 2026-07-14. They stop the day the global identity gate landed, which is what has been holding the line since. The `includeIf hasconfig:remote.*.url` blocks for `*nhangen/**` and `*awesomemotive/**` are why commits are correctly attributed today; the exposure is any repo whose remote matches neither pattern and that has no local identity.

The identity was never load-bearing here. Both tests assert on the monitor's state file, not on a byline. So it moves to per-process `GIT_AUTHOR_*` / `GIT_COMMITTER_*` exports, which reach git the same way and die with the process.

That change alone still leaves the fixture commits refused by the identity gate, which is the red-locally-green-in-CI problem in llm-tools#397. A new `init_fixture_repo` helper points each fixture's `core.hooksPath` at an empty directory under `$TMP`. An explicit opt-out inside a repo that exists for two assertions beats teaching the gate to guess which repos are real, and it cannot leak to a repo you might push. The empty directory sits outside the repo deliberately: git ignores an empty directory, so putting it inside would pass today and then silently invert the clean-worktree assertion the first time a file landed in it.

llm-tools#397 proposed exempting any repo with no `origin` and a worktree under the system temp dir. That is not done here, and shouldn't be. It matches a fresh `git init` in `/tmp` that later gets a remote added and pushed, and by then the byline is permanent. The issue's own warning covers it: a fixture-shaped exemption a real repo could match is worse than the papercut.

## Testing Procedure

1. Check out this branch.
2. `shasum -a 256 ~/.gitconfig` and keep the digest.
3. `bash scripts/ceo-git-monitor.test.sh` on `main` first. On a machine with the global identity gate installed it aborts: `commit blocked — Committer identity is a placeholder/guest`.
4. Run the same file on this branch. Expect `All tests passed. (2 tests)`.
5. Run the whole suite the way CI does: `printf '%s\n' scripts/*.test.sh | xargs -P 4 -I {} bash -c 'bash "$1"' _ {}`. Expect all 49 files green.
6. Re-run `shasum -a 256 ~/.gitconfig`. Expect the same digest as step 2. That is the assertion that matters, since the whole bug was an invisible write.
7. `shellcheck --severity=warning scripts/ceo-git-monitor.test.sh` for parity with the CI job.

All seven done locally: baseline reproduces the refusal, the branch is green on all 49 files, shellcheck is clean, and the `~/.gitconfig` digest is byte-identical before and after a full run.

## Additional Notes / HelpScout Tickets

Three follow-ups sit outside this repo and are deliberately not in this PR:

- Remove the `[user]` block from `~/.gitconfig`. Ordered after this merge, or the next suite run just writes it again. Both `includeIf` blocks already supply real identities, so an unmatched remote will now fail with `please tell me who you are` instead of committing under whatever `[user]` holds. Failing loudly is the point, but automation committing into such a repo will start hard-failing.
- A `.mailmap` in `nhangen/llm-tools` so `git log`, `shortlog`, and `blame` attribute those 44 commits correctly. No history rewrite: the work is fine, only the byline is wrong, and rewriting pushed history across 30-odd branches is not worth it.
- An llm-tools issue for the actual gap. The gate refuses the commit, but nothing notices that the global identity was clobbered in the first place. That is why this ran for two and a half months and was only found by tripping over it.
