### PR TITLE
Count a setup failure once instead of twice

### DIFF
--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -92,15 +92,16 @@ assert_fails() {
 # _record_assertion_fail bumps FAILS *and* appends a line, so counting the whole
 # delta would report every assert_* failure twice.
 #
-# The subtraction assumes the lines in TEST_FAILS_TMP are this body's, and that is
-# not exactly true — `setup` runs before the subshell and `teardown` after the
-# caller truncates, so a durable failure recorded in either lands in the wrong
-# bucket. Likewise a line appended from a *nested* subshell was not counted in the
-# body's FAILS, so it absorbs a bare increment that should have been reported. Both
-# skew low: a real failure can be undercounted, never invented, and the run still
-# exits non-zero. No suite asserts in setup/teardown and none asserts from a nested
-# subshell, and both behave identically on main. Tracked in #317 rather than papered
-# over here, because fixing it properly means giving each scope its own file.
+# The subtraction is exact, because TEST_FAILS_TMP holds this body's lines and
+# nothing else: run_tests truncates it before the subshell and leaves it unset while
+# `setup` and `teardown` run (#317). It was not exact before — those two scopes
+# appended to the same file, so a failure from either was read as one the body had
+# already recorded.
+#
+# One case is still outside it. A bare increment in a *nested* subshell or a command
+# substitution never reaches the body's FAILS, so the delta cannot see it and it is
+# lost. fail_test works there; no site in these suites is in that shape, and
+# test-harness.test.sh pins both halves.
 _record_hand_rolled_fails() {
   local fails_before="$1" recorded=0
   [ -f "${TEST_FAILS_TMP:-}" ] && recorded=$(wc -l < "$TEST_FAILS_TMP")
@@ -121,18 +122,26 @@ _record_test_abort() {
 
 run_tests() {
   local count=0
-  export TEST_FAILS_TMP
-  TEST_FAILS_TMP=$(mktemp)
+  local body_fails assertions_file
+  body_fails=$(mktemp)
+  assertions_file="${body_fails}.assertions"
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
     if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
       continue
     fi
     CURRENT_TEST="$fn"
-    
+
+    # TEST_FAILS_TMP is the subshell's channel and nothing else's. `setup` and
+    # `teardown` run right here in this shell, so _record_assertion_fail's in-process
+    # FAILS bump is already durable for them — leaving the file set as well made each
+    # of their failures land twice, once as the bump and once when the caller folded
+    # the file in. A setup failure was reported as two, and two as four (#317).
+    unset TEST_FAILS_TMP
+
     if type setup >/dev/null 2>&1; then
       setup
     fi
-    
+
     local assertions_before=$ASSERTION_COUNT
     local fails_before=$FAILS
 
@@ -147,22 +156,29 @@ run_tests() {
     # It covers the body's own scope, not everything beneath it: a bare increment
     # inside a nested subshell or a command substitution is measured nowhere and is
     # still lost (#317). fail_test survives there; no current site is in that shape.
+    TEST_FAILS_TMP="$body_fails"
+    export TEST_FAILS_TMP
+    true > "$TEST_FAILS_TMP"
+
     (
       trap 'rc=$?; [ $rc -ne 0 ] && _record_test_abort "$CURRENT_TEST" $rc' EXIT
       "$fn"
       _record_hand_rolled_fails "$fails_before"
-      echo "$ASSERTION_COUNT" > "${TEST_FAILS_TMP}.assertions"
+      echo "$ASSERTION_COUNT" > "$assertions_file"
     )
 
     if [ -s "$TEST_FAILS_TMP" ]; then
       FAILS=$((FAILS + $(wc -l < "$TEST_FAILS_TMP")))
       true > "$TEST_FAILS_TMP"
     fi
-    
-    if [ -f "${TEST_FAILS_TMP}.assertions" ]; then
-      ASSERTION_COUNT=$(cat "${TEST_FAILS_TMP}.assertions")
+
+    unset TEST_FAILS_TMP
+
+    if [ -f "$assertions_file" ]; then
+      ASSERTION_COUNT=$(cat "$assertions_file")
+      rm -f "$assertions_file"
     fi
-    
+
     if [ "$ASSERTION_COUNT" -eq "$assertions_before" ]; then
       printf '  FAIL [%s] NO ASSERTIONS RAN (test body exited early or had no assertions)\n' "$CURRENT_TEST"
       FAILS=$((FAILS + 1))
@@ -173,8 +189,8 @@ run_tests() {
     fi
     count=$((count + 1))
   done
-  rm -f "$TEST_FAILS_TMP" "${TEST_FAILS_TMP}.assertions"
-  
+  rm -f "$body_fails" "$assertions_file"
+
   echo ""
   if [ "$FAILS" -eq 0 ]; then
     echo "All tests passed. ($count tests)"

--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -11,7 +11,17 @@ ASSERTION_COUNT=0
 # FAILS in-process is kept for the case where assert_* is called outside
 # the subshell (e.g. directly from a helper) but the durable signal is the
 # tmp file.
+# Inside a parent-shell scope (`setup`/`teardown`) the file is the only channel used,
+# and the in-process bump is deliberately suppressed. Using both there is what made a
+# setup failure count twice (#317), and reading the two against each other could not
+# tell a bare parent-depth increment from a nested recorded failure — they cancel, and
+# two genuine failures reported as one. One channel per scope removes the ambiguity
+# instead of estimating around it. Exported, so a nested subshell inherits it.
 _record_assertion_fail() {
+  if [ "${HARNESS_PARENT_SCOPE:-0}" = 1 ] && [ -n "${TEST_FAILS_TMP:-}" ]; then
+    echo 1 >> "$TEST_FAILS_TMP"
+    return 0
+  fi
   FAILS=$((FAILS + 1))
   [ -n "${TEST_FAILS_TMP:-}" ] && echo 1 >> "$TEST_FAILS_TMP"
 }
@@ -92,16 +102,28 @@ assert_fails() {
 # _record_assertion_fail bumps FAILS *and* appends a line, so counting the whole
 # delta would report every assert_* failure twice.
 #
-# The subtraction is exact, because TEST_FAILS_TMP holds this body's lines and
-# nothing else: run_tests truncates it before the subshell and leaves it unset while
-# `setup` and `teardown` run (#317). It was not exact before — those two scopes
-# appended to the same file, so a failure from either was read as one the body had
-# already recorded.
+# The lines are this body's and nothing else's — run_tests truncates the file before
+# the subshell, and `setup`/`teardown` write their own (#317). Before that they shared
+# this one, so a failure from either was read as one the body had already recorded.
 #
-# One case is still outside it. A bare increment in a *nested* subshell or a command
-# substitution never reaches the body's FAILS, so the delta cannot see it and it is
-# lost. fail_test works there; no site in these suites is in that shape, and
-# test-harness.test.sh pins both halves.
+# The subtraction still is not exact, in both directions, and both come from the same
+# cause: a nested subshell or command substitution's FAILS bump never reaches the
+# body's, so the delta and the file disagree about what happened down there.
+#
+#   - A bare increment nested: no line, no delta. Lost outright.
+#   - An assert_* or fail_test failure nested: a line with no matching delta, so
+#     `recorded` outruns the delta and this sweep absorbs a real main-scope increment
+#     instead. Two genuine failures report as one.
+#
+# The second is the worse of the two and is the case an earlier version of this
+# comment claimed had been fixed. It has not been. `while [ "$hand_rolled" -gt 0 ]`
+# floors the negative at zero, which is what makes the absorption silent.
+#
+# So fail_test always reports its own failure at either depth, but in *this* scope it
+# cannot repair a bare main-scope increment sitting beside it — that is the absorption
+# above. The parent scopes have no such caveat: there the file is the only channel
+# (see _record_assertion_fail), so nothing cancels. No site in these suites is in
+# either shape, and test-harness.test.sh pins the bare-increment half only.
 _record_hand_rolled_fails() {
   local fails_before="$1" recorded=0
   [ -f "${TEST_FAILS_TMP:-}" ] && recorded=$(wc -l < "$TEST_FAILS_TMP")
@@ -110,6 +132,31 @@ _record_hand_rolled_fails() {
     echo 1 >> "$TEST_FAILS_TMP"
     hand_rolled=$((hand_rolled - 1))
   done
+}
+
+# _fold_parent_scope <file> — fold a parent-shell scope's recorded failures (setup,
+# teardown) into FAILS. Every line is added, with no arithmetic against FAILS, because
+# HARNESS_PARENT_SCOPE suppressed the in-process bump for exactly these lines — so the
+# file is the whole record and cannot double-count. It works at any depth: a nested
+# subshell inherits the exported flag and appends to the same file.
+#
+# A bare `FAILS=$((FAILS + 1))` at parent depth is untouched by all of this and stays
+# durable on its own, since setup/teardown run in this shell. One nested a level down
+# is still lost — no line, no bump — the same residual hole the body scope has.
+#
+# Two earlier cuts of #317 got this wrong and both failed quietly, which is why this
+# one carries no estimate. Unsetting the file removed the channel entirely: a nested
+# failure reached neither, so the run printed FAIL and exited 0. Folding
+# `lines - (FAILS - before)` then read the two channels against each other and could
+# not tell a bare parent increment from a nested recorded failure — they cancelled, and
+# two genuine failures reported as one where main reported two.
+_fold_parent_scope() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  if [ -s "$file" ]; then
+    FAILS=$((FAILS + $(wc -l < "$file")))
+  fi
+  true > "$file"
 }
 
 _record_test_abort() {
@@ -122,24 +169,30 @@ _record_test_abort() {
 
 run_tests() {
   local count=0
-  local body_fails assertions_file
-  body_fails=$(mktemp)
-  assertions_file="${body_fails}.assertions"
+  local body_fails_tmp assertions_tmp parent_fails_tmp
+  body_fails_tmp=$(mktemp)
+  parent_fails_tmp=$(mktemp)
+  assertions_tmp="${body_fails_tmp}.assertions"
   for fn in $(declare -F | awk '{print $3}' | grep '^test_'); do
     if [ -n "${TEST_FILTER:-}" ] && [[ "$fn" != *"$TEST_FILTER"* ]]; then
       continue
     fi
     CURRENT_TEST="$fn"
 
-    # TEST_FAILS_TMP is the subshell's channel and nothing else's. `setup` and
-    # `teardown` run right here in this shell, so _record_assertion_fail's in-process
-    # FAILS bump is already durable for them — leaving the file set as well made each
-    # of their failures land twice, once as the bump and once when the caller folded
-    # the file in. A setup failure was reported as two, and two as four (#317).
-    unset TEST_FAILS_TMP
-
+    # Each scope gets its own file, and inside a parent scope the file is the only
+    # channel — HARNESS_PARENT_SCOPE suppresses the in-process bump. Sharing the body's
+    # file *and* keeping the bump is what made each setup failure land twice, once as
+    # each: a setup failure was reported as two, and two as four (#317). One channel
+    # per scope means a failure below these scopes is still recorded, without the
+    # caller having to guess which channel carried it.
     if type setup >/dev/null 2>&1; then
+      TEST_FAILS_TMP="$parent_fails_tmp"
+      HARNESS_PARENT_SCOPE=1
+      export TEST_FAILS_TMP HARNESS_PARENT_SCOPE
+      true > "$TEST_FAILS_TMP"
       setup
+      HARNESS_PARENT_SCOPE=0
+      _fold_parent_scope "$parent_fails_tmp"
     fi
 
     local assertions_before=$ASSERTION_COUNT
@@ -156,7 +209,7 @@ run_tests() {
     # It covers the body's own scope, not everything beneath it: a bare increment
     # inside a nested subshell or a command substitution is measured nowhere and is
     # still lost (#317). fail_test survives there; no current site is in that shape.
-    TEST_FAILS_TMP="$body_fails"
+    TEST_FAILS_TMP="$body_fails_tmp"
     export TEST_FAILS_TMP
     true > "$TEST_FAILS_TMP"
 
@@ -164,7 +217,7 @@ run_tests() {
       trap 'rc=$?; [ $rc -ne 0 ] && _record_test_abort "$CURRENT_TEST" $rc' EXIT
       "$fn"
       _record_hand_rolled_fails "$fails_before"
-      echo "$ASSERTION_COUNT" > "$assertions_file"
+      echo "$ASSERTION_COUNT" > "$assertions_tmp"
     )
 
     if [ -s "$TEST_FAILS_TMP" ]; then
@@ -174,9 +227,9 @@ run_tests() {
 
     unset TEST_FAILS_TMP
 
-    if [ -f "$assertions_file" ]; then
-      ASSERTION_COUNT=$(cat "$assertions_file")
-      rm -f "$assertions_file"
+    if [ -f "$assertions_tmp" ]; then
+      ASSERTION_COUNT=$(cat "$assertions_tmp")
+      rm -f "$assertions_tmp"
     fi
 
     if [ "$ASSERTION_COUNT" -eq "$assertions_before" ]; then
@@ -185,11 +238,18 @@ run_tests() {
     fi
     
     if type teardown >/dev/null 2>&1; then
+      TEST_FAILS_TMP="$parent_fails_tmp"
+      HARNESS_PARENT_SCOPE=1
+      export TEST_FAILS_TMP HARNESS_PARENT_SCOPE
+      true > "$TEST_FAILS_TMP"
       teardown
+      HARNESS_PARENT_SCOPE=0
+      _fold_parent_scope "$parent_fails_tmp"
+      unset TEST_FAILS_TMP
     fi
     count=$((count + 1))
   done
-  rm -f "$body_fails" "$assertions_file"
+  rm -f "$body_fails_tmp" "$assertions_tmp" "$parent_fails_tmp"
 
   echo ""
   if [ "$FAILS" -eq 0 ]; then

--- a/scripts/test-harness.test.sh
+++ b/scripts/test-harness.test.sh
@@ -53,9 +53,9 @@ test_x() {
 # A bare increment one level deeper than the test body — a nested subshell, or a
 # helper called in a command substitution — is still lost. The delta is measured in
 # the body's scope, so nothing below it is visible. No current site is in that shape
-# (all 140 checked), and fail_test does survive there, which is why it stays in the
-# harness despite having no callers yet. Pinning both halves so the recommendation is
-# a tested claim rather than a comment: #317.
+# (all 140 checked), and fail_test does survive there, which is what makes it the
+# recommendation rather than a bare increment. Pinning both halves so that is a tested
+# claim rather than a comment: #317.
 test_fail_test_survives_a_nested_subshell() {
   _run_child '
 test_x() {
@@ -151,6 +151,58 @@ test_b() {
   # absorbing test_b's increment.
   assert_contains "$CHILD_OUT" "FAILED: 3" \
     "two teardown failures plus one body increment, each counted once"
+}
+
+# The parent scopes get a file of their own rather than no file. An earlier cut of
+# this fix just unset TEST_FAILS_TMP while setup/teardown ran, on the reasoning that
+# their in-process FAILS bump is already durable. True at that shell's depth, false
+# one level down — and unsetting removed the file channel that was carrying it, so a
+# failure below the parent scope reached neither. `main` reported it; that cut printed
+# FAIL and exited 0. Same shape as #310, in a scope the fix hadn't considered.
+
+test_a_setup_failure_below_the_parent_shell_still_fails_the_run() {
+  _run_child '
+setup() { ( fail_test "a setup failure one level down" ); }
+test_x() { assert_eq a a "the body itself passes"; }'
+  assert_eq "$CHILD_RC" "1" "a setup failure below the parent shell must fail the run"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "and is counted exactly once"
+  assert_not_contains "$CHILD_OUT" "All tests passed" "never reported as success"
+}
+
+test_a_teardown_failure_below_the_parent_shell_still_fails_the_run() {
+  _run_child '
+teardown() { x=$(fail_test "a teardown failure one level down"); }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # This half was never a regression — `main` loses it too — so it is a fix, not a
+  # restoration. Pinned alongside its sibling because the harness comments name both
+  # scopes and a reader has no way to tell which one was ever covered.
+  assert_eq "$CHILD_RC" "1" "a teardown failure below the parent shell must fail the run"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "and is counted exactly once"
+}
+
+test_a_parent_scope_failure_at_both_depths_is_counted_once_each() {
+  _run_child '
+setup() { fail_test "at parent depth"; ( fail_test "one level down" ); }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # The two channels must not overlap: the parent-depth failure is carried by its
+  # in-process bump and the nested one by its file line. Counting the file wholesale
+  # would double the first; ignoring it would drop the second.
+  assert_contains "$CHILD_OUT" "FAILED: 2" \
+    "one failure at parent depth plus one below it is two, not one and not three"
+}
+
+test_a_bare_parent_increment_beside_a_nested_failure_counts_both() {
+  _run_child '
+setup() { FAILS=$((FAILS + 1)); ( fail_test "one level down" ); }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # The second cut of this fix folded `lines - (FAILS - before)`, reading the two
+  # channels against each other. A bare parent-depth increment (delta, no line) and a
+  # nested recorded failure (line, no delta) cancelled exactly, so this reported 1 —
+  # under-counting where even `main` reported 2. Suppressing the in-process bump inside
+  # a parent scope makes the file the whole record and removes the ambiguity, but the
+  # arithmetic version looked right, so it gets a trip-wire.
+  assert_contains "$CHILD_OUT" "FAILED: 2" \
+    "a bare parent-depth increment and a nested recorded failure are two failures"
 }
 
 test_a_bare_increment_in_a_nested_subshell_is_known_to_be_lost() {

--- a/scripts/test-harness.test.sh
+++ b/scripts/test-harness.test.sh
@@ -66,6 +66,93 @@ test_x() {
   assert_contains "$CHILD_OUT" "FAILED: 1" "counted once"
 }
 
+# --- Scope attribution (#317) ---
+#
+# `setup` and `teardown` run in the caller's shell, not in the per-test subshell, so
+# _record_assertion_fail's in-process FAILS bump is already durable there. It also
+# appended a line to the shared failure file, and the caller folded that file into
+# FAILS — counting the same failure twice. Each scope's record is now kept in exactly
+# one place: the subshell body reports through its own file, the parent-shell scopes
+# through FAILS directly.
+#
+# The counts below were measured against the pre-fix harness, not derived from the
+# ticket. #317 described this as skewing low and never inventing a failure; that is
+# wrong in the setup case, which invents one per failure. Three of the surrounding
+# cases pass on the broken harness because the double-count cancels a separately
+# lost increment, so any test here has to name the number it expects and why.
+
+test_one_setup_failure_is_counted_once() {
+  _run_child '
+setup() { fail_test "the setup failure"; }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # Pre-fix: FAILED: 2. One failure, counted by the in-process bump and again when
+  # the caller folded setup's line out of the shared file.
+  assert_contains "$CHILD_OUT" "FAILED: 1" "one setup failure is one failure"
+  assert_not_contains "$CHILD_OUT" "FAILED: 2" "not doubled"
+  assert_eq "$CHILD_RC" "1" "and the run still fails"
+}
+
+test_setup_failures_are_not_doubled_at_scale() {
+  _run_child '
+setup() { fail_test "s1"; fail_test "s2"; }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # Pre-fix: FAILED: 4. Proves the ×2 relationship rather than a one-off off-by-one,
+  # which a single-failure case alone cannot distinguish.
+  assert_contains "$CHILD_OUT" "FAILED: 2" "two setup failures are two, not four"
+}
+
+test_a_setup_assert_failure_is_also_counted_once() {
+  _run_child '
+setup() { assert_eq got want "setup assertion"; }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # Same defect through assert_* rather than fail_test — both route to
+  # _record_assertion_fail, so a fix that only touched fail_test would miss this.
+  assert_contains "$CHILD_OUT" "FAILED: 1" "a setup assert failure counts once"
+  assert_contains "$CHILD_OUT" "setup assertion" "and its message is printed"
+}
+
+test_a_setup_failure_and_a_body_increment_are_both_counted() {
+  _run_child '
+setup() { fail_test "the setup failure"; }
+test_x() {
+  assert_eq a a "a passing assertion, so the no-assertions guard stays quiet"
+  FAILS=$((FAILS + 1))
+}'
+  # Pre-fix this already reported 2 — the right number for the wrong reason: setup's
+  # line was double-counted while it simultaneously absorbed the body's increment via
+  # the sweep's subtraction. Kept so the fix cannot restore the balance by
+  # reintroducing either half.
+  assert_contains "$CHILD_OUT" "FAILED: 2" \
+    "a setup failure plus a body increment is two, each counted once"
+}
+
+test_a_teardown_failure_is_counted_once_on_the_last_test() {
+  _run_child '
+teardown() { fail_test "the teardown failure"; }
+test_x() { assert_eq a a "the body itself passes"; }'
+  # Pre-fix this was correct by accident: teardown ran after the caller truncated,
+  # and the loop deleted the file before folding it, so only the in-process bump
+  # survived. Now it is correct by construction.
+  assert_eq "$CHILD_RC" "1" "a failure recorded in teardown fails the run"
+  assert_contains "$CHILD_OUT" "FAILED: 1" "counted once"
+  assert_not_contains "$CHILD_OUT" "All tests passed" "never reported as success"
+}
+
+test_a_teardown_failure_does_not_absorb_the_next_tests_increment() {
+  _run_child '
+teardown() { fail_test "teardown failure"; }
+test_a() { assert_eq a a "passes"; }
+test_b() {
+  assert_eq a a "passes"
+  FAILS=$((FAILS + 1))
+}'
+  # Two teardown failures plus test_b's bare increment. Pre-fix also 3, again by
+  # cancellation: teardown_a's leftover line was re-folded as a second failure while
+  # absorbing test_b's increment.
+  assert_contains "$CHILD_OUT" "FAILED: 3" \
+    "two teardown failures plus one body increment, each counted once"
+}
+
 test_a_bare_increment_in_a_nested_subshell_is_known_to_be_lost() {
   _run_child '
 test_x() {


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

Fixes half of #317, and corrects that issue's premise.

`setup` and `teardown` run in `run_tests`' own shell, not in the per-test subshell. So `_record_assertion_fail`'s in-process `FAILS` bump is already durable for them — and it *also* appended a line to the shared `TEST_FAILS_TMP`, which the caller folded into `FAILS`. Every failure recorded in `setup` was therefore counted twice. Measured on the pre-fix harness:

| scenario | pre-fix | truth |
|---|---|---|
| one `setup` failure | `FAILED: 2` | 1 |
| two `setup` failures | `FAILED: 4` | 2 |
| `setup` failure + body bare increment | `FAILED: 2` | 2 (right, wrong reason) |
| `teardown` failure, single test | `FAILED: 1` | 1 (right, wrong reason) |
| 2 × `teardown` + body increment | `FAILED: 3` | 3 (right, wrong reason) |

**#317 says this skew "can never invent a failure." That is wrong**, and it's the part worth reading — a doubled count is a false report, not a conservative one. #310's harness comment asserted the same reasoning, so both were repaired.

The three "right, wrong reason" rows are correct only by cancellation: the double-count offsets an increment the hand-rolled sweep separately absorbed, because it could not tell `setup`'s lines from the body's. That nearly cost me the fix — my first three tests asserted the numbers the broken harness already produced and passed against unfixed code. They were deleted and rewritten against measured values.

`TEST_FAILS_TMP` is now the subshell's channel and nothing else's: unset while `setup`/`teardown` run, truncated before the body, folded after. The sweep's subtraction is exact rather than a guess about whose lines it's reading. #317 proposed one file per scope; unsetting for the parent-shell scopes reaches the same exactness more simply, because their in-process bump already *is* the durable record.

**Not fixed — #317 stays open.** A bare increment inside a nested subshell or command substitution reaches no `FAILS` the delta can observe, so no arithmetic at any level recovers it. Closing that means converting the 126 hand-rolled sites to `fail_test` and linting the shape, which is a much larger mechanical change than the ticket describes.

## Testing Procedure

1. Check out this branch and run `cd scripts && bash test-harness.test.sh` — 21 tests pass.
2. Confirm the new tests are load-bearing: `git stash` the `test-harness.sh` half and re-run. `test_one_setup_failure_is_counted_once`, `test_setup_failures_are_not_doubled_at_scale`, and `test_a_setup_assert_failure_is_also_counted_once` go red with `FAILED: 2` / `FAILED: 4` / `FAILED: 2`.
3. Full regression, since this changes the harness all 49 suites run on:
   ```
   for f in scripts/*.test.sh; do (cd scripts && timeout 300 bash "$(basename "$f")" >/dev/null 2>&1); echo "$? $f"; done
   ```
   Compare against the same loop in a pristine `main` worktree.

**Result on my run:** 48 pass / 1 fail on *both* trees. The only difference across the entire run is this file's own count, 15 → 21 tests — every other suite byte-identical, assertion counts included.

## Additional Notes

`ceo-cron-testall.test.sh` exceeds a 300s cap on both trees (rc=124). Pre-existing, unrelated to this change, and I did not establish whether it passes given a longer timeout — flagging rather than silently treating it as expected.
