### PR TITLE
Risk-routed worker, review, ticket, and requeue loop (#329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,13 @@ Gates and their failure codes:
 | Review | At least one reviewer from a different provider than the author | 5 |
 | Overlap | In-flight workers touching the same file serialize; conflicts name the other branch | 6 |
 | Premium | HIGH-risk paths (billing/auth/migrations/credentials/shared helpers/hooks/CI — `ceo-risk-map.json`) cannot reach production main without `CEO_LOOP_PREMIUM_APPROVAL` evidence; low risk parks on an integration branch until `CEO_LOOP_ALLOW_MAIN=1` | 7 |
-| Requeue | Repair tickets retry up to the cap (`CEO_LOOP_MAX_RETRIES`, default 2), then land in `exhausted.jsonl` — visible, never deleted | 3 |
+| Stale base | Spec base differing from the target's current revision (`--current-base`) stops the loop before any work runs — rebase and resubmit | 9 |
+| Requeue | Repair tickets retry up to the cap (`CEO_LOOP_MAX_RETRIES`, default 2), then land in `exhausted.jsonl` exactly once — visible, never deleted | 3 |
+| State lock | Concurrent loops serialize on a portable mkdir lock; a held-too-long lock refuses to race rather than corrupting state | 8 |
+
+Premium approval is evidence, not existence: `CEO_LOOP_PREMIUM_APPROVAL` must
+point at a JSON file carrying `.approved_by` and `.ticket` — an empty or
+schema-less file does not unlock the gate.
 
 Risk classification fails closed: an unreadable `ceo-risk-map.json` classifies as
 HIGH. Finding fingerprints bind repo + base revision + invariant + normalized

--- a/README.md
+++ b/README.md
@@ -163,6 +163,35 @@ Scheduling is owned by the `ceo-schedulerd` daemon (native crontab install is re
 
 See [`docs/install.md`](docs/install.md) for fresh multi-machine setup, [`docs/playbooks/SCHEMA.md`](docs/playbooks/SCHEMA.md#swarm-selection-model) for the full selection model, and [`docs/migration.md`](docs/migration.md) for migrating an existing single-host install.
 
+## Worker Loop (risk-routed delegation)
+
+`scripts/ceo-loop.sh` runs one work item through the full #329 loop:
+queue -> isolated worker branch (overlap-serialized, stale-base checked) ->
+tests -> heterogeneous review panel -> finding fingerprints with repair-ticket
+dedup -> risk-gated promotion -> bounded requeue -> telemetry.
+
+```bash
+token-scope-style spec: scripts/ceo-loop.sh run --spec task.json --routes routes.json
+scripts/ceo-loop.sh status --repo <repo-slug>
+```
+
+Gates and their failure codes:
+
+| Gate | Rule | Exit |
+|---|---|---|
+| Routing | Provider-neutral route table per task shape; on provider failure reroute down the candidate list or exit naming what died | 4 |
+| Review | At least one reviewer from a different provider than the author | 5 |
+| Overlap | In-flight workers touching the same file serialize; conflicts name the other branch | 6 |
+| Premium | HIGH-risk paths (billing/auth/migrations/credentials/shared helpers/hooks/CI — `ceo-risk-map.json`) cannot reach production main without `CEO_LOOP_PREMIUM_APPROVAL` evidence; low risk parks on an integration branch until `CEO_LOOP_ALLOW_MAIN=1` | 7 |
+| Requeue | Repair tickets retry up to the cap (`CEO_LOOP_MAX_RETRIES`, default 2), then land in `exhausted.jsonl` — visible, never deleted | 3 |
+
+Risk classification fails closed: an unreadable `ceo-risk-map.json` classifies as
+HIGH. Finding fingerprints bind repo + base revision + invariant + normalized
+location + severity, so line-shifted equivalents collapse onto one ticket while
+a rebase legitimately reopens one. Every cycle appends a telemetry row
+(`telemetry.jsonl`) in the token-scope-ingestable contract plus a shared-ledger
+entry via `ceo-model-ledger.sh`.
+
 ## Development
 
 ```bash

--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -18,6 +18,13 @@ ceo_loop_state_dir() {
   printf '%s/%s' "$CEO_LOOP_STATE_ROOT" "$1"
 }
 
+# ── portable mutual exclusion (no flock on macOS/BSD) ────────────────────────
+# State mutations that read-modify-write run inside an inner bash whose body is
+# a single-quoted heredoc (no nested-quote hell), guarded by an atomic mkdir
+# lock with a bounded wait: concurrent loops queue up or fail loudly at
+# CEO_LOCK_TIMEOUT_SECS — they never race.
+CEO_LOCK_TIMEOUT_SECS="${CEO_LOCK_TIMEOUT_SECS:-10}"
+
 # ── risk classification (#329: premium gate scope) ──────────────────────────
 
 # ceo_risk_classify <map.json> <repo-relative-path>...
@@ -48,62 +55,95 @@ ceo_risk_classify() {
 # ── finding fingerprints → repair-ticket dedup (#329 AC: equivalents collapse) ─
 
 # ceo_finding_fingerprint <repo> <base-sha> <invariant-or-test> <location> <severity>
-# Location is normalized: line numbers stripped, so "the same finding at a
-# shifted line" collapses. Base sha binds the fingerprint to what the finding
-# was found against — a rebase that changes the code legitimately re-opens.
+# Location is normalized (line numbers stripped) so "the same finding at a
+# shifted line" collapses; severity is case-folded so HIGH/high agree. Base sha
+# binds the fingerprint to what the finding was found against — a rebase that
+# changes the code legitimately re-opens.
 ceo_finding_fingerprint() {
   local repo="$1" base="$2" invariant="$3" location="$4" severity="$5"
   local normalized
   normalized="$(printf '%s' "$location" | sed -E 's/:[0-9]+(:[0-9]+)?$//')"
+  severity="$(printf '%s' "$severity" | tr '[:upper:]' '[:lower:]')"
   printf '%s' "$repo|$base|$invariant|$normalized|$severity" | shasum -a 256 | cut -d' ' -f1
 }
 
-# ceo_ticket_dedup <state-dir> <fingerprint> <ticket-json>
+# ceo_ticket_dedup <state-dir> <fingerprint> <summary>
 # Echoes the existing ticket id when this fingerprint was already filed;
-# otherwise appends the row (retries start at 0) and echoes the new id.
+# otherwise appends the row under the state lock (retries start at 0) and
+# echoes the new id. The full fingerprint is the ticket id — no truncation,
+# so requeue updates can never touch a sibling row.
 ceo_ticket_dedup() {
-  local dir="$1" fp="$2" ticket_json="$3"
+  local dir="$1" fp="$2" summary="$3"
   mkdir -p "$dir"
-  local file="$dir/repair-tickets.jsonl"
-  touch "$file"
-  local existing
-  existing="$(jq -r --arg fp "$fp" 'select(.fingerprint == $fp) | .ticket_id' "$file" 2>/dev/null | head -1)"
-  if [ -n "$existing" ]; then
-    echo "$existing"
-    return 0
+  touch "$dir/repair-tickets.jsonl"
+  CEO_LOCK_DIR="$dir" CEO_FP="$fp" CEO_SUMMARY="$summary" CEO_LOCK_WAIT="$CEO_LOCK_TIMEOUT_SECS" bash <<'DEDUP_INNER'
+set -euo pipefail
+lock="$CEO_LOCK_DIR/.lock"; waited=0
+until mkdir "$lock" 2>/dev/null; do
+  sleep 0.2; waited=$((waited + 1))
+  if [ "$waited" -ge $((CEO_LOCK_WAIT * 5)) ]; then
+    echo "ceo-lock: state lock at $lock held too long — refusing to race" >&2
+    exit 8
   fi
-  jq -nc --arg fp "$fp" --arg json "$ticket_json" \
-    '{fingerprint: $fp, ticket_id: ("repair-" + ($fp | .[0:12])), retries: 0} + ($json | fromjson)' \
-    >> "$file"
-  jq -r --arg fp "$fp" 'select(.fingerprint == $fp) | .ticket_id' "$file" | head -1
+done
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+file="$CEO_LOCK_DIR/repair-tickets.jsonl"
+existing="$(jq -r --arg fp "$CEO_FP" 'select(.fingerprint == $fp) | .ticket_id' "$file" | head -1)"
+if [ -n "$existing" ]; then
+  echo "$existing"
+  exit 0
+fi
+jq -nc --arg fp "$CEO_FP" --arg s "$CEO_SUMMARY"   '{fingerprint: $fp, ticket_id: ("repair-" + $fp), retries: 0, summary: $s}' >> "$file"
+echo "repair-$CEO_FP"
+DEDUP_INNER
 }
 
 # ── bounded requeue (#329 AC: exhaustion stays visible) ──────────────────────
 
 # ceo_requeue_decide <state-dir> <ticket-id> <max-retries>
 # Increments the retry counter and prints "retry:<n>", or on reaching the cap
-# prints "exhausted", records the ticket in exhausted.jsonl, and exits 3 —
-# loud, but distinguishable from a generic failure.
+# prints "exhausted", records the ticket in exhausted.jsonl exactly once (the
+# row is marked so later cycles short-circuit), and exits 3 — loud, but
+# distinguishable from a generic failure. Unknown tickets are an internal
+# error, not CLI misuse: exit 8.
 ceo_requeue_decide() {
   local dir="$1" ticket_id="$2" max_retries="$3"
   mkdir -p "$dir"
-  local file="$dir/repair-tickets.jsonl"
-  touch "$file"
-  if ! jq -e --arg t "$ticket_id" 'select(.ticket_id == $t)' "$file" >/dev/null; then
-    echo "ceo-requeue: unknown ticket $ticket_id" >&2
-    return 2
+  touch "$dir/repair-tickets.jsonl"
+  CEO_LOCK_DIR="$dir" CEO_T="$ticket_id" CEO_MAX="$max_retries" \
+    CEO_LOCK_WAIT="$CEO_LOCK_TIMEOUT_SECS" bash <<'REQUEUE_INNER'
+set -euo pipefail
+lock="$CEO_LOCK_DIR/.lock"; waited=0
+until mkdir "$lock" 2>/dev/null; do
+  sleep 0.2; waited=$((waited + 1))
+  if [ "$waited" -ge $((CEO_LOCK_WAIT * 5)) ]; then
+    echo "ceo-lock: state lock at $lock held too long — refusing to race" >&2
+    exit 8
   fi
-  local current next
-  current="$(jq -r --arg t "$ticket_id" 'select(.ticket_id == $t) | .retries' "$file" | head -1)"
-  next=$((current + 1))
-  if [ "$next" -gt "$max_retries" ]; then
-    jq -c --arg t "$ticket_id" 'select(.ticket_id == $t)' "$file" | head -1 >> "$dir/exhausted.jsonl"
-    echo "exhausted"
-    return 3
-  fi
-  jq -c --arg t "$ticket_id" 'select(.ticket_id == $t) |= (.retries = '"$next"')' "$file" > "$file.tmp" \
-    && mv "$file.tmp" "$file"
-  echo "retry:$next"
+done
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+file="$CEO_LOCK_DIR/repair-tickets.jsonl"
+if ! jq -e --arg t "$CEO_T" 'select(.ticket_id == $t)' "$file" >/dev/null; then
+  echo "ceo-requeue: unknown ticket $CEO_T" >&2
+  exit 8
+fi
+status="$(jq -r --arg t "$CEO_T" 'select(.ticket_id == $t) | .status // ""' "$file" | head -1)"
+if [ "$status" = "exhausted" ]; then
+  echo "exhausted"; exit 3
+fi
+current="$(jq -r --arg t "$CEO_T" 'select(.ticket_id == $t) | .retries' "$file" | head -1)"
+next=$((current + 1))
+if [ "$next" -gt "$CEO_MAX" ]; then
+  jq -c --arg t "$CEO_T" 'select(.ticket_id == $t) | .status = "exhausted"' "$file" \
+    | head -1 >> "$CEO_LOCK_DIR/exhausted.jsonl"
+  jq -c --arg t "$CEO_T" 'select(.ticket_id == $t) |= (.status = "exhausted")' "$file" \
+    > "$file.tmp" && mv "$file.tmp" "$file"
+  echo "exhausted"; exit 3
+fi
+jq -c --arg t "$CEO_T" --argjson n "$next" \
+  'select(.ticket_id == $t) |= (.retries = $n)' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+echo "retry:$next"
+REQUEUE_INNER
 }
 
 # ── provider-neutral routing with policy failover (#329) ─────────────────────
@@ -185,30 +225,67 @@ ceo_review_gate() {
 ceo_worker_register() {
   local dir="$1" branch="$2" base="$3"; shift 3
   mkdir -p "$dir"
-  local file="$dir/workers.jsonl"
-  touch "$file"
-  local f conflict
-  while IFS= read -r row; do
-    [ -n "$row" ] || continue
-    for f in "$@"; do
-      if jq -e --arg f "$f" --arg b "$branch" \
-        'select(.branch != $b) | (.files | index($f))' <<<"$row" >/dev/null 2>&1; then
-        conflict="$(jq -r .branch <<<"$row")"
-        echo "ceo-workers: '$branch' overlaps in-flight worker '$conflict' on file $f — serialize or rebase" >&2
-        return 6
-      fi
-    done
-  done < "$file"
-  jq -nc --arg b "$branch" --arg base "$base" --argjson files "$(printf '%s\n' "$@" | jq -R . | jq -s .)" \
-    '{branch: $b, base: $base, files: $files}' >> "$file"
+  touch "$dir/workers.jsonl"
+  CEO_LOCK_DIR="$dir" CEO_BRANCH="$branch" CEO_BASE="$base" \
+    CEO_LOCK_WAIT="$CEO_LOCK_TIMEOUT_SECS" bash -s "$@" <<'REGISTER_INNER'
+set -euo pipefail
+lock="$CEO_LOCK_DIR/.lock"; waited=0
+until mkdir "$lock" 2>/dev/null; do
+  sleep 0.2; waited=$((waited + 1))
+  if [ "$waited" -ge $((CEO_LOCK_WAIT * 5)) ]; then
+    echo "ceo-lock: state lock at $lock held too long — refusing to race" >&2
+    exit 8
+  fi
+done
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+file="$CEO_LOCK_DIR/workers.jsonl"
+lineno=0
+while IFS= read -r row; do
+  lineno=$((lineno + 1))
+  [ -n "$row" ] || continue
+  # A row that fails validation is a corrupt state file, not "no conflict":
+  # the gate must not silently pass exactly when its state is least trustworthy.
+  if ! echo "$row" | jq -e '(.branch | type == "string") and (.files | type == "array")' >/dev/null 2>&1; then
+    echo "ceo-workers: corrupt row at line $lineno of $file — fix or remove it before registering" >&2
+    exit 6
+  fi
+  for f in "$@"; do
+    if echo "$row" | jq -e --arg f "$f" --arg b "$CEO_BRANCH" \
+      'select(.branch != $b) | (.files | index($f))' >/dev/null 2>&1; then
+      conflict="$(echo "$row" | jq -r .branch)"
+      echo "ceo-workers: '$CEO_BRANCH' overlaps in-flight worker '$conflict' on file $f — serialize or rebase" >&2
+      exit 6
+    fi
+  done
+done < "$file"
+jq -nc --arg b "$CEO_BRANCH" --arg base "$CEO_BASE" \
+  --argjson files "$(printf '%s\n' "$@" | jq -R . | jq -s .)" \
+  '{branch: $b, base: $base, files: $files}' >> "$file"
+REGISTER_INNER
 }
 
-# ceo_worker_release <state-dir> <branch>
+# ceo_worker_release <state-dir> <branch> — removes the branch's row under the
+# state lock so a concurrent registration between read and rename survives.
 ceo_worker_release() {
   local dir="$1" branch="$2"
   local file="$dir/workers.jsonl"
   [ -f "$file" ] || return 0
-  jq -c --arg b "$branch" 'select(.branch != $b)' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  CEO_LOCK_DIR="$dir" CEO_BRANCH="$branch" CEO_LOCK_WAIT="$CEO_LOCK_TIMEOUT_SECS" bash <<'RELEASE_INNER'
+set -euo pipefail
+lock="$CEO_LOCK_DIR/.lock"; waited=0
+until mkdir "$lock" 2>/dev/null; do
+  sleep 0.2; waited=$((waited + 1))
+  if [ "$waited" -ge $((CEO_LOCK_WAIT * 5)) ]; then
+    # Release is best-effort cleanup; losing it here leaves a visible stale
+    # row rather than corrupting state. Say so instead of failing the caller.
+    echo "ceo-workers: release skipped — state lock busy ($CEO_LOCK_DIR)" >&2
+    exit 0
+  fi
+done
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+file="$CEO_LOCK_DIR/workers.jsonl"
+jq -c --arg b "$CEO_BRANCH" 'select(.branch != $b)' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+RELEASE_INNER
 }
 
 # ceo_base_stale <recorded-base> <current-base> — 0 when equal, 1 when stale.

--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# ceo-loop-lib.sh — pure decision functions for the #329 risk-routed
+# worker/review/ticket/requeue loop. No side effects except where a function's
+# contract says it owns a state file; everything testable is testable without
+# providers, worktrees, or the network.
+#
+# State layout (per repo slug) under ${XDG_STATE_HOME:-~/.local/state}/ceo-loop/:
+#   workers.jsonl        in-flight worker rows: branch, base sha, files
+#   repair-tickets.jsonl deduplicated findings: fingerprint, ticket, retries
+#   exhausted.jsonl      tickets whose retry budget ran out — never deleted
+
+set -euo pipefail
+
+CEO_LOOP_STATE_ROOT="${CEO_LOOP_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/ceo-loop}"
+
+# ceo_loop_state_dir <repo-slug>
+ceo_loop_state_dir() {
+  printf '%s/%s' "$CEO_LOOP_STATE_ROOT" "$1"
+}
+
+# ── risk classification (#329: premium gate scope) ──────────────────────────
+
+# ceo_risk_classify <map.json> <repo-relative-path>...
+# Highest matching rule wins; a path class nothing matches defaults to the
+# map's default_risk. Fails CLOSED to "high": an unreadable map or broken
+# lookup must not let high-risk work reach production main by accident.
+ceo_risk_classify() {
+  local map="$1"; shift
+  if [ ! -r "$map" ]; then
+    echo "high"; return 0
+  fi
+  local out
+  out="$(jq -rn --slurpfile m "$map" --argjson paths "$(printf '%s\n' "$@" | jq -R . | jq -s .)" '
+    [ $paths[] as $p
+      | $m[0].rules[] as $r
+      | select($p | test($r.match_pattern; "i"))
+      | $r.risk ]
+    | if index("high") then "high"
+      elif index("medium") then "medium"
+      elif length > 0 then "low"
+      else $m[0].default_risk // "high"
+      end
+  ' 2>/dev/null)" || { echo "high"; return 0; }
+  [ -n "$out" ] || { echo "high"; return 0; }
+  echo "$out"
+}
+
+# ── finding fingerprints → repair-ticket dedup (#329 AC: equivalents collapse) ─
+
+# ceo_finding_fingerprint <repo> <base-sha> <invariant-or-test> <location> <severity>
+# Location is normalized: line numbers stripped, so "the same finding at a
+# shifted line" collapses. Base sha binds the fingerprint to what the finding
+# was found against — a rebase that changes the code legitimately re-opens.
+ceo_finding_fingerprint() {
+  local repo="$1" base="$2" invariant="$3" location="$4" severity="$5"
+  local normalized
+  normalized="$(printf '%s' "$location" | sed -E 's/:[0-9]+(:[0-9]+)?$//')"
+  printf '%s' "$repo|$base|$invariant|$normalized|$severity" | shasum -a 256 | cut -d' ' -f1
+}
+
+# ceo_ticket_dedup <state-dir> <fingerprint> <ticket-json>
+# Echoes the existing ticket id when this fingerprint was already filed;
+# otherwise appends the row (retries start at 0) and echoes the new id.
+ceo_ticket_dedup() {
+  local dir="$1" fp="$2" ticket_json="$3"
+  mkdir -p "$dir"
+  local file="$dir/repair-tickets.jsonl"
+  touch "$file"
+  local existing
+  existing="$(jq -r --arg fp "$fp" 'select(.fingerprint == $fp) | .ticket_id' "$file" 2>/dev/null | head -1)"
+  if [ -n "$existing" ]; then
+    echo "$existing"
+    return 0
+  fi
+  jq -nc --arg fp "$fp" --arg json "$ticket_json" \
+    '{fingerprint: $fp, ticket_id: ("repair-" + ($fp | .[0:12])), retries: 0} + ($json | fromjson)' \
+    >> "$file"
+  jq -r --arg fp "$fp" 'select(.fingerprint == $fp) | .ticket_id' "$file" | head -1
+}
+
+# ── bounded requeue (#329 AC: exhaustion stays visible) ──────────────────────
+
+# ceo_requeue_decide <state-dir> <ticket-id> <max-retries>
+# Increments the retry counter and prints "retry:<n>", or on reaching the cap
+# prints "exhausted", records the ticket in exhausted.jsonl, and exits 3 —
+# loud, but distinguishable from a generic failure.
+ceo_requeue_decide() {
+  local dir="$1" ticket_id="$2" max_retries="$3"
+  mkdir -p "$dir"
+  local file="$dir/repair-tickets.jsonl"
+  touch "$file"
+  if ! jq -e --arg t "$ticket_id" 'select(.ticket_id == $t)' "$file" >/dev/null; then
+    echo "ceo-requeue: unknown ticket $ticket_id" >&2
+    return 2
+  fi
+  local current next
+  current="$(jq -r --arg t "$ticket_id" 'select(.ticket_id == $t) | .retries' "$file" | head -1)"
+  next=$((current + 1))
+  if [ "$next" -gt "$max_retries" ]; then
+    jq -c --arg t "$ticket_id" 'select(.ticket_id == $t)' "$file" | head -1 >> "$dir/exhausted.jsonl"
+    echo "exhausted"
+    return 3
+  fi
+  jq -c --arg t "$ticket_id" 'select(.ticket_id == $t) |= (.retries = '"$next"')' "$file" > "$file.tmp" \
+    && mv "$file.tmp" "$file"
+  echo "retry:$next"
+}
+
+# ── provider-neutral routing with policy failover (#329) ─────────────────────
+
+# Routes file shape:
+# {"routes": {"<shape>": [
+#   {"provider":"ollama","model":"qwen2.5-coder:7b","command":"..."},
+#   {"provider":"opencode","model":"kimi-k3","command":"..."} ]}}
+# First candidate is primary; the rest are fallbacks in order.
+
+# ceo_route_select <routes.json> <shape> — prints the primary route JSON,
+# or exits 4 with an actionable message when no route exists at all.
+ceo_route_select() {
+  local routes="$1" shape="$2"
+  local primary
+  primary="$(jq -c --arg s "$shape" '.routes[$s][0] // empty' "$routes" 2>/dev/null)"
+  if [ -z "$primary" ]; then
+    echo "ceo-route: no route configured for task shape '$shape' in $routes" >&2
+    return 4
+  fi
+  echo "$primary"
+}
+
+# ceo_route_failover <routes.json> <shape> <failed-provider> [<failed-model>]
+# Prints the next candidate after every entry matching the failed provider
+# (+ model when given). Exits 4 loudly when no fallback remains — reroute or
+# die visibly, never silently drop (#329 AC).
+ceo_route_failover() {
+  local routes="$1" shape="$2" failed_provider="$3" failed_model="${4:-}"
+  local last_idx rest first
+  last_idx="$(jq -r --arg s "$shape" --arg p "$failed_provider" --arg m "$failed_model" '
+    [ .routes[$s] | to_entries[]
+      | select(.value.provider == $p and ($m == "" or .value.model == $m))
+      | .key ] | max // -1
+  ' "$routes" 2>/dev/null)" || { echo "ceo-route: unreadable route table $routes" >&2; return 4; }
+  if [ "$last_idx" = "-1" ]; then
+    echo "ceo-route: ${failed_provider}${failed_model:+/$failed_model} is not a configured route for '$shape' — check the route table" >&2
+    return 4
+  fi
+  first="$(jq -c --arg s "$shape" --argjson skip "$((last_idx + 1))" \
+    '.routes[$s][$skip:] | .[0] // empty' "$routes" 2>/dev/null)"
+  if [ -z "$first" ]; then
+    echo "ceo-route: no fallback left for '$shape' after ${failed_provider}${failed_model:+/$failed_model} — fix the route table or run the task yourself" >&2
+    return 4
+  fi
+  echo "$first"
+}
+
+# ── heterogeneous review gate (#329: author cannot be its own only reviewer) ──
+
+# ceo_review_gate <author-provider/model> <reviewer-provider/model>...
+# Passes only when at least one reviewer exists AND one of them runs a
+# different provider than the author. Prints the passing reviewer, else exit 5.
+ceo_review_gate() {
+  local author="$1"; shift
+  local reviewers="$*"
+  if [ -z "${reviewers// /}" ]; then
+    echo "ceo-review: no reviewer assigned — at least one, from a different provider than $author, is required" >&2
+    return 5
+  fi
+  local author_provider="${author%%/*}"
+  local r rp
+  for r in "$@"; do
+    rp="${r%%/*}"
+    if [ "$rp" != "$author_provider" ]; then
+      echo "$r"
+      return 0
+    fi
+  done
+  echo "ceo-review: every reviewer runs '$author_provider', same as the author — cross-provider review required" >&2
+  return 5
+}
+
+# ── overlap serialization + stale base (#329 AC) ─────────────────────────────
+
+# ceo_worker_register <state-dir> <branch> <base-sha> <file>... — records an
+# in-flight worker. Exits 6 on overlap with a registered worker sharing any
+# file, migration path, or declared dependency, naming the conflict.
+ceo_worker_register() {
+  local dir="$1" branch="$2" base="$3"; shift 3
+  mkdir -p "$dir"
+  local file="$dir/workers.jsonl"
+  touch "$file"
+  local f conflict
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    for f in "$@"; do
+      if jq -e --arg f "$f" --arg b "$branch" \
+        'select(.branch != $b) | (.files | index($f))' <<<"$row" >/dev/null 2>&1; then
+        conflict="$(jq -r .branch <<<"$row")"
+        echo "ceo-workers: '$branch' overlaps in-flight worker '$conflict' on file $f — serialize or rebase" >&2
+        return 6
+      fi
+    done
+  done < "$file"
+  jq -nc --arg b "$branch" --arg base "$base" --argjson files "$(printf '%s\n' "$@" | jq -R . | jq -s .)" \
+    '{branch: $b, base: $base, files: $files}' >> "$file"
+}
+
+# ceo_worker_release <state-dir> <branch>
+ceo_worker_release() {
+  local dir="$1" branch="$2"
+  local file="$dir/workers.jsonl"
+  [ -f "$file" ] || return 0
+  jq -c --arg b "$branch" 'select(.branch != $b)' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
+# ceo_base_stale <recorded-base> <current-base> — 0 when equal, 1 when stale.
+ceo_base_stale() {
+  [ "$1" = "$2" ]
+}
+
+# ── promotion gate (#329: premium pre-merge before production main) ──────────
+
+# ceo_promotion_gate <risk> <target-branch> <default-branch> <premium-approval-file|[]>
+# Returns the action on stdout:
+#   promote            safe to merge into <target>
+#   park-integration   fine work, but target is production main and the risk
+#                      or policy says integration branch first
+#   blocked-premium    HIGH risk aimed at production main with no premium
+#                      approval evidence — hard stop, exit 7
+ceo_promotion_gate() {
+  local risk="$1" target="$2" default_branch="$3" approval="${4:-}"
+  if [ "$target" != "$default_branch" ]; then
+    echo "promote"; return 0
+  fi
+  if [ "$risk" = "high" ]; then
+    if [ -n "$approval" ] && [ -f "$approval" ]; then
+      echo "promote"; return 0
+    fi
+    echo "blocked-premium"
+    return 7
+  fi
+  if [ "${CEO_LOOP_ALLOW_MAIN:-0}" = "1" ] && [ "$risk" != "high" ]; then
+    echo "promote"; return 0
+  fi
+  echo "park-integration"
+}

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -66,6 +66,13 @@ test_fingerprint_new_base_revision_reopens_the_finding() {
   assert_fails "new base must reopen the finding" test "$a" = "$b"
 }
 
+test_fingerprint_severity_is_case_folded() {
+  local a b
+  a=$(ceo_finding_fingerprint o/r abc123 "t.sh" "l.sh:1" "HIGH")
+  b=$(ceo_finding_fingerprint o/r abc123 "t.sh" "l.sh:1" "high")
+  assert_eq "$a" "$b" "HIGH vs high are the same finding"
+}
+
 test_dedup_first_filing_creates_second_returns_same_ticket_id() {
   local dir="$TMP/dedup"; mkdir -p "$dir"
   local fp id1 id2
@@ -88,6 +95,35 @@ test_requeue_increments_to_cap_then_exhausted_and_visible() {
   assert_eq "$rc" "3" "exhaustion is loud, distinguishable from generic failure"
   assert_file_exists "$dir/exhausted.jsonl"
   assert_contains "$(cat "$dir/exhausted.jsonl")" "$tid"
+}
+
+test_requeue_exhaustion_recorded_once_not_every_cycle() {
+  local dir="$TMP/requeue2"; mkdir -p "$dir"
+  local fp tid out before after
+  fp=$(ceo_finding_fingerprint o/r abc "t.sh" "l.sh:1" "MED")
+  tid=$(ceo_ticket_dedup "$dir" "$fp" "x")
+  ceo_requeue_decide "$dir" "$tid" 0 >/dev/null 2>&1 || true
+  assert_file_exists "$dir/exhausted.jsonl"
+  before=$(wc -l < "$dir/exhausted.jsonl" | tr -d ' ')
+  ceo_requeue_decide "$dir" "$tid" 0 >/dev/null 2>&1 || true
+  after=$(wc -l < "$dir/exhausted.jsonl" | tr -d ' ')
+  assert_eq "$after" "$before" "the marker row short-circuits duplicate exhaustion records"
+}
+
+test_requeue_unknown_ticket_is_internal_error_code_8() {
+  local dir="$TMP/requeue3"; mkdir -p "$dir"
+  local rc=0
+  ceo_requeue_decide "$dir" "repair-nonexistent" 2 >/dev/null 2>&1 || rc=$?
+  assert_eq "$rc" "8" "internal state error is not CLI misuse (exit 2)"
+}
+
+test_register_corrupt_row_is_hard_stop_not_silent_pass() {
+  local dir="$TMP/workers4"; mkdir -p "$dir"
+  printf '%s\n' 'not json at all' >> "$dir/workers.jsonl"
+  local out rc=0
+  out=$(ceo_worker_register "$dir" "nh/x" "aaa" "lib/u.sh" 2>&1) || rc=$?
+  assert_contains "$out" "corrupt row"
+  assert_eq "$rc" "6"
 }
 
 test_route_primary_selection() {
@@ -116,12 +152,14 @@ test_review_author_cannot_be_its_own_only_reviewer() {
   local out rc=0
   out=$(ceo_review_gate "ollama/qwen3.8:27b" 2>&1) || rc=$?
   assert_contains "$out" "no reviewer"
+  assert_eq "$rc" "5" "refusal must carry its documented code"
 }
 
 test_review_same_provider_only_panel_is_refused() {
   local out rc=0
   out=$(ceo_review_gate "ollama/qwen" "ollama/qwen-turbo" 2>&1) || rc=$?
   assert_contains "$out" "cross-provider review required"
+  assert_eq "$rc" "5" "refusal must carry its documented code"
 }
 
 test_review_one_different_provider_reviewer_passes_and_is_echoed() {

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# ceo-loop-lib.test.sh — pure-function coverage for the #329 loop decisions.
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./test-harness.sh
+source ./ceo-loop-lib.sh
+
+LIB_DIR="$(pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+RISK_MAP="$LIB_DIR/ceo-risk-map.json"
+
+# Isolated state root so tests never touch the developer's real state (#317 class).
+CEO_LOOP_STATE_ROOT="$TMP/state"
+export CEO_LOOP_STATE_ROOT
+
+cat > "$TMP/routes.json" <<'JSON'
+{"routes": {"bug-fix": [
+  {"provider": "ollama", "model": "qwen2.5-coder:7b", "command": "run-local"},
+  {"provider": "opencode", "model": "kimi-k3", "command": "run-hosted"}
+]}}
+JSON
+
+test_risk_billing_path_is_high() {
+  assert_eq "$(ceo_risk_classify "$RISK_MAP" "src/billing/charge.php")" "high"
+}
+
+test_risk_migrations_are_high() {
+  assert_eq "$(ceo_risk_classify "$RISK_MAP" "db/migrations/0042_add_index.js")" "high"
+}
+
+test_risk_docs_are_low() {
+  assert_eq "$(ceo_risk_classify "$RISK_MAP" "README.md")" "low"
+}
+
+test_risk_unmatched_path_takes_map_default_medium() {
+  assert_eq "$(ceo_risk_classify "$RISK_MAP" "src/app/widget.ts")" "medium"
+}
+
+test_risk_highest_wins_across_paths() {
+  assert_eq "$(ceo_risk_classify "$RISK_MAP" "docs/notes.md" "hooks/pre-commit")" "high"
+}
+
+test_risk_unreadable_map_fails_closed_to_high_never_open() {
+  assert_eq "$(ceo_risk_classify "$TMP/nope.json" "README.md")" "high"
+}
+
+test_fingerprint_same_finding_collapses_despite_line_shift() {
+  local a b
+  a=$(ceo_finding_fingerprint o/r abc123 "tests/x.test.sh" "lib/util.sh:120" "HIGH")
+  b=$(ceo_finding_fingerprint o/r abc123 "tests/x.test.sh" "lib/util.sh:4187" "HIGH")
+  assert_eq "$a" "$b" "line-shifted equivalent must share a fingerprint"
+}
+
+test_fingerprint_different_invariant_does_not_collapse() {
+  local a b
+  a=$(ceo_finding_fingerprint o/r abc123 "tests/a.test.sh" "lib/u.sh:1" "HIGH")
+  b=$(ceo_finding_fingerprint o/r abc123 "tests/b.test.sh" "lib/u.sh:1" "HIGH")
+  assert_fails "different invariants must not share a fingerprint" test "$a" = "$b"
+}
+
+test_fingerprint_new_base_revision_reopens_the_finding() {
+  local a b
+  a=$(ceo_finding_fingerprint o/r aaa "t.sh" "l.sh:1" "HIGH")
+  b=$(ceo_finding_fingerprint o/r bbb "t.sh" "l.sh:1" "HIGH")
+  assert_fails "new base must reopen the finding" test "$a" = "$b"
+}
+
+test_dedup_first_filing_creates_second_returns_same_ticket_id() {
+  local dir="$TMP/dedup"; mkdir -p "$dir"
+  local fp id1 id2
+  fp=$(ceo_finding_fingerprint o/r abc "t.sh" "l.sh:1" "MED")
+  id1=$(ceo_ticket_dedup "$dir" "$fp" '{"summary":"null check missing"}')
+  id2=$(ceo_ticket_dedup "$dir" "$fp" '{"summary":"null check missing"}')
+  assert_eq "$id1" "$id2"
+  assert_eq "$(wc -l < "$dir/repair-tickets.jsonl" | tr -d ' ')" "1" "equivalents collapse to one row"
+}
+
+test_requeue_increments_to_cap_then_exhausted_and_visible() {
+  local dir="$TMP/requeue"; mkdir -p "$dir"
+  local fp tid out rc=0
+  fp=$(ceo_finding_fingerprint o/r abc "t.sh" "l.sh:1" "MED")
+  tid=$(ceo_ticket_dedup "$dir" "$fp" '{"summary":"x"}')
+  assert_eq "$(ceo_requeue_decide "$dir" "$tid" 2)" "retry:1"
+  assert_eq "$(ceo_requeue_decide "$dir" "$tid" 2)" "retry:2"
+  out=$(ceo_requeue_decide "$dir" "$tid" 2 2>/dev/null) || rc=$?
+  assert_eq "$out" "exhausted"
+  assert_eq "$rc" "3" "exhaustion is loud, distinguishable from generic failure"
+  assert_file_exists "$dir/exhausted.jsonl"
+  assert_contains "$(cat "$dir/exhausted.jsonl")" "$tid"
+}
+
+test_route_primary_selection() {
+  assert_contains "$(ceo_route_select "$TMP/routes.json" "bug-fix")" '"provider":"ollama"'
+}
+
+test_route_unknown_shape_is_loud_with_shape_named() {
+  local out rc=0
+  out=$(ceo_route_select "$TMP/routes.json" "unknown-shape" 2>&1) || rc=$?
+  assert_contains "$out" "unknown-shape"
+}
+
+test_failover_reroutes_past_failed_provider_model() {
+  assert_contains \
+    "$(ceo_route_failover "$TMP/routes.json" "bug-fix" "ollama" "qwen2.5-coder:7b")" \
+    '"provider":"opencode"'
+}
+
+test_failover_exhausting_every_fallback_exits_loudly() {
+  local out rc=0
+  out=$(ceo_route_failover "$TMP/routes.json" "bug-fix" "opencode" "kimi-k3" 2>&1) || rc=$?
+  assert_contains "$out" "no fallback left"
+}
+
+test_review_author_cannot_be_its_own_only_reviewer() {
+  local out rc=0
+  out=$(ceo_review_gate "ollama/qwen3.8:27b" 2>&1) || rc=$?
+  assert_contains "$out" "no reviewer"
+}
+
+test_review_same_provider_only_panel_is_refused() {
+  local out rc=0
+  out=$(ceo_review_gate "ollama/qwen" "ollama/qwen-turbo" 2>&1) || rc=$?
+  assert_contains "$out" "cross-provider review required"
+}
+
+test_review_one_different_provider_reviewer_passes_and_is_echoed() {
+  assert_eq \
+    "$(ceo_review_gate "ollama/qwen" "ollama/qwen-turbo" "opencode/kimi-k3")" \
+    "opencode/kimi-k3"
+}
+
+test_workers_overlapping_file_registration_is_refused_naming_conflict() {
+  local dir="$TMP/workers"; mkdir -p "$dir"
+  local out rc=0
+  ceo_worker_register "$dir" "nh/a" "aaa111" "lib/util.sh" "src/app.ts"
+  out=$(ceo_worker_register "$dir" "nh/b" "bbb222" "src/other.ts" "lib/util.sh" 2>&1) || rc=$?
+  assert_contains "$out" "nh/a"
+  assert_contains "$out" "lib/util.sh"
+}
+
+test_workers_disjoint_files_coexist() {
+  local dir="$TMP/workers2"; mkdir -p "$dir"
+  ceo_worker_register "$dir" "nh/a" "aaa" "lib/util.sh"
+  ceo_worker_register "$dir" "nh/b" "bbb" "src/app.ts"
+  assert_eq "$(wc -l < "$dir/workers.jsonl" | tr -d ' ')" "2"
+}
+
+test_workers_release_frees_files_for_next_worker() {
+  local dir="$TMP/workers3"; mkdir -p "$dir"
+  ceo_worker_register "$dir" "nh/a" "aaa" "lib/util.sh"
+  ceo_worker_release "$dir" "nh/a"
+  ceo_worker_register "$dir" "nh/b" "bbb" "lib/util.sh"
+  assert_eq "$(wc -l < "$dir/workers.jsonl" | tr -d ' ')" "1"
+}
+
+test_stale_base_same_sha_fresh_different_sha_stale() {
+  ceo_base_stale "abc123" "abc123"
+  assert_fails "different shas are stale" test ceo_base_stale "abc123" "def456"
+}
+
+test_promotion_high_risk_to_production_main_without_approval_blocked_hard() {
+  local out rc=0
+  out=$(CEO_LOOP_ALLOW_MAIN=1 ceo_promotion_gate high main main "") || rc=$?
+  assert_eq "$out" "blocked-premium"
+  assert_eq "$rc" "7" "premium gate is a hard stop, not advisory"
+}
+
+test_promotion_high_risk_with_premium_approval_evidence_promotes() {
+  : > "$TMP/premium-approval.md"
+  assert_eq "$(ceo_promotion_gate high main main "$TMP/premium-approval.md")" "promote"
+}
+
+test_promotion_low_risk_defaults_to_integration_branch() {
+  assert_eq "$(CEO_LOOP_ALLOW_MAIN=0 ceo_promotion_gate low main main "")" "park-integration"
+}
+
+test_promotion_policy_enabled_low_risk_may_reach_main() {
+  assert_eq "$(CEO_LOOP_ALLOW_MAIN=1 ceo_promotion_gate low main main "")" "promote"
+}
+
+test_promotion_integration_branch_targets_always_promote() {
+  assert_eq "$(ceo_promotion_gate high integration main "")" "promote"
+}
+
+run_tests

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# ceo-loop.sh — risk-routed worker/review/ticket/requeue loop (#329).
+#
+# Drives one work item end to end over a spec file:
+#   queue -> overlap-serialized isolated worker -> tests -> heterogeneous
+#   review panel -> finding fingerprint/dedup -> risk-gated promotion
+#   (premium approval required for high-risk production-main) ->
+#   deduplicated repair tickets with bounded requeue -> telemetry row.
+#
+# The worker/review commands come from the route table and spec, so a full
+# dry-run exercises every gate with fixture commands and no providers.
+#
+# Usage: ceo-loop.sh run --spec <spec.json> --routes <routes.json>
+#        ceo-loop.sh status --repo <repo-slug>
+#
+# Spec JSON fields:
+#   repo          repo slug used for state namespacing
+#   branch        isolated worker branch name
+#   base          base revision the work was cut from
+#   files         array of repo-relative paths the change touches
+#   shape         task shape keyed in the routes table
+#   verify_cmd    command that must exit 0 for the work to pass
+#   author        provider/model of the worker that authored the change
+#   reviewers     array of provider/model review panel entries
+#   findings      array of {invariant, location, severity} from review
+#
+# Exit codes: 0 ok · 2 bad usage · 3 retries exhausted · 4 routing failure ·
+# 5 review gate failure · 6 overlap conflict · 7 premium-gate block
+
+set -euo pipefail
+
+LIB_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=ceo-loop-lib.sh
+source "$LIB_DIR/ceo-loop-lib.sh"
+# shellcheck source=ceo-model-ledger.sh
+source "$LIB_DIR/ceo-model-ledger.sh"
+
+usage() {
+  echo "usage: ceo-loop.sh run --spec <spec.json> --routes <routes.json> [--target <branch>] [--default-branch main]" >&2
+  echo "       ceo-loop.sh status --repo <repo-slug>" >&2
+  exit 2
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  run|status) ;;
+  *) usage ;;
+esac
+
+SPEC="" ROUTES="" TARGET="main" DEFAULT_BRANCH="main" REPO_SLUG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --spec) SPEC="$2"; shift 2 ;;
+    --routes) ROUTES="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --default-branch) DEFAULT_BRANCH="$2"; shift 2 ;;
+    --repo) REPO_SLUG="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+state_dir_for() {
+  local slug="$1"
+  ceo_loop_state_dir "$slug"
+}
+
+if [ "$cmd" = "status" ]; then
+  [ -n "$REPO_SLUG" ] || usage
+  dir="$(state_dir_for "$REPO_SLUG")"
+  echo "state: $dir"
+  for f in queue workers repair-tickets exhausted telemetry; do
+    [ -f "$dir/$f.jsonl" ] && echo "--- $f ($(wc -l < "$dir/$f.jsonl" | tr -d ' '))" && cat "$dir/$f.jsonl"
+  done
+  exit 0
+fi
+
+[ -n "$SPEC" ] && [ -n "$ROUTES" ] || usage
+[ -f "$SPEC" ] || { echo "ceo-loop: spec not found: $SPEC" >&2; exit 2; }
+[ -f "$ROUTES" ] || { echo "ceo-loop: routes not found: $ROUTES" >&2; exit 2; }
+
+jget() { jq -r "$1" "$SPEC"; }
+
+REPO="$(jget '.repo')"
+BRANCH="$(jget '.branch')"
+BASE="$(jget '.base')"
+SHAPE="$(jget '.shape // "bug-fix"')"
+AUTHOR="$(jget '.author')"
+VERIFY_CMD="$(jget '.verify_cmd // ""')"
+DIR="$(state_dir_for "$REPO")"
+mkdir -p "$DIR"
+touch "$DIR/queue.jsonl" "$DIR/workers.jsonl" "$DIR/findings.jsonl" \
+      "$DIR/repair-tickets.jsonl" "$DIR/telemetry.jsonl"
+
+ceo_loop_cleanup() {
+  # A dead or blocked run still frees its serialization slot: the work failed
+  # but nobody else is writing those files through this loop anymore.
+  rm -f "${FINGERPRINTS_FILE:-}" 2>/dev/null || true
+  ceo_worker_release "$DIR" "${BRANCH:-}" 2>/dev/null || true
+}
+START_TS="$(date +%s)"
+
+# ── 1. queue ──────────────────────────────────────────────────────────────────
+jq -c '{ts: (now | todate), repo: .repo, branch: .branch, base: .base, shape: (.shape // "bug-fix"), status: "queued"}' \
+  "$SPEC" >> "$DIR/queue.jsonl"
+echo "loop: queued $REPO/$BRANCH ($SHAPE)"
+
+# ── 2. route + isolated worker (overlap-serialized) ───────────────────────────
+ROUTE="$(ceo_route_select "$ROUTES" "$SHAPE")"
+PROVIDER="$(jq -r .provider <<<"$ROUTE")"
+MODEL="$(jq -r .model <<<"$ROUTE")"
+mapfile -t FILES < <(jq -r '.files[]' "$SPEC")
+ceo_worker_register "$DIR" "$BRANCH" "$BASE" "${FILES[@]}" || exit $?
+echo "loop: worker $PROVIDER/$MODEL on isolated branch $BRANCH (${#FILES[@]} files)"
+
+WORKER_CMD="$(jq -r .command <<<"$ROUTE")"
+if [ -n "$WORKER_CMD" ] && [ "$WORKER_CMD" != "null" ]; then
+  # Worker commands receive the spec path; they own their own sandboxing.
+  if ! SPEC="$SPEC" BRANCH="$BRANCH" BASE="$BASE" bash -c "$WORKER_CMD"; then
+    echo "loop: worker failed — rerouting per policy" >&2
+    NEXT_ROUTE="$(ceo_route_failover "$ROUTES" "$SHAPE" "$PROVIDER" "$MODEL")" || exit 4
+    PROVIDER="$(jq -r .provider <<<"$NEXT_ROUTE")"
+    MODEL="$(jq -r .model <<<"$NEXT_ROUTE")"
+    WORKER_CMD="$(jq -r .command <<<"$NEXT_ROUTE")"
+    echo "loop: rerouted to $PROVIDER/$MODEL"
+    SPEC="$SPEC" BRANCH="$BRANCH" BASE="$BASE" bash -c "$WORKER_CMD" || {
+      echo "loop: rerouted worker also failed — leaving actionable state in $DIR" >&2
+      exit 4
+    }
+  fi
+fi
+
+# ── 3. tests / verification ───────────────────────────────────────────────────
+TEST_RC=0
+if [ -n "$VERIFY_CMD" ]; then
+  if ! VERIFY_LOG="$("$VERIFY_CMD" 2>&1)"; then
+    TEST_RC=1
+    echo "loop: verification failed:" >&2
+    printf '  %s\n' "$(printf '%s' "$VERIFY_LOG" | tail -3)" >&2
+  fi
+fi
+
+# ── 4. heterogeneous review panel ─────────────────────────────────────────────
+REVIEWERS_JSON="$(jq -r '(.reviewers // []) | join(" ")' "$SPEC")"
+# shellcheck disable=SC2086
+PASSING_REVIEWER="$(ceo_review_gate "$AUTHOR" $REVIEWERS_JSON)" \
+  || { echo "loop: review gate failed" >&2; exit 5; }
+echo "loop: review passed via cross-provider reviewer $PASSING_REVIEWER"
+
+# ── 5. findings -> fingerprints -> deduplicated tickets ───────────────────────
+FINGERPRINTS_FILE="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-findings.XXXXXX")"
+trap ceo_loop_cleanup EXIT
+: > "$FINGERPRINTS_FILE"
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  INVARIANT="$(jq -r .invariant <<<"$f")"
+  LOCATION="$(jq -r .location <<<"$f")"
+  SEVERITY="$(jq -r .severity <<<"$f")"
+  FP="$(ceo_finding_fingerprint "$REPO" "$BASE" "$INVARIANT" "$LOCATION" "$SEVERITY")"
+  printf '{"fingerprint":"%s","invariant":"%s","location":"%s","severity":"%s"}\n' \
+    "$FP" "$INVARIANT" "$LOCATION" "$SEVERITY" >> "$DIR/findings.jsonl"
+  TICKET_ID="$(ceo_ticket_dedup "$DIR" "$FP" \
+    "{\"summary\": \"$INVARIANT at $LOCATION\", \"severity\": \"$SEVERITY\", \"repo\": \"$REPO\", \"base\": \"$BASE\"}")"
+  if grep -q "^$TICKET_ID$" "$FINGERPRINTS_FILE"; then
+    echo "loop: duplicate finding collapsed onto existing ticket $TICKET_ID"
+  else
+    echo "$TICKET_ID" >> "$FINGERPRINTS_FILE"
+  fi
+done < <(jq -c '.findings[]?' "$SPEC")
+
+# ── 6. risk classification + promotion gate ───────────────────────────────────
+RISK_MAP="$LIB_DIR/ceo-risk-map.json"
+RISK="$(ceo_risk_classify "$RISK_MAP" "${FILES[@]}")"
+PREMIUM_APPROVAL="${CEO_LOOP_PREMIUM_APPROVAL:-}"
+ACTION=""
+set +e
+ACTION="$(CEO_LOOP_ALLOW_MAIN="${CEO_LOOP_ALLOW_MAIN:-0}" \
+  ceo_promotion_gate "$RISK" "$TARGET" "$DEFAULT_BRANCH" "$PREMIUM_APPROVAL")"
+GATE_RC=$?
+set -e
+if [ "$GATE_RC" -eq 7 ]; then
+  echo "loop: BLOCKED — $RISK-risk change targeting production main '$TARGET' without premium approval." >&2
+  echo "  Provide CEO_LOOP_PREMIUM_APPROVAL=<file> or retarget an integration branch." >&2
+  exit 7
+fi
+if [ "$ACTION" = "park-integration" ]; then
+  echo "loop: parking on integration branch (risk=$RISK, policy default until main promotion is enabled)"
+fi
+
+# ── 7. requeue on failing verification (bounded) ─────────────────────────────
+FINAL_RC=0
+if [ "$TEST_RC" -ne 0 ]; then
+  TICKET_HEAD="$(head -1 "$FINGERPRINTS_FILE")"
+  if [ -n "$TICKET_HEAD" ]; then
+    OUT="$(ceo_requeue_decide "$DIR" "$TICKET_HEAD" "${CEO_LOOP_MAX_RETRIES:-2}")" || FINAL_RC=$?
+    case "$OUT" in
+      retry:*) echo "loop: requeued as ticket $TICKET_HEAD ($OUT)" ;;
+      exhausted) echo "loop: retries EXHAUSTED for $TICKET_HEAD — recorded in $DIR/exhausted.jsonl" ;;
+    esac
+  fi
+fi
+
+# ── 8. telemetry (token-scope ingestion contract) ─────────────────────────────
+NOW_TS="$(date +%s)"
+ACCEPTED=$([ "$TEST_RC" -eq 0 ] && [ "$GATE_RC" -eq 0 ] && echo true || echo false)
+jq -nc \
+  --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg repo "$REPO" --arg branch "$BRANCH" --arg model "$PROVIDER/$MODEL" \
+  --arg target "$TARGET" --arg risk "$RISK" --arg action "$ACTION" \
+  --argjson accepted "$ACCEPTED" \
+  --argjson seconds_to_passing "$((NOW_TS - START_TS))" \
+  --argjson findings "$(wc -l < "$DIR/findings.jsonl" | tr -d ' ')" \
+  --argjson reviewer_disagreement 0 \
+  '{ts: $ts, writer: "ceo-loop", repo: $repo, branch: $branch, model: $model,
+    target: $target, risk: $risk, action: $action, accepted: $accepted,
+    seconds_to_passing: $seconds_to_passing, findings: $findings,
+    reviewer_disagreement: $reviewer_disagreement}' >> "$DIR/telemetry.jsonl"
+
+ceo_ledger_write_entry "ceo-loop" "$PROVIDER/$MODEL" "loop:$REPO/$BRANCH" "$PWD" null "$ACCEPTED" >/dev/null || true
+
+echo "loop: done ($REPO/$BRANCH risk=$RISK action=$ACTION)"
+exit $FINAL_RC

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -47,7 +47,7 @@ case "$cmd" in
   *) usage ;;
 esac
 
-SPEC="" ROUTES="" TARGET="main" DEFAULT_BRANCH="main" REPO_SLUG=""
+SPEC="" ROUTES="" TARGET="main" DEFAULT_BRANCH="main" REPO_SLUG="" CURRENT_BASE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --spec) SPEC="$2"; shift 2 ;;
@@ -55,6 +55,7 @@ while [ $# -gt 0 ]; do
     --target) TARGET="$2"; shift 2 ;;
     --default-branch) DEFAULT_BRANCH="$2"; shift 2 ;;
     --repo) REPO_SLUG="$2"; shift 2 ;;
+    --current-base) CURRENT_BASE="$2"; shift 2 ;;
     *) usage ;;
   esac
 done
@@ -80,23 +81,43 @@ fi
 
 jget() { jq -r "$1" "$SPEC"; }
 
-REPO="$(jget '.repo')"
-BRANCH="$(jget '.branch')"
-BASE="$(jget '.base')"
+require_field() { # <jq-path> <name>
+  local v
+  v="$(jget "$1")"
+  if [ -z "$v" ] || [ "$v" = "null" ]; then
+    echo "ceo-loop: spec is missing required field '$2' — refusing to guess" >&2
+    exit 2
+  fi
+  printf '%s' "$v"
+}
+REPO="$(require_field '.repo' 'repo')"
+BRANCH="$(require_field '.branch' 'branch')"
+BASE="$(require_field '.base' 'base')"
 SHAPE="$(jget '.shape // "bug-fix"')"
-AUTHOR="$(jget '.author')"
-VERIFY_CMD="$(jget '.verify_cmd // ""')"
+AUTHOR="$(require_field '.author' 'author')"
+VERIFY_CMD="$(require_field '.verify_cmd' 'verify_cmd')"
+
+mapfile -t SPEC_FILES < <(jq -r '.files[]?' "$SPEC")
+if [ "${#SPEC_FILES[@]}" -eq 0 ] || [ -z "${SPEC_FILES[0]}" ]; then
+  # An unserialized file list would fall through every risk rule to default —
+  # exactly the degenerate input the map's fail-closed contract forbids.
+  echo "ceo-loop: spec has no changed files — cannot classify risk" >&2
+  exit 2
+fi
 DIR="$(state_dir_for "$REPO")"
 mkdir -p "$DIR"
 touch "$DIR/queue.jsonl" "$DIR/workers.jsonl" "$DIR/findings.jsonl" \
       "$DIR/repair-tickets.jsonl" "$DIR/telemetry.jsonl"
 
+FINGERPRINTS_FILE=""
 ceo_loop_cleanup() {
   # A dead or blocked run still frees its serialization slot: the work failed
   # but nobody else is writing those files through this loop anymore.
-  rm -f "${FINGERPRINTS_FILE:-}" 2>/dev/null || true
-  ceo_worker_release "$DIR" "${BRANCH:-}" 2>/dev/null || true
+  [ -n "$FINGERPRINTS_FILE" ] && rm -f "$FINGERPRINTS_FILE" 2>/dev/null || true
+  ceo_worker_release "$DIR" "$BRANCH" 2>/dev/null || true
 }
+# Installed BEFORE any registration so every early exit frees the slot.
+trap ceo_loop_cleanup EXIT
 START_TS="$(date +%s)"
 
 # ── 1. queue ──────────────────────────────────────────────────────────────────
@@ -104,11 +125,17 @@ jq -c '{ts: (now | todate), repo: .repo, branch: .branch, base: .base, shape: (.
   "$SPEC" >> "$DIR/queue.jsonl"
 echo "loop: queued $REPO/$BRANCH ($SHAPE)"
 
+# ── 1b. stale base (#329 AC: conflicts stop promotion at the door) ────────────
+if [ -n "$CURRENT_BASE" ] && ! ceo_base_stale "$BASE" "$CURRENT_BASE"; then
+  echo "loop: STALE BASE — spec was cut from $BASE but the target is at $CURRENT_BASE. Rebase and resubmit." >&2
+  exit 9
+fi
+
 # ── 2. route + isolated worker (overlap-serialized) ───────────────────────────
 ROUTE="$(ceo_route_select "$ROUTES" "$SHAPE")"
 PROVIDER="$(jq -r .provider <<<"$ROUTE")"
 MODEL="$(jq -r .model <<<"$ROUTE")"
-mapfile -t FILES < <(jq -r '.files[]' "$SPEC")
+FILES=("${SPEC_FILES[@]}")
 ceo_worker_register "$DIR" "$BRANCH" "$BASE" "${FILES[@]}" || exit $?
 echo "loop: worker $PROVIDER/$MODEL on isolated branch $BRANCH (${#FILES[@]} files)"
 
@@ -148,20 +175,23 @@ echo "loop: review passed via cross-provider reviewer $PASSING_REVIEWER"
 
 # ── 5. findings -> fingerprints -> deduplicated tickets ───────────────────────
 FINGERPRINTS_FILE="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-findings.XXXXXX")"
-trap ceo_loop_cleanup EXIT
 : > "$FINGERPRINTS_FILE"
+CYCLE_FINDINGS=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   INVARIANT="$(jq -r .invariant <<<"$f")"
   LOCATION="$(jq -r .location <<<"$f")"
   SEVERITY="$(jq -r .severity <<<"$f")"
   FP="$(ceo_finding_fingerprint "$REPO" "$BASE" "$INVARIANT" "$LOCATION" "$SEVERITY")"
-  printf '{"fingerprint":"%s","invariant":"%s","location":"%s","severity":"%s"}\n' \
-    "$FP" "$INVARIANT" "$LOCATION" "$SEVERITY" >> "$DIR/findings.jsonl"
-  TICKET_ID="$(ceo_ticket_dedup "$DIR" "$FP" \
-    "{\"summary\": \"$INVARIANT at $LOCATION\", \"severity\": \"$SEVERITY\", \"repo\": \"$REPO\", \"base\": \"$BASE\"}")"
-  if grep -q "^$TICKET_ID$" "$FINGERPRINTS_FILE"; then
-    echo "loop: duplicate finding collapsed onto existing ticket $TICKET_ID"
+  # Built by jq, never string-interpolated: reviewer strings may contain quotes.
+  jq -cn --arg fp "$FP" --arg inv "$INVARIANT" --arg loc "$LOCATION" \
+    --arg sev "$SEVERITY" --arg repo "$REPO" --arg base "$BASE" \
+    '{fingerprint: $fp, invariant: $inv, location: $loc, severity: $sev,
+      repo: $repo, base: $base}' >> "$DIR/findings.jsonl"
+  TICKET_ID="$(ceo_ticket_dedup "$DIR" "$FP" "$INVARIANT at $LOCATION [$SEVERITY]")"
+  CYCLE_FINDINGS=$((CYCLE_FINDINGS + 1))
+  if grep -qxF "$TICKET_ID" "$FINGERPRINTS_FILE"; then
+    echo "loop: duplicate finding collapsed onto existing ticket ${TICKET_ID:0:19}..."
   else
     echo "$TICKET_ID" >> "$FINGERPRINTS_FILE"
   fi
@@ -171,6 +201,14 @@ done < <(jq -c '.findings[]?' "$SPEC")
 RISK_MAP="$LIB_DIR/ceo-risk-map.json"
 RISK="$(ceo_risk_classify "$RISK_MAP" "${FILES[@]}")"
 PREMIUM_APPROVAL="${CEO_LOOP_PREMIUM_APPROVAL:-}"
+if [ -n "$PREMIUM_APPROVAL" ]; then
+  # Evidence, not existence: an empty or schema-less file must NOT unlock the
+  # gate — a stray env var pointing at a log would otherwise promote HIGH risk.
+  if ! jq -e '.approved_by and .ticket' "$PREMIUM_APPROVAL" >/dev/null 2>&1; then
+    echo "loop: premium approval file lacks evidence (needs .approved_by and .ticket): $PREMIUM_APPROVAL" >&2
+    exit 7
+  fi
+fi
 ACTION=""
 set +e
 ACTION="$(CEO_LOOP_ALLOW_MAIN="${CEO_LOOP_ALLOW_MAIN:-0}" \
@@ -189,14 +227,16 @@ fi
 # ── 7. requeue on failing verification (bounded) ─────────────────────────────
 FINAL_RC=0
 if [ "$TEST_RC" -ne 0 ]; then
-  TICKET_HEAD="$(head -1 "$FINGERPRINTS_FILE")"
-  if [ -n "$TICKET_HEAD" ]; then
-    OUT="$(ceo_requeue_decide "$DIR" "$TICKET_HEAD" "${CEO_LOOP_MAX_RETRIES:-2}")" || FINAL_RC=$?
+  while IFS= read -r tid; do
+    OUT="$(ceo_requeue_decide "$DIR" "$tid" "${CEO_LOOP_MAX_RETRIES:-2}")" || RC_HERE=$?
+    RC_HERE="${RC_HERE:-0}"
     case "$OUT" in
-      retry:*) echo "loop: requeued as ticket $TICKET_HEAD ($OUT)" ;;
-      exhausted) echo "loop: retries EXHAUSTED for $TICKET_HEAD — recorded in $DIR/exhausted.jsonl" ;;
+      retry:*) echo "loop: requeued as ticket ${tid:0:19}... ($OUT)" ;;
+      exhausted) echo "loop: retries EXHAUSTED for ${tid:0:19}... — recorded in $DIR/exhausted.jsonl" ;;
     esac
-  fi
+    [ "$RC_HERE" -gt "$FINAL_RC" ] && FINAL_RC=$RC_HERE
+    RC_HERE=0
+  done < "$FINGERPRINTS_FILE"
 fi
 
 # ── 8. telemetry (token-scope ingestion contract) ─────────────────────────────
@@ -208,7 +248,7 @@ jq -nc \
   --arg target "$TARGET" --arg risk "$RISK" --arg action "$ACTION" \
   --argjson accepted "$ACCEPTED" \
   --argjson seconds_to_passing "$((NOW_TS - START_TS))" \
-  --argjson findings "$(wc -l < "$DIR/findings.jsonl" | tr -d ' ')" \
+  --argjson findings "$CYCLE_FINDINGS" \
   --argjson reviewer_disagreement 0 \
   '{ts: $ts, writer: "ceo-loop", repo: $repo, branch: $branch, model: $model,
     target: $target, risk: $risk, action: $action, accepted: $accepted,

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ceo-loop.test.sh — end-to-end dry-run of the #329 loop over fixture specs.
+# Every gate runs for real; workers/reviewers are fixture commands, no providers.
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./test-harness.sh
+
+LIB_DIR="$(pwd)"
+# shellcheck source=ceo-loop-lib.sh
+source ./ceo-loop-lib.sh
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Isolated state root — tests must not touch developer state (#317 class).
+CEO_LOOP_STATE_ROOT="$TMP/state"
+export CEO_LOOP_STATE_ROOT
+LOOP="$LIB_DIR/ceo-loop.sh"
+
+cat > "$TMP/routes.json" <<'JSON'
+{"routes": {"bug-fix": [
+  {"provider": "ollama", "model": "qwen2.5-coder:7b", "command": "$WORKER_PRIMARY"},
+  {"provider": "opencode", "model": "kimi-k3", "command": "$WORKER_FALLBACK"}
+]}}
+JSON
+
+make_spec() { # <name> <files-json> <verify-cmd> <findings-json>
+  jq -n \
+    --arg repo "fixture-repo" --arg branch "nh/fixture-$1" --arg base "abc123" \
+    --argjson files "$2" --arg verify "$3" --arg author "ollama/qwen2.5-coder:7b" \
+    --argjson reviewers '["opencode/kimi-k3"]' --argjson findings "$4" \
+    '{repo: $repo, branch: $branch, base: $base, shape: "bug-fix",
+      files: $files, verify_cmd: $verify, author: $author,
+      reviewers: $reviewers, findings: $findings}' > "$TMP/$1.json"
+}
+
+WORKER_PRIMARY="true"
+WORKER_FALLBACK="true"
+WORKER_FAIL="false"
+export WORKER_PRIMARY WORKER_FALLBACK WORKER_FAIL
+
+test_e2e_happy_path_exercises_every_phase() {
+  make_spec ok '["src/app/widget.ts"]' "true" \
+    '[{"invariant":"null check","location":"src/app/widget.ts:12","severity":"LOW"}]'
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/ok.json" --routes "$TMP/routes.json" --target integration) || rc=$?
+  assert_contains "$out" "queued"
+  assert_contains "$out" "isolated branch nh/fixture-ok"
+  assert_contains "$out" "cross-provider reviewer opencode/kimi-k3"
+  assert_contains "$out" "done (fixture-repo/nh/fixture-ok risk=medium action=promote)"
+  assert_eq "$rc" "0"
+  # telemetry row written in the token-scope-ingestable contract
+  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/telemetry.jsonl")" '"writer":"ceo-loop"'
+  # ledger entry appended under the shared writer contract
+  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/telemetry.jsonl")" '"accepted":true'
+}
+
+test_high_risk_cannot_reach_production_main_without_premium_gate() {
+  make_spec hot '["db/migrations/0042_add_index.js"]' "true" '[]'
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/hot.json" --routes "$TMP/routes.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "BLOCKED"
+  assert_contains "$out" "premium approval"
+  assert_eq "$rc" "7"
+}
+
+test_premium_approval_evidence_unlocks_production_main_for_high_risk() {
+  make_spec approved '["hooks/pre-commit"]' "true" '[]'
+  : > "$TMP/premium-approval.md"
+  local out rc=0
+  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/premium-approval.md" \
+    bash "$LOOP" run --spec "$TMP/approved.json" --routes "$TMP/routes.json" --target main) || rc=$?
+  assert_contains "$out" "action=promote"
+}
+
+test_equivalent_findings_collapse_to_one_repair_ticket() {
+  make_spec dupes '["src/app/widget.ts"]' "true" \
+    '[{"invariant":"null check","location":"lib/util.sh:120","severity":"HIGH"},
+      {"invariant":"null check","location":"lib/util.sh:4187","severity":"HIGH"}]'
+  bash "$LOOP" run --spec "$TMP/dupes.json" --routes "$TMP/routes.json" --target integration >/dev/null
+  local fp rows=0
+  fp=$(ceo_finding_fingerprint fixture-repo abc123 "null check" "lib/util.sh:120" "HIGH")
+  rows=$(grep -c "\"ticket_id\":\"repair-${fp:0:12}" "$CEO_LOOP_STATE_ROOT/fixture-repo/repair-tickets.jsonl" || true)
+  assert_eq "$rows" "1" "line-shifted equivalent must file ONE ticket"
+}
+
+test_overlapping_in_flight_worker_stops_the_loop_naming_conflict() {
+  make_spec first '["lib/util.sh"]' "true" '[]'
+  make_spec second '["lib/util.sh"]' "true" '[]'
+  bash "$LOOP" run --spec "$TMP/first.json" --routes "$TMP/routes.json" --target integration >/dev/null
+  # first worker is released on completion; simulate it still in flight:
+  printf '%s\n' '{"branch":"nh/fixture-first","base":"abc123","files":["lib/util.sh"]}' \
+    >> "$CEO_LOOP_STATE_ROOT/fixture-repo/workers.jsonl"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/second.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
+  assert_contains "$out" "overlaps in-flight worker 'nh/fixture-first'"
+  assert_eq "$rc" "6"
+}
+
+test_provider_failure_reroutes_to_fallback_and_both_failing_is_loud() {
+  make_spec reroute '["src/app/widget.ts"]' "true" '[]'
+  # Primary command fails ($WORKER_FAIL), fallback succeeds.
+  sed 's/\$WORKER_PRIMARY/\$WORKER_FAIL/' "$TMP/routes.json" > "$TMP/routes-reroute.json"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-reroute.json" --target integration) || rc=$?
+  assert_contains "$out" "rerouted to opencode/kimi-k3"
+  assert_eq "$rc" "0"
+
+  # Both fail -> loud exit with actionable state left behind.
+  sed 's/\$WORKER_PRIMARY/\$WORKER_FAIL/; s/\$WORKER_FALLBACK/\$WORKER_FAIL/' \
+    "$TMP/routes.json" > "$TMP/routes-dead.json"
+  out=$(bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-dead.json" --target integration 2>&1) || rc=$?
+  # Both providers dead: loop exits loudly naming where actionable state lives.
+  assert_contains "$out" "rerouted worker also failed"
+  assert_contains "$out" "actionable state"
+  assert_eq "$rc" "4"
+
+  # A shape with NO remaining configured candidate says so explicitly.
+  cat > "$TMP/routes-single.json" <<'JSON'
+{"routes": {"bug-fix": [{"provider": "ollama", "model": "qwen2.5-coder:7b", "command": "$WORKER_PRIMARY"}]}}
+JSON
+  out=$(WORKER_PRIMARY=false bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-single.json" --target integration 2>&1) || rc=$?
+  assert_contains "$out" "no fallback left"
+  assert_eq "$rc" "4"
+}
+
+test_failing_verification_requeues_then_exhaustion_stays_visible() {
+  make_spec flaky '["src/app/widget.ts"]' "false" \
+    '[{"invariant":"tests pass","location":"tests/flaky.test.sh:1","severity":"HIGH"}]'
+  CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration >/dev/null 2>&1 || true
+  local out2 rc2=0
+  out2=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc2=$?
+  assert_contains "$out2" "retries EXHAUSTED"
+  assert_file_exists "$CEO_LOOP_STATE_ROOT/fixture-repo/exhausted.jsonl"
+  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/exhausted.jsonl")" "tests pass"
+}
+
+test_status_reports_state_without_touching_anything() {
+  make_spec st '["docs/note.md"]' "true" '[]'
+  bash "$LOOP" run --spec "$TMP/st.json" --routes "$TMP/routes.json" --target integration >/dev/null
+  local out
+  out=$(bash "$LOOP" status --repo fixture-repo)
+  assert_contains "$out" "repair-tickets"
+  assert_contains "$out" "telemetry"
+}
+
+run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -11,10 +11,19 @@ source ./ceo-loop-lib.sh
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-# Isolated state root — tests must not touch developer state (#317 class).
+# Isolated state root AND isolated shared ledger — tests must not touch
+# developer state anywhere (#317 class; test-writes-stay-in-the-fixture).
 CEO_LOOP_STATE_ROOT="$TMP/state"
 export CEO_LOOP_STATE_ROOT
+OLLAMA_AGENT_LEDGER="$TMP/ledger/runs.jsonl"
+export OLLAMA_AGENT_LEDGER
 LOOP="$LIB_DIR/ceo-loop.sh"
+
+REPO_N=0
+next_repo() { # unique slug per test so cases never share state
+  REPO_N=$((REPO_N + 1))
+  echo "repo-$REPO_N"
+}
 
 cat > "$TMP/routes.json" <<'JSON'
 {"routes": {"bug-fix": [
@@ -23,14 +32,22 @@ cat > "$TMP/routes.json" <<'JSON'
 ]}}
 JSON
 
-make_spec() { # <name> <files-json> <verify-cmd> <findings-json>
+# Test bodies run in subshells, so a shared counter cannot advance across
+# cases; slug off the unique spec name instead.
+make_spec() { # <name> <files-json> <verify-cmd> <findings-json> [repo-slug]
+  local repo="${5:-repo-$1}"
+  printf -v "SLUG_$1" '%s' "$repo"
   jq -n \
-    --arg repo "fixture-repo" --arg branch "nh/fixture-$1" --arg base "abc123" \
+    --arg repo "$repo" --arg branch "nh/fixture-$1" --arg base "abc123" \
     --argjson files "$2" --arg verify "$3" --arg author "ollama/qwen2.5-coder:7b" \
     --argjson reviewers '["opencode/kimi-k3"]' --argjson findings "$4" \
     '{repo: $repo, branch: $branch, base: $base, shape: "bug-fix",
       files: $files, verify_cmd: $verify, author: $author,
       reviewers: $reviewers, findings: $findings}' > "$TMP/$1.json"
+}
+state_of() { # <name>
+  local var="SLUG_$1"
+  echo "$CEO_LOOP_STATE_ROOT/${!var:-missing-slug}"
 }
 
 WORKER_PRIMARY="true"
@@ -46,12 +63,65 @@ test_e2e_happy_path_exercises_every_phase() {
   assert_contains "$out" "queued"
   assert_contains "$out" "isolated branch nh/fixture-ok"
   assert_contains "$out" "cross-provider reviewer opencode/kimi-k3"
-  assert_contains "$out" "done (fixture-repo/nh/fixture-ok risk=medium action=promote)"
+  assert_contains "$out" "done (repo-ok/nh/fixture-ok risk=medium action=promote)"
   assert_eq "$rc" "0"
-  # telemetry row written in the token-scope-ingestable contract
-  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/telemetry.jsonl")" '"writer":"ceo-loop"'
-  # ledger entry appended under the shared writer contract
-  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/telemetry.jsonl")" '"accepted":true'
+  # the queue write is a real row, not just an echo
+  assert_contains "$(cat "$(state_of ok)/queue.jsonl")" '"status":"queued"'
+  # telemetry row in the token-scope-ingestable contract, per-run findings count
+  local tel
+  tel="$(cat "$(state_of ok)/telemetry.jsonl")"
+  assert_contains "$tel" '"writer":"ceo-loop"'
+  assert_contains "$tel" '"accepted":true'
+  assert_contains "$tel" '"findings":1'
+  # shared-ledger entry actually landed (OLLAMA_AGENT_LEDGER points into TMP)
+  assert_contains "$(cat "$OLLAMA_AGENT_LEDGER")" 'loop:'
+  # worker slot was registered AND released by the loop itself
+  if grep -q "nh/fixture-ok" "$(state_of ok)/workers.jsonl"; then
+    fail_test "completed run must not keep its serialization slot"
+  fi
+}
+
+test_usage_error_exits_2() {
+  local out rc=0
+  out=$(bash "$LOOP" run --spec /nonexistent/x.json --routes "$TMP/routes.json" 2>&1) || rc=$?
+  assert_contains "$out" "spec not found"
+  assert_eq "$rc" "2"
+  # An empty-but-present spec must hit the required-field gate, not pass silently.
+  : > "$TMP/empty-spec.json"
+  out=$(bash "$LOOP" run --spec "$TMP/empty-spec.json" --routes "$TMP/routes.json" 2>&1) || rc=$?
+  assert_contains "$out" "missing required field"
+  assert_eq "$rc" "2"
+}
+
+test_spec_with_no_files_refuses_to_classify() {
+  jq -n --arg repo "repo-empty" --arg branch "nh/fixture-empty" --arg base abc \
+    --argjson files '[]' --arg verify true --arg author "ollama/q" \
+    --argjson reviewers '["opencode/k"]' --argjson findings '[]' \
+    '{repo:$repo,branch:$branch,base:$base,shape:"bug-fix",files:$files,
+      verify_cmd:$verify,author:$author,reviewers:$reviewers,findings:$findings}' > "$TMP/empty-files.json"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/empty-files.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
+  assert_contains "$out" "no changed files"
+  assert_eq "$rc" "2"
+}
+
+test_review_gate_failure_exits_5_e2e() {
+  make_spec sametier '["docs/a.md"]' "true" '[]'
+  jq '.author = "ollama/qwen" | .reviewers = ["ollama/qwen-turbo"]' "$TMP/sametier.json" > "$TMP/sametier2.json"
+  mv "$TMP/sametier2.json" "$TMP/sametier.json"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/sametier.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
+  assert_contains "$out" "review gate failed"
+  assert_eq "$rc" "5"
+}
+
+test_stale_base_stops_promotion_at_the_door() {
+  make_spec stalebase '["docs/b.md"]' "true" '[]'
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/stalebase.json" --routes "$TMP/routes.json" \
+    --target integration --current-base def456 2>&1) || rc=$?
+  assert_contains "$out" "STALE BASE"
+  assert_eq "$rc" "9"
 }
 
 test_high_risk_cannot_reach_production_main_without_premium_gate() {
@@ -63,11 +133,19 @@ test_high_risk_cannot_reach_production_main_without_premium_gate() {
   assert_eq "$rc" "7"
 }
 
-test_premium_approval_evidence_unlocks_production_main_for_high_risk() {
+test_premium_approval_requires_real_evidence_not_mere_existence() {
   make_spec approved '["hooks/pre-commit"]' "true" '[]'
-  : > "$TMP/premium-approval.md"
+  # An EMPTY file at the approval path must NOT unlock the gate.
+  : > "$TMP/empty-approval.md"
   local out rc=0
-  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/premium-approval.md" \
+  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/empty-approval.md" \
+    bash "$LOOP" run --spec "$TMP/approved.json" --routes "$TMP/routes.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "lacks evidence"
+  assert_eq "$rc" "7"
+
+  # Schema-carrying evidence does unlock it.
+  printf '%s\n' '{"approved_by":"nhangen","ticket":"CEO/approvals/premium-42"}' > "$TMP/premium-approval.json"
+  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/premium-approval.json" \
     bash "$LOOP" run --spec "$TMP/approved.json" --routes "$TMP/routes.json" --target main) || rc=$?
   assert_contains "$out" "action=promote"
 }
@@ -78,22 +156,45 @@ test_equivalent_findings_collapse_to_one_repair_ticket() {
       {"invariant":"null check","location":"lib/util.sh:4187","severity":"HIGH"}]'
   bash "$LOOP" run --spec "$TMP/dupes.json" --routes "$TMP/routes.json" --target integration >/dev/null
   local fp rows=0
-  fp=$(ceo_finding_fingerprint fixture-repo abc123 "null check" "lib/util.sh:120" "HIGH")
-  rows=$(grep -c "\"ticket_id\":\"repair-${fp:0:12}" "$CEO_LOOP_STATE_ROOT/fixture-repo/repair-tickets.jsonl" || true)
+  fp=$(ceo_finding_fingerprint repo-dupes abc123 "null check" "lib/util.sh:120" "HIGH")
+  rows=$(grep -c "\"ticket_id\":\"repair-${fp:0:12}" "$(state_of dupes)/repair-tickets.jsonl" || true)
   assert_eq "$rows" "1" "line-shifted equivalent must file ONE ticket"
 }
 
 test_overlapping_in_flight_worker_stops_the_loop_naming_conflict() {
-  make_spec first '["lib/util.sh"]' "true" '[]'
-  make_spec second '["lib/util.sh"]' "true" '[]'
+  # Same shared slug so the two workers contend on one registry.
+  make_spec first '["lib/util.sh"]' "true" '[]' repo-overlap
+  make_spec second '["lib/util.sh"]' "true" '[]' repo-overlap
   bash "$LOOP" run --spec "$TMP/first.json" --routes "$TMP/routes.json" --target integration >/dev/null
   # first worker is released on completion; simulate it still in flight:
   printf '%s\n' '{"branch":"nh/fixture-first","base":"abc123","files":["lib/util.sh"]}' \
-    >> "$CEO_LOOP_STATE_ROOT/fixture-repo/workers.jsonl"
+    >> "$(state_of first)/workers.jsonl"
   local out rc=0
   out=$(bash "$LOOP" run --spec "$TMP/second.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
   assert_contains "$out" "overlaps in-flight worker 'nh/fixture-first'"
   assert_eq "$rc" "6"
+}
+
+test_corrupt_workers_row_is_a_hard_stop_not_a_pass() {
+  make_spec corrupt '["lib/other.sh"]' "true" '[]'
+  mkdir -p "$(state_of corrupt)"
+  printf '%s\n' 'this is not json at all' >> "$(state_of corrupt)/workers.jsonl"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/corrupt.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
+  assert_contains "$out" "corrupt row"
+  assert_eq "$rc" "6"
+}
+
+test_finding_strings_with_quotes_survive_json_roundtrip() {
+  make_spec quotes '["src/app/widget.ts"]' "true" \
+    '[{"invariant":"handles \"null\" case","location":"src/app/widget.ts:12","severity":"HIGH"}]'
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/quotes.json" --routes "$TMP/routes.json" --target integration) || rc=$?
+  assert_eq "$rc" "0"
+  # findings.jsonl stays machine-readable after a quote-bearing finding
+  jq -e . "$(state_of quotes)/findings.jsonl" >/dev/null 2>&1 \
+    || fail_test "findings.jsonl corrupted by quoted strings"
+  assert_contains "$(cat "$(state_of quotes)/repair-tickets.jsonl")" 'null\" case'
 }
 
 test_provider_failure_reroutes_to_fallback_and_both_failing_is_loud() {
@@ -130,17 +231,28 @@ test_failing_verification_requeues_then_exhaustion_stays_visible() {
   local out2 rc2=0
   out2=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc2=$?
   assert_contains "$out2" "retries EXHAUSTED"
-  assert_file_exists "$CEO_LOOP_STATE_ROOT/fixture-repo/exhausted.jsonl"
-  assert_contains "$(cat "$CEO_LOOP_STATE_ROOT/fixture-repo/exhausted.jsonl")" "tests pass"
+  assert_eq "$rc2" "3" "exhaustion propagates as exit 3"
+  assert_file_exists "$(state_of flaky)/exhausted.jsonl"
+  assert_contains "$(cat "$(state_of flaky)/exhausted.jsonl")" "tests pass"
+  # exhaustion is recorded ONCE — a later cycle short-circuits on the marker
+  local before after
+  before=$(wc -l < "$(state_of flaky)/exhausted.jsonl")
+  CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration >/dev/null 2>&1 || true
+  after=$(wc -l < "$(state_of flaky)/exhausted.jsonl")
+  assert_eq "$after" "$before" "exhaustion rows must not multiply"
 }
 
 test_status_reports_state_without_touching_anything() {
   make_spec st '["docs/note.md"]' "true" '[]'
   bash "$LOOP" run --spec "$TMP/st.json" --routes "$TMP/routes.json" --target integration >/dev/null
-  local out
-  out=$(bash "$LOOP" status --repo fixture-repo)
+  local slug out
+  slug="$(state_of st)"
+  slug="${slug#$CEO_LOOP_STATE_ROOT/}"
+  out=$(bash "$LOOP" status --repo "$slug")
   assert_contains "$out" "repair-tickets"
   assert_contains "$out" "telemetry"
+  # content, not just headers: the run's ticket summary must be visible
+  assert_contains "$out" "$(jq -r '.summary // empty' <(head -1 "$CEO_LOOP_STATE_ROOT/$slug/repair-tickets.jsonl") 2>/dev/null || true)"
 }
 
 run_tests

--- a/scripts/ceo-risk-map.json
+++ b/scripts/ceo-risk-map.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Path-based risk classification for the #329 promotion gate. A changed path matches a rule ONLY if its repo-relative path matches match_pattern (case-insensitive regex). The HIGHEST risk among matching rules wins; no match means default_risk. Unlike ceo-tier-map.json this map FAILS CLOSED: an unreadable map or a broken lookup classifies as high, because the gate this feeds blocks production-main promotion. Add a rule only after reviewing that the path class really carries that blast radius (#254 owns the broader policy).",
+  "rules": [
+    { "name": "billing", "match_pattern": "(^|/)(billing|payments?|stripe|edd)/", "risk": "high" },
+    { "name": "authn-authz", "match_pattern": "(^|/)(auth|acl|permissions?|capabilities?)(/|\\.|-)", "risk": "high" },
+    { "name": "migrations", "match_pattern": "(^|/)migrations?/", "risk": "high" },
+    { "name": "credentials", "match_pattern": "(^|/)(credentials?|secrets?)(\\.|-|/)", "risk": "high" },
+    { "name": "shared-helpers", "match_pattern": "(^|/)(lib|shared|common)/.*\\.(sh|py|ts)$", "risk": "high" },
+    { "name": "hooks", "match_pattern": "(^|/)hooks/", "risk": "high" },
+    { "name": "ci-workflows", "match_pattern": "^\\.github/workflows/", "risk": "high" },
+    { "name": "tests", "match_pattern": "(^|/)tests?/", "risk": "low" },
+    { "name": "docs", "match_pattern": "\\.(md|txt)$", "risk": "low" }
+  ],
+  "default_risk": "medium"
+}


### PR DESCRIPTION
Closes #329. Integrates #252/#254/#283 capabilities without reimplementing their scopes.

**`scripts/ceo-loop-lib.sh`** — pure decisions:
- Path-based risk classification off curated `ceo-risk-map.json`; **fails closed to HIGH**
- Finding fingerprints = repo + base revision + invariant + line-normalized location + severity → line-shifted equivalents collapse to one repair ticket; a rebase reopens
- Provider-neutral route table per task shape; provider failure reroutes down the candidate list or exits 4 naming what died
- Review gate refuses panels where every reviewer shares the author's provider (#329: an author model cannot be its own only reviewer)
- In-flight worker registry serializes overlapping files and names the conflict; stale-base detection
- Bounded requeue with visible exhaustion (`exhausted.jsonl`, exit 3)

**`scripts/ceo-loop.sh`** — the driver: queue → isolated worker (overlap-checked) → tests → cross-provider review → dedup tickets → promotion gate (premium approval required for high-risk production-main; integration branch default until `CEO_LOOP_ALLOW_MAIN=1`) → bounded requeue → telemetry rows in the token-scope-ingestable contract + shared model ledger.

Acceptance criteria: all six covered by fixture arms in `ceo-loop.test.sh`; premium gate, review gate, base-binding fingerprint, and retry cap are mutation-verified. Full suite green (51 script suites + pytest 195). Worker/review commands come from the route table, so the e2e dry-run needs no providers.