### PR TITLE
Prove branch ownership by tip before reclaiming, and validate the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Gates and their failure codes:
 | State lock | Concurrent loops serialize on a portable mkdir lock; a held-too-long lock refuses to race rather than corrupting state | 8 |
 | Branch name | `.branch` must satisfy `git check-ref-format` and must not begin with `-`; the name becomes both a ref and a worktree path, so it is validated before either is built | 2 |
 | Ownership | The loop reclaims a branch only while `refs/ceo-loop/owned/<key>` still records that branch's current tip. Anything else — a name it never created, or one that moved since — is refused, never deleted | 6 |
-| Worker commit | The worker's output must commit. The changed-file list is read from the working tree, so a rejected commit (a repo-level `pre-commit` hook) would have the run classify and review a change the branch does not hold | 6 |
+| Worker output | Staging or committing the worker's output must succeed; either failing refuses the run. The changed-file list is read from the working tree, so output that never reaches the branch would otherwise be classified, reviewed, and reported as accepted work | 6 |
 
 The ownership marker is durable state: `refs/ceo-loop/owned/<key>` under the
 target repo, one ref per branch the loop created, where `<key>` is a hash of the

--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Gates and their failure codes:
 | Stale base | Spec base differing from the target's current revision (`--current-base`) stops the loop before any work runs — rebase and resubmit | 9 |
 | Requeue | Repair tickets retry up to the cap (`CEO_LOOP_MAX_RETRIES`, default 2), then land in `exhausted.jsonl` exactly once — visible, never deleted | 3 |
 | State lock | Concurrent loops serialize on a portable mkdir lock; a held-too-long lock refuses to race rather than corrupting state | 8 |
+| Branch name | `.branch` must satisfy `git check-ref-format` and must not begin with `-`; the name becomes both a ref and a worktree path, so it is validated before either is built | 2 |
+| Ownership | The loop reclaims a branch only while `refs/ceo-loop/owned/<key>` still records that branch's current tip. Anything else — a name it never created, or one that moved since — is refused, never deleted | 6 |
+| Worker commit | The worker's output must commit. The changed-file list is read from the working tree, so a rejected commit (a repo-level `pre-commit` hook) would have the run classify and review a change the branch does not hold | 6 |
+
+The ownership marker is durable state: `refs/ceo-loop/owned/<key>` under the
+target repo, one ref per branch the loop created, where `<key>` is a hash of the
+branch name (a ref namespace cannot hold both `topic` and `topic/sub`). Each ref
+holds the tip the loop last wrote. A marker whose branch is gone is pruned on the
+next run for that name; an orphan is harmless in the meantime, because a tip that
+does not match refuses rather than deletes.
 
 Premium approval is evidence, not existence: `CEO_LOOP_PREMIUM_APPROVAL` must
 point at a JSON file carrying `.approved_by` and `.ticket` — an empty or

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -101,6 +101,19 @@ require_field() { # <jq-path> <name>
 }
 REPO="$(require_field '.repo' 'repo' | tr '/' '-')" # keep state paths one level deep
 BRANCH="$(require_field '.branch' 'branch')"
+# The branch name becomes both a git ref and a filesystem path, so it is
+# validated before either is built from it. ".." survives the slash collapse
+# below untouched, which made WT resolve to $REPO_DIR itself and pointed the
+# reclaim's `rm -rf` at the repository root (#332).
+# `git check-ref-format` accepts a leading dash, and only `checkout -b` happens
+# to refuse one later — every other interpolation of $BRANCH would read it as an
+# option — so that case is rejected here rather than left to luck.
+if ! git check-ref-format "refs/heads/$BRANCH" 2>/dev/null \
+   || case "$BRANCH" in -*) true ;; *) false ;; esac \
+   || [ "${BRANCH//\//_}" = "." ] || [ "${BRANCH//\//_}" = ".." ]; then
+  echo "ceo-loop: '$BRANCH' is not a valid git branch name — refusing to build a ref or a worktree path from it" >&2
+  exit 2
+fi
 SHAPE="$(jget '.shape // "bug-fix"')"
 VERIFY_CMD="$(require_field '.verify_cmd' 'verify_cmd')"
 
