### PR TITLE
Clear the shellcheck warnings that have kept main red

### DIFF
--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -102,7 +102,6 @@ require_field() { # <jq-path> <name>
 REPO="$(require_field '.repo' 'repo' | tr '/' '-')" # keep state paths one level deep
 BRANCH="$(require_field '.branch' 'branch')"
 SHAPE="$(jget '.shape // "bug-fix"')"
-AUTHOR="" # derived from the route that actually ran — never self-attested
 VERIFY_CMD="$(require_field '.verify_cmd' 'verify_cmd')"
 
 # Real git mechanics need a real repository (#329 audit: nothing was created).
@@ -255,7 +254,6 @@ done
 
 FILES=()
 HIGH_FINDINGS=0
-FINDINGS_JSONL=""
 if [ "$DRY_RUN" != "1" ]; then
   # Authoritative file list: the actual diff against the base revision.
   mapfile -t FILES < <(git -C "$WT" diff --name-only "$CURRENT_BASE" 2>/dev/null | grep -v '^$' || true)

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -19,7 +19,6 @@ export CEO_LOOP_STATE_ROOT
 OLLAMA_AGENT_LEDGER="$TMP/ledger/runs.jsonl"
 export OLLAMA_AGENT_LEDGER
 
-REPO_N=0
 STATE_N=0
 fresh_state() { # isolate each test's loop state so order can never matter
   STATE_N=$((STATE_N + 1))
@@ -57,8 +56,9 @@ mkspec() { # <file> <repo-dir> <branch> <verify-cmd>
       verify_cmd: $verify}' > "$1"
 }
 
+# The body of the default worker, written into a script file by write_script.
+# Not exported: it is passed as an argument, never inherited.
 WORKER_WRITE='cd "$WT" && echo feature > feature.txt'
-export WORKER_WRITE WORKER_FAIL=false
 
 write_script() { # <path> <body> — exec bit required: routes run commands directly
   printf '#!/bin/bash\n%s\n' "$2" > "$1"
@@ -402,7 +402,7 @@ EOF
 JSON
   mkspec "$TMP/fr.json" "$repo" nh/loop-fr "false"   # work fails verification too
   git -C "$repo" branch integration
-  for i in 1 2 3; do
+  for _ in 1 2 3; do
     CEO_LOOP_MAX_RETRIES=1 bash "$LOOP" run --spec "$TMP/fr.json" --routes "$TMP/routes-fr.json" \
       --target integration >/dev/null 2>&1 || true
   done


### PR DESCRIPTION
Closes #334

## Description (Issue Fixed & New Behavior)

#331 merged over a failing `shellcheck` job and `main` has been red since. Six warnings, none a live bug — but a red required check has now cost two finished PRs (#335, #339) their merge, and a lint job nobody can read is a lint job that stops catching things.

Four dead variables, each confirmed dead by grepping every script for a read and finding only its own assignment:

- `ceo-loop.sh:105` `AUTHOR=""` — the route-derived author is `AUTHOR_PROVIDER`, set from `WORKER_IDENTITY` and read twice. This one was never read.
- `ceo-loop.sh:258` `FINDINGS_JSONL=""` — a leftover from #330's structure; findings go to `FINDINGS_TMP`. (#333 is about that buffer and does not touch this line, so this does not conflict with #339.)
- `ceo-loop.test.sh:22` `REPO_N=0` — `mkrepo` never increments it; `STATE_N` is the counter that does the work.
- `WORKER_FAIL=false`, sharing an `export` with `WORKER_WRITE` — read nowhere.

Dropping that `export` is what actually cleared SC2089/SC2090. Those fire because a variable holding a shell snippet looks like a command being built, and exporting it is what makes that reading plausible. It isn't: `WORKER_WRITE` is passed to `write_script` as an argument and `printf`'d into a file, so nothing inherits it and the quotes were never at risk. A comment now says so, rather than a `disable` directive that would suppress the check for a future line that really is building a command.

`for i in 1 2 3` becomes `for _ in 1 2 3` — the loop repeats, it does not count.

## Testing Procedure

1. Reproduce CI's own invocation — the workflow is `scandir: ./scripts` with `severity: warning`:
   `shellcheck -S warning $(find ./scripts -name '*.sh')`
   Expect no output.
2. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` → `All tests passed. (19 tests)`
3. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh` → `All tests passed. (32 tests)`

The suites need bash 4+ for `mapfile`; macOS's stock `/bin/bash` is 3.2 and fails every arm.

## Additional Notes / HelpScout Tickets

Merging this unblocks #335 and #339, both of which are `UNSTABLE` solely because they inherit these six warnings. Neither adds one.
