### PR TITLE
Rank the Search Console fix list by which pages actually sell

### DIFF
--- a/docs/playbooks/analytics.md
+++ b/docs/playbooks/analytics.md
@@ -1,0 +1,128 @@
+---
+name: analytics
+description: Weekly Search Console fix list for the live sites, ordered by the revenue rank of the page each finding points at
+trigger: cron
+schedule: "0 8 * * 1"
+preflight: none
+tier: read
+status: draft
+runner: script
+script: ceo-analytics.sh
+artifact: CEO/reports/analytics/{TODAY}.md
+scope: single
+requires: ["GA_SERVICE_ACCOUNT_JSON"]
+---
+
+# Analytics
+
+Shell-only playbook. The dispatcher invokes `scripts/ceo-analytics.sh` directly — no LLM call.
+
+## What it does
+
+Pulls Search Console for each configured site over the trailing 7 days, pulls the 7 days before that,
+and writes a single report to `<VAULT>/CEO/reports/analytics/<TODAY>.md` containing four ranked lists
+per site:
+
+1. Pages losing clicks week-over-week.
+2. Queries sitting at position 5–20 with ≥100 impressions and CTR under 2% — the title/meta fix list.
+3. Pages with ≥50 impressions and zero clicks.
+4. Queries newly entering the top 25 by impressions.
+
+On the **money site** every finding is ordered by the revenue rank of the page it points at, so a
+small decline on a best seller outranks a large decline on a page that has never sold. Other sites are
+reported unweighted and labelled as such.
+
+## Why traffic, and not revenue
+
+Payment on this stack happens off-site: WooCommerce creates the order, Zoho emails a Stripe payment
+link, the customer pays later. GA4 therefore never sees a purchase event and there is no
+session-to-paid join, so per-query or per-campaign attribution does not exist. Traffic is the lever
+that can actually be moved, and Search Console is where it is measured.
+
+The report says this in its own body rather than leaving it implied, and
+`test_the_report_never_claims_revenue_attribution` pins that it never prints a ROAS figure.
+
+## What it deliberately does not do
+
+Each of these is a decision, not an omission:
+
+- **No WooCommerce `/orders` read.** That endpoint returns customer names, emails, phone numbers and
+  street addresses, and this writes into a Syncthing-synced vault. If Woo is ever read here it is the
+  aggregate `reports/` endpoints only.
+- **No revenue figure of its own.** norx-operations owns that number, reconciled across
+  Woo/Zoho/Stripe/Mercury. Woo alone, Zoho alone and Stripe alone all disagree; they only cohere
+  through that plugin's link graph. A second source of truth would contradict it every week.
+- **No `CEO/alerts/` state file and no `CEO/inbox.md` line.** Those arrive only once a threshold has
+  been observed firing rarely across real weeks. Wiring an alert before that is the disk-monitor
+  failure mode — 64 hours of identical hourly inbox appends with no clear-state path
+  (`ceo-automated-writers-are-playbooks`).
+- **No Google Ads.** Basic Access to the Ads API needs a non-test manager account holding a developer
+  token plus a reviewed access application; it is not a self-serve key.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CEO_ANALYTICS_SITES` | `https://norxpeptides.com/,https://deconpinn.com/` | Comma-separated Search Console property URLs |
+| `CEO_ANALYTICS_MONEY_SITE` | `https://norxpeptides.com/` | The one site whose findings are revenue-weighted |
+| `CEO_ANALYTICS_RANK_FILE` | `CEO/reports/analytics/product-revenue.tsv` | `url<TAB>rank`, lowest rank = best seller |
+| `CEO_ANALYTICS_LAG_DAYS` | `3` | How far back "this week" ends. GSC reports on a 2–3 day lag |
+| `CEO_ANALYTICS_FIXTURE_DIR` | unset | Test-only: replaces the API call with recorded TSVs |
+
+The rank file is currently maintained by hand from norx-operations' aggregate product totals. **Its
+absence does not fail the run** — the report says "unranked" and falls back to traffic ordering,
+because an unranked list is otherwise indistinguishable from a ranked one.
+
+## Install / credentials
+
+One-time, and it needs a human in the Google Cloud console:
+
+1. Create a service account; download its JSON key.
+2. `mv` the key to `~/.config/ceo/ga-service-account.json` and `chmod 600` it.
+3. Add `GA_SERVICE_ACCOUNT_JSON=$HOME/.config/ceo/ga-service-account.json` to
+   `~/.config/ceo/credentials.env`. The variable holds a **path**, never the key material.
+4. In Search Console, add the service account's `client_email` as a user on each property. Read
+   permission is sufficient; the requested scope is `webmasters.readonly`.
+5. `ceo creds check analytics` to confirm the variable resolves.
+
+The script requests only `webmasters.readonly`. `norxpeptides.com` carries live Google Ads spend
+(`AW-6771070082`), so nothing here is ever granted a write scope.
+
+Verify without credentials or a network call:
+
+```bash
+CEO_ANALYTICS_FIXTURE_DIR=/path/to/fixtures scripts/ceo-analytics.sh --dry-run
+```
+
+`--dry-run` prints the report to stdout and writes nothing to the vault.
+
+## Scheduling
+
+`scope: single`, so it runs on exactly one owner host and **runs nowhere until an owner is assigned**:
+
+```bash
+ceo swarm doctor            # confirm/assign the owner (ML-1)
+ceo playbook scan           # ML-1 only — rewrites the host-local registry
+```
+
+`status: draft` means `ceo playbook scan` installs no schedule; run it on demand with
+`ceo-cron.sh analytics` for a few weeks first. Promote to `active` once the output has proven useful
+and the thresholds have proven quiet.
+
+## Tests
+
+`scripts/ceo-analytics.test.sh` — 15 tests. The fixture seam sits at `_gsc_query`, so the ranking,
+delta, threshold and rendering logic under test is the same code production runs; nothing stubs the
+logic being checked. Covered: revenue rank beating a larger raw decline, a new page not counted as a
+fall from zero, both edges of the 5–20 position band, the missing-rank-file disclosure, the
+no-attribution guarantee, `--dry-run` leaving the vault untouched, the artifact landing at the
+declared path, and a missing credential failing loudly rather than producing an empty report.
+
+## Known gaps
+
+- **Ads spend is not in the expense set**, and 62 Mercury debits totalling $15,413.50 are
+  uncategorized in norx-operations. So "am I profitable" stays unanswerable regardless of this
+  report — that is bookkeeping, not analytics, and it is the higher-dollar item.
+- The rank file is manual until norx-operations exposes a product→revenue aggregate.
+- `deconpinn.com`'s Search Console verification is presumed from the shared Google account, not
+  confirmed. If the first run returns nothing for it, that is why.

