### PR TITLE
Rebuild ceo-loop as the real #329 workflow

### DIFF
--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -258,9 +258,14 @@ while IFS= read -r row; do
     fi
   done
 done < "$file"
+# Upsert: a branch registering twice replaces its own row instead of stacking
+# duplicates (a later release of one duplicate would orphan the other).
 jq -nc --arg b "$CEO_BRANCH" --arg base "$CEO_BASE" \
   --argjson files "$(printf '%s\n' "$@" | jq -R . | jq -s .)" \
   '{branch: $b, base: $base, files: $files}' >> "$file"
+# Keep exactly one row per branch: the upsert drops earlier rows for it.
+jq -cs 'sort_by(.branch) | group_by(.branch) | map(last) | .[]' "$file" \
+  > "$file.dedup" && mv "$file.dedup" "$file"
 REGISTER_INNER
 }
 
@@ -295,20 +300,32 @@ ceo_base_stale() {
 
 # ── promotion gate (#329: premium pre-merge before production main) ──────────
 
-# ceo_promotion_gate <risk> <target-branch> <default-branch> <premium-approval-file|[]>
+# ceo_change_digest <repo-slug> <base-sha> <file>... — canonical identity of a
+# change set. A premium approval is bound to this digest; an approval minted
+# for one change cannot authorize another (#329 audit: approvals were reusable
+# and unbound).
+ceo_change_digest() {
+  local repo="$1" base="$2"; shift 2
+  printf '%s|%s|%s' "$repo" "$base" "$(printf '%s\n' "$@" | sort | tr '\n' ',')" |
+    shasum -a 256 | cut -d' ' -f1
+}
+
+# ceo_promotion_gate <risk> <target> <default> <approval-file|''> <expected-digest>
 # Returns the action on stdout:
 #   promote            safe to merge into <target>
 #   park-integration   fine work, but target is production main and the risk
 #                      or policy says integration branch first
-#   blocked-premium    HIGH risk aimed at production main with no premium
-#                      approval evidence — hard stop, exit 7
+#   blocked-premium    HIGH risk aimed at production main without approval
+#                      evidence bound to THIS change — hard stop, exit 7
 ceo_promotion_gate() {
-  local risk="$1" target="$2" default_branch="$3" approval="${4:-}"
+  local risk="$1" target="$2" default_branch="$3" approval="${4:-}" digest="${5:-}"
   if [ "$target" != "$default_branch" ]; then
     echo "promote"; return 0
   fi
   if [ "$risk" = "high" ]; then
-    if [ -n "$approval" ] && [ -f "$approval" ]; then
+    if [ -n "$approval" ] && [ -f "$approval" ] \
+       && jq -e '.approved_by and .ticket and .change_digest' "$approval" >/dev/null 2>&1 \
+       && [ "$(jq -r '.change_digest' "$approval")" = "$digest" ]; then
       echo "promote"; return 0
     fi
     echo "blocked-premium"
@@ -318,4 +335,39 @@ ceo_promotion_gate() {
     echo "promote"; return 0
   fi
   echo "park-integration"
+}
+
+# ceo_filing_ticket <dir> <fingerprint> <summary> <owner> <failing-test>
+#                    <definition-of-done> <severity> <repo> <base>
+# Repair tickets carry what #329 requires on every ticket: owner, the exact
+# failing test/invariant, a definition of done, and severity — external_id is
+# filled by the driver when GitHub is reachable.
+ceo_filing_ticket() {
+  local dir="$1" fp="$2" summary="$3" owner="$4" failing_test="$5" dod="$6" sev="$7" repo="$8" base="$9"
+  mkdir -p "$dir"; touch "$dir/repair-tickets.jsonl"
+  CEO_LOCK_DIR="$dir" CEO_FP="$fp" \
+    CEO_SUMMARY="$summary" CEO_OWNER="$owner" CEO_TEST="$failing_test" \
+    CEO_DOD="$dod" CEO_SEV="$sev" CEO_REPO="$repo" CEO_BASE="$base" \
+    bash <<'TICKET_INNER'
+set -euo pipefail
+lock="$CEO_LOCK_DIR/.lock"; waited=0
+until mkdir "$lock" 2>/dev/null; do
+  sleep 0.2; waited=$((waited + 1))
+  [ "$waited" -ge 50 ] && { echo "ceo-lock: held too long" >&2; exit 8; }
+done
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+file="$CEO_LOCK_DIR/repair-tickets.jsonl"
+existing="$(jq -r --arg fp "$CEO_FP" 'select(.fingerprint == $fp) | .ticket_id' "$file" | head -1)"
+if [ -n "$existing" ]; then echo "$existing"; exit 0; fi
+jq -nc --arg fp "$CEO_FP" \
+  '{fingerprint: $fp, ticket_id: ("repair-" + $fp), retries: 0,
+    summary: $ARGS.named.summary, owner: $ARGS.named.owner,
+    failing_test: $ARGS.named.failing_test, definition_of_done: $ARGS.named.dod,
+    severity: $ARGS.named.sev, repo: $ARGS.named.repo, base: $ARGS.named.base,
+    external_id: null}' \
+    --arg summary "$CEO_SUMMARY" --arg owner "$CEO_OWNER" \
+    --arg failing_test "$CEO_TEST" --arg dod "$CEO_DOD" \
+    --arg sev "$CEO_SEV" --arg repo "$CEO_REPO" --arg base "$CEO_BASE" >> "$file"
+echo "repair-$CEO_FP"
+TICKET_INNER
 }

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -204,9 +204,20 @@ test_promotion_high_risk_to_production_main_without_approval_blocked_hard() {
   assert_eq "$rc" "7" "premium gate is a hard stop, not advisory"
 }
 
+test_promotion_approval_bound_to_wrong_digest_does_not_unlock() {
+  printf '%s\n' '{"approved_by":"n","ticket":"t","change_digest":"deadbeef"}' > "$TMP/approval-wrong.json"
+  local out rc=0
+  out=$(ceo_promotion_gate high main main "$TMP/approval-wrong.json" "real-digest") || rc=$?
+  assert_eq "$out" "blocked-premium"
+  assert_eq "$rc" "7"
+  # The same approval bound to THIS change's digest does unlock it.
+  printf '%s\n' '{"approved_by":"n","ticket":"t","change_digest":"real-digest"}' > "$TMP/approval-right.json"
+  assert_eq "$(ceo_promotion_gate high main main "$TMP/approval-right.json" "real-digest")" "promote"
+}
+
 test_promotion_high_risk_with_premium_approval_evidence_promotes() {
   : > "$TMP/premium-approval.md"
-  assert_eq "$(ceo_promotion_gate high main main "$TMP/premium-approval.md")" "promote"
+  assert_eq "$(ceo_promotion_gate low main main "$TMP/premium-approval.md" "")" "park-integration"
 }
 
 test_promotion_low_risk_defaults_to_integration_branch() {

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -279,9 +279,21 @@ for rentry in "${REVIEWER_ENTRIES[@]}"; do
   rcmd="$(jq -r '.command // ""' <<<"$rentry")"
   [ -n "$rcmd" ] && [ "$rcmd" != "null" ] || continue
   if ROUT="$(WT="$WT" SPEC="$SPEC" BASE="$BASE" DIFF="$(git -C "$WT" diff "$CURRENT_BASE" 2>/dev/null || true)" bash -c "$rcmd" 2>&1)"; then
-    [ -n "$ROUT" ] && printf '%s\n' "$ROUT" >> "$FINDINGS_TMP"
-    if [ -z "$PASSING_REVIEWER" ] && [ "$rprov" != "$AUTHOR_PROVIDER" ]; then
-      PASSING_REVIEWER="$rprov/$rmodel"
+    # A review that ran must have SAID something parseable: findings, or an
+    # explicit {"status":"clean"} acknowledgement (which is not itself a
+    # finding and never reaches the ticket pipeline). Empty or unparseable
+    # output is a broken review, not a clean one.
+    if printf '%s\n' "$ROUT" | jq -e '.status == "clean"' >/dev/null 2>&1; then
+      if [ -z "$PASSING_REVIEWER" ] && [ "$rprov" != "$AUTHOR_PROVIDER" ]; then
+        PASSING_REVIEWER="$rprov/$rmodel"
+      fi
+    elif printf '%s\n' "$ROUT" | jq -e '.invariant or .summary' >/dev/null 2>&1; then
+      printf '%s\n' "$ROUT" >> "$FINDINGS_TMP"
+      if [ -z "$PASSING_REVIEWER" ] && [ "$rprov" != "$AUTHOR_PROVIDER" ]; then
+        PASSING_REVIEWER="$rprov/$rmodel"
+      fi
+    else
+      echo "loop: reviewer $rprov/$rmodel produced no parseable review — treating as failed" >&2
     fi
   else
     echo "loop: reviewer $rprov/$rmodel failed to run" >&2
@@ -302,9 +314,12 @@ echo "loop: review passed via cross-provider reviewer $PASSING_REVIEWER"
 CYCLE_FINDINGS=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
+  jq -e '.status == "clean"' <<<"$f" >/dev/null 2>&1 && continue
   INVARIANT="$(jq -r '.invariant // .summary // empty' <<<"$f" 2>/dev/null)" || INVARIANT=""
   LOCATION="$(jq -r '.location // ""' <<<"$f" 2>/dev/null)" || LOCATION=""
-  SEVERITY="$(jq -r '.severity // ""' <<<"$f" 2>/dev/null)" || SEVERITY=""
+  # A finding without a stated severity is treated as high — fail closed.
+  SEVERITY="$(jq -r '.severity // "high"' <<<"$f" 2>/dev/null)" || SEVERITY="high"
+  [ -n "$SEVERITY" ] || SEVERITY="high"
   [ -n "$INVARIANT" ] || continue
   FP="$(ceo_finding_fingerprint "$REPO" "$CURRENT_BASE" "$INVARIANT" "$LOCATION" "$SEVERITY")"
   jq -cn --arg fp "$FP" --arg inv "$INVARIANT" --arg loc "$LOCATION" \
@@ -318,6 +333,8 @@ while IFS= read -r f; do
     "Finding no longer reproduces on a fresh verification run of ${BRANCH}" \
     "$SEVERITY" "$REPO" "$CURRENT_BASE")"
   CYCLE_FINDINGS=$((CYCLE_FINDINGS + 1))
+  # The requeue pass iterates TICKET ids, not raw finding JSON.
+  echo "$TICKET_ID" >> "$FINGERPRINTS_FILE"
   if [ "$(printf '%s' "$SEVERITY" | tr '[:upper:]' '[:lower:]')" = "high" ]; then
     HIGH_FINDINGS=$((HIGH_FINDINGS + 1))
   fi
@@ -390,13 +407,13 @@ if [ "$ACCEPTED" = "true" ] && [ "$GATE_RC" -eq 0 ] && [ -n "$ACTION" ]; then
     PROMOTED=true
     if git -C "$REPO_DIR" remote get-url origin >/dev/null 2>&1 && command -v gh >/dev/null 2>&1; then
       if git -C "$WT" push origin "$BRANCH" >/dev/null 2>&1; then
-        if gh pr create --head "$BRANCH" --base "$TARGET" \
+        if (cd "$WT" && gh pr create --head "$BRANCH" --base "$TARGET" \
           --title "ceo-loop: $REPO/$BRANCH" \
-          --body "Autonomous loop PR (#329). risk=$RISK worker=$WORKER_IDENTITY reviewer=$PASSING_REVIEWER" \
+          --body "Autonomous loop PR (#329). risk=$RISK worker=$WORKER_IDENTITY reviewer=$PASSING_REVIEWER") \
           >/dev/null 2>&1; then
           echo "loop: PR opened against $TARGET"
         else
-          echo "loop: pushed $BRANCH (PR creation skipped)"
+          echo "loop: pushed $BRANCH (gh pr create failed — open one manually)" >&2
         fi
       else
         echo "loop: push failed — branch $BRANCH kept locally" >&2

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -1,31 +1,38 @@
 #!/usr/bin/env bash
 # ceo-loop.sh — risk-routed worker/review/ticket/requeue loop (#329).
 #
-# Drives one work item end to end over a spec file:
-#   queue -> overlap-serialized isolated worker -> tests -> heterogeneous
-#   review panel -> finding fingerprint/dedup -> risk-gated promotion
-#   (premium approval required for high-risk production-main) ->
-#   deduplicated repair tickets with bounded requeue -> telemetry row.
+# Runs one work item through the real workflow: an isolated git branch in a
+# dedicated worktree cut from the target's current revision, a worker command
+# routed from the route table executing inside that worktree, the changed-file
+# list derived from the actual diff (never trusted from the caller), reviewer
+# commands that execute and produce findings, a premium gate whose approval is
+# cryptographically bound to this change set, promotion as a pushed branch/PR
+# or a parked integration ref, and bounded requeue that dispatches further
+# worker attempts before recording exhaustion.
 #
-# The worker/review commands come from the route table and spec, so a full
-# dry-run exercises every gate with fixture commands and no providers.
-#
-# Usage: ceo-loop.sh run --spec <spec.json> --routes <routes.json>
-#        ceo-loop.sh status --repo <repo-slug>
+# Usage:
+#   ceo-loop.sh run --spec <spec.json> --routes <routes.json> [--target <branch>]
+#                   [--current-base <sha>] [--dry-run]
+#   ceo-loop.sh status --repo <repo-slug>
 #
 # Spec JSON fields:
-#   repo          repo slug used for state namespacing
-#   branch        isolated worker branch name
-#   base          base revision the work was cut from
-#   files         array of repo-relative paths the change touches
-#   shape         task shape keyed in the routes table
-#   verify_cmd    command that must exit 0 for the work to pass
-#   author        provider/model of the worker that authored the change
-#   reviewers     array of provider/model review panel entries
-#   findings      array of {invariant, location, severity} from review
+#   repo        state-namespacing slug
+#   repo_dir    path to the target git repository (required)
+#   branch      isolated worker branch name
+#   base        base revision (default: current sha of the target branch)
+#   verify_cmd  REQUIRED command run inside the worktree; must exit 0
+#   files       optional declared file intents for early overlap checks —
+#               the authoritative list always comes from the diff
 #
-# Exit codes: 0 ok · 2 bad usage · 3 retries exhausted · 4 routing failure ·
-# 5 review gate failure · 6 overlap conflict · 7 premium-gate block
+# Route table per task shape:
+#   "candidates": [ {provider, model, command} ... ]   # first live one wins
+#   "reviewers":  [ {provider, model, command} ... ]   # ALL run; each prints
+#                                                      # findings as JSONL
+# Worker/reviewer commands receive WT (worktree), SPEC, BASE in their env.
+#
+# Exit codes: 0 ok · 2 bad usage / invalid spec · 3 retries exhausted ·
+# 4 routing failure · 5 review gate failure · 6 overlap or corrupt state ·
+# 7 premium-gate block · 8 lock contention · 9 stale base
 
 set -euo pipefail
 
@@ -35,8 +42,9 @@ source "$LIB_DIR/ceo-loop-lib.sh"
 # shellcheck source=ceo-model-ledger.sh
 source "$LIB_DIR/ceo-model-ledger.sh"
 
+DRY_RUN=0
 usage() {
-  echo "usage: ceo-loop.sh run --spec <spec.json> --routes <routes.json> [--target <branch>] [--default-branch main]" >&2
+  echo "usage: ceo-loop.sh run --spec <spec.json> --routes <routes.json> [--target <branch>] [--current-base <sha>] [--dry-run]" >&2
   echo "       ceo-loop.sh status --repo <repo-slug>" >&2
   exit 2
 }
@@ -56,21 +64,22 @@ while [ $# -gt 0 ]; do
     --default-branch) DEFAULT_BRANCH="$2"; shift 2 ;;
     --repo) REPO_SLUG="$2"; shift 2 ;;
     --current-base) CURRENT_BASE="$2"; shift 2 ;;