@@ -186,9 +199,47 @@ ATTEMPT=0
 WORKER_IDENTITY=""
 TEST_RC=1
 VERIFY_LOG=""
+# One key per branch name, used for both the ownership ref and the worktree
+# directory. Keying either on the name itself is what produced two bugs: a ref
+# namespace cannot hold "topic" and "topic/sub" at once, and collapsing "/" to
+# "_" made nh/loop-x and the literal nh_loop-x share one worktree, so the second
+# run evicted the first run's checkout.
+branch_key() { # <branch-name> -> stable hex, whichever hasher this host has
+  local h
+  h="$(printf '%s' "$1" | shasum 2>/dev/null | awk '{print $1}')"
+  [ -n "$h" ] || h="$(printf '%s' "$1" | sha1sum 2>/dev/null | awk '{print $1}')"
+  [ -n "$h" ] || h="$(printf '%s' "$1" | cksum | awk '{print $1"-"$2}')"
+  printf '%s' "$h"
+}
+BRANCH_KEY="$(branch_key "$BRANCH")"
+
 if [ "$DRY_RUN" != "1" ]; then
-  WT="$REPO_DIR/.ceo-loop/${BRANCH//\//_}"
-  # Reclaim leftovers from a prior failed attempt: this loop owns the branch.
+  WT="$REPO_DIR/.ceo-loop/${BRANCH//\//_}-${BRANCH_KEY:0:12}"
+  OWNED_REF="refs/ceo-loop/owned/$BRANCH_KEY"
+  # The marker records the tip it vouches for, and is re-pointed every time the
+  # loop advances the branch. Existence alone is not ownership: a name freed by
+  # a merge and later reused by a person left the old marker standing, and the
+  # loop deleted their work on the strength of it. A tip that does not match is
+  # somebody else's commit, whoever made it.
+  ceo_claim_branch() {
+    git -C "$REPO_DIR" update-ref "$OWNED_REF" "$(git -C "$WT" rev-parse HEAD)" \
+      || { echo "ceo-loop: could not record ownership of $BRANCH" >&2; exit 6; }
+  }
+  BRANCH_TIP="$(git -C "$REPO_DIR" rev-parse --verify -q "refs/heads/$BRANCH" 2>/dev/null || true)"
+  OWNED_TIP="$(git -C "$REPO_DIR" rev-parse --verify -q "$OWNED_REF" 2>/dev/null || true)"
+  if [ -z "$BRANCH_TIP" ]; then
+    # No branch: a marker left behind by an earlier run vouches for nothing, and
+    # keeping it is what let the next holder of the name be deleted.
+    [ -z "$OWNED_TIP" ] || git -C "$REPO_DIR" update-ref -d "$OWNED_REF" 2>/dev/null || true
+  elif [ "$BRANCH_TIP" != "$OWNED_TIP" ]; then
+    if [ -z "$OWNED_TIP" ]; then
+      echo "ceo-loop: branch $BRANCH already exists and was not created by ceo-loop — refusing to delete it." >&2
+    else
+      echo "ceo-loop: branch $BRANCH has moved since ceo-loop last wrote it ($OWNED_TIP -> $BRANCH_TIP) — refusing to delete it." >&2
+    fi
+    echo "  Choose a different .branch in the spec, or delete the branch yourself if it is disposable." >&2
+    exit 6
+  fi
   # Reclaim leftovers from prior attempts: deregister the worktree first
   # (a branch checked out in a registered worktree cannot be deleted), prune,
   # then drop the loop-owned branch.
@@ -200,6 +251,9 @@ if [ "$DRY_RUN" != "1" ]; then
     || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }
   git -C "$WT" checkout -b "$BRANCH" "$CURRENT_BASE" >/dev/null 2>&1 \
     || { echo "ceo-loop: could not create branch $BRANCH" >&2; exit 6; }
+  # Claim it in the same step that creates it, so a run killed later still
+  # leaves a branch the next run is allowed to reclaim.
+  ceo_claim_branch
 fi
 
 # Early registration with declared intent (if any) so concurrent loops on the
@@ -236,6 +290,9 @@ while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
     git -C "$WT" add -A >/dev/null 2>&1 || true
     if ! git -C "$WT" diff --cached --quiet 2>/dev/null; then
       git -C "$WT" commit -q -m "ceo-loop: worker output ($WORKER_IDENTITY)" || true