--- a/scripts/ceo-analytics.sh
+++ b/scripts/ceo-analytics.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+# ceo-analytics.sh — Weekly Search Console fix list, ordered by product revenue.
+#
+# Traffic is the revenue lever on this stack: payment happens off-site through a
+# Zoho/Stripe link, so no GA4 purchase event exists and per-query attribution is
+# not computable. What *is* actionable is the top of the funnel, which is what
+# Search Console measures. So this reports traffic and orders it by the revenue
+# rank of the page it points at — it never claims a query earned a dollar.
+#
+# Deliberately absent, and each absence is load-bearing:
+#   - No WooCommerce /orders read. That endpoint returns customer names, emails
+#     and street addresses, and this writes into a Syncthing-synced vault.
+#   - No revenue figure of its own. norx-operations owns that number, reconciled
+#     across Woo/Zoho/Stripe/Mercury; a second source of truth would contradict
+#     it weekly.
+#   - No alerts/ state file and no inbox line. Those come after a threshold has
+#     proven it fires rarely (ceo-automated-writers-are-playbooks).
+#
+# Invoked by ceo-cron.sh when the analytics playbook (runner:script) fires.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=ceo-config.sh
+source "$SCRIPT_DIR/ceo-config.sh"
+
+ceo_load_config || { echo "ERROR: CEO config not found" >&2; exit 1; }
+ceo_pin_home_or_warn || true
+ceo_augment_path
+
+VAULT="$CEO_VAULT"
+CEO_DIR="$VAULT/CEO"
+REPORT_DIR="$CEO_DIR/reports/analytics"
+TODAY="${CEO_ANALYTICS_TODAY:-$(date +%Y-%m-%d)}"
+REPORT_FILE="$REPORT_DIR/$TODAY.md"
+
+# Site list is config, not code: this playbook is not NRX-specific. The money
+# site is weighted by product revenue; the others are reported unweighted.
+SITES="${CEO_ANALYTICS_SITES:-https://norxpeptides.com/,https://deconpinn.com/}"
+MONEY_SITE="${CEO_ANALYTICS_MONEY_SITE:-https://norxpeptides.com/}"
+
+# url<TAB>revenue_rank, lowest rank = best seller. Written by whatever owns the
+# ledger (today: by hand from norx-operations' aggregate product totals). Its
+# absence is reported in full rather than silently degrading to an
+# impressions ordering — an unranked list looks identical to a ranked one.
+RANK_FILE="${CEO_ANALYTICS_RANK_FILE:-$REPORT_DIR/product-revenue.tsv}"
+
+# Search Console reports on a 2-3 day lag, so "this week" ends 3 days back.
+# Comparing a fresh window against a settled one manufactures a decline.
+LAG_DAYS="${CEO_ANALYTICS_LAG_DAYS:-3}"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+# Global, and the trap reads it defensively. An EXIT trap runs after the
+# function that declared its variables has returned, so a `local tmp` here made
+# the cleanup dereference an out-of-scope name under `set -u` — every otherwise
+# successful run exited 1, which ceo-cron records as a failed playbook.
+_WORKDIR=""
+trap 'rm -rf "${_WORKDIR:-}"' EXIT
+
+# --- date helpers -------------------------------------------------------------
+# BSD and GNU date disagree on relative-date syntax and neither errors on the
+# other's flags in a way worth guessing at, so pick by probing.
+_days_ago() {
+  local n="$1"
+  if date -v-1d +%Y-%m-%d >/dev/null 2>&1; then
+    date -v-"${n}"d +%Y-%m-%d
+  else
+    date -d "$n days ago" +%Y-%m-%d
+  fi
+}
+
+# --- auth ---------------------------------------------------------------------
+# The key is referenced by path and never echoed; no response body is logged.
+# See no-secrets-in-logs.
+_b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+_access_token() {
+  local keyfile="${GA_SERVICE_ACCOUNT_JSON:-}"
+  : "${keyfile:?GA_SERVICE_ACCOUNT_JSON not set; see docs/playbooks/analytics.md}"
+  [ -f "$keyfile" ] || { echo "ERROR: service account key not found: $keyfile" >&2; return 1; }
+
+  local iss now exp header claims unsigned sig assertion resp token
+  iss=$(jq -r '.client_email' "$keyfile")
+  now=$(date +%s); exp=$((now + 3600))
+  header=$(printf '{"alg":"RS256","typ":"JWT"}' | _b64url)
+  claims=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/webmasters.readonly","aud":"https://oauth2.googleapis.com/token","exp":%s,"iat":%s}' \
+    "$iss" "$exp" "$now" | _b64url)
+  unsigned="$header.$claims"
+
+  # The PEM goes to openssl on a fd, never a temp file another process could read.
+  sig=$(printf '%s' "$unsigned" \
+    | openssl dgst -sha256 -sign <(jq -r '.private_key' "$keyfile") \
+    | _b64url)
+  assertion="$unsigned.$sig"
+
+  resp=$(curl -sS --fail-with-body -X POST https://oauth2.googleapis.com/token \
+    -d grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer \
+    --data-urlencode "assertion=$assertion" 2>&1) || {
+    echo "ERROR: token request failed (response withheld: may echo the assertion)" >&2
+    return 1
+  }
+  token=$(printf '%s' "$resp" | jq -r '.access_token // empty')
+  [ -n "$token" ] || { echo "ERROR: no access_token in token response" >&2; return 1; }
+  printf '%s' "$token"
+}
+
+# --- data seam ----------------------------------------------------------------
+# _gsc_query <site> <start> <end> <dimension> -> TSV: key clicks impressions ctr position
+#
+# CEO_ANALYTICS_FIXTURE_DIR replaces the network call with recorded responses.
+# The seam is here rather than around the whole report so the ranking, delta and
+# rendering logic under test is the same code that runs in production
+# (test-the-fix-not-the-investigation).
+_gsc_query() {
+  local site="$1" start="$2" end="$3" dim="$4"
+  local body resp
+
+  if [ -n "${CEO_ANALYTICS_FIXTURE_DIR:-}" ]; then
+    local slug
+    slug=$(printf '%s' "$site" | tr -cd 'a-zA-Z0-9')
+    local f="$CEO_ANALYTICS_FIXTURE_DIR/$slug-$start-$dim.tsv"
+    [ -f "$f" ] && cat "$f"
+    return 0
+  fi
+
+  body=$(jq -nc --arg s "$start" --arg e "$end" --arg d "$dim" \
+    '{startDate:$s,endDate:$e,dimensions:[$d],rowLimit:250}')
+  resp=$(curl -sS --fail-with-body -X POST \
+    "https://searchconsole.googleapis.com/webmasters/v3/sites/$(_urlencode "$site")/searchAnalytics/query" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "$body") || { echo "ERROR: Search Console query failed for $site ($dim)" >&2; return 1; }
+
+  printf '%s' "$resp" | jq -r '.rows[]? | [.keys[0], .clicks, .impressions, .ctr, .position] | @tsv'
+}
+
+_urlencode() { jq -rn --arg v "$1" '$v|@uri'; }
+
+# --- ranking ------------------------------------------------------------------
+# Rank of the page a finding points at. 0 = unranked (never sold, or no rank
+# file). Lower is better, so unranked sorts last via the 9999 substitution.
+_rank_of() {
+  local url="$1"
+  [ -f "$RANK_FILE" ] || { printf '0'; return 0; }
+  awk -F'\t' -v u="$url" '$1==u {print $2; found=1; exit} END{if(!found) print 0}' "$RANK_FILE"
+}
+
+_sort_key() { local r="$1"; [ "$r" = "0" ] && printf '9999' || printf '%s' "$r"; }
+
+# --- findings -----------------------------------------------------------------
+# _clicks_lost <cur.tsv> <prior.tsv> -> rank_key url cur_clicks prior_clicks delta
+# Emits only real declines. A page absent from the prior window is new, not
+# down, so it is skipped rather than counted as a fall from zero.
+_clicks_lost() {
+  local cur="$1" prior="$2" url c p d rk
+  while IFS=$'\t' read -r url c _ _ _; do
+    [ -n "$url" ] || continue
+    p=$(awk -F'\t' -v u="$url" '$1==u {print $2; exit}' "$prior")
+    [ -n "$p" ] || continue
+    d=$(awk -v a="$c" -v b="$p" 'BEGIN{printf "%.0f", a-b}')
+    [ "$d" -lt 0 ] || continue
+    rk=$(_rank_of "$url")
+    printf '%s\t%s\t%s\t%s\t%s\n' "$(_sort_key "$rk")" "$url" "$c" "$p" "$d"
+  done < "$cur" | sort -t$'\t' -k1,1n -k5,5n
+}
+
+# Position 5-20 with impressions and a weak click rate: the title/meta tag list.
+# Above 5 there is little headroom; past 20 nobody scrolls that far.
+_ctr_opportunities() {
+  local cur="$1" q c i ctr pos
+  while IFS=$'\t' read -r q c i ctr pos; do
+    [ -n "$q" ] || continue
+    awk -v p="$pos" -v i="$i" -v ctr="$ctr" \
+      'BEGIN{exit !(p>=5 && p<=20 && i>=100 && ctr<0.02)}' || continue
+    printf '%s\t%s\t%s\t%s\t%s\n' "$i" "$q" "$c" "$ctr" "$pos"
+  done < "$cur" | sort -t$'\t' -k1,1nr
+}
+
+# Impressions but no clicks at all — a listing people see and refuse.
+_zero_click_pages() {
+  local cur="$1" url c i rk
+  while IFS=$'\t' read -r url c i _ _; do
+    [ -n "$url" ] || continue
+    [ "${c%%.*}" -eq 0 ] 2>/dev/null || continue
+    awk -v i="$i" 'BEGIN{exit !(i>=50)}' || continue
+    rk=$(_rank_of "$url")
+    printf '%s\t%s\t%s\n' "$(_sort_key "$rk")" "$url" "$i"
+  done < "$cur" | sort -t$'\t' -k1,1n -k3,3nr
+}
+
+_new_queries() {
+  local cur="$1" prior="$2" q i
+  while IFS=$'\t' read -r q _ i _ _; do
+    [ -n "$q" ] || continue
+    grep -qF "$(printf '%s\t' "$q")" "$prior" && continue
+    printf '%s\t%s\n' "$i" "$q"
+  done < "$cur" | sort -t$'\t' -k1,1nr | head -10
+}
+
+# --- report -------------------------------------------------------------------
+_render_site() {
+  local site="$1" cur_end="$2" cur_start="$3" prior_end="$4" prior_start="$5"
+  local pc="$6" pp="$7" qc="$8" qp="$9"
+  local weighted=0 n
+  [ "$site" = "$MONEY_SITE" ] && weighted=1
+
+  printf '## %s\n\n' "$site"
+  if [ "$weighted" = 1 ] && [ ! -f "$RANK_FILE" ]; then
+    printf 'Findings are **unranked** — no product-revenue file at `%s`, so this is ordered by traffic, not dollars.\n\n' \
+      "${RANK_FILE/#$VAULT\//}"
+  elif [ "$weighted" = 0 ]; then
+    printf 'No commerce on this site; findings are unweighted.\n\n'
+  fi
+
+  printf '### Pages losing clicks\n\n'
+  n=0
+  while IFS=$'\t' read -r rk url c p d; do
+    n=$((n + 1))
+    printf -- '- %s — %s clicks (was %s, %s)%s\n' "$url" "$c" "$p" "$d" \
+      "$([ "$rk" != 9999 ] && printf ' — revenue rank %s' "$rk")"
+  done < <(_clicks_lost "$pc" "$pp")
+  [ "$n" -eq 0 ] && printf -- '- none\n'
+  printf '\n'
+
+  printf '### Title/meta opportunities (position 5-20, weak click rate)\n\n'
+  n=0
+  while IFS=$'\t' read -r i q c ctr pos; do
+    n=$((n + 1))
+    printf -- '- `%s` — position %.1f, %s impressions, %s clicks, CTR %.2f%%\n' \
+      "$q" "$pos" "$i" "$c" "$(awk -v c="$ctr" 'BEGIN{print c*100}')"
+  done < <(_ctr_opportunities "$qc")
+  [ "$n" -eq 0 ] && printf -- '- none\n'
+  printf '\n'
+
+  printf '### Pages with impressions and zero clicks\n\n'
+  n=0
+  while IFS=$'\t' read -r rk url i; do
+    n=$((n + 1))
+    printf -- '- %s — %s impressions, 0 clicks%s\n' "$url" "$i" \
+      "$([ "$rk" != 9999 ] && printf ' — revenue rank %s' "$rk")"
+  done < <(_zero_click_pages "$pc")
+  [ "$n" -eq 0 ] && printf -- '- none\n'
+  printf '\n'
+
+  printf '### New queries in the top 25\n\n'
+  n=0
+  while IFS=$'\t' read -r i q; do
+    n=$((n + 1))
+    printf -- '- `%s` — %s impressions\n' "$q" "$i"
+  done < <(_new_queries "$qc" "$qp")
+  [ "$n" -eq 0 ] && printf -- '- none\n'
+  printf '\n'
+}
+
+main() {
+  mkdir -p "$REPORT_DIR"
+
+  local cur_end cur_start prior_end prior_start
+  cur_end=$(_days_ago "$LAG_DAYS")
+  cur_start=$(_days_ago $((LAG_DAYS + 6)))
+  prior_end=$(_days_ago $((LAG_DAYS + 7)))
+  prior_start=$(_days_ago $((LAG_DAYS + 13)))
+
+  ACCESS_TOKEN=""
+  if [ -z "${CEO_ANALYTICS_FIXTURE_DIR:-}" ]; then
+    ACCESS_TOKEN=$(_access_token) || return 1
+  fi
+
+  _WORKDIR=$(mktemp -d)
+  local tmp="$_WORKDIR"
+
+  {
+    printf -- '---\ndate: %s\ntype: report\ntags: [analytics, search-console]\nsource: ceo-analytics\n---\n\n' "$TODAY"
+    printf '# Search Console — week of %s\n\n' "$cur_start"
+    printf 'This week %s → %s, compared against %s → %s. Search Console lags ~%s days.\n\n' \
+      "$cur_start" "$cur_end" "$prior_start" "$prior_end" "$LAG_DAYS"
+    printf 'Traffic only. No revenue figure is computed here and no query is credited with a sale — payment happens off-site, so that attribution does not exist. Findings on the money site are ordered by the revenue rank of the page they point at.\n\n'
+
+    local site slug
+    while IFS=',' read -r -d, site || [ -n "$site" ]; do
+      site="${site#"${site%%[![:space:]]*}"}"; site="${site%"${site##*[![:space:]]}"}"
+      [ -n "$site" ] || continue
+      slug=$(printf '%s' "$site" | tr -cd 'a-zA-Z0-9')
+      _gsc_query "$site" "$cur_start"   "$cur_end"   page  > "$tmp/$slug-pc.tsv"
+      _gsc_query "$site" "$prior_start" "$prior_end" page  > "$tmp/$slug-pp.tsv"
+      _gsc_query "$site" "$cur_start"   "$cur_end"   query > "$tmp/$slug-qc.tsv"
+      _gsc_query "$site" "$prior_start" "$prior_end" query > "$tmp/$slug-qp.tsv"
+      _render_site "$site" "$cur_end" "$cur_start" "$prior_end" "$prior_start" \
+        "$tmp/$slug-pc.tsv" "$tmp/$slug-pp.tsv" "$tmp/$slug-qc.tsv" "$tmp/$slug-qp.tsv"
+    done < <(printf '%s,' "$SITES")
+  } > "$tmp/report.md"
+
+  if [ "$DRY_RUN" = 1 ]; then
+    cat "$tmp/report.md"
+    printf '\n(dry run — not written to %s)\n' "${REPORT_FILE/#$VAULT\//}" >&2
+    return 0
+  fi
+
+  mv "$tmp/report.md" "$REPORT_FILE"
+  printf 'ok %s\n' "${REPORT_FILE/#$VAULT\//}"
+}
+
+main "$@"

--- a/scripts/ceo-analytics.test.sh
+++ b/scripts/ceo-analytics.test.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Tests for ceo-analytics.sh — the report logic, exercised through the real
+# entry point with the Search Console call replaced by recorded fixtures.
+#
+# The fixture seam sits at _gsc_query, so ranking, delta detection, thresholds
+# and rendering under test are the same code paths production runs. Nothing here
+# stubs the logic it is checking.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANALYTICS="$SCRIPT_DIR/ceo-analytics.sh"
+
+source "$SCRIPT_DIR/test-harness.sh"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  HOME_BACKUP="$HOME"
+  export HOME="$TEST_HOME"
+  export CEO_VAULT="$TEST_HOME/vault"
+  export CEO_HOSTNAME="testhost"
+  mkdir -p "$CEO_VAULT/CEO"
+  touch "$CEO_VAULT/CEO/inbox.md"   # satisfies ceo_validate_vault
+
+  export CEO_ANALYTICS_TODAY="2026-08-14"
+  export CEO_ANALYTICS_SITES="https://shop.test/,https://blog.test/"
+  export CEO_ANALYTICS_MONEY_SITE="https://shop.test/"
+  export CEO_ANALYTICS_LAG_DAYS=3
+
+  FIXTURES="$TEST_HOME/fixtures"
+  mkdir -p "$FIXTURES"
+  export CEO_ANALYTICS_FIXTURE_DIR="$FIXTURES"
+
+  export CEO_ANALYTICS_RANK_FILE="$TEST_HOME/product-revenue.tsv"
+
+  # Window starts the script will compute from CEO_ANALYTICS_TODAY is relative to
+  # *now*, not to that variable, so resolve them the same way the script does and
+  # name the fixtures accordingly.
+  if date -v-1d +%Y-%m-%d >/dev/null 2>&1; then
+    CUR_START=$(date -v-9d +%Y-%m-%d);  PRIOR_START=$(date -v-16d +%Y-%m-%d)
+  else
+    CUR_START=$(date -d '9 days ago' +%Y-%m-%d); PRIOR_START=$(date -d '16 days ago' +%Y-%m-%d)
+  fi
+}
+
+teardown() {
+  export HOME="$HOME_BACKUP"
+  [ -n "${TEST_HOME:-}" ] && rm -rf "$TEST_HOME"
+}
+
+# _fixture <site-slug> <window: cur|prior> <dim> <rows...>
+_fixture() {
+  local slug="$1" window="$2" dim="$3"; shift 3
+  local start; [ "$window" = cur ] && start="$CUR_START" || start="$PRIOR_START"
+  printf '%s\n' "$@" > "$FIXTURES/$slug-$start-$dim.tsv"
+}
+
+_run() {
+  OUT=$(bash "$ANALYTICS" --dry-run 2>/dev/null)
+  RC=$?
+}
+
+# A query excluded from the CTR list still legitimately shows up under "new
+# queries", so a whole-report assert_not_contains passes or fails for the wrong
+# reason. Scope the negative to the section under test.
+_ctr_section() {
+  printf '%s\n' "$OUT" | sed -n '/Title\/meta opportunities/,/^###/p'
+}
+
+# Every site needs all four fixtures or the run reports on empty input, which
+# would make an assertion about "none" pass for the wrong reason.
+_empty_all() {
+  local slug
+  for slug in httpsshoptest httpsblogtest; do
+    _fixture "$slug" cur page ""; _fixture "$slug" prior page ""
+    _fixture "$slug" cur query ""; _fixture "$slug" prior query ""
+  done
+}
+
+test_a_page_losing_clicks_is_reported_with_its_revenue_rank() {
+  _empty_all
+  printf 'https://shop.test/p/alpha\t1\n' > "$CEO_ANALYTICS_RANK_FILE"
+  _fixture httpsshoptest cur   page "$(printf 'https://shop.test/p/alpha\t40\t900\t0.044\t7.1')"
+  _fixture httpsshoptest prior page "$(printf 'https://shop.test/p/alpha\t100\t1000\t0.1\t6.4')"
+  _run
+  assert_eq "$RC" "0" "dry run exits clean"
+  assert_contains "$OUT" "https://shop.test/p/alpha — 40 clicks (was 100, -60)" \
+    "the decline is reported with both windows and the delta"
+  assert_contains "$OUT" "revenue rank 1" "and carries the page's revenue rank"
+}
+
+test_a_best_seller_outranks_an_unranked_page_in_the_decline_list() {
+  _empty_all
+  printf 'https://shop.test/p/best\t1\n' > "$CEO_ANALYTICS_RANK_FILE"
+  _fixture httpsshoptest cur page \
+    "$(printf 'https://shop.test/p/never-sold\t1\t500\t0.002\t9')" \
+    "$(printf 'https://shop.test/p/best\t50\t800\t0.06\t6')"
+  _fixture httpsshoptest prior page \
+    "$(printf 'https://shop.test/p/never-sold\t90\t520\t0.17\t8')" \
+    "$(printf 'https://shop.test/p/best\t60\t810\t0.07\t6')"
+  _run
+  # The unranked page lost 89 clicks and the best seller only 10, so an
+  # impressions- or delta-ordered list would invert this. Revenue rank wins.
+  local best_pos unranked_pos
+  best_pos=$(printf '%s\n' "$OUT" | grep -n 'p/best' | head -1 | cut -d: -f1)
+  unranked_pos=$(printf '%s\n' "$OUT" | grep -n 'p/never-sold' | head -1 | cut -d: -f1)
+  assert_eq "$([ "$best_pos" -lt "$unranked_pos" ] && echo yes || echo no)" "yes" \
+    "the revenue-ranked page is listed before the unranked one despite a smaller drop"
+}
+
+test_a_page_new_this_week_is_not_counted_as_a_decline() {
+  _empty_all
+  _fixture httpsshoptest cur   page "$(printf 'https://shop.test/p/brand-new\t5\t100\t0.05\t12')"
+  _fixture httpsshoptest prior page ""
+  _run
+  assert_not_contains "$OUT" "p/brand-new — 5 clicks" \
+    "absent from the prior window means new, not a fall from zero"
+}
+
+test_a_missing_rank_file_is_disclosed_not_silently_ignored() {
+  _empty_all
+  rm -f "$CEO_ANALYTICS_RANK_FILE"
+  _fixture httpsshoptest cur   page "$(printf 'https://shop.test/p/alpha\t40\t900\t0.044\t7')"
+  _fixture httpsshoptest prior page "$(printf 'https://shop.test/p/alpha\t100\t1000\t0.1\t6')"
+  _run
+  assert_contains "$OUT" "unranked" \
+    "an unranked run says so — it is otherwise indistinguishable from a ranked one"
+}
+
+test_a_ctr_opportunity_in_the_position_band_is_reported() {
+  _empty_all
+  _fixture httpsshoptest cur query "$(printf 'buy alpha peptide\t4\t2000\t0.002\t8.4')"
+  _run
+  assert_contains "$OUT" 'buy alpha peptide' "position 8 with 2000 impressions and 0.2% CTR qualifies"
+  assert_contains "$OUT" "position 8.4" "and reports the position it sits at"
+}
+
+test_a_top_three_query_is_not_a_ctr_opportunity() {
+  _empty_all
+  _fixture httpsshoptest cur query "$(printf 'alpha peptide\t10\t3000\t0.003\t2.1')"
+  _run
+  assert_not_contains "$(_ctr_section)" 'alpha peptide' \
+    "already in the top 3 — there is no ranking headroom to win"
+}
+
+test_a_query_past_position_twenty_is_not_a_ctr_opportunity() {
+  _empty_all
+  _fixture httpsshoptest cur query "$(printf 'obscure long tail\t0\t4000\t0.0\t44')"
+  _run
+  assert_not_contains "$(_ctr_section)" 'obscure long tail' "nobody scrolls to position 44"
+}
+
+test_a_zero_click_page_is_reported() {
+  _empty_all
+  _fixture httpsshoptest cur page "$(printf 'https://shop.test/p/ignored\t0\t800\t0.0\t11')"
+  _run
+  assert_contains "$OUT" "https://shop.test/p/ignored — 800 impressions, 0 clicks" \
+    "seen and refused is a distinct finding from losing clicks"
+}
+
+test_a_new_query_is_reported_and_a_returning_one_is_not() {
+  _empty_all
+  _fixture httpsshoptest cur   query \
+    "$(printf 'fresh demand\t2\t300\t0.006\t14')" \
+    "$(printf 'old demand\t9\t400\t0.02\t9')"
+  _fixture httpsshoptest prior query "$(printf 'old demand\t8\t380\t0.02\t9')"
+  _run
+  local newsec
+  newsec=$(printf '%s\n' "$OUT" | sed -n '/New queries in the top 25/,/^## \|^### Pages/p')
+  assert_contains "$newsec" 'fresh demand' "a query absent last week is new"
+  assert_not_contains "$newsec" 'old demand' "one present last week is not"
+}
+
+test_the_non_commerce_site_is_reported_unweighted() {
+  _empty_all
+  _fixture httpsblogtest cur   page "$(printf 'https://blog.test/post\t3\t200\t0.015\t18')"
+  _fixture httpsblogtest prior page "$(printf 'https://blog.test/post\t30\t210\t0.14\t17')"
+  _run
+  assert_contains "$OUT" "https://blog.test/" "the second site appears"
+  assert_contains "$OUT" "No commerce on this site" "and is labelled unweighted"
+}
+
+test_the_report_never_claims_revenue_attribution() {
+  _empty_all
+  _run
+  assert_contains "$OUT" "no query is credited with a sale" \
+    "the report states the attribution limit rather than leaving it implied"
+  assert_not_contains "$OUT" "ROAS" "and never prints a figure the stack cannot support"
+}
+
+test_a_dry_run_writes_nothing_to_the_vault() {
+  _empty_all
+  _run
+  assert_eq "$(ls "$CEO_VAULT/CEO/reports/analytics"/*.md 2>/dev/null | wc -l | tr -d ' ')" "0" \
+    "--dry-run prints the report and leaves the vault alone"
+}
+
+test_a_real_run_writes_the_declared_artifact_path() {
+  _empty_all
+  OUT=$(bash "$ANALYTICS" 2>/dev/null); RC=$?
+  assert_eq "$RC" "0" "the run succeeds"
+  assert_file_exists "$CEO_VAULT/CEO/reports/analytics/$CEO_ANALYTICS_TODAY.md" \
+    "written where the playbook's artifact: field declares (ceo doctor cross-checks this)"
+}
+
+test_the_report_carries_frontmatter() {
+  _empty_all
+  bash "$ANALYTICS" >/dev/null 2>&1
+  local head5
+  head5=$(head -5 "$CEO_VAULT/CEO/reports/analytics/$CEO_ANALYTICS_TODAY.md")
+  assert_contains "$head5" "type: report" "vault notes carry frontmatter"
+}
+
+test_a_missing_credential_fails_loudly_rather_than_reporting_nothing() {
+  _empty_all
+  unset CEO_ANALYTICS_FIXTURE_DIR
+  unset GA_SERVICE_ACCOUNT_JSON
+  local err rc
+  err=$(bash "$ANALYTICS" --dry-run 2>&1 >/dev/null); rc=$?
+  assert_eq "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)" "nonzero" \
+    "no credential is a failure, not an empty report"
+  assert_contains "$err" "GA_SERVICE_ACCOUNT_JSON" "and names the variable to set"
+  export CEO_ANALYTICS_FIXTURE_DIR="$FIXTURES"
+}
+
+run_tests