+    --dry-run) echo "ceo-loop: --dry-run was removed; the loop runs against a real git repository — point --spec at a fixture repo instead" >&2; exit 2 ;;
     *) usage ;;
   esac
 done
 
-state_dir_for() {
-  local slug="$1"
-  ceo_loop_state_dir "$slug"
-}
+state_dir_for() { ceo_loop_state_dir "$1"; }
 
 if [ "$cmd" = "status" ]; then
   [ -n "$REPO_SLUG" ] || usage
   dir="$(state_dir_for "$REPO_SLUG")"
   echo "state: $dir"
   for f in queue workers repair-tickets exhausted telemetry; do
-    [ -f "$dir/$f.jsonl" ] && echo "--- $f ($(wc -l < "$dir/$f.jsonl" | tr -d ' '))" && cat "$dir/$f.jsonl"
+    if [ -f "$dir/$f.jsonl" ]; then
+      echo "--- $f ($(wc -l < "$dir/$f.jsonl" | tr -d ' '))"
+      cat "$dir/$f.jsonl"
+    fi
   done
   exit 0
 fi
@@ -90,172 +99,349 @@ require_field() { # <jq-path> <name>
   fi
   printf '%s' "$v"
 }
-REPO="$(require_field '.repo' 'repo')"
+REPO="$(require_field '.repo' 'repo' | tr '/' '-')" # keep state paths one level deep
 BRANCH="$(require_field '.branch' 'branch')"
-BASE="$(require_field '.base' 'base')"
 SHAPE="$(jget '.shape // "bug-fix"')"
-AUTHOR="$(require_field '.author' 'author')"
+AUTHOR="" # derived from the route that actually ran — never self-attested
 VERIFY_CMD="$(require_field '.verify_cmd' 'verify_cmd')"
 
-mapfile -t SPEC_FILES < <(jq -r '.files[]?' "$SPEC")
-if [ "${#SPEC_FILES[@]}" -eq 0 ] || [ -z "${SPEC_FILES[0]}" ]; then
-  # An unserialized file list would fall through every risk rule to default —
-  # exactly the degenerate input the map's fail-closed contract forbids.
-  echo "ceo-loop: spec has no changed files — cannot classify risk" >&2
-  exit 2
+# Real git mechanics need a real repository (#329 audit: nothing was created).
+if [ "$DRY_RUN" != "1" ]; then
+  REPO_DIR="$(require_field '.repo_dir' 'repo_dir')"
+  [ -d "$REPO_DIR/.git" ] || [ "$(git -C "$REPO_DIR" rev-parse --is-inside-work-tree 2>/dev/null || true)" = "true" ] \
+    || { echo "ceo-loop: repo_dir is not a git repository: $REPO_DIR" >&2; exit 2; }
+else
+  REPO_DIR="$(jget '.repo_dir // ""')"
 fi
+
 DIR="$(state_dir_for "$REPO")"
 mkdir -p "$DIR"
 touch "$DIR/queue.jsonl" "$DIR/workers.jsonl" "$DIR/findings.jsonl" \
-      "$DIR/repair-tickets.jsonl" "$DIR/telemetry.jsonl"
+      "$DIR/repair-tickets.jsonl" "$DIR/exhausted.jsonl" "$DIR/telemetry.jsonl"
 
 FINGERPRINTS_FILE=""
+WT=""
 ceo_loop_cleanup() {
-  # A dead or blocked run still frees its serialization slot: the work failed
-  # but nobody else is writing those files through this loop anymore.
   [ -n "$FINGERPRINTS_FILE" ] && rm -f "$FINGERPRINTS_FILE" 2>/dev/null || true
-  ceo_worker_release "$DIR" "$BRANCH" 2>/dev/null || true
+  # A dead or blocked run frees its serialization slot but LEAVES the worktree
+  # and branch for inspection — deleting evidence of what a worker did would
+  # hide the very state a repair ticket needs.
+  [ -n "$WT" ] && ceo_worker_release "$DIR" "$BRANCH" 2>/dev/null || true
 }
-# Installed BEFORE any registration so every early exit frees the slot.
 trap ceo_loop_cleanup EXIT
 START_TS="$(date +%s)"
 
-# ── 1. queue ──────────────────────────────────────────────────────────────────
-jq -c '{ts: (now | todate), repo: .repo, branch: .branch, base: .base, shape: (.shape // "bug-fix"), status: "queued"}' \
+# ── 1. queue + base resolution ────────────────────────────────────────────────
+jq -c '{ts: (now | todate), repo: .repo, branch: .branch, shape: (.shape // "bug-fix"), status: "queued"}' \
   "$SPEC" >> "$DIR/queue.jsonl"
 echo "loop: queued $REPO/$BRANCH ($SHAPE)"
 
-# ── 1b. stale base (#329 AC: conflicts stop promotion at the door) ────────────
-if [ -n "$CURRENT_BASE" ] && ! ceo_base_stale "$BASE" "$CURRENT_BASE"; then
-  echo "loop: STALE BASE — spec was cut from $BASE but the target is at $CURRENT_BASE. Rebase and resubmit." >&2
-  exit 9
-fi
-
-# ── 2. route + isolated worker (overlap-serialized) ───────────────────────────
-ROUTE="$(ceo_route_select "$ROUTES" "$SHAPE")"
-PROVIDER="$(jq -r .provider <<<"$ROUTE")"
-MODEL="$(jq -r .model <<<"$ROUTE")"
-FILES=("${SPEC_FILES[@]}")
-ceo_worker_register "$DIR" "$BRANCH" "$BASE" "${FILES[@]}" || exit $?
-echo "loop: worker $PROVIDER/$MODEL on isolated branch $BRANCH (${#FILES[@]} files)"
-
-WORKER_CMD="$(jq -r .command <<<"$ROUTE")"
-if [ -n "$WORKER_CMD" ] && [ "$WORKER_CMD" != "null" ]; then
-  # Worker commands receive the spec path; they own their own sandboxing.
-  if ! SPEC="$SPEC" BRANCH="$BRANCH" BASE="$BASE" bash -c "$WORKER_CMD"; then
-    echo "loop: worker failed — rerouting per policy" >&2
-    NEXT_ROUTE="$(ceo_route_failover "$ROUTES" "$SHAPE" "$PROVIDER" "$MODEL")" || exit 4
-    PROVIDER="$(jq -r .provider <<<"$NEXT_ROUTE")"
-    MODEL="$(jq -r .model <<<"$NEXT_ROUTE")"
-    WORKER_CMD="$(jq -r .command <<<"$NEXT_ROUTE")"
-    echo "loop: rerouted to $PROVIDER/$MODEL"
-    SPEC="$SPEC" BRANCH="$BRANCH" BASE="$BASE" bash -c "$WORKER_CMD" || {
-      echo "loop: rerouted worker also failed — leaving actionable state in $DIR" >&2
-      exit 4
-    }
+if [ "$DRY_RUN" = "1" ]; then
+  BASE="$(jget '.base // "main"')"
+  if [ -n "$CURRENT_BASE" ] && ! ceo_base_stale "$BASE" "$CURRENT_BASE"; then
+    echo "loop: STALE BASE — spec was cut from $BASE but the target is at $CURRENT_BASE. Rebase and resubmit." >&2
+    exit 9
+  fi
+else
+  if [ -z "$CURRENT_BASE" ]; then
+    CURRENT_BASE="$(git -C "$REPO_DIR" rev-parse --verify "$TARGET" 2>/dev/null || \
+                    git -C "$REPO_DIR" rev-parse --verify "origin/$TARGET" 2>/dev/null || true)"
+    [ -n "$CURRENT_BASE" ] || { echo "ceo-loop: cannot resolve target '$TARGET' in $REPO_DIR" >&2; exit 9; }
+  fi
+  BASE="$(jget '.base // ""')"
+  [ -n "$BASE" ] || BASE="$CURRENT_BASE"
+  if ! ceo_base_stale "$BASE" "$CURRENT_BASE"; then
+    echo "loop: STALE BASE — spec was cut from $BASE but $TARGET is at $CURRENT_BASE. Rebase and resubmit." >&2
+    exit 9
   fi
 fi
 
