### PR TITLE
Fix exit-code corruption by de-aliasing findings and ticket ID buffers

### DIFF
--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -133,9 +133,11 @@ touch "$DIR/queue.jsonl" "$DIR/workers.jsonl" "$DIR/findings.jsonl" \
       "$DIR/repair-tickets.jsonl" "$DIR/exhausted.jsonl" "$DIR/telemetry.jsonl"
 
 FINGERPRINTS_FILE=""
+FINDINGS_TMP=""
 WT=""
 ceo_loop_cleanup() {
   [ -n "$FINGERPRINTS_FILE" ] && rm -f "$FINGERPRINTS_FILE" 2>/dev/null || true
+  [ -n "$FINDINGS_TMP" ] && rm -f "$FINDINGS_TMP" 2>/dev/null || true
   # A dead or blocked run frees its serialization slot but LEAVES the worktree
   # and branch for inspection — deleting evidence of what a worker did would
   # hide the very state a repair ticket needs.
@@ -342,8 +344,9 @@ mapfile -t REVIEWER_ENTRIES < <(jq -c '.reviewers[]' "$ROUTES" 2>/dev/null | gre
 AUTHOR_PROVIDER="${WORKER_IDENTITY%%/*}"
 PASSING_REVIEWER=""
 FINDINGS_TMP="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-findings.XXXXXX")"
-FINGERPRINTS_FILE="$FINDINGS_TMP"
+FINGERPRINTS_FILE="$(mktemp "${TMPDIR:-/tmp}/ceo-loop-fingerprints.XXXXXX")"
 : > "$FINDINGS_TMP"
+: > "$FINGERPRINTS_FILE"
 for rentry in "${REVIEWER_ENTRIES[@]}"; do
   rprov="$(jq -r .provider <<<"$rentry")"
   rmodel="$(jq -r .model <<<"$rentry")"
@@ -441,7 +444,7 @@ if [ "$TEST_RC" -ne 0 ]; then
     "${CEO_LOOP_TICKET_OWNER:-unassigned}" \
     "$VERIFY_CMD" \
     "verify_cmd exits 0 inside the worktree" "HIGH" "$REPO" "$CURRENT_BASE")"
-  echo "$VTID" >> "$FINDINGS_TMP"
+  echo "$VTID" >> "$FINGERPRINTS_FILE"
 fi
 if [ "$TEST_RC" -ne 0 ] || [ "$HIGH_FINDINGS" -gt 0 ]; then
   # Bounded requeue already spent its attempts above; record exhaustion.

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -605,4 +605,60 @@ test_a_failed_stage_is_not_reported_as_accepted_work() {
     "the branch is empty — which is why the run must not claim otherwise"
 }
 
+test_exhausted_retries_exit_3_not_lock_contention() {
+  # #333: FINGERPRINTS_FILE aliases FINDINGS_TMP, so the requeue pass reads the
+  # raw reviewer JSON still sitting in that file as if each line were a ticket
+  # id. ceo_requeue_decide rejects them and exits 8, and FINAL_RC keeps the
+  # highest code it saw — so a plain exhausted run reports lock contention.
+  local repo; repo="$(mkrepo exitcontract)"
+  local wscript="${TMP}/w-ec.sh"; write_script "$wscript" 'cd "$WT" && mkdir -p src/lib && echo q > src/lib/util.sh'
+  local rscript="${TMP}/r-ec.sh"
+  cat > "$rscript" <<'EOF'
+#!/bin/bash
+echo '{"invariant":"helper stays pure","location":"src/lib/util.sh:7","severity":"MEDIUM"}'
+EOF
+  chmod +x "$rscript"
+  cat > "$TMP/routes-ec.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen-test", "command": "$wscript"}],
+ "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "$rscript"}]}
+JSON
+  # verify_cmd fails and the only finding is MEDIUM, so nothing forces FINAL_RC=5.
+  mkspec "$TMP/ec.json" "$repo" nh/loop-ec "false"
+  git -C "$repo" branch integration
+  local out rc=0
+  out=$(CEO_LOOP_MAX_RETRIES=0 bash "$LOOP" run --spec "$TMP/ec.json" \
+    --routes "$TMP/routes-ec.json" --target integration 2>&1) || rc=$?
+  assert_eq "$rc" "3" "exhausted retries are exit 3, not 8 (lock contention)"
+  assert_not_contains "$out" "unknown ticket"
+}
+
+test_the_requeue_pass_reads_ticket_ids_only() {
+  # The direct statement of the same invariant: whatever the requeue loop
+  # iterates holds ticket ids, never the raw finding JSON the reviewers emit.
+  # Both a review finding and the synthesized verification finding must land
+  # there, or one of the two stops reaching exhaustion.
+  local repo; repo="$(mkrepo ticketbuffer)"
+  local wscript="${TMP}/w-tb.sh"; write_script "$wscript" 'cd "$WT" && mkdir -p src/lib && echo q > src/lib/util.sh'
+  local rscript="${TMP}/r-tb.sh"
+  cat > "$rscript" <<'EOF'
+#!/bin/bash
+echo '{"invariant":"helper stays pure","location":"src/lib/util.sh:7","severity":"MEDIUM"}'
+EOF
+  chmod +x "$rscript"
+  cat > "$TMP/routes-tb.json" <<JSON
+{"candidates": [{"provider": "ollama", "model": "qwen-test", "command": "$wscript"}],
+ "reviewers": [{"provider": "anthropic", "model": "claude-test", "command": "$rscript"}]}
+JSON
+  mkspec "$TMP/tb.json" "$repo" nh/loop-tb "false"
+  git -C "$repo" branch integration
+  local out
+  out=$(CEO_LOOP_MAX_RETRIES=0 bash "$LOOP" run --spec "$TMP/tb.json" \
+    --routes "$TMP/routes-tb.json" --target integration 2>&1) || true
+  local exh
+  exh=$(find "$CEO_LOOP_STATE_ROOT" -path "*ticketbuffer*" -name exhausted.jsonl -exec cat {} \;)
+  assert_contains "$exh" "helper stays pure"
+  assert_contains "$exh" "verification failed"
+  assert_not_contains "$out" "unknown ticket"
+}
+
 run_tests


### PR DESCRIPTION
Closes #333

## Description (Issue Fixed & New Behavior)
Fixes a bug where `FINGERPRINTS_FILE` was aliased to `FINDINGS_TMP` in `scripts/ceo-loop.sh`, causing raw reviewer JSON findings to be mixed with ticket IDs in the same temporary buffer. When Section 7 iterated the buffer during the requeue pass, raw finding JSON was passed to `ceo_requeue_decide`, triggering an internal "unknown ticket" error and causing `FINAL_RC` to exit 8 (lock contention/corrupt state) instead of 3 (retries exhausted).

This change:
- Allocates separate temporary files for `FINDINGS_TMP` and `FINGERPRINTS_FILE` via distinct `mktemp` invocations and truncates both.
- Updates `ceo_loop_cleanup` to clean up both `FINDINGS_TMP` and `FINGERPRINTS_FILE` on exit, initializing `FINDINGS_TMP=""` upfront.
- Retargets the verification failure ticket ID append (`$VTID`) to `FINGERPRINTS_FILE` so both review findings and verification failure tickets feed the requeue pass.

## Testing Procedure
1. Check out branch `nh/fix/333-fingerprints-buffer`.
2. Run `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh`.
3. Verify that all 21 tests pass, specifically `test_exhausted_retries_exit_3_not_lock_contention` and `test_the_requeue_pass_reads_ticket_ids_only`.

## Additional Notes / HelpScout Tickets
N/A