### PR TITLE
Record why a run ended, not just whether it finished

### DIFF
--- a/ollama-agent/ollama_agent/agent.py
+++ b/ollama-agent/ollama_agent/agent.py
@@ -72,12 +72,19 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
     failure back and the loop continues, so the run drives to a green gate rather
     than to the model's own say-so. `verified` is None when no gate is configured,
     else the last check's pass/fail; the turn cap still bounds the loop.
+
+    `reason` says why the loop ended in one field, so a consumer needn't join
+    two nullable ones: "ok" (the model stopped and the gate passed, or none
+    was configured), "turn-cap" (ungated run out of turns), or
+    "verify-failed" (out of turns, gate last observed red). It carries no
+    value for a crash or a kill — neither reaches the ledger write.
     """
     messages = [{"role": "system", "content": system},
                 {"role": "user", "content": task}]
     transcript = list(messages)
     completed = False
     verified = None
+    reason = None
     turns = 0
     ollama_input_tokens = 0
     ollama_output_tokens = 0
@@ -100,6 +107,7 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
                 if res.get("returncode") == 0:
                     verified = True
                     completed = True
+                    reason = "ok"
                     break
                 verified = False
                 feedback = {"role": "user", "content": (
@@ -112,6 +120,7 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
                 messages.append(feedback)
                 continue
             completed = True
+            reason = "ok"
             break
         for c in calls:
             fn_obj = c.get("function") or {}
@@ -128,9 +137,17 @@ def run_agent(task, system, transport, toolbox, tools, turn_cap=8, run_id=None,
             tool_msg = {"role": "tool", "content": result}
             transcript.append(tool_msg)
             messages.append(tool_msg)
+    if reason is None:
+        # Fell out of the while condition rather than breaking, so the cap is
+        # exhausted. `verified is False` means a gate was configured and was
+        # red the last time it ran — which may be several turns back, if the
+        # model kept calling tools afterwards and never stopped again. None
+        # means no gate was configured, so nothing failed: it ran out of turns.
+        reason = "verify-failed" if verified is False else "turn-cap"
     return {
         "completed": completed,
         "verified": verified,
+        "reason": reason,
         "turns": turns,
         "run_id": run_id,
         "ollama_input_tokens": ollama_input_tokens,

--- a/ollama-agent/ollama_agent/ledger.py
+++ b/ollama-agent/ollama_agent/ledger.py
@@ -54,6 +54,7 @@ def append_run(rec, model, task_name, cwd, now=None, path=None):
         "turns": rec.get("turns"),
         "completed": rec.get("completed"),
         "verified": rec.get("verified"),
+        "reason": rec.get("reason"),
     }
     try:
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/ollama-agent/tests/test_agent.py
+++ b/ollama-agent/tests/test_agent.py
@@ -465,3 +465,47 @@ def test_parse_chat_response_error_body_raises():
 def test_parse_chat_response_missing_message_raises():
     with pytest.raises(RuntimeError, match="no message"):
         parse_chat_response(200, json.dumps({"done": True}))
+
+
+# --- why the run ended (reason) ---
+#
+# The ledger's outcome was a two-field truth table with a null in it:
+# (completed, verified). Across 57 real rows the shapes are (True, None) x28,
+# (True, True) x17, (False, False) x7, (False, None) x5 — so reading "did this
+# work" means joining two nullable fields and knowing that None means "no gate
+# configured", not "unknown". `reason` says it in one field.
+#
+# Only the three values the loop can actually reach are emitted. A RuntimeError
+# returns from cli before the ledger write, and an OOM kill takes the process
+# with it, so "error"/"killed" would be values nothing ever writes.
+
+def test_reason_ok_when_model_stops_ungated(tmp_path):
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, verify_cmd=None)
+    assert rec["reason"] == "ok"
+
+
+def test_reason_ok_when_the_gate_passes(tmp_path):
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("noop", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, verify_cmd="true")
+    assert rec["reason"] == "ok"
+
+
+def test_reason_turn_cap_when_ungated_run_exhausts_the_cap(tmp_path):
+    # The 5 real (False, None) rows: the model never stopped and no gate was
+    # configured, so nothing failed — it just ran out of turns.
+    transport = _script({"role": "assistant", "tool_calls": [
+        {"function": {"name": "list_dir", "arguments": {"path": "."}}}]})
+    rec = run_agent("loop forever", "sys", transport, ToolBox(cwd=tmp_path), TOOLS, turn_cap=4)
+    assert rec["completed"] is False
+    assert rec["reason"] == "turn-cap"
+
+
+def test_reason_verify_failed_when_the_gate_is_still_red_at_the_cap(tmp_path):
+    # The 7 real (False, False) rows, all at turns == cap. Distinct from the
+    # case above: work was attempted and the gate rejected it every time.
+    transport = _script({"role": "assistant", "content": "done"})
+    rec = run_agent("fix it", "sys", transport, ToolBox(cwd=tmp_path), TOOLS,
+                    turn_cap=3, verify_cmd="false")
+    assert rec["completed"] is False
+    assert rec["reason"] == "verify-failed"

--- a/ollama-agent/tests/test_cli.py
+++ b/ollama-agent/tests/test_cli.py
@@ -484,3 +484,22 @@ def test_cli_tools_are_offered_by_default(tmp_path, monkeypatch):
                    "--no-rules", "--no-skills", "--ungated"])
     assert rc == 0
     assert captured["tools"], "the default must keep offering the toolset"
+
+
+def test_cli_writes_the_reason_to_a_real_ledger(tmp_path, monkeypatch, capsys):
+    # End-to-end through the wiring the other cli tests stub out: real run_agent,
+    # real append_run, a real ledger file. Only the network transport is faked.
+    # `_stub` replaces both run_agent and append_run, so a `reason` asserted only
+    # there would pass with the field never reaching a ledger row.
+    ledger = tmp_path / "runs.jsonl"
+    monkeypatch.setenv("OLLAMA_AGENT_LEDGER", str(ledger))
+    monkeypatch.setattr(cli, "ollama_transport",
+                        lambda *a, **k: (lambda m, t: ({"role": "assistant", "content": "ok"},
+                                                       {"input": 10, "output": 20})))
+    rc = cli.main(["--ungated", "--task", "fix it", "--cwd", str(tmp_path),
+                   "--no-rules", "--no-skills", "--verify-cmd", "false", "--turn-cap", "2"])
+    assert rc == 0
+    row = json.loads(ledger.read_text().strip())
+    assert row["completed"] is False
+    assert row["verified"] is False
+    assert row["reason"] == "verify-failed"

--- a/ollama-agent/tests/test_ledger.py
+++ b/ollama-agent/tests/test_ledger.py
@@ -91,3 +91,21 @@ def test_ledger_path_uses_xdg_state(monkeypatch, tmp_path):
     monkeypatch.delenv("OLLAMA_AGENT_LEDGER", raising=False)
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     assert ledger_path() == tmp_path / "ollama-agent" / "runs.jsonl"
+
+
+def test_append_run_records_the_reason(tmp_path):
+    p = tmp_path / "runs.jsonl"
+    append_run(_rec(completed=False, verified=False, reason="verify-failed"),
+               "m", "t", "/c", path=str(p))
+    assert json.loads(p.read_text().strip())["reason"] == "verify-failed"
+
+
+def test_append_run_reason_absent_reads_as_null(tmp_path):
+    # Rows written before this field existed have no reason; a consumer must be
+    # able to tell "not recorded" from any real value rather than get a default
+    # that reads as a claim about the run.
+    p = tmp_path / "runs.jsonl"
+    rec = _rec()
+    rec.pop("reason", None)
+    append_run(rec, "m", "t", "/c", path=str(p))
+    assert json.loads(p.read_text().strip())["reason"] is None


### PR DESCRIPTION
Closes nhangen/llm-tools#447

## Description

The ledger reported a run's outcome as `(completed, verified)` — a two-field truth table with a null in it, where `None` meant "no gate was configured" rather than "unknown". Reading "did this work?" meant joining two nullable fields and knowing that convention. This adds a `reason` field that says it in one.

Three values, because three are all the loop can reach:

- `ok` — the model stopped and the gate passed, or no gate was configured
- `turn-cap` — an ungated run ran out of turns
- `verify-failed` — out of turns with the gate last observed red

The ticket named two more, `error` and `killed`. Neither is emittable: a `RuntimeError` returns from `cli.main` at line 227 *before* `append_run` at line 240, and an OOM kill takes the process before any write. Shipping them would put values in the schema that nothing ever writes.

Counted across the 57 rows in the live ledger, the shapes are `(True, None)` ×28, `(True, True)` ×17, `(False, False)` ×7 (all at exactly `turns == cap`), `(False, None)` ×5. So every `completed: false` row is a cap exhaustion — 7 with a red gate, 5 ungated — and that is the split `reason` makes explicit.

## Testing Procedure

1. Check out this branch and `cd ollama-agent`.
2. `python3 -m pytest -q` — 195 pass.
3. Confirm the coverage is load-bearing rather than decorative:
   - Delete the `"reason": rec.get("reason")` line from `ollama_agent/ledger.py` → `test_cli_writes_the_reason_to_a_real_ledger` fails with `KeyError`.
   - Collapse the fallthrough in `agent.py` to a bare `reason = "turn-cap"` → two tests fail, including the end-to-end one.
4. The cli test is the one that matters: the other cli tests stub both `run_agent` and `append_run`, so a field asserted only there would pass while never reaching a ledger row. This one fakes only the network transport and reads the row back off disk.

## Additional Notes

Two gaps this deliberately leaves open, both worth their own tickets:

- A crashed run writes **no ledger row at all**, so its ollama tokens vanish with the exception. Recording a row in the `except RuntimeError` branch is a few lines, but the token counts are unrecoverable at that point, so the row would understate cost — a decision that wants its own change.
- token-scope's savings report still infers the turn-cap/verify-failed split from `completed`/`verified`. The new field has no consumer yet.