### PR DESCRIPTION
Closes #323

## Description (Issue Fixed & New Behavior)

Adds an `analytics` playbook: weekly Search Console pull for the live sites, written to
`CEO/reports/analytics/{TODAY}.md` as four ranked lists per site — pages losing clicks, queries at
position 5–20 with weak CTR (the title/meta fix list), pages with impressions and zero clicks, and
queries newly entering the top 25.

The new behavior worth reviewing is the **ordering**. On the money site every finding is sorted by the
revenue rank of the page it points at, so a 10-click drop on a best seller outranks an 89-click drop on
a page that has never sold. That is the whole point: it is a traffic report ordered by money.

It never claims a query earned a dollar, and the report body states that limit rather than leaving it
implied. Payment on this stack happens off-site — Woo creates the order, Zoho emails a Stripe link, the
customer pays later — so GA4 never sees a purchase event, there is no session-to-paid join, and
per-query attribution does not exist. `test_the_report_never_claims_revenue_attribution` pins it.

Four absences are decisions, each documented in the playbook with its reason:

- No `/wc/v3/orders` read — that endpoint returns customer names, emails and street addresses, and this
  writes into a Syncthing-synced vault.
- No revenue figure of its own — norx-operations owns that number, reconciled across
  Woo/Zoho/Stripe/Mercury. Woo, Zoho and Stripe each disagree in isolation.
