### PR TITLE
Let a caller run one completion instead of an agentic loop

### DIFF
--- a/ollama-agent/cli.py
+++ b/ollama-agent/cli.py
@@ -50,6 +50,23 @@ def main(argv=None):
     p.add_argument("--host", default="127.0.0.1:11434")
     p.add_argument("--temperature", type=float, default=0.7)
     p.add_argument("--num-ctx", type=int, default=16384)
+    # A thinking model can spend an entire turn reasoning and never reach an answer. On
+    # one long analytic turn that is fatal (measured: qwen3.8:27b over a 1,464-token diff
+    # never answered inside the 600s request timeout, and finished in 62s with thinking
+    # off); across many short turns it costs nothing. So the caller says, and the default
+    # is whatever the model does on its own — unchanged from before this flag existed.
+    p.add_argument("--no-think", dest="think", action="store_const", const=False,
+                   default=None, help="Suppress a thinking model's reasoning phase.")
+    p.add_argument("--timeout", type=int, default=600,
+                   help="Seconds to wait on one ollama request (default 600).")
+    # Some tasks are one completion, not an agentic loop — a code review reads a diff that
+    # is already inline and answers. Offered tools, a model explores instead: measured on
+    # qwen3.8:27b reviewing a diff, three turns went to grep and sed against the very file
+    # pasted into the prompt, the turn cap ran out, and the run returned a tool result
+    # instead of findings. Telling it not to in the prompt did not stop it; withholding the
+    # tools does.
+    p.add_argument("--no-tools", action="store_true",
+                   help="Offer the model no tools — for a single-completion task.")
     p.add_argument("--turn-cap", type=int, default=8)
     p.add_argument("--verify-cmd", default=None,
                    help="Shell command that gates completion: the agent keeps "
@@ -170,7 +187,7 @@ def main(argv=None):
     if skills:
         system = f"{render_catalog(skills)}\n\n{system}"
         print(f"skills: {len(skills)} available (use_skill enabled)", file=sys.stderr)
-    tools = TOOLS + ([USE_SKILL_TOOL] if skills else [])
+    tools = [] if a.no_tools else TOOLS + ([USE_SKILL_TOOL] if skills else [])
 
     mcp_transport, mcp_client, mcp_names = None, None, {}
     if a.mcp:
@@ -202,7 +219,8 @@ def main(argv=None):
 
     toolbox = ToolBox(cwd=a.cwd, timeout=a.shell_timeout, skills=skills,
                       mcp_client=mcp_client, mcp_names=mcp_names)
-    transport = ollama_transport(a.model, host=a.host, temperature=a.temperature, num_ctx=a.num_ctx)
+    transport = ollama_transport(a.model, host=a.host, temperature=a.temperature,
+                                 num_ctx=a.num_ctx, timeout=a.timeout, think=a.think)
     try:
         rec = run_agent(a.task, system, transport, toolbox, tools, turn_cap=a.turn_cap,
                         run_id=a.run_id, verify_cmd=a.verify_cmd)

--- a/ollama-agent/ollama_agent/transport.py
+++ b/ollama-agent/ollama_agent/transport.py
@@ -31,22 +31,37 @@ def parse_chat_response(status, body):
     return data["message"], usage
 
 
-def ollama_transport(model, host=DEFAULT_HOST, temperature=0.7, num_ctx=16384, timeout=600):
+def ollama_transport(model, host=DEFAULT_HOST, temperature=0.7, num_ctx=16384, timeout=600,
+                     think=None):
     """Return a transport(messages, tools) -> (assistant message dict, usage dict).
 
     Raises RuntimeError on any non-success response and re-raises URLError
     (daemon down) so the caller sees a failure rather than a silent hang.
+
+    `think` controls a thinking model's reasoning phase: None leaves it to the model
+    (the historical behaviour), False suppresses it. It is a caller decision rather
+    than a per-model default because the right answer depends on the shape of the
+    turn, not on the weights. Measured on qwen3.8:27b, 2026-08-17: one long analytic
+    turn over a 1,464-token diff spent its whole output budget thinking and never
+    reached an answer inside 600s, while the same request with think=False finished
+    in 62s; a task made of many short turns is unaffected either way.
     """
     url = f"http://{host}/api/chat"
 
     def transport(messages, tools):
-        payload = json.dumps({
+        body = {
             "model": model,
             "messages": messages,
             "tools": tools,
             "stream": False,
             "options": {"temperature": temperature, "num_ctx": num_ctx},
-        }).encode()
+        }
+        # Omitted entirely when None. Sending "think": null asks older daemons to parse
+        # a field they do not know, and the default has to stay byte-identical to what
+        # shipped before this parameter existed.
+        if think is not None:
+            body["think"] = think
+        payload = json.dumps(body).encode()
         req = urllib.request.Request(url, data=payload,
                                      headers={"Content-Type": "application/json"})
         try:

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -374,6 +374,45 @@ def test_transport_success(monkeypatch):
     assert usage == {"input": 7, "output": 11}
 
 
+def _captured_payload(monkeypatch, **kwargs):
+    """Return the JSON body ollama_transport would POST, plus the timeout it passed."""
+    import ollama_agent.transport as t
+    seen = {}
+
+    def fake_urlopen(req, timeout):
+        seen["body"] = json.loads(req.data.decode())
+        seen["timeout"] = timeout
+        return _FakeResp(200, json.dumps({"message": {"role": "assistant", "content": "ok"},
+                                          "prompt_eval_count": 1, "eval_count": 1}))
+
+    monkeypatch.setattr(t.urllib.request, "urlopen", fake_urlopen)
+    t.ollama_transport("m", **kwargs)([{"role": "user", "content": "hi"}], [])
+    return seen
+
+
+def test_transport_omits_think_by_default(monkeypatch):
+    # The default has to stay byte-identical to what shipped before the parameter existed:
+    # an older daemon should not be handed a field it does not know, and "think": null is
+    # not the same request as no "think" key at all.
+    seen = _captured_payload(monkeypatch)
+    assert "think" not in seen["body"]
+    assert seen["timeout"] == 600
+
+
+def test_transport_sends_think_false_when_asked(monkeypatch):
+    # A thinking model can spend a whole turn reasoning and never answer. Measured on
+    # qwen3.8:27b over a 1,464-token diff: no answer inside 600s with thinking on, 62s
+    # with it off. The flag is the only thing that reaches the daemon — a "/no_think"
+    # prompt prefix was measured doing nothing at all.
+    seen = _captured_payload(monkeypatch, think=False)
+    assert seen["body"]["think"] is False
+
+
+def test_transport_timeout_is_caller_settable(monkeypatch):
+    seen = _captured_payload(monkeypatch, timeout=42)
+    assert seen["timeout"] == 42
+
+
 def test_transport_httperror_routes_through_success_parser(monkeypatch):
     import io
     import ollama_agent.transport as t

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -431,3 +431,56 @@ def test_cli_ungated_opt_in_runs(tmp_path, monkeypatch, capsys):
     rc = cli.main(["--task", "do work", "--cwd", str(tmp_path), "--no-rules", "--no-skills", "--ungated"])
     assert rc == 0
     assert "system" in captured       # run_agent reached
+
+
+def _transport_kwargs(tmp_path, monkeypatch, argv):
+    """Run main() offline and return the kwargs it handed ollama_transport."""
+    captured = {}
+    _stub(monkeypatch, captured)
+    seen = {}
+    monkeypatch.setattr(cli, "ollama_transport",
+                        lambda *a, **k: seen.update(k) or (lambda m, t: {"role": "assistant", "content": "ok"}))
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path),
+                   "--no-rules", "--no-skills", "--ungated"] + argv)
+    assert rc == 0
+    return seen
+
+
+def test_cli_defaults_leave_thinking_to_the_model(tmp_path, monkeypatch):
+    # Existing callers must be unaffected: think=None means the payload carries no
+    # "think" key at all, which is what shipped before the flag existed.
+    seen = _transport_kwargs(tmp_path, monkeypatch, [])
+    assert seen["think"] is None
+    assert seen["timeout"] == 600
+
+
+def test_cli_no_think_reaches_the_transport(tmp_path, monkeypatch):
+    # The wrapper that needs this (ollama-review.sh) runs one long analytic turn, where
+    # a thinking model spends the whole turn reasoning and never answers.
+    seen = _transport_kwargs(tmp_path, monkeypatch, ["--no-think"])
+    assert seen["think"] is False
+
+
+def test_cli_timeout_reaches_the_transport(tmp_path, monkeypatch):
+    seen = _transport_kwargs(tmp_path, monkeypatch, ["--timeout", "1200"])
+    assert seen["timeout"] == 1200
+
+
+def test_cli_no_tools_offers_an_empty_toolset(tmp_path, monkeypatch):
+    # A review is one completion. Given tools, the model was measured spending its whole
+    # turn budget grepping the file already pasted into its prompt and never answering.
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "review this", "--cwd", str(tmp_path),
+                   "--no-rules", "--no-skills", "--ungated", "--no-tools"])
+    assert rc == 0
+    assert captured["tools"] == []
+
+
+def test_cli_tools_are_offered_by_default(tmp_path, monkeypatch):
+    captured = {}
+    _stub(monkeypatch, captured)
+    rc = cli.main(["--task", "do work", "--cwd", str(tmp_path),
+                   "--no-rules", "--no-skills", "--ungated"])
+    assert rc == 0
+    assert captured["tools"], "the default must keep offering the toolset"