+      # The marker tracks the tip, so it has to follow every commit the loop
+      # makes or the next run reads its own work as a stranger's.
+      ceo_claim_branch
     fi
   fi
 

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -104,15 +104,14 @@ require_field() { # <jq-path> <name>
 REPO="$(require_field '.repo' 'repo' | tr '/' '-')" # keep state paths one level deep
 BRANCH="$(require_field '.branch' 'branch')"
 # The branch name becomes both a git ref and a filesystem path, so it is
-# validated before either is built from it. ".." survives the slash collapse
-# below untouched, which made WT resolve to $REPO_DIR itself and pointed the
-# reclaim's `rm -rf` at the repository root (#332).
-# `git check-ref-format` accepts a leading dash, and only `checkout -b` happens
-# to refuse one later — every other interpolation of $BRANCH would read it as an
-# option — so that case is rejected here rather than left to luck.
+# validated before either is built from it. `check-ref-format` is the authority
+# and covers the case that mattered: ".." reached the slash collapse below, WT
+# resolved to $REPO_DIR, and the reclaim's `rm -rf` aimed at the repository root
+# (#332). The one thing it accepts and should not is a leading dash — today only
+# `checkout -b` happens to refuse that, and every other interpolation of $BRANCH
+# would read it as an option, so it is rejected here rather than left to luck.
 if ! git check-ref-format "refs/heads/$BRANCH" 2>/dev/null \
-   || case "$BRANCH" in -*) true ;; *) false ;; esac \
-   || [ "${BRANCH//\//_}" = "." ] || [ "${BRANCH//\//_}" = ".." ]; then
+   || case "$BRANCH" in -*) true ;; *) false ;; esac; then
   echo "ceo-loop: '$BRANCH' is not a valid git branch name — refusing to build a ref or a worktree path from it" >&2
   exit 2
 fi

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -18,7 +18,8 @@
 # Spec JSON fields:
 #   repo        state-namespacing slug
 #   repo_dir    path to the target git repository (required)
-#   branch      isolated worker branch name
+#   branch      isolated worker branch name; must satisfy
+#               `git check-ref-format` and must not begin with '-'
 #   base        base revision (default: current sha of the target branch)
 #   verify_cmd  REQUIRED command run inside the worktree; must exit 0
 #   files       optional declared file intents for early overlap checks —
@@ -31,7 +32,8 @@
 # Worker/reviewer commands receive WT (worktree), SPEC, BASE in their env.
 #
 # Exit codes: 0 ok · 2 bad usage / invalid spec · 3 retries exhausted ·
-# 4 routing failure · 5 review gate failure · 6 overlap or corrupt state ·
+# 4 routing failure · 5 review gate failure ·
+# 6 overlap, branch not owned, uncommittable worker output, or corrupt state ·
 # 7 premium-gate block · 8 lock contention · 9 stale base
 
 set -euo pipefail
@@ -289,7 +291,13 @@ while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
     # (and therefore the file list) is fully observable.
     git -C "$WT" add -A >/dev/null 2>&1 || true
     if ! git -C "$WT" diff --cached --quiet 2>/dev/null; then
-      git -C "$WT" commit -q -m "ceo-loop: worker output ($WORKER_IDENTITY)" || true
+      # Not optional. FILES below comes from `git diff --name-only` against the
+      # WORKING TREE, so a swallowed rejection (a repo-level pre-commit hook —
+      # worktrees share $REPO_DIR/.git/hooks) leaves risk classification and the
+      # reviewers reading a change the branch does not hold, and the run then
+      # reports "holds accepted work" over an empty branch.
+      git -C "$WT" commit -q -m "ceo-loop: worker output ($WORKER_IDENTITY)" \
+        || { echo "ceo-loop: could not commit the worker's output on $BRANCH — it is uncommitted in $WT and the next reclaim would discard it" >&2; exit 6; }
       # The marker tracks the tip, so it has to follow every commit the loop
       # makes or the next run reads its own work as a stranger's.
       ceo_claim_branch

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -288,13 +288,22 @@ while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
   if [ "$DRY_RUN" != "1" ]; then
     # The loop owns committing whatever the worker left behind, so the diff
     # (and therefore the file list) is fully observable.