- No `CEO/alerts/` file and no `CEO/inbox.md` line until a threshold has been observed firing rarely.
  Wiring an alert first is the disk-monitor failure mode.
- No Google Ads API — Basic Access needs a manager account and a reviewed application.

Also includes a real bug found while writing the tests: `local tmp` in `main` combined with
`trap 'rm -rf "$tmp"' EXIT` meant the trap dereferenced an out-of-scope name under `set -u`, so **every
otherwise-successful run exited 1** — which `ceo-cron` records as a failed playbook. The workdir is
global now and the trap reads it defensively.

Ships `status: draft`, so `ceo playbook scan` installs no schedule.

## Testing Procedure

1. Check out this branch.
2. `bash scripts/ceo-analytics.test.sh` → `All tests passed. (15 tests)`.
3. Confirm the ordering test is load-bearing: in `test_a_best_seller_outranks_an_unranked_page_in_the_decline_list`
   the unranked page loses 89 clicks and the best seller 10, so any impressions- or delta-ordered
   implementation inverts it.
4. Confirm the trap fix is load-bearing: restore `local tmp; trap 'rm -rf "$tmp"' EXIT` in `main` and
   re-run — `test_a_page_losing_clicks_is_reported_with_its_revenue_rank` and
   `test_a_real_run_writes_the_declared_artifact_path` both go red on their rc assertions.