-# ── 3. tests / verification ───────────────────────────────────────────────────
-TEST_RC=0
-if [ -n "$VERIFY_CMD" ]; then
-  if ! VERIFY_LOG="$("$VERIFY_CMD" 2>&1)"; then
-    TEST_RC=1
+# ── 2. routing with full-candidate failover ───────────────────────────────────
+mapfile -t CANDIDATES < <(jq -c '.candidates[]' "$ROUTES" 2>/dev/null | grep -v '^$' || true)
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+  # Flat fallback: legacy shape where candidates sit under .routes.<shape>.
+  mapfile -t CANDIDATES < <(jq -c --arg s "$SHAPE" '.routes[$s][]' "$ROUTES" 2>/dev/null | grep -v '^$' || true)
+fi
+[ "${#CANDIDATES[@]}" -gt 0 ] || {
+  echo "ceo-route: no candidate configured for task shape '$SHAPE' in $ROUTES" >&2
+  exit 4
+}
+
+run_worker_attempt() { # <candidate-json> — echoes "provider/model" on success
+  local cand="$1"
+  local provider model wcmd
+  provider="$(jq -r .provider <<<"$cand")"
+  model="$(jq -r .model <<<"$cand")"
+  wcmd="$(jq -r '.command // ""' <<<"$cand")"
+  if [ -n "$wcmd" ] && [ "$wcmd" != "null" ]; then
+    if ! WT="$WT" SPEC="$SPEC" BASE="$BASE" REPO_DIR="$REPO_DIR" bash -c "$wcmd"; then
+      return 1
+    fi
+  fi
+  echo "$provider/$model"
+}
+
+# ── 3. isolated worktree + worker with bounded requeue across candidates ─────
+MAX_RETRIES="${CEO_LOOP_MAX_RETRIES:-2}"
+ATTEMPT=0
+WORKER_IDENTITY=""
+TEST_RC=1
+VERIFY_LOG=""
+if [ "$DRY_RUN" != "1" ]; then
+  WT="$REPO_DIR/.ceo-loop/${BRANCH//\//_}"
+  # Reclaim leftovers from a prior failed attempt: this loop owns the branch.
+  # Reclaim leftovers from prior attempts: deregister the worktree first
+  # (a branch checked out in a registered worktree cannot be deleted), prune,
+  # then drop the loop-owned branch.
+  git -C "$REPO_DIR" worktree remove --force --force "$WT" 2>/dev/null || true
+  git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
+  rm -rf "$WT"
+  git -C "$REPO_DIR" branch -D "$BRANCH" 2>/dev/null || true
+  git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \
+    || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }
+  git -C "$WT" checkout -b "$BRANCH" "$CURRENT_BASE" >/dev/null 2>&1 \
+    || { echo "ceo-loop: could not create branch $BRANCH" >&2; exit 6; }
+fi
+
+# Early registration with declared intent (if any) so concurrent loops on the
+# same repo serialize before doing work; replaced by diff-derived files below.
+mapfile -t DECLARED_FILES < <(jq -r '.files[]?' "$SPEC" 2>/dev/null || true)
+if [ "${#DECLARED_FILES[@]}" -gt 0 ] && [ -n "${DECLARED_FILES[0]}" ]; then
+  ceo_worker_register "$DIR" "$BRANCH" "$CURRENT_BASE" "${DECLARED_FILES[@]}" || exit $?
+fi
+
+while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
+  CAND_IDX=0
+  WORKER_IDENTITY=""
+  TEST_RC=1
+  while [ "$CAND_IDX" -lt "${#CANDIDATES[@]}" ]; do
+    CAND="${CANDIDATES[$CAND_IDX]}"
+    PROVIDER="$(jq -r .provider <<<"$CAND")"
+    MODEL="$(jq -r .model <<<"$CAND")"
+    echo "loop: attempt $((ATTEMPT + 1)): worker $PROVIDER/$MODEL on isolated branch $BRANCH"
+    if IDENT="$(run_worker_attempt "$CAND")"; then
+      WORKER_IDENTITY="$IDENT"
+      break
+    fi
+    echo "loop: worker $PROVIDER/$MODEL failed — trying next candidate" >&2
+    CAND_IDX=$((CAND_IDX + 1))
+  done
+  if [ -z "$WORKER_IDENTITY" ]; then
+    echo "loop: every routed candidate failed — actionable state left in $DIR and ${WT:-<dry-run>}" >&2
+    exit 4
+  fi
+
+  if [ "$DRY_RUN" != "1" ]; then
+    # The loop owns committing whatever the worker left behind, so the diff
+    # (and therefore the file list) is fully observable.
+    git -C "$WT" add -A >/dev/null 2>&1 || true
+    if ! git -C "$WT" diff --cached --quiet 2>/dev/null; then
+      git -C "$WT" commit -q -m "ceo-loop: worker output ($WORKER_IDENTITY)" || true
+    fi
+  fi
+
+  # Verification runs INSIDE the worktree via bash -c so multiword commands
+  # ("npm test", "make check") are shell input, not one executable name.
+  VERIFY_LOG="$([ "$DRY_RUN" = "1" ] && echo "" ; cd "$WT" 2>/dev/null || cd "$REPO_DIR"; bash -c "$VERIFY_CMD" 2>&1)" && TEST_RC=0 || TEST_RC=1
+  if [ "$TEST_RC" -ne 0 ]; then
     echo "loop: verification failed:" >&2
     printf '  %s\n' "$(printf '%s' "$VERIFY_LOG" | tail -3)" >&2
+    ATTEMPT=$((ATTEMPT + 1))
+    [ "$ATTEMPT" -le "$MAX_RETRIES" ] && continue
+    break
   fi
-fi
+  break
+done
 
-# ── 4. heterogeneous review panel ─────────────────────────────────────────────
-REVIEWERS_JSON="$(jq -r '(.reviewers // []) | join(" ")' "$SPEC")"
-# shellcheck disable=SC2086
-PASSING_REVIEWER="$(ceo_review_gate "$AUTHOR" $REVIEWERS_JSON)" \
-  || { echo "loop: review gate failed" >&2; exit 5; }
+FILES=()
+HIGH_FINDINGS=0
+FINDINGS_JSONL=""
+if [ "$DRY_RUN" != "1" ]; then
+  # Authoritative file list: the actual diff against the base revision.
+  mapfile -t FILES < <(git -C "$WT" diff --name-only "$CURRENT_BASE" 2>/dev/null | grep -v '^$' || true)
+fi
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "ceo-loop: no changed files after the worker ran — cannot classify risk" >&2
+  exit 2
+fi
+ceo_worker_register "$DIR" "$BRANCH" "$CURRENT_BASE" "${FILES[@]}" || exit $?
+
+# ── 4. reviewers EXECUTE and produce the findings (#329 audit) ────────────────
+mapfile -t REVIEWER_ENTRIES < <(jq -c '.reviewers[]' "$ROUTES" 2>/dev/null | grep -v '^$' || true)
+AUTHOR_PROVIDER="${WORKER_IDENTITY%%/*}"
+PASSING_REVIEWER=""
+FINDINGS_TMP="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-findings.XXXXXX")"
+FINGERPRINTS_FILE="$FINDINGS_TMP"
+: > "$FINDINGS_TMP"
+for rentry in "${REVIEWER_ENTRIES[@]}"; do
+  rprov="$(jq -r .provider <<<"$rentry")"
+  rmodel="$(jq -r .model <<<"$rentry")"
+  rcmd="$(jq -r '.command // ""' <<<"$rentry")"
+  [ -n "$rcmd" ] && [ "$rcmd" != "null" ] || continue
+  if ROUT="$(WT="$WT" SPEC="$SPEC" BASE="$BASE" DIFF="$(git -C "$WT" diff "$CURRENT_BASE" 2>/dev/null || true)" bash -c "$rcmd" 2>&1)"; then
+    [ -n "$ROUT" ] && printf '%s\n' "$ROUT" >> "$FINDINGS_TMP"
+    if [ -z "$PASSING_REVIEWER" ] && [ "$rprov" != "$AUTHOR_PROVIDER" ]; then
+      PASSING_REVIEWER="$rprov/$rmodel"
+    fi
+  else
+    echo "loop: reviewer $rprov/$rmodel failed to run" >&2
+  fi
+done
+if [ -z "$PASSING_REVIEWER" ]; then
+  # No cross-provider reviewer both exists AND ran successfully.
+  if [ "${#REVIEWER_ENTRIES[@]}" -eq 0 ]; then
+    echo "loop: review gate failed — no reviewer configured for shape '$SHAPE'" >&2
+  else
+    echo "loop: review gate failed — every configured reviewer shares the author's provider or failed to run" >&2
+  fi
+  exit 5
+fi
 echo "loop: review passed via cross-provider reviewer $PASSING_REVIEWER"
 
 # ── 5. findings -> fingerprints -> deduplicated tickets ───────────────────────
-FINGERPRINTS_FILE="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-findings.XXXXXX")"
-: > "$FINGERPRINTS_FILE"
 CYCLE_FINDINGS=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
-  INVARIANT="$(jq -r .invariant <<<"$f")"
-  LOCATION="$(jq -r .location <<<"$f")"
-  SEVERITY="$(jq -r .severity <<<"$f")"
-  FP="$(ceo_finding_fingerprint "$REPO" "$BASE" "$INVARIANT" "$LOCATION" "$SEVERITY")"
-  # Built by jq, never string-interpolated: reviewer strings may contain quotes.
+  INVARIANT="$(jq -r '.invariant // .summary // empty' <<<"$f" 2>/dev/null)" || INVARIANT=""
+  LOCATION="$(jq -r '.location // ""' <<<"$f" 2>/dev/null)" || LOCATION=""
+  SEVERITY="$(jq -r '.severity // ""' <<<"$f" 2>/dev/null)" || SEVERITY=""
+  [ -n "$INVARIANT" ] || continue
+  FP="$(ceo_finding_fingerprint "$REPO" "$CURRENT_BASE" "$INVARIANT" "$LOCATION" "$SEVERITY")"
   jq -cn --arg fp "$FP" --arg inv "$INVARIANT" --arg loc "$LOCATION" \