### PR DESCRIPTION
Closes #none

## Description (Issue Fixed & New Behavior)

The bridge is built for a loop: offer tools, let the model think, iterate until a verify
command passes. Some tasks are one completion — a code review reads a diff that is already
inline and answers — and on those, two of those defaults are fatal rather than merely
wasteful. Both were found while building `ollama-review.sh` in nhangen/llm-tools (#433), which
could not review any realistic diff.

Adds three flags, all defaulting to today's behaviour: `--no-think`, `--no-tools`, `--timeout`.

### Why, measured on `qwen3.8:27b` over a 1,464-token diff (2026-08-17)

**Thinking spends the whole turn.** The model never reached an answer inside the 600s request
timeout, so every pass died on `socket.timeout`. The same request with `think: false` finished
in **62.5s**, `done_reason: stop`, and answered correctly. Isolated separately: a `/no_think`
prompt prefix does **nothing** on its own — 1,333 characters of thinking and an empty
`.response` — so the API field is the only lever, and `transport.py` built its payload
hardcoded with no way to reach it and no env hook.

**Offered tools, the model explores instead of answering.** Three turns went to `grep` and
`sed` against the very file pasted into its prompt, the turn cap ran out, and the run returned
a tool result where findings should have been. Instructing it not to read files in the prompt
did not stop it; withholding the tools did. With both flags the same review completed in
**3m34s** with properly formatted findings.

### Design notes

- **`think` is caller-passed, not a per-model table.** The right value depends on the shape of
  the turn, not on the weights: the same model wants thinking *on* across many short authoring
  turns and *off* on one long analytic one. A per-model default would encode the wrong variable
  and be wrong for exactly the two callers that exist.
- **`think=None` omits the key rather than sending `null`.** An older daemon should not be
  handed a field it does not know, and the default request has to stay byte-identical to what
  shipped before the parameter existed.
- **The existing `ollama-author` path passes none of these and is unchanged.** Its runs survive
  thinking because each turn is short — that is luck of turn shape rather than immunity, and
  `--timeout` is there for when it runs out.

### Considered and rejected

Bypassing the bridge and calling ollama's HTTP API directly from the shell script. That would
have meant a second writer for `runs.jsonl`, whose schema this repo's `ledger.py` owns and
`token-scope --savings` consumes without validating — so a field added or renamed here would
have let the downstream parse keep succeeding while review rows quietly stopped counting.

## Testing Procedure

1. Check out this branch, `cd ollama-agent`.
2. `python3 -m pytest -q` → **188 passed**.
3. The four new payload assertions check the JSON the transport would POST rather than mocking
   around it: no `think` key by default (with `timeout == 600`), `think: false` when asked, a
   caller-set timeout reaching `urlopen`, and — at the CLI level — an empty toolset under
   `--no-tools` with the default still offering tools.
4. Confirm the change is load-bearing: delete the `if think is not None:` block from
   `transport.py` → `test_transport_sends_think_false_when_asked` fails.
5. Live, with ollama serving `qwen3.8:27b`:

   ```
   python3 cli.py --task "Review the diff. One finding per line as SEVERITY|file:line|summary.

   <a ~1.5k-token diff>" --model qwen3.8:27b --cwd /tmp --num-ctx 65536 --turn-cap 3 \
     --no-think --no-tools --no-skills --no-rules --ungated
   ```

   Completes in ~3m30s with pipe-formatted findings. Drop `--no-think` and it times out at
   600s; drop `--no-tools` and it burns the turn cap on shell calls.

## Additional Notes / HelpScout Tickets

**Verified on:** macOS, real local ollama 0.32.13 serving `qwen3.8:27b` (Q4_K_M, 27.3B) — a
live provider, not a stub, for the timing claims; the unit tests stub `urlopen`.

Worked from a dedicated worktree because the main clone was on a stale `main` and may be in
use by another session.

**Not done here, worth a follow-up:** `stream: true` would convert the timeout from
total-request to per-chunk idle, which is the general fix rather than a bigger number. Left out
to keep this change to the flags and their defaults.

One measurement caveat I would not want a reader to over-read: the recall claim for this tool
(three of three planted defects found) was measured with thinking **on**, on a small diff. That
`think: false` preserves finding quality is not yet established — the llm-tools side re-runs
the planted-defect fixture before relying on it.