-    git -C "$WT" add -A >/dev/null 2>&1 || true
+    # Neither of these is optional, and the reason is one invariant rather than
+    # two commands: FILES below comes from `git diff --name-only` against the
+    # WORKING TREE, so any path that leaves the worker's output uncommitted has
+    # risk classification, the reviewers, and the promotion summary all reading
+    # a change the branch does not hold — and the run then reports "holds
+    # accepted work" over an empty branch.
+    #
+    # A failed `add` is the subtler half: nothing is staged, so the commit block
+    # below is skipped entirely and takes its own refusal with it. A wedged
+    # index.lock does it, which is exactly what a concurrent git in the same
+    # worktree leaves behind.
+    git -C "$WT" add -A >/dev/null 2>&1 \
+      || { echo "ceo-loop: could not stage the worker's output in $WT — refusing to report work the branch does not hold" >&2; exit 6; }
     if ! git -C "$WT" diff --cached --quiet 2>/dev/null; then
-      # Not optional. FILES below comes from `git diff --name-only` against the
-      # WORKING TREE, so a swallowed rejection (a repo-level pre-commit hook —
-      # worktrees share $REPO_DIR/.git/hooks) leaves risk classification and the
-      # reviewers reading a change the branch does not hold, and the run then
-      # reports "holds accepted work" over an empty branch.
+      # A rejected commit is the other half — a repo-level pre-commit hook
+      # reaches here, since worktrees share $REPO_DIR/.git/hooks.
       git -C "$WT" commit -q -m "ceo-loop: worker output ($WORKER_IDENTITY)" \
         || { echo "ceo-loop: could not commit the worker's output on $BRANCH — it is uncommitted in $WT and the next reclaim would discard it" >&2; exit 6; }
       # The marker tracks the tip, so it has to follow every commit the loop

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -434,4 +434,135 @@ JSON
   assert_contains "$(grep -rh "unlabeled finding" "$CEO_LOOP_STATE_ROOT" --include="repair-tickets.jsonl")" '"severity":"high"'
 }
 