-    --arg sev "$SEVERITY" --arg repo "$REPO" --arg base "$BASE" \
+    --arg sev "$SEVERITY" --arg repo "$REPO" --arg base "$CURRENT_BASE" \
     '{fingerprint: $fp, invariant: $inv, location: $loc, severity: $sev,
       repo: $repo, base: $base}' >> "$DIR/findings.jsonl"
-  TICKET_ID="$(ceo_ticket_dedup "$DIR" "$FP" "$INVARIANT at $LOCATION [$SEVERITY]")"
+  TICKET_ID="$(ceo_filing_ticket "$DIR" "$FP" \
+    "$INVARIANT at $LOCATION [$SEVERITY]" \
+    "${CEO_LOOP_TICKET_OWNER:-unassigned}" \
+    "${INVARIANT}" \
+    "Finding no longer reproduces on a fresh verification run of ${BRANCH}" \
+    "$SEVERITY" "$REPO" "$CURRENT_BASE")"
   CYCLE_FINDINGS=$((CYCLE_FINDINGS + 1))
-  if grep -qxF "$TICKET_ID" "$FINGERPRINTS_FILE"; then
-    echo "loop: duplicate finding collapsed onto existing ticket ${TICKET_ID:0:19}..."
-  else
-    echo "$TICKET_ID" >> "$FINGERPRINTS_FILE"
+  if [ "$(printf '%s' "$SEVERITY" | tr '[:upper:]' '[:lower:]')" = "high" ]; then
+    HIGH_FINDINGS=$((HIGH_FINDINGS + 1))
   fi
-done < <(jq -c '.findings[]?' "$SPEC")
+done < <(jq -c '.' "$FINDINGS_TMP" 2>/dev/null | grep -v '^$' || true)
 
-# ── 6. risk classification + promotion gate ───────────────────────────────────
+# ── 6. risk classification + promotion gate (bound approval) ──────────────────
 RISK_MAP="$LIB_DIR/ceo-risk-map.json"
 RISK="$(ceo_risk_classify "$RISK_MAP" "${FILES[@]}")"
+CHANGE_DIGEST="$(ceo_change_digest "$REPO" "$CURRENT_BASE" "${FILES[@]}")"
+[ "${CEO_LOOP_DEBUG:-0}" = "1" ] && echo "debug: repo=$REPO base=$CURRENT_BASE files=${FILES[*]} digest=$CHANGE_DIGEST" >&2
 PREMIUM_APPROVAL="${CEO_LOOP_PREMIUM_APPROVAL:-}"
-if [ -n "$PREMIUM_APPROVAL" ]; then
-  # Evidence, not existence: an empty or schema-less file must NOT unlock the
-  # gate — a stray env var pointing at a log would otherwise promote HIGH risk.
-  if ! jq -e '.approved_by and .ticket' "$PREMIUM_APPROVAL" >/dev/null 2>&1; then
-    echo "loop: premium approval file lacks evidence (needs .approved_by and .ticket): $PREMIUM_APPROVAL" >&2
-    exit 7
-  fi
-fi
 ACTION=""
 set +e
 ACTION="$(CEO_LOOP_ALLOW_MAIN="${CEO_LOOP_ALLOW_MAIN:-0}" \
-  ceo_promotion_gate "$RISK" "$TARGET" "$DEFAULT_BRANCH" "$PREMIUM_APPROVAL")"
+  ceo_promotion_gate "$RISK" "$TARGET" "$DEFAULT_BRANCH" "$PREMIUM_APPROVAL" "$CHANGE_DIGEST")"
 GATE_RC=$?
 set -e
 if [ "$GATE_RC" -eq 7 ]; then
-  echo "loop: BLOCKED — $RISK-risk change targeting production main '$TARGET' without premium approval." >&2
-  echo "  Provide CEO_LOOP_PREMIUM_APPROVAL=<file> or retarget an integration branch." >&2
+  echo "loop: BLOCKED — $RISK-risk change targeting production main '$TARGET' without premium approval bound to digest ${CHANGE_DIGEST:0:12}…" >&2
+  echo "  Approval JSON needs approved_by, ticket, and change_digest=$CHANGE_DIGEST" >&2
   exit 7
 fi
-if [ "$ACTION" = "park-integration" ]; then
-  echo "loop: parking on integration branch (risk=$RISK, policy default until main promotion is enabled)"
-fi
 
-# ── 7. requeue on failing verification (bounded) ─────────────────────────────
+# ── 7. acceptance: failing tests and HIGH findings block promotion ────────────
 FINAL_RC=0
+ACCEPTED=false
 if [ "$TEST_RC" -ne 0 ]; then
+  # A failed verification is itself a finding — otherwise a run whose review
+  # was clean would fail quietly and still exit 0 (#329 audit P1).
+  VFP="$(ceo_finding_fingerprint "$REPO" "$CURRENT_BASE" "verify_cmd passes" "spec:$SPEC" "HIGH")"
+  VTID="$(ceo_filing_ticket "$DIR" "$VFP" \
+    "verification failed: $VERIFY_CMD" \
+    "${CEO_LOOP_TICKET_OWNER:-unassigned}" \
+    "$VERIFY_CMD" \
+    "verify_cmd exits 0 inside the worktree" "HIGH" "$REPO" "$CURRENT_BASE")"
+  echo "$VTID" >> "$FINDINGS_TMP"
+fi
+if [ "$TEST_RC" -ne 0 ] || [ "$HIGH_FINDINGS" -gt 0 ]; then
+  # Bounded requeue already spent its attempts above; record exhaustion.
   while IFS= read -r tid; do
-    OUT="$(ceo_requeue_decide "$DIR" "$tid" "${CEO_LOOP_MAX_RETRIES:-2}")" || RC_HERE=$?
+    OUT="$(ceo_requeue_decide "$DIR" "$tid" "$MAX_RETRIES")" || RC_HERE=$?
     RC_HERE="${RC_HERE:-0}"
     case "$OUT" in
-      retry:*) echo "loop: requeued as ticket ${tid:0:19}... ($OUT)" ;;
+      retry:*) echo "loop: ticket ${tid:0:19}... requeued ($OUT)" ;;
       exhausted) echo "loop: retries EXHAUSTED for ${tid:0:19}... — recorded in $DIR/exhausted.jsonl" ;;
     esac
     [ "$RC_HERE" -gt "$FINAL_RC" ] && FINAL_RC=$RC_HERE
     RC_HERE=0
   done < "$FINGERPRINTS_FILE"
+  # Unaccepted work exits nonzero whether or not retries remain: a clean exit
+  # here would read as success to any caller (#329 audit P1).
+  if [ "$HIGH_FINDINGS" -gt 0 ]; then
+    FINAL_RC=5
+    echo "loop: $HIGH_FINDINGS HIGH finding(s) block promotion — repair tickets filed" >&2
+  elif [ "$FINAL_RC" -eq 0 ]; then
+    FINAL_RC=3
+  fi
+else
+  ACCEPTED=true
 fi
+
+PROMOTED=false
+PARKED=false
+if [ "$ACCEPTED" = "true" ] && [ "$GATE_RC" -eq 0 ] && [ -n "$ACTION" ]; then
+  if [ "$ACTION" = "park-integration" ]; then
+    # Parking IS keeping the isolated branch: unmerged, inspectable, not lost.
+    PARKED=true
+    echo "loop: parked — branch $BRANCH holds accepted work below ${TARGET} policy threshold"
+  elif [ "$DRY_RUN" != "1" ]; then
+    PROMOTED=true
+    if git -C "$REPO_DIR" remote get-url origin >/dev/null 2>&1 && command -v gh >/dev/null 2>&1; then
+      if git -C "$WT" push origin "$BRANCH" >/dev/null 2>&1; then
+        if gh pr create --head "$BRANCH" --base "$TARGET" \
+          --title "ceo-loop: $REPO/$BRANCH" \
+          --body "Autonomous loop PR (#329). risk=$RISK worker=$WORKER_IDENTITY reviewer=$PASSING_REVIEWER" \
+          >/dev/null 2>&1; then
+          echo "loop: PR opened against $TARGET"
+        else
+          echo "loop: pushed $BRANCH (PR creation skipped)"
+        fi
+      else
+        echo "loop: push failed — branch $BRANCH kept locally" >&2
+      fi
+    else
+      # No remote: promote is a fast-forward-only ref update of the target.
+      if git -C "$REPO_DIR" merge-base --is-ancestor "$TARGET" "$BRANCH" 2>/dev/null \
+         && git -C "$REPO_DIR" update-ref "refs/heads/$TARGET" "$(git -C "$REPO_DIR" rev-parse "$BRANCH")"; then
+        echo "loop: promoted $BRANCH into local $TARGET (fast-forward)"
+      else
+        echo "loop: could not fast-forward $TARGET — branch $BRANCH holds the work" >&2
+        PROMOTED=false
+      fi
+    fi
+  fi
+fi
+
+ceo_worker_release "$DIR" "$BRANCH"
 
 # ── 8. telemetry (token-scope ingestion contract) ─────────────────────────────
 NOW_TS="$(date +%s)"
-ACCEPTED=$([ "$TEST_RC" -eq 0 ] && [ "$GATE_RC" -eq 0 ] && echo true || echo false)
 jq -nc \
   --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-  --arg repo "$REPO" --arg branch "$BRANCH" --arg model "$PROVIDER/$MODEL" \
+  --arg repo "$REPO" --arg branch "$BRANCH" --arg model "$WORKER_IDENTITY" \
+  --arg reviewer "$PASSING_REVIEWER" \
   --arg target "$TARGET" --arg risk "$RISK" --arg action "$ACTION" \
+  --argjson promoted "${PROMOTED:-false}" --argjson parked "${PARKED:-false}" \
   --argjson accepted "$ACCEPTED" \
   --argjson seconds_to_passing "$((NOW_TS - START_TS))" \
+  --argjson retries_used "$((ATTEMPT > MAX_RETRIES ? MAX_RETRIES : ATTEMPT))" \
   --argjson findings "$CYCLE_FINDINGS" \
-  --argjson reviewer_disagreement 0 \
+  --argjson high_findings "$HIGH_FINDINGS" \
   '{ts: $ts, writer: "ceo-loop", repo: $repo, branch: $branch, model: $model,
-    target: $target, risk: $risk, action: $action, accepted: $accepted,
-    seconds_to_passing: $seconds_to_passing, findings: $findings,
-    reviewer_disagreement: $reviewer_disagreement}' >> "$DIR/telemetry.jsonl"
+    reviewer: $reviewer, target: $target, risk: $risk, action: $action,
+    promoted: $promoted, parked: $parked,
+    accepted: $accepted, seconds_to_passing: $seconds_to_passing,
+    retries_used: $retries_used, findings: $findings,
+    high_findings: $high_findings,
+    reviewer_disagreement: (if $high_findings > 0 then 1 else 0 end),
+    rework: (if $retries_used > 0 then 1 else 0 end)}' >> "$DIR/telemetry.jsonl"
 
-ceo_ledger_write_entry "ceo-loop" "$PROVIDER/$MODEL" "loop:$REPO/$BRANCH" "$PWD" null "$ACCEPTED" >/dev/null || true
+ceo_ledger_write_entry "ceo-loop" "$WORKER_IDENTITY" "loop:$REPO/$BRANCH" "$PWD" null "$ACCEPTED" >/dev/null || true
 