5. `bash scripts/ceo-scan.test.sh` → 17 tests, validates the new playbook's frontmatter (artifact
   tokens, `scope`, `requires`, `status`).
6. Run it with no credential and no fixtures: it must exit non-zero and name `GA_SERVICE_ACCOUNT_JSON`
   rather than emitting an empty report.
7. `shellcheck --severity=warning scripts/ceo-analytics.sh scripts/ceo-analytics.test.sh` → clean
   (info-level SC2016 on markdown backticks inside single-quoted printf formats is expected).

Suites that enumerate `docs/playbooks/` were run and are green: `ceo-cron-scriptmode-2` (41),
`ceo-scan` (17), `ceo-sync` (8), `repo-hygiene` (6), `morning-cutover` (1), `morning-playbook` (1).

Not verified against the live Search Console API — no service account exists yet. Every result above is
against recorded fixtures via the `_gsc_query` seam.

## Additional Notes / HelpScout Tickets

**Blocked on one manual step before it can run for real:** a Google service account, its JSON key at
`~/.config/ceo/ga-service-account.json` (`chmod 600`), `GA_SERVICE_ACCOUNT_JSON` pointing at that path
in `credentials.env`, and the service account's `client_email` added as a Search Console user. Scope is
`webmasters.readonly` only — `norxpeptides.com` carries live Google Ads spend, so nothing here gets a
write scope.

`scope: single` means it runs nowhere until an owner is assigned (`ceo swarm doctor`, then
`ceo playbook scan` on ML-1).

Two known gaps in the playbook doc: the product→revenue rank file is hand-maintained until
norx-operations exposes an aggregate, and `deconpinn.com`'s Search Console verification is presumed
from the shared Google account rather than confirmed.

Higher-dollar than this PR, and out of its scope: 62 Mercury debits totalling $15,413.50 are
uncategorized and Ads spend is absent from the expense set, so "am I profitable" stays unanswerable
regardless of what this reports.

Plan and the two audits behind it: vault note
`Projects/Development/nhangen/claude-ceo/2026-08-14-website-analytics-playbook-plan.md`