+test_refuses_to_delete_a_branch_the_loop_did_not_create() {
+  # #332: "this loop owns the branch" was an assumption, not a check. A spec
+  # whose .branch collides with existing work force-deleted it and exited 0.
+  local repo; repo="$(mkrepo reclaim)"
+  git -C "$repo" checkout -q -b important-work
+  echo irreplaceable > "$repo/only-here.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "work that exists nowhere else"
+  local doomed; doomed="$(git -C "$repo" rev-parse important-work)"
+  git -C "$repo" checkout -q main
+  local wscript="${TMP}/w-reclaim.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-reclaim.json" "$wscript" true
+  mkspec "$TMP/reclaim.json" "$repo" important-work "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/reclaim.json" --routes "$TMP/routes-reclaim.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "6" "a branch the loop cannot prove it created is refused, not deleted"
+  assert_contains "$out" "was not created by ceo-loop"
+  assert_eq "$(git -C "$repo" rev-parse important-work 2>/dev/null || echo GONE)" "$doomed" \
+    "the pre-existing branch still points at its own commit"
+}
+
+test_reclaims_its_own_branch_across_runs() {
+  # The refusal above must not break the reclaim it replaces: a branch this
+  # loop created is still reclaimable on the next run.
+  local repo; repo="$(mkrepo reown)"
+  local wscript="${TMP}/w-reown.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-reown.json" "$wscript" true
+  mkspec "$TMP/reown.json" "$repo" nh/loop-reown "true"
+  bash "$LOOP" run --spec "$TMP/reown.json" --routes "$TMP/routes-reown.json" --target main >/dev/null 2>&1 || true
+  assert_eq "$(git -C "$repo" for-each-ref --format='%(objectname)' refs/ceo-loop/owned \
+    | grep -cx "$(git -C "$repo" rev-parse nh/loop-reown)")" "1" \
+    "the loop records ownership pointing at the branch tip it created"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/reown.json" --routes "$TMP/routes-reown.json" --target main 2>&1) || rc=$?
+  assert_not_contains "$out" "was not created by ceo-loop"
+  assert_contains "$out" "isolated branch nh/loop-reown"
+}
+
+test_rejects_a_branch_name_git_would_not_accept() {
+  # ".." survives the ${BRANCH//\//_} collapse untouched, so WT resolved to
+  # $REPO_DIR and line 198's rm -rf targeted the repo root. Only rm's own
+  # refusal to unlink ".." prevented the deletion.
+  local repo; repo="$(mkrepo badname)"
+  local wscript="${TMP}/w-bad.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-bad.json" "$wscript" true
+  mkspec "$TMP/bad.json" "$repo" .. "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/bad.json" --routes "$TMP/routes-bad.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "2" "an invalid branch name is rejected at spec validation"
+  assert_contains "$out" "not a valid git branch name"
+  assert_file_exists "$repo/base.txt"
+}
+
+test_a_stale_ownership_marker_does_not_authorize_deleting_a_stranger() {
+  # #332 audit: the marker must vouch for the branch that is there NOW. A name
+  # freed after a merge and later reused by a person left the old marker
+  # standing, and the loop deleted their branch on the strength of it.
+  local repo; repo="$(mkrepo reusedname)"
+  local wscript="${TMP}/w-reused.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-reused.json" "$wscript" true
+  mkspec "$TMP/reused.json" "$repo" nh/reused "true"
+  bash "$LOOP" run --spec "$TMP/reused.json" --routes "$TMP/routes-reused.json" --target main >/dev/null 2>&1 || true
+  # The branch is merged and deleted, as it would be after a PR lands.
+  git -C "$repo" worktree list --porcelain | awk '/^worktree .*\.ceo-loop/{print $2}' \
+    | while read -r w; do git -C "$repo" worktree remove --force --force "$w" 2>/dev/null || true; done
+  git -C "$repo" worktree prune
+  git -C "$repo" branch -D nh/reused >/dev/null 2>&1 || true
+  # A person now reuses the freed name for unrelated work.
+  git -C "$repo" checkout -q -b nh/reused main
+  echo mine > "$repo/human-only.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "human work on a reused name"
+  local doomed; doomed="$(git -C "$repo" rev-parse nh/reused)"
+  git -C "$repo" checkout -q main
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/reused.json" --routes "$TMP/routes-reused.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "6" "a marker that no longer matches the branch tip proves nothing"
+  assert_eq "$(git -C "$repo" rev-parse nh/reused 2>/dev/null || echo GONE)" "$doomed" \
+    "the human branch that reused the name still points at its own commit"
+  assert_eq "$(git -C "$repo" cat-file -e nh/reused:human-only.txt 2>/dev/null && echo yes || echo no)" \
+    "yes" "the human commit's content is still reachable"
+}
+
+test_ownership_markers_do_not_collide_across_nested_branch_names() {
+  # A ref namespace keyed on the branch name cannot hold both "topic" and
+  # "topic/sub": one loose ref would have to be a file and a directory.
+  local repo; repo="$(mkrepo nested)"
+  local wscript="${TMP}/w-nested.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-nested.json" "$wscript" true
+  mkspec "$TMP/nested-a.json" "$repo" topic/sub "true"
+  bash "$LOOP" run --spec "$TMP/nested-a.json" --routes "$TMP/routes-nested.json" --target main >/dev/null 2>&1 || true
+  git -C "$repo" worktree list --porcelain | awk '/^worktree .*\.ceo-loop/{print $2}' \
+    | while read -r w; do git -C "$repo" worktree remove --force --force "$w" 2>/dev/null || true; done
+  git -C "$repo" worktree prune
+  git -C "$repo" branch -D topic/sub >/dev/null 2>&1 || true
+  mkspec "$TMP/nested-b.json" "$repo" topic "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/nested-b.json" --routes "$TMP/routes-nested.json" --target main 2>&1) || rc=$?
+  assert_not_contains "$out" "could not record ownership"
+  assert_not_contains "$out" "was not created by ceo-loop"
+  assert_eq "$rc" "0" "a branch whose name is a prefix of an owned one still runs"
+}
+
+test_two_branch_names_never_share_one_worktree_directory() {
+  # WT collapsed "/" to "_", so nh/loop-x and the literal nh_loop-x landed in
+  # the same directory and the second run evicted the first run's worktree.
+  local repo; repo="$(mkrepo collapse)"
+  local wscript="${TMP}/w-collapse.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-collapse.json" "$wscript" true
+  mkspec "$TMP/collapse-a.json" "$repo" nh/loop-x "true"
+  bash "$LOOP" run --spec "$TMP/collapse-a.json" --routes "$TMP/routes-collapse.json" --target main >/dev/null 2>&1 || true
+  local before; before="$(git -C "$repo" worktree list | grep -c 'ceo-loop' || true)"
+  mkspec "$TMP/collapse-b.json" "$repo" nh_loop-x "true"
+  bash "$LOOP" run --spec "$TMP/collapse-b.json" --routes "$TMP/routes-collapse.json" --target main >/dev/null 2>&1 || true
+  assert_eq "$(git -C "$repo" worktree list | grep -c 'ceo-loop' || true)" "$((before + 1))" \
+    "the second branch gets its own worktree instead of evicting the first"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-x >/dev/null && echo yes || echo no)" \
+    "yes" "the first branch survives the second run"
+}
+
+test_rejects_a_branch_name_that_would_be_read_as_an_option() {
+  # git check-ref-format accepts a leading dash; only `checkout -b` happens to
+  # refuse it later, and every other interpolation of $BRANCH would not.
+  local repo; repo="$(mkrepo dashname)"
+  local wscript="${TMP}/w-dash.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-dash.json" "$wscript" true
+  mkspec "$TMP/dash.json" "$repo" -oProxyCommand=x "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/dash.json" --routes "$TMP/routes-dash.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "2" "a branch name starting with - is rejected at spec validation"
+  assert_contains "$out" "not a valid git branch name"
+}
+
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -585,4 +585,24 @@ test_a_rejected_commit_is_not_reported_as_accepted_work() {
     "the branch is empty — which is exactly why the run must not claim otherwise"
 }
 