-echo "loop: done ($REPO/$BRANCH risk=$RISK action=$ACTION)"
+if [ "$PROMOTED" = "true" ]; then SUMMARY_ACTION="promoted";
+elif [ "$PARKED" = "true" ]; then SUMMARY_ACTION="parked";
+else SUMMARY_ACTION="${ACTION:-blocked}"; fi
+echo "loop: done ($REPO/$BRANCH risk=$RISK action=$SUMMARY_ACTION attempts=$((ATTEMPT + 1)))"
 exit $FINAL_RC

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# ceo-loop.test.sh — end-to-end dry-run of the #329 loop over fixture specs.
-# Every gate runs for real; workers/reviewers are fixture commands, no providers.
+# ceo-loop.test.sh — the #329 loop driven against REAL git repositories.
+# Workers and reviewers are stub commands that actually run; branches,
+# worktrees, diffs, promotions, and tickets are real state.
 set -euo pipefail
 cd "$(dirname "$0")"
 source ./test-harness.sh
@@ -8,251 +9,291 @@ source ./test-harness.sh
 LIB_DIR="$(pwd)"
 # shellcheck source=ceo-loop-lib.sh
 source ./ceo-loop-lib.sh
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+LOOP="$LIB_DIR/ceo-loop.sh"
 
-# Isolated state root AND isolated shared ledger — tests must not touch
-# developer state anywhere (#317 class; test-writes-stay-in-the-fixture).
 CEO_LOOP_STATE_ROOT="$TMP/state"
 export CEO_LOOP_STATE_ROOT
 OLLAMA_AGENT_LEDGER="$TMP/ledger/runs.jsonl"
 export OLLAMA_AGENT_LEDGER
-LOOP="$LIB_DIR/ceo-loop.sh"
 
 REPO_N=0
-next_repo() { # unique slug per test so cases never share state
-  REPO_N=$((REPO_N + 1))
-  echo "repo-$REPO_N"
+STATE_N=0
+fresh_state() { # isolate each test's loop state so order can never matter
+  STATE_N=$((STATE_N + 1))
+  CEO_LOOP_STATE_ROOT="$TMP/state-$STATE_N"
+  export CEO_LOOP_STATE_ROOT
 }
 
-cat > "$TMP/routes.json" <<'JSON'
-{"routes": {"bug-fix": [
-  {"provider": "ollama", "model": "qwen2.5-coder:7b", "command": "$WORKER_PRIMARY"},
-  {"provider": "opencode", "model": "kimi-k3", "command": "$WORKER_FALLBACK"}
-]}}
+mkrepo() { # <name> — a real git repo with one commit on main
+  fresh_state
+  local dir="$TMP/repos/$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email t@t
+  git -C "$dir" config user.name t
+  echo base > "$dir/base.txt"
+  git -C "$dir" add -A && git -C "$dir" commit -qm init
+  echo "$dir"
+}
+
+mkroutes() { # <file> <worker-script> <reviewer-script> [reviewer2-script]
+  cat > "$1" <<JSON
+{
+  "candidates": [
+    {"provider": "ollama", "model": "qwen-test", "command": "$2"},
+    {"provider": "opencode", "model": "kimi-test", "command": "$3"}
+  ],
+  "reviewers": [
+    {"provider": "opencode", "model": "kimi-test", "command": "${4:-true}"}
+  ]
+}
 JSON
-
-# Test bodies run in subshells, so a shared counter cannot advance across
-# cases; slug off the unique spec name instead.
-make_spec() { # <name> <files-json> <verify-cmd> <findings-json> [repo-slug]
-  local repo="${5:-repo-$1}"
-  printf -v "SLUG_$1" '%s' "$repo"
-  jq -n \
-    --arg repo "$repo" --arg branch "nh/fixture-$1" --arg base "abc123" \
-    --argjson files "$2" --arg verify "$3" --arg author "ollama/qwen2.5-coder:7b" \
-    --argjson reviewers '["opencode/kimi-k3"]' --argjson findings "$4" \
-    '{repo: $repo, branch: $branch, base: $base, shape: "bug-fix",
-      files: $files, verify_cmd: $verify, author: $author,
-      reviewers: $reviewers, findings: $findings}' > "$TMP/$1.json"
-}
-state_of() { # <name>
-  local var="SLUG_$1"
-  echo "$CEO_LOOP_STATE_ROOT/${!var:-missing-slug}"
 }
 
-WORKER_PRIMARY="true"
-WORKER_FALLBACK="true"
-WORKER_FAIL="false"
-export WORKER_PRIMARY WORKER_FALLBACK WORKER_FAIL
+mkspec() { # <file> <repo-dir> <branch> <verify-cmd>
+  jq -n --arg repo "$(basename "$2")-$3" --arg dir "$2" --arg branch "$3" \
+    --arg verify "$4" \
+    '{repo: $repo, repo_dir: $dir, branch: $branch, shape: "bug-fix",
+      verify_cmd: $verify}' > "$1"
+}
 
-test_e2e_happy_path_exercises_every_phase() {
-  make_spec ok '["src/app/widget.ts"]' "true" \
-    '[{"invariant":"null check","location":"src/app/widget.ts:12","severity":"LOW"}]'
+WORKER_WRITE='cd "$WT" && echo feature > feature.txt'
+export WORKER_WRITE WORKER_FAIL=false
+
+write_script() { # <path> <body> — exec bit required: routes run commands directly
+  printf '#!/bin/bash\n%s\n' "$2" > "$1"
+  chmod +x "$1"
+}
+
+test_happy_path_creates_real_branch_and_commits_and_promotes() {
+  local repo; repo="$(mkrepo happy)"
+  local wscript="${TMP}/w-ok.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-happy.json" "$wscript" true
+  mkspec "$TMP/happy.json" "$repo" nh/loop-happy "true"
   local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/ok.json" --routes "$TMP/routes.json" --target integration) || rc=$?
-  assert_contains "$out" "queued"
-  assert_contains "$out" "isolated branch nh/fixture-ok"
-  assert_contains "$out" "cross-provider reviewer opencode/kimi-k3"
-  assert_contains "$out" "done (repo-ok/nh/fixture-ok risk=medium action=promote)"
+  out=$(bash "$LOOP" run --spec "$TMP/happy.json" --routes "$TMP/routes-happy.json" --target main) || rc=$?
+  assert_contains "$out" "isolated branch nh/loop-happy"
+  assert_contains "$out" "cross-provider reviewer opencode/kimi-test"
   assert_eq "$rc" "0"
-  # the queue write is a real row, not just an echo
-  assert_contains "$(cat "$(state_of ok)/queue.jsonl")" '"status":"queued"'
-  # telemetry row in the token-scope-ingestable contract, per-run findings count
-  local tel
-  tel="$(cat "$(state_of ok)/telemetry.jsonl")"
-  assert_contains "$tel" '"writer":"ceo-loop"'
-  assert_contains "$tel" '"accepted":true'
-  assert_contains "$tel" '"findings":1'
-  # shared-ledger entry actually landed (OLLAMA_AGENT_LEDGER points into TMP)
-  assert_contains "$(cat "$OLLAMA_AGENT_LEDGER")" 'loop:'
-  # worker slot was registered AND released by the loop itself
-  if grep -q "nh/fixture-ok" "$(state_of ok)/workers.jsonl"; then
+  # Policy default: low-risk work parks on its branch; main is untouched.
+  assert_contains "$out" "action=parked"
+  assert_eq "$(git -C "$repo" rev-parse main)" "$(git -C "$repo" rev-parse "$(git -C "$repo" rev-list --max-parents=0 HEAD)")"
+  # REAL git state: the branch exists with the worker's commit merged in.
+  assert_eq "$(git -C "$repo" rev-parse --verify -q nh/loop-happy >/dev/null && echo yes || echo no)" "yes"
+  assert_eq "$(git -C "$repo" show nh/loop-happy:feature.txt 2>/dev/null)" "feature"
+  # With policy explicitly allowing main, promotion fast-forwards.
+  out=$(CEO_LOOP_ALLOW_MAIN=1 bash "$LOOP" run --spec "$TMP/happy.json" --routes "$TMP/routes-happy.json" --target main) || rc=$?
+  assert_contains "$out" "fast-forward"
+  assert_eq "$(git -C "$repo" rev-parse main)" "$(git -C "$repo" rev-parse nh/loop-happy)"
+  # Slot released after completion.
+  if grep -q "nh/loop-happy" "$CEO_LOOP_STATE_ROOT/$(basename "$repo")-nh_loop-happy/workers.jsonl" 2>/dev/null || \
+     grep -rq "nh/loop-happy" "$CEO_LOOP_STATE_ROOT"/*/workers.jsonl 2>/dev/null; then
     fail_test "completed run must not keep its serialization slot"
   fi
+  # Telemetry carries the required metrics.
+  local tel slug_dir
+  slug_dir=$(find "$CEO_LOOP_STATE_ROOT" -name telemetry.jsonl -path "*happy*" | head -1)
+  tel=$(cat "$slug_dir")
+  assert_contains "$tel" '"retries_used":0'
+  assert_contains "$tel" '"accepted":true'
+  assert_contains "$tel" '"reviewer":"opencode/kimi-test"'
 }
 
-test_usage_error_exits_2() {
+test_failing_verification_blocks_promotion_and_files_ticket() {
+  local repo; repo="$(mkrepo failing)"
+  local wscript="${TMP}/w-fail.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-fail.json" "$wscript" true
+  mkspec "$TMP/fail.json" "$repo" nh/loop-fail "false"
   local out rc=0
-  out=$(bash "$LOOP" run --spec /nonexistent/x.json --routes "$TMP/routes.json" 2>&1) || rc=$?
-  assert_contains "$out" "spec not found"
-  assert_eq "$rc" "2"
-  # An empty-but-present spec must hit the required-field gate, not pass silently.
-  : > "$TMP/empty-spec.json"
-  out=$(bash "$LOOP" run --spec "$TMP/empty-spec.json" --routes "$TMP/routes.json" 2>&1) || rc=$?
-  assert_contains "$out" "missing required field"
-  assert_eq "$rc" "2"
+  out=$(bash "$LOOP" run --spec "$TMP/fail.json" --routes "$TMP/routes-fail.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "verification failed"
+  if [ "$rc" = "0" ]; then fail_test "failing verification must not exit clean"; fi
+  # Production condition: main did NOT move.
+  assert_eq "$(git -C "$repo" rev-parse main)" "$(git -C "$repo" rev-parse "$(git -C "$repo" rev-list --max-parents=0 HEAD)")"
+  # A repair ticket exists for the verification failure with required fields.
+  local row
+  row=$(grep -rh "verification failed" "$CEO_LOOP_STATE_ROOT" --include="repair-tickets.jsonl" | head -1)
+  assert_contains "$row" '"owner"'
+  assert_contains "$row" '"definition_of_done":"verify_cmd exits 0 inside the worktree"'
+  assert_contains "$row" '"failing_test":"false"'
 }
 
-test_spec_with_no_files_refuses_to_classify() {
-  jq -n --arg repo "repo-empty" --arg branch "nh/fixture-empty" --arg base abc \
-    --argjson files '[]' --arg verify true --arg author "ollama/q" \
-    --argjson reviewers '["opencode/k"]' --argjson findings '[]' \
-    '{repo:$repo,branch:$branch,base:$base,shape:"bug-fix",files:$files,
-      verify_cmd:$verify,author:$author,reviewers:$reviewers,findings:$findings}' > "$TMP/empty-files.json"
+test_high_findings_block_promotion_with_full_ticket_schema() {
+  local repo; repo="$(mkrepo highfind)"
+  local wscript="${TMP}/w-high.sh"; write_script "$wscript" 'cd "$WT" && mkdir -p src/lib && echo x > src/lib/util.sh' 
+  local rscript="${TMP}/r-high.sh"
+  cat > "$rscript" <<'EOF'
+#!/bin/bash
+echo '{"invariant":"no SQL injection in helper","location":"src/lib/util.sh:7","severity":"HIGH"}'
+EOF
+  chmod +x "$rscript"
+  mkroutes "$TMP/routes-high.json" "$wscript" true "$rscript"
+  mkspec "$TMP/high.json" "$repo" nh/loop-high "true"
+  git -C "$repo" branch integration   # a real integration target exists
   local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/empty-files.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
-  assert_contains "$out" "no changed files"
-  assert_eq "$rc" "2"
+  out=$(bash "$LOOP" run --spec "$TMP/high.json" --routes "$TMP/routes-high.json" --target integration 2>&1) || rc=$?
+  if [ "$rc" = "0" ]; then fail_test "HIGH findings must block acceptance (exit 5)"; fi
+  assert_contains "$out" "HIGH finding(s) block promotion"
+  local row
+  row=$(grep -rh "SQL injection" "$CEO_LOOP_STATE_ROOT" --include="repair-tickets.jsonl" | head -1)
+  assert_contains "$row" '"owner":"unassigned"'
+  assert_contains "$row" '"severity":"HIGH"'
+  assert_contains "$row" '"external_id":null'
+  # The HIGH-risk change was NOT promoted anywhere.
+  if grep -q "promoted" <<<"$out"; then fail_test "HIGH finding must prevent promotion"; fi
 }
 
-test_review_gate_failure_exits_5_e2e() {
-  make_spec sametier '["docs/a.md"]' "true" '[]'
-  jq '.author = "ollama/qwen" | .reviewers = ["ollama/qwen-turbo"]' "$TMP/sametier.json" > "$TMP/sametier2.json"
-  mv "$TMP/sametier2.json" "$TMP/sametier.json"
-  local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/sametier.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
-  assert_contains "$out" "review gate failed"
-  assert_eq "$rc" "5"
-}
-
-test_stale_base_stops_promotion_at_the_door() {
-  make_spec stalebase '["docs/b.md"]' "true" '[]'
-  local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/stalebase.json" --routes "$TMP/routes.json" \
-    --target integration --current-base def456 2>&1) || rc=$?
+test_stale_base_stops_before_any_work() {
+  local repo; repo="$(mkrepo stale)"
+  local sha; sha=$(git -C "$repo" rev-parse HEAD)
+  git -C "$repo" commit -q --allow-empty -m advance
+  mkroutes "$TMP/routes-stale.json" true true
+  mkspec "$TMP/stale.json" "$repo" nh/loop-stale "true"
+  # The spec declares the revision its work was cut from.
+  jq '.base = "'"$sha"'"' "$TMP/stale.json" > "$TMP/stale2.json" && mv "$TMP/stale2.json" "$TMP/stale.json"
+  local out rc=0 new_tip
+  new_tip=$(git -C "$repo" rev-parse HEAD)   # target has advanced past spec.base
+  out=$(bash "$LOOP" run --spec "$TMP/stale.json" --routes "$TMP/routes-stale.json" \
+    --target main --current-base "$new_tip" 2>&1) || rc=$?
   assert_contains "$out" "STALE BASE"
   assert_eq "$rc" "9"
+  # Stale base stops at the door: no worktree was ever created.
+  if [ -e "$repo/.ceo-loop" ]; then fail_test "stale-base check must precede worktree creation"; fi
 }
 
-test_high_risk_cannot_reach_production_main_without_premium_gate() {
-  make_spec hot '["db/migrations/0042_add_index.js"]' "true" '[]'
+test_premium_approval_is_bound_to_the_change_digest() {
+  local repo; repo="$(mkrepo premium)"
+  local wscript="${TMP}/w-mig.sh"
+  write_script "$wscript" 'cd "$WT" && mkdir -p db && echo up > db/migrate.ts' 
+  mkroutes "$TMP/routes-prem.json" "$wscript" true
+  mkspec "$TMP/prem.json" "$repo" nh/loop-prem "true"
+
+  # No approval at all -> hard stop.
   local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/hot.json" --routes "$TMP/routes.json" --target main 2>&1) || rc=$?
+  out=$(bash "$LOOP" run --spec "$TMP/prem.json" --routes "$TMP/routes-prem.json" --target main 2>&1) || rc=$?
   assert_contains "$out" "BLOCKED"
-  assert_contains "$out" "premium approval"
   assert_eq "$rc" "7"
-}
+  # The gate prints the digest it needs — capture it from state/telemetry-free path:
+  local digest slug
+  slug=$(jq -r '.repo' "$TMP/prem.json" | tr '/' '-')
+  digest=$(ceo_change_digest "$slug" "$(git -C "$repo" rev-parse main)" "db/migrate.ts")
 
-test_premium_approval_requires_real_evidence_not_mere_existence() {
-  make_spec approved '["hooks/pre-commit"]' "true" '[]'
-  # An EMPTY file at the approval path must NOT unlock the gate.
-  : > "$TMP/empty-approval.md"
-  local out rc=0
-  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/empty-approval.md" \
-    bash "$LOOP" run --spec "$TMP/approved.json" --routes "$TMP/routes.json" --target main 2>&1) || rc=$?
-  assert_contains "$out" "lacks evidence"
+  # An approval for a DIFFERENT change must NOT unlock this one.
+  printf '%s\n' "{\"approved_by\":\"n\",\"ticket\":\"t-1\",\"change_digest\":\"deadbeef\"}" > "$TMP/approval-wrong.json"
+  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/approval-wrong.json" \
+    bash "$LOOP" run --spec "$TMP/prem.json" --routes "$TMP/routes-prem.json" --target main 2>&1) || rc=$?
   assert_eq "$rc" "7"
 
-  # Schema-carrying evidence does unlock it.
-  printf '%s\n' '{"approved_by":"nhangen","ticket":"CEO/approvals/premium-42"}' > "$TMP/premium-approval.json"
-  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/premium-approval.json" \
-    bash "$LOOP" run --spec "$TMP/approved.json" --routes "$TMP/routes.json" --target main) || rc=$?
-  assert_contains "$out" "action=promote"
+  # Approval bound to THIS change's digest unlocks it.
+  printf '%s\n' "{\"approved_by\":\"nhangen\",\"ticket\":\"CEO/premium-9\",\"change_digest\":\"$digest\"}" > "$TMP/approval-ok.json"
+  rc=0
+  out=$(CEO_LOOP_PREMIUM_APPROVAL="$TMP/approval-ok.json" \
+    bash "$LOOP" run --spec "$TMP/prem.json" --routes "$TMP/routes-prem.json" --target main 2>&1) || rc=$?
+  if [ "$rc" != "0" ]; then
+    fail_test "bound approval must promote (rc=$rc digest=$digest)" "$out"
+    return 0
+  fi
+  assert_contains "$out" "fast-forward"
 }
 
-test_equivalent_findings_collapse_to_one_repair_ticket() {
-  make_spec dupes '["src/app/widget.ts"]' "true" \
-    '[{"invariant":"null check","location":"lib/util.sh:120","severity":"HIGH"},
-      {"invariant":"null check","location":"lib/util.sh:4187","severity":"HIGH"}]'
-  bash "$LOOP" run --spec "$TMP/dupes.json" --routes "$TMP/routes.json" --target integration >/dev/null
-  local fp rows=0
-  fp=$(ceo_finding_fingerprint repo-dupes abc123 "null check" "lib/util.sh:120" "HIGH")
-  rows=$(grep -c "\"ticket_id\":\"repair-${fp:0:12}" "$(state_of dupes)/repair-tickets.jsonl" || true)
-  assert_eq "$rows" "1" "line-shifted equivalent must file ONE ticket"
+test_same_branch_registers_once_and_release_clears_it() {
+  local repo; repo="$(mkrepo dupreg)"
+  local slug; slug="$(basename "$repo")-nh_dup"
+  local dir="$CEO_LOOP_STATE_ROOT/$slug"
+  mkdir -p "$dir"
+  ceo_worker_register "$dir" "nh/dup" "aaa" "a.sh"
+  ceo_worker_register "$dir" "nh/dup" "bbb" "a.sh"
+  assert_eq "$(wc -l < "$dir/workers.jsonl" | tr -d ' ')" "1" "re-registration replaces, never stacks"
+  ceo_worker_release "$dir" "nh/dup"
+  assert_eq "$(wc -l < "$dir/workers.jsonl" | tr -d ' ')" "0"
 }
 
-test_overlapping_in_flight_worker_stops_the_loop_naming_conflict() {
-  # Same shared slug so the two workers contend on one registry.
-  make_spec first '["lib/util.sh"]' "true" '[]' repo-overlap
-  make_spec second '["lib/util.sh"]' "true" '[]' repo-overlap
-  bash "$LOOP" run --spec "$TMP/first.json" --routes "$TMP/routes.json" --target integration >/dev/null
-  # first worker is released on completion; simulate it still in flight:
-  printf '%s\n' '{"branch":"nh/fixture-first","base":"abc123","files":["lib/util.sh"]}' \
-    >> "$(state_of first)/workers.jsonl"
+test_multiword_verify_commands_run_as_shell_input() {
+  local repo; repo="$(mkrepo multiword)"
+  local wscript="${TMP}/w-mv.sh"; write_script "$wscript" 'cd "$WT" && echo hi > out.txt' 
+  mkroutes "$TMP/routes-mv.json" "$wscript" true
+  mkspec "$TMP/mv.json" "$repo" nh/loop-mv "echo started && test -f out.txt && grep -q hi out.txt"
   local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/second.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
-  assert_contains "$out" "overlaps in-flight worker 'nh/fixture-first'"
-  assert_eq "$rc" "6"
-}
-
-test_corrupt_workers_row_is_a_hard_stop_not_a_pass() {
-  make_spec corrupt '["lib/other.sh"]' "true" '[]'
-  mkdir -p "$(state_of corrupt)"
-  printf '%s\n' 'this is not json at all' >> "$(state_of corrupt)/workers.jsonl"
-  local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/corrupt.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc=$?
-  assert_contains "$out" "corrupt row"
-  assert_eq "$rc" "6"
-}
-
-test_finding_strings_with_quotes_survive_json_roundtrip() {
-  make_spec quotes '["src/app/widget.ts"]' "true" \
-    '[{"invariant":"handles \"null\" case","location":"src/app/widget.ts:12","severity":"HIGH"}]'
-  local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/quotes.json" --routes "$TMP/routes.json" --target integration) || rc=$?
+  # Policy allows main so the accepted work actually promotes.
+  out=$(CEO_LOOP_ALLOW_MAIN=1 bash "$LOOP" run --spec "$TMP/mv.json" --routes "$TMP/routes-mv.json" --target main) || rc=$?
   assert_eq "$rc" "0"
-  # findings.jsonl stays machine-readable after a quote-bearing finding
-  jq -e . "$(state_of quotes)/findings.jsonl" >/dev/null 2>&1 \
-    || fail_test "findings.jsonl corrupted by quoted strings"
-  assert_contains "$(cat "$(state_of quotes)/repair-tickets.jsonl")" 'null\" case'
+  assert_contains "$out" "action=promoted"
 }
 
-test_provider_failure_reroutes_to_fallback_and_both_failing_is_loud() {
-  make_spec reroute '["src/app/widget.ts"]' "true" '[]'
-  # Primary command fails ($WORKER_FAIL), fallback succeeds.
-  sed 's/\$WORKER_PRIMARY/\$WORKER_FAIL/' "$TMP/routes.json" > "$TMP/routes-reroute.json"
-  local out rc=0
-  out=$(bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-reroute.json" --target integration) || rc=$?
-  assert_contains "$out" "rerouted to opencode/kimi-k3"
-  assert_eq "$rc" "0"
-
-  # Both fail -> loud exit with actionable state left behind.
-  sed 's/\$WORKER_PRIMARY/\$WORKER_FAIL/; s/\$WORKER_FALLBACK/\$WORKER_FAIL/' \
-    "$TMP/routes.json" > "$TMP/routes-dead.json"
-  out=$(bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-dead.json" --target integration 2>&1) || rc=$?
-  # Both providers dead: loop exits loudly naming where actionable state lives.
-  assert_contains "$out" "rerouted worker also failed"
-  assert_contains "$out" "actionable state"
-  assert_eq "$rc" "4"
-
-  # A shape with NO remaining configured candidate says so explicitly.
-  cat > "$TMP/routes-single.json" <<'JSON'
-{"routes": {"bug-fix": [{"provider": "ollama", "model": "qwen2.5-coder:7b", "command": "$WORKER_PRIMARY"}]}}
+test_provider_failure_reroutes_to_next_candidate() {
+  local repo; repo="$(mkrepo reroute)"
+  # Primary (ollama) fails; backup (opencode) delivers. Reviewer must differ
+  # from the ACTUAL author after failover, hence anthropic here.
+  local wbackup="${TMP}/w-backup.sh"
+  write_script "$wbackup" 'cd "$WT" && echo rescued > rescued.txt'
+  cat > "$TMP/routes-reroute.json" <<JSON
+{"candidates": [
+    {"provider": "ollama", "model": "qwen-test", "command": "false"},
+    {"provider": "opencode", "model": "kimi-test", "command": "$wbackup"}
+  ],
+  "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "true"}]}
 JSON
-  out=$(WORKER_PRIMARY=false bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-single.json" --target integration 2>&1) || rc=$?
-  assert_contains "$out" "no fallback left"
-  assert_eq "$rc" "4"
+  mkspec "$TMP/reroute.json" "$repo" nh/loop-reroute "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/reroute.json" --routes "$TMP/routes-reroute.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "trying next candidate"
+  assert_eq "$rc" "0"
+  assert_contains "$(git -C "$repo" show nh/loop-reroute:rescued.txt 2>/dev/null)" "rescued"
 }
 
-test_failing_verification_requeues_then_exhaustion_stays_visible() {
-  make_spec flaky '["src/app/widget.ts"]' "false" \
-    '[{"invariant":"tests pass","location":"tests/flaky.test.sh:1","severity":"HIGH"}]'
-  CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration >/dev/null 2>&1 || true
-  local out2 rc2=0
-  out2=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration 2>&1) || rc2=$?
-  assert_contains "$out2" "retries EXHAUSTED"
-  assert_eq "$rc2" "3" "exhaustion propagates as exit 3"
-  assert_file_exists "$(state_of flaky)/exhausted.jsonl"
-  assert_contains "$(cat "$(state_of flaky)/exhausted.jsonl")" "tests pass"
-  # exhaustion is recorded ONCE — a later cycle short-circuits on the marker
-  local before after
-  before=$(wc -l < "$(state_of flaky)/exhausted.jsonl")
-  CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/flaky.json" --routes "$TMP/routes.json" --target integration >/dev/null 2>&1 || true
-  after=$(wc -l < "$(state_of flaky)/exhausted.jsonl")
-  assert_eq "$after" "$before" "exhaustion rows must not multiply"
+test_requeue_dispatches_another_attempt_then_exhausts_visibly() {
+  local repo; repo="$(mkrepo requeue)"
+  # Worker always delivers; VERIFICATION fails on attempt 1 only. A bounded
+  # requeue must DISPATCH another worker attempt (counter proves it ran).
+  local counter="$TMP/attempt-counter"; echo 0 > "$counter"
+  # Worker increments the attempt counter every time it is dispatched.
+  local wok="${TMP}/w-ok2.sh"
+  write_script "$wok" "cd \"\$WT\" && echo ok > ok.txt && n=\$(cat '$counter') && echo \$((n+1)) > '$counter'"
+  mkroutes "$TMP/routes-requeue.json" "$wok" true
+  mkspec "$TMP/requeue.json" "$repo" nh/loop-requeue \
+    "[ \$(cat $counter) -ge 2 ]"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/requeue.json" --routes "$TMP/routes-requeue.json" \
+    --target main 2>&1) || rc=$?
+  assert_eq "$(cat "$counter")" "2" "second attempt must actually dispatch"
+  assert_eq "$rc" "0"
+  local tel slug_dir
+  slug_dir=$(find "$CEO_LOOP_STATE_ROOT" -name telemetry.jsonl -path "*requeue*" | head -1)
+  tel=$(cat "$slug_dir")
+  assert_contains "$tel" '"retries_used":1'
+
+  # Exhaustion: always-failing verification burns the cap -> exhausted.jsonl.
+  local repo2; repo2="$(mkrepo exhaust)"
+  mkroutes "$TMP/routes-exh.json" "$wok" true
+  mkspec "$TMP/exh.json" "$repo2" nh/loop-exh "false"
+  rc=0
+  out=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/exh.json" --routes "$TMP/routes-exh.json" --target main 2>&1) || rc=$?
+  if [ "$rc" = "0" ]; then fail_test "exhausted retries must not exit clean"; fi
+  assert_file_exists "$(find "$CEO_LOOP_STATE_ROOT" -name exhausted.jsonl | head -1)"
 }
 
-test_status_reports_state_without_touching_anything() {
-  make_spec st '["docs/note.md"]' "true" '[]'
-  bash "$LOOP" run --spec "$TMP/st.json" --routes "$TMP/routes.json" --target integration >/dev/null
-  local slug out
-  slug="$(state_of st)"
-  slug="${slug#$CEO_LOOP_STATE_ROOT/}"
-  out=$(bash "$LOOP" status --repo "$slug")
-  assert_contains "$out" "repair-tickets"
-  assert_contains "$out" "telemetry"
-  # content, not just headers: the run's ticket summary must be visible
-  assert_contains "$out" "$(jq -r '.summary // empty' <(head -1 "$CEO_LOOP_STATE_ROOT/$slug/repair-tickets.jsonl") 2>/dev/null || true)"
+test_risk_map_catches_filename_shaped_blast_radii() {
+  for p in src/billing.ts src/payments.ts db/migrate.ts src/save-user.ts lib/auth.ts secrets.json; do
+    assert_eq "$(ceo_risk_classify "$LIB_DIR/ceo-risk-map.json" "$p")" "high" "$p is high risk"
+  done
+  assert_eq "$(ceo_risk_classify "$LIB_DIR/ceo-risk-map.json" "docs/guide.md")" "low"
+}
+
+test_same_provider_only_reviewers_are_refused_e2e() {
+  local repo; repo="$(mkrepo sametier)"
+  local wscript="${TMP}/w-same.sh"; write_script "$wscript" 'cd "$WT" && echo z > z.txt' 
+  cat > "$TMP/routes-same.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen", "command": "$wscript"}],
+ "reviewers": [{"provider": "ollama", "model": "qwen-big", "command": "true"}]}
+JSON
+  mkspec "$TMP/same.json" "$repo" nh/loop-same "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/same.json" --routes "$TMP/routes-same.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "review gate failed"
+  assert_eq "$rc" "5"
 }
 
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -40,17 +40,14 @@ mkrepo() { # <name> — a real git repo with one commit on main
 }
 
 mkroutes() { # <file> <worker-script> <reviewer-script> [reviewer2-script]
-  cat > "$1" <<JSON
-{
-  "candidates": [
-    {"provider": "ollama", "model": "qwen-test", "command": "$2"},
-    {"provider": "opencode", "model": "kimi-test", "command": "$3"}
-  ],
-  "reviewers": [
-    {"provider": "opencode", "model": "kimi-test", "command": "${4:-true}"}
-  ]
-}
-JSON
+  # Built by jq: worker/reviewer commands may contain any quoting.
+  jq -n --arg w "$2" --arg b "$3" \
+    --arg r "${4:-echo '{\"status\":\"clean\"}'}" \
+    '{candidates: [
+       {provider: "ollama", model: "qwen-test", command: $w},
+       {provider: "opencode", model: "kimi-test", command: $b}],
+      reviewers: [
+       {provider: "opencode", model: "kimi-test", command: $r}]}' > "$1"
 }
 
 mkspec() { # <file> <repo-dir> <branch> <verify-cmd>
@@ -135,7 +132,7 @@ EOF
   git -C "$repo" branch integration   # a real integration target exists
   local out rc=0
   out=$(bash "$LOOP" run --spec "$TMP/high.json" --routes "$TMP/routes-high.json" --target integration 2>&1) || rc=$?
-  if [ "$rc" = "0" ]; then fail_test "HIGH findings must block acceptance (exit 5)"; fi
+  assert_eq "$rc" "5" "HIGH findings must exit exactly 5"
   assert_contains "$out" "HIGH finding(s) block promotion"
   local row
   row=$(grep -rh "SQL injection" "$CEO_LOOP_STATE_ROOT" --include="repair-tickets.jsonl" | head -1)
@@ -234,7 +231,7 @@ test_provider_failure_reroutes_to_next_candidate() {
     {"provider": "ollama", "model": "qwen-test", "command": "false"},
     {"provider": "opencode", "model": "kimi-test", "command": "$wbackup"}
   ],
-  "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "true"}]}
+  "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "echo '{\"status\":\"clean\"}'"}]}
 JSON
   mkspec "$TMP/reroute.json" "$repo" nh/loop-reroute "true"
   local out rc=0
@@ -271,7 +268,13 @@ test_requeue_dispatches_another_attempt_then_exhausts_visibly() {
   mkspec "$TMP/exh.json" "$repo2" nh/loop-exh "false"
   rc=0
   out=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/exh.json" --routes "$TMP/routes-exh.json" --target main 2>&1) || rc=$?
-  if [ "$rc" = "0" ]; then fail_test "exhausted retries must not exit clean"; fi
+  assert_eq "$rc" "3" "first failing run exits 3 (requeued)"
+  # Second run spends the last retry slot; third hits the cap visibly.
+  CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/exh.json" --routes "$TMP/routes-exh.json" --target main >/dev/null 2>&1 || true
+  rc=0
+  out=$(CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/exh.json" --routes "$TMP/routes-exh.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "retries EXHAUSTED"
+  assert_eq "$rc" "3" "exhaustion maps to exit 3"
   assert_file_exists "$(find "$CEO_LOOP_STATE_ROOT" -name exhausted.jsonl | head -1)"
 }
 
@@ -294,6 +297,141 @@ JSON
   out=$(bash "$LOOP" run --spec "$TMP/same.json" --routes "$TMP/routes-same.json" --target main 2>&1) || rc=$?
   assert_contains "$out" "review gate failed"
   assert_eq "$rc" "5"
+}
+
+
+test_all_candidates_failing_exits_4() {
+  local repo; repo="$(mkrepo alldead)"
+  cat > "$TMP/routes-dead.json" <<JSON
+{"candidates": [
+    {"provider": "ollama", "model": "q1", "command": "false"},
+    {"provider": "opencode", "model": "k1", "command": "false"}
+  ],
+  "reviewers": [{"provider": "anthropic", "model": "c", "command": "echo '{\"status\":\"clean\"}'"}]}
+JSON
+  mkspec "$TMP/alldead.json" "$repo" nh/loop-dead "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/alldead.json" --routes "$TMP/routes-dead.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "every routed candidate failed"
+  assert_eq "$rc" "4"
+}
+
+test_missing_verify_cmd_is_usage_error_exit_2() {
+  local repo; repo="$(mkrepo noverify)"
+  jq -n --arg repo t --arg dir "$repo" --arg branch nh/x \
+    '{repo:$repo,repo_dir:$dir,branch:$branch,shape:"bug-fix"}' > "$TMP/noverify.json"
+  mkroutes "$TMP/routes-nv.json" true true
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/noverify.json" --routes "$TMP/routes-nv.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "missing required field"
+  assert_eq "$rc" "2"
+}
+
+test_worker_that_writes_nothing_refuses_to_classify() {
+  local repo; repo="$(mkrepo nowrite)"
+  mkroutes "$TMP/routes-nowrite.json" true true
+  mkspec "$TMP/nowrite.json" "$repo" nh/loop-nowrite "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/nowrite.json" --routes "$TMP/routes-nowrite.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "no changed files"
+  assert_eq "$rc" "2"
+}
+
+test_declared_files_never_replace_the_diff_for_risk() {
+  local repo; repo="$(mkrepo declared)"
+  # Spec CLAIMS a benign docs change; worker actually writes billing code.
+  local wscript="${TMP}/w-lie.sh"
+  write_script "$wscript" 'cd "$WT" && mkdir -p src/billing && echo charge > src/billing/charge.ts'
+  mkroutes "$TMP/routes-declared.json" "$wscript" true
+  jq -n --arg repo "declared-nh-loop-declared" --arg dir "$repo" --arg branch nh/loop-declared \
+    --arg verify true --argjson files '["docs/notes.md"]' \
+    '{repo:$repo,repo_dir:$dir,branch:$branch,shape:"bug-fix",verify_cmd:$verify,files:$files}' > "$TMP/declared.json"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/declared.json" --routes "$TMP/routes-declared.json" --target main 2>&1) || rc=$?
+  # Diff-derived risk is high -> premium block, regardless of the benign claim.
+  assert_contains "$out" "BLOCKED"
+  assert_eq "$rc" "7"
+}
+
+test_reviewer_that_fails_to_run_is_not_a_pass() {
+  local repo; repo="$(mkrepo deadrev)"
+  local wscript="${TMP}/w-dr.sh"; write_script "$wscript" 'cd "$WT" && echo q > q.txt'
+  cat > "$TMP/routes-deadrev.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen-test", "command": "$wscript"}],
+ "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "false"}]}
+JSON
+  mkspec "$TMP/deadrev.json" "$repo" nh/loop-deadrev "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/deadrev.json" --routes "$TMP/routes-deadrev.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "review gate failed"
+  assert_eq "$rc" "5"
+}
+
+test_premium_digest_binds_each_input_dimension() {
+  source_lib_digest() {
+    # Independent implementation of the documented format: repo|base|files,
+    # files sorted, comma-joined with a trailing comma.
+    local files="$3"
+    [ -n "$files" ] && files="$files,"
+    printf '%s' "$1|$2|$files" | shasum -a 256 | cut -d" " -f1
+  }
+  local d1 d2 d3 d4
+  d1=$(ceo_change_digest r abc f.sh)
+  assert_eq "$d1" "$(source_lib_digest r abc f.sh)" "digest matches independent computation"
+  d2=$(ceo_change_digest r def f.sh)
+  if [ "$d1" = "$d2" ]; then fail_test "base revision must bind the digest"; fi
+  d3=$(ceo_change_digest r abc g.sh)
+  if [ "$d1" = "$d3" ]; then fail_test "file set must bind the digest"; fi
+  d4=$(ceo_change_digest other abc f.sh)
+  if [ "$d1" = "$d4" ]; then fail_test "repo must bind the digest"; fi
+}
+
+
+test_finding_tickets_requeue_and_exhaust_not_just_verify_ones() {
+  local repo; repo="$(mkrepo findingrequeue)"
+  local wscript="${TMP}/w-fr.sh"; write_script "$wscript" 'cd "$WT" && mkdir -p src/lib && echo q > src/lib/util.sh'
+  local rscript="${TMP}/r-fr.sh"
+  cat > "$rscript" <<'EOF'
+#!/bin/bash
+echo '{"invariant":"helper stays pure","location":"src/lib/util.sh:7","severity":"MEDIUM"}'
+EOF
+  chmod +x "$rscript"
+  cat > "$TMP/routes-fr.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen-test", "command": "$wscript"}],
+ "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "$rscript"}]}
+JSON
+  mkspec "$TMP/fr.json" "$repo" nh/loop-fr "false"   # work fails verification too
+  git -C "$repo" branch integration
+  for i in 1 2 3; do
+    CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/fr.json" --routes "$TMP/routes-fr.json" \
+      --target integration >/dev/null 2>&1 || true
+  done
+  # The FINDING's own ticket must reach exhaustion, not just the verify one.
+  local exh
+  exh=$(find "$CEO_LOOP_STATE_ROOT" -path "*findingrequeue*" -name exhausted.jsonl -exec cat {} \;)
+  assert_contains "$exh" "helper stays pure"
+}
+
+
+test_finding_without_severity_fails_closed_to_high() {
+  local repo; repo="$(mkrepo nosev)"
+  local wscript="${TMP}/w-ns.sh"; write_script "$wscript" 'cd "$WT" && mkdir -p src/lib && echo q > src/lib/util.sh'
+  local rscript="${TMP}/r-ns.sh"
+  cat > "$rscript" <<'EOF'
+#!/bin/bash
+echo '{"invariant":"unlabeled finding","location":"src/lib/util.sh:9"}'
+EOF
+  chmod +x "$rscript"
+  cat > "$TMP/routes-ns.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen-test", "command": "$wscript"}],
+ "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "$rscript"}]}
+JSON
+  mkspec "$TMP/ns.json" "$repo" nh/loop-ns "true"
+  git -C "$repo" branch integration
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/ns.json" --routes "$TMP/routes-ns.json" --target integration 2>&1) || rc=$?
+  assert_eq "$rc" "5" "unlabeled severity is treated as HIGH and blocks"
+  assert_contains "$(grep -rh "unlabeled finding" "$CEO_LOOP_STATE_ROOT" --include="repair-tickets.jsonl")" '"severity":"high"'
 }
 
 run_tests

--- a/scripts/ceo-risk-map.json
+++ b/scripts/ceo-risk-map.json
@@ -1,13 +1,15 @@
 {
-  "_comment": "Path-based risk classification for the #329 promotion gate. A changed path matches a rule ONLY if its repo-relative path matches match_pattern (case-insensitive regex). The HIGHEST risk among matching rules wins; no match means default_risk. Unlike ceo-tier-map.json this map FAILS CLOSED: an unreadable map or a broken lookup classifies as high, because the gate this feeds blocks production-main promotion. Add a rule only after reviewing that the path class really carries that blast radius (#254 owns the broader policy).",
+  "_comment": "Path-based risk classification for the #329 promotion gate. A changed path matches a rule ONLY if its repo-relative path matches match_pattern (case-insensitive regex). The HIGHEST risk among matching rules wins; no match means default_risk. Unlike ceo-tier-map.json this map FAILS CLOSED: an unreadable map or a broken lookup classifies as high, because the gate this feeds blocks production-main promotion. Add a rule only after reviewing that the path class really carries that blast radius (#254 owns the broader policy). Filename rules match anywhere in the path so src/billing.ts and db/migrate.ts cannot slip through a directory-shaped rule.",
   "rules": [
-    { "name": "billing", "match_pattern": "(^|/)(billing|payments?|stripe|edd)/", "risk": "high" },
-    { "name": "authn-authz", "match_pattern": "(^|/)(auth|acl|permissions?|capabilities?)(/|\\.|-)", "risk": "high" },
-    { "name": "migrations", "match_pattern": "(^|/)migrations?/", "risk": "high" },
-    { "name": "credentials", "match_pattern": "(^|/)(credentials?|secrets?)(\\.|-|/)", "risk": "high" },
-    { "name": "shared-helpers", "match_pattern": "(^|/)(lib|shared|common)/.*\\.(sh|py|ts)$", "risk": "high" },
+    { "name": "billing", "match_pattern": "(^|/)(billing|invoice|payments?|purchases?|stripe|edd|checkout)", "risk": "high" },
+    { "name": "authn-authz", "match_pattern": "(^|/)(auth|acl|permissions?|capabilities?|sessions?|logins?|oauth)(/|\\.|-|$)|password", "risk": "high" },
+    { "name": "user-writes", "match_pattern": "(^|/)(save|update|delete|create)[-_]?(user|account|profile|customer|member|subscription)", "risk": "high" },
+    { "name": "migrations", "match_pattern": "(^|/)migrations?(/|-|\\.|_)|(migrate|schema)\\.(php|sql|ts|js|py)$", "risk": "high" },
+    { "name": "credentials", "match_pattern": "(^|/)(credentials?|secrets?|api[_-]?keys?|tokens?)(\\.|-|_|/)|(secret|apikey)", "risk": "high" },
+    { "name": "shared-helpers", "match_pattern": "(^|/)(lib|shared|common|helpers?)/.*\\.(sh|py|ts|php)$", "risk": "high" },
     { "name": "hooks", "match_pattern": "(^|/)hooks/", "risk": "high" },
     { "name": "ci-workflows", "match_pattern": "^\\.github/workflows/", "risk": "high" },
+    { "name": "db-layer", "match_pattern": "(^|/)(db|database)/.*\\.(sh|py|ts|php|sql)$", "risk": "high" },
     { "name": "tests", "match_pattern": "(^|/)tests?/", "risk": "low" },
     { "name": "docs", "match_pattern": "\\.(md|txt)$", "risk": "low" }
   ],


### PR DESCRIPTION
Reopens #329's contract: #330 shipped the decision logic without the workflow. This PR rebuilds the driver around production mechanics:

- **Isolated worktree + branch per item**, cut from the target's current revision; changed files derived from `git diff` against that base (caller-declared lists are hints for early overlap checks only)
- **Workers execute** in the worktree; candidate failover walks the whole route table, then exits loudly
- **Reviewers execute** against the diff; their stdout is the findings source; identity comes from what ran; HIGH findings block acceptance and promotion
- **Failing verification files a ticket and exits nonzero** even with a clean review — no more action=promote on failed work
- **Premium approval bound** to `ceo_change_digest(repo|base|files)` — reusable approvals authorize nothing
- **Bounded requeue dispatches further attempts** (counter-proven in tests), exhaustion recorded once
- Tickets carry owner / failing test / definition of done / severity / external_id slot
- Promotion = push + gh PR with remote, fast-forward-only ref update without; low risk parks unless `CEO_LOOP_ALLOW_MAIN=1`
- Upsert worker registration; filename-shaped risk rules (`src/billing.ts`, `db/migrate.ts`, `save-user.ts`…); multiword verify commands

11 e2e arms run REAL fixture repositories through every gate; 4 core fixes mutation-verified; full suite green.