+test_a_failed_stage_is_not_reported_as_accepted_work() {
+  # Sibling of the rejected-commit arm, and the same invariant: `git add -A`
+  # failing leaves nothing staged, so `diff --cached --quiet` skips the whole
+  # commit block — including its refusal. FILES still reads the working tree,
+  # so a modified tracked file keeps the run looking productive.
+  local repo; repo="$(mkrepo failedstage)"
+  local wscript="${TMP}/w-addfail.sh"
+  # Edit a TRACKED file (so the working-tree diff is non-empty), then wedge the
+  # index so the loop's own `git add` cannot run.
+  write_script "$wscript" 'cd "$WT" && echo edited > base.txt && touch "$(git rev-parse --git-dir)/index.lock"'
+  mkroutes "$TMP/routes-addfail.json" "$wscript" true
+  mkspec "$TMP/addfail.json" "$repo" nh/loop-addfail "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/addfail.json" --routes "$TMP/routes-addfail.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "6" "a failed stage stops the run instead of reporting work the branch does not hold"
+  assert_not_contains "$out" "holds accepted work"
+  assert_eq "$(git -C "$repo" log --oneline main..nh/loop-addfail 2>/dev/null | wc -l | tr -d ' ')" "0" \
+    "the branch is empty — which is why the run must not claim otherwise"
+}
+
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -565,4 +565,24 @@ test_rejects_a_branch_name_that_would_be_read_as_an_option() {
   assert_contains "$out" "not a valid git branch name"
 }
 
+test_a_rejected_commit_is_not_reported_as_accepted_work() {
+  # The loop's whole file-list contract rests on the worker's output being
+  # committed: FILES comes from `git diff --name-only "$CURRENT_BASE"`, which
+  # reads the WORKING TREE. With the commit swallowed, the risk classifier and
+  # the reviewers see a change the branch does not hold, the run prints "holds
+  # accepted work", and ceo_claim_branch certifies the empty branch as owned.
+  local repo; repo="$(mkrepo rejectedcommit)"
+  printf '#!/bin/sh\nexit 1\n' > "$repo/.git/hooks/pre-commit"
+  chmod +x "$repo/.git/hooks/pre-commit"
+  local wscript="${TMP}/w-rej.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-rej.json" "$wscript" true
+  mkspec "$TMP/rej.json" "$repo" nh/loop-rej "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/rej.json" --routes "$TMP/routes-rej.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "6" "a rejected commit stops the run instead of certifying an empty branch"
+  assert_not_contains "$out" "holds accepted work"
+  assert_eq "$(git -C "$repo" log --oneline main..nh/loop-rej 2>/dev/null | wc -l | tr -d ' ')" "0" \
+    "the branch is empty — which is exactly why the run must not claim otherwise"
+}
+
 run_tests


### PR DESCRIPTION
Closes #332

## Description (Issue Fixed & New Behavior)

`ceo-loop.sh` reclaimed the spec's branch by running `git branch -D` on whatever
held that name, under a comment asserting "this loop owns the branch". Nothing
checked that. A colliding `.branch` destroyed commits reachable from no other
ref and the loop exited 0 reporting "done" — and a deleted branch's tip is found
by no `git reflog`, only by `git fsck --unreachable`, and only until the next gc.

Four changes, all one defect class: the loop never established which branch it
was actually holding.

- **Ownership is proved by tip, not by a marker existing.** The loop writes
  `refs/ceo-loop/owned/<key>` recording the tip it vouches for, re-points it on
  every commit it makes, and reclaims only when that tip still matches the
  branch. A marker whose branch is gone is pruned rather than left standing.
- **`<key>` is a hash of the branch name.** A ref namespace cannot hold both
  `topic` and `topic/sub`, so a name-keyed marker collided with itself and
  locked the loop out of a branch it had legitimately created.
- **The worktree directory carries the same key.** `${BRANCH//\//_}` mapped
  `nh/loop-x` and the literal `nh_loop-x` onto one path, and the ownership check
  could not see it because it keys on the ref — so a second run force-removed
  the first run's live worktree.
- **`.branch` is validated before anything is built from it,** via
  `git check-ref-format` plus two cases it does not cover. `..` survived the
  slash collapse, so `WT` resolved to `$REPO_DIR` and the reclaim's unguarded
  `rm -rf "$WT"` aimed at the repository root; only `rm`'s own refusal to unlink
  `..` prevented the deletion. And a leading dash is accepted by
  check-ref-format — today only `checkout -b` happens to refuse it, leaving
  every other interpolation of `$BRANCH` relying on luck.

The first version of this fix keyed ownership on the marker merely existing. A
pre-push audit killed it, and `test_a_stale_ownership_marker_does_not_authorize_deleting_a_stranger`
is that case: a name freed by a merge and later reused by a person left the old
marker standing, and the loop deleted their branch on the strength of it — the
exact scenario the issue was filed over, only harder to reach.

Exit codes are unchanged: invalid `.branch` is 2 (invalid spec), a refused
reclaim is 6 (overlap or corrupt state).

## Testing Procedure

The suite needs bash 4+ for `mapfile`, so it **cannot run under macOS's stock
bash 3.2** — every arm dies with `mapfile: command not found`. It has only ever
run in CI. Use Homebrew's bash:

1. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh`
   → `All tests passed. (26 tests)`
2. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh`
   → `All tests passed. (32 tests)`
3. Each of the four guards was mutation-tested on its own, and each fails only
   its own arms:
   - Weaken the tip match to `elif [ -z "$OWNED_TIP" ]` → the reused-name arm
     fails all three assertions, including reading the victim branch's sha back.
   - Restore `WT="$REPO_DIR/.ceo-loop/${BRANCH//\//_}"` → the shared-worktree arm
     fails.
   - Delete the leading-dash case from the validation → the option-name arm fails.
   - Delete the `ceo_claim_branch` call after the worker commit → 9 assertions
     across 5 arms fail, including promotion and requeue.
4. To watch the original bug: create a branch with a commit, point a spec's
   `.branch` at it, run the loop. Before this change the branch is deleted and
   the loop exits 0; after it, the run exits 6 and the branch is untouched.

## Additional Notes

- `main`'s `shellcheck` job is already failing on pre-existing warnings (#334),
  so CI here will be red for a reason that predates this branch. This diff adds
  no new shellcheck findings — verified by diffing the output against `main`.
- `mkrepo` in the test harness silently shares a directory when two tests pass
  the same name, which crossed two unrelated tests here until one was renamed.
  Not fixed in this PR.
- Found reviewing #330/#331, both of which merged with no in-PR review.
