### PR TITLE
ceo-cleanup default branch & ownership refs, and target ref validation (#338)

### DIFF
--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -8,12 +8,21 @@ set -euo pipefail
 # Usage: ceo-cleanup.sh
 # Requires: CEO_VAULT env var or defaults to ~/Documents/Obsidian
 
-_CLEANUP_DIR="$(cd "$(dirname "$0")" && pwd)"
+_CLEANUP_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck source=ceo-config.sh
 source "$_CLEANUP_DIR/ceo-config.sh"
 # shellcheck source=ceo-loop-lib.sh
 source "$_CLEANUP_DIR/ceo-loop-lib.sh"
 ceo_require_vault
+
+# A branch name is usable as an ancestry target only if it resolves to a commit
+# on this host — as a remote-tracking ref or as a local branch. Used to reject a
+# stale origin/HEAD before it is trusted as the default branch.
+ceo_branch_resolves() { # <repo-path> <branch-name>
+  git -C "$1" rev-parse --verify -q "refs/remotes/origin/$2" >/dev/null 2>&1 \
+    || git -C "$1" rev-parse --verify -q "refs/heads/$2" >/dev/null 2>&1
+}
+
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
 LOG_DIR="$CEO_DIR/log"
@@ -51,17 +60,30 @@ if [ -f "$REPOS_FILE" ]; then
 
     echo "REPO: $REPO_PATH"
 
-    # Resolve default branch: origin/HEAD -> main -> master
+    # Resolve default branch: origin/HEAD -> main -> master.
+    #
+    # `symbolic-ref` does not verify its target, and a remote that renames its
+    # default branch leaves the symref pointing at a ref that no longer exists.
+    # Accepting that name unchecked reproduces the bug this reaper exists to fix:
+    # both ancestry probes below reference a dead ref, both exit 128 into
+    # /dev/null, and nothing is ever reaped or reported (#341).
     DEFAULT_BRANCH="$(git -C "$REPO_PATH" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)"
+    if [ -n "$DEFAULT_BRANCH" ] \
+       && ! ceo_branch_resolves "$REPO_PATH" "$DEFAULT_BRANCH"; then
+      DEFAULT_BRANCH=""
+    fi
     if [ -z "$DEFAULT_BRANCH" ]; then
-      if git -C "$REPO_PATH" rev-parse --verify -q refs/remotes/origin/main >/dev/null 2>&1 \
-         || git -C "$REPO_PATH" rev-parse --verify -q refs/heads/main >/dev/null 2>&1; then
+      if ceo_branch_resolves "$REPO_PATH" main; then
         DEFAULT_BRANCH="main"
-      elif git -C "$REPO_PATH" rev-parse --verify -q refs/remotes/origin/master >/dev/null 2>&1 \
-           || git -C "$REPO_PATH" rev-parse --verify -q refs/heads/master >/dev/null 2>&1; then
+      elif ceo_branch_resolves "$REPO_PATH" master; then
         DEFAULT_BRANCH="master"
       else
-        DEFAULT_BRANCH="main"
+        # Inventing a name here would hand both ancestry probes a ref that
+        # resolves nowhere, so every branch reads as unmerged and the repo is
+        # silently skipped anyway — as an "all branches active" report rather
+        # than as the failure it is.
+        echo "  DEFAULT_BRANCH_UNRESOLVED: no origin/HEAD, main, or master"
+        continue
       fi
     fi
     echo "  DEFAULT_BRANCH: $DEFAULT_BRANCH"
@@ -89,14 +111,25 @@ if [ -f "$REPOS_FILE" ]; then
           git -C "$REPO_PATH" worktree remove "$WT_PATH" 2>/dev/null && echo "  WORKTREE_REMOVED: $WT_PATH" || echo "  WORKTREE_REMOVE_FAILED: $WT_PATH"
         fi
 
-        # Delete local branch
-        git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null && echo "  BRANCH_DELETED: $BRANCH" || echo "  BRANCH_DELETE_FAILED: $BRANCH"
-
-        # Delete loop ownership marker if present (#338)
-        BRANCH_KEY="$(branch_key "$BRANCH")"
-        OWNED_REF="refs/ceo-loop/owned/$BRANCH_KEY"
-        if git -C "$REPO_PATH" show-ref --verify -q "$OWNED_REF" 2>/dev/null; then
-          git -C "$REPO_PATH" update-ref -d "$OWNED_REF" 2>/dev/null || true
+        # Delete local branch, and only then its ownership marker (#338).
+        #
+        # The two judgments disagree: the ancestry probe above is answered by
+        # origin/$DEFAULT_BRANCH, while `branch -d` is answered by the local
+        # branch. In a clone whose local default branch lags the remote — the
+        # ordinary state — the first says merged and the second refuses. Deleting
+        # the marker there leaves the branch standing with no ownership record,
+        # and ceo-loop then reads it as a stranger's branch and refuses it
+        # forever (exit 6), recoverable only by a hand-written update-ref (#341).
+        if git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null; then
+          echo "  BRANCH_DELETED: $BRANCH"
+          OWNED_REF="refs/ceo-loop/owned/$(branch_key "$BRANCH")"
+          if git -C "$REPO_PATH" show-ref --verify -q "$OWNED_REF" 2>/dev/null; then
+            git -C "$REPO_PATH" update-ref -d "$OWNED_REF" 2>/dev/null \
+              && echo "  MARKER_DELETED: $OWNED_REF" \
+              || echo "  MARKER_DELETE_FAILED: $OWNED_REF"
+          fi
+        else
+          echo "  BRANCH_DELETE_FAILED: $BRANCH"
         fi
         MERGED_COUNT=$((MERGED_COUNT + 1))
       else

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 _CLEANUP_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=ceo-config.sh
 source "$_CLEANUP_DIR/ceo-config.sh"
+# shellcheck source=ceo-loop-lib.sh
+source "$_CLEANUP_DIR/ceo-loop-lib.sh"
 ceo_require_vault
 VAULT="$CEO_VAULT"
 CEO_DIR="$VAULT/CEO"
@@ -89,6 +91,13 @@ if [ -f "$REPOS_FILE" ]; then
 
         # Delete local branch
         git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null && echo "  BRANCH_DELETED: $BRANCH" || echo "  BRANCH_DELETE_FAILED: $BRANCH"
+
+        # Delete loop ownership marker if present (#338)
+        BRANCH_KEY="$(branch_key "$BRANCH")"
+        OWNED_REF="refs/ceo-loop/owned/$BRANCH_KEY"
+        if git -C "$REPO_PATH" show-ref --verify -q "$OWNED_REF" 2>/dev/null; then
+          git -C "$REPO_PATH" update-ref -d "$OWNED_REF" 2>/dev/null || true
+        fi
         MERGED_COUNT=$((MERGED_COUNT + 1))
       else
         # Check if branch has an open PR

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # Usage: ceo-cleanup.sh
 # Requires: CEO_VAULT env var or defaults to ~/Documents/Obsidian
 
-_CLEANUP_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+_CLEANUP_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=ceo-config.sh
 source "$_CLEANUP_DIR/ceo-config.sh"
 ceo_require_vault
 VAULT="$CEO_VAULT"
@@ -48,8 +49,26 @@ if [ -f "$REPOS_FILE" ]; then
 
     echo "REPO: $REPO_PATH"
 
+    # Resolve default branch: origin/HEAD -> main -> master
+    DEFAULT_BRANCH="$(git -C "$REPO_PATH" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)"
+    if [ -z "$DEFAULT_BRANCH" ]; then
+      if git -C "$REPO_PATH" rev-parse --verify -q refs/remotes/origin/main >/dev/null 2>&1 \
+         || git -C "$REPO_PATH" rev-parse --verify -q refs/heads/main >/dev/null 2>&1; then
+        DEFAULT_BRANCH="main"
+      elif git -C "$REPO_PATH" rev-parse --verify -q refs/remotes/origin/master >/dev/null 2>&1 \
+           || git -C "$REPO_PATH" rev-parse --verify -q refs/heads/master >/dev/null 2>&1; then
+        DEFAULT_BRANCH="master"
+      else
+        DEFAULT_BRANCH="main"
+      fi
+    fi
+    echo "  DEFAULT_BRANCH: $DEFAULT_BRANCH"
+
+    # Fetch default branch once per repo if remote exists
+    git -C "$REPO_PATH" fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+
     # List CEO branches
-    CEO_BRANCHES=$(git -C "$REPO_PATH" branch --list "${BRANCH_PREFIX}*" 2>/dev/null | sed 's/^[* ]*//' || true)
+    CEO_BRANCHES=$(git -C "$REPO_PATH" branch --list --format="%(refname:short)" "${BRANCH_PREFIX}*" 2>/dev/null || true)
 
     if [ -z "$CEO_BRANCHES" ]; then
       echo "  BRANCHES: none"
@@ -57,13 +76,13 @@ if [ -f "$REPOS_FILE" ]; then
     fi
 
     for BRANCH in $CEO_BRANCHES; do
-      # Check if branch is merged into origin/master
-      git -C "$REPO_PATH" fetch origin master --quiet 2>/dev/null || true
-      if git -C "$REPO_PATH" merge-base --is-ancestor "$BRANCH" origin/master 2>/dev/null; then
+      # Check if branch is merged into default branch (origin or local)
+      if git -C "$REPO_PATH" merge-base --is-ancestor "$BRANCH" "origin/$DEFAULT_BRANCH" 2>/dev/null \
+         || git -C "$REPO_PATH" merge-base --is-ancestor "$BRANCH" "$DEFAULT_BRANCH" 2>/dev/null; then
         echo "  MERGED: $BRANCH"
 
         # Find and remove worktree for this branch
-        WT_PATH=$(git -C "$REPO_PATH" worktree list --porcelain 2>/dev/null | grep -B1 "branch refs/heads/$BRANCH" | grep "^worktree" | sed 's/worktree //' || true)
+        WT_PATH=$(git -C "$REPO_PATH" worktree list --porcelain 2>/dev/null | awk -v target="branch refs/heads/$BRANCH" '/^worktree /{wt=substr($0, 10)} $0==target{print wt}')
         if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
           git -C "$REPO_PATH" worktree remove "$WT_PATH" 2>/dev/null && echo "  WORKTREE_REMOVED: $WT_PATH" || echo "  WORKTREE_REMOVE_FAILED: $WT_PATH"
         fi

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -19,6 +19,10 @@ mkdir -p "$CEO_VAULT/CEO/log"
 mkrepo_cleanup() {
   local name="$1" default_branch="$2"
   local dir="$TMP/repos/$name"
+  # A second call on the same name re-inits, and `git commit` then writes
+  # "nothing to commit" to STDOUT, which is captured into the returned path.
+  # Every later `git -C "$repo"` dies on it and the arm still reports pass.
+  [ ! -e "$dir" ] || { echo "mkrepo_cleanup: duplicate fixture name '$name'" >&2; return 1; }
   mkdir -p "$dir"
   git -C "$dir" init -q -b "$default_branch"
   git -C "$dir" config user.email t@t
@@ -182,6 +186,142 @@ test_cleanup_deletes_owned_ref_for_merged_branch() {
     "ownership marker must be deleted when branch is reaped"
   assert_eq "$(git -C "$repo" for-each-ref refs/ceo-loop/owned | wc -l | tr -d ' ')" "0" \
     "for-each-ref refs/ceo-loop/owned must be empty"
+}
+
+# A repo cloned from a bare origin, with `main` already carrying a merged ceo
+# branch on the remote. `local_lag` rewinds the clone's local main so the merge
+# is visible ONLY through origin/main — the state every one of the four original
+# arms lacked, and the reason reverting the remote half of the fix left them green.
+mkclone_cleanup() { # <name> <default-branch> <ceo-branch> <local_lag|no_lag>
+  local name="$1" default_branch="$2" ceo_branch="$3" mode="$4"
+  local origin="$TMP/repos/$name.git" clone="$TMP/repos/$name"
+  [ ! -e "$clone" ] || { echo "mkclone_cleanup: duplicate fixture name '$name'" >&2; return 1; }
+  git init -q --bare -b "$default_branch" "$origin"
+  git clone -q "$origin" "$clone" 2>/dev/null
+  git -C "$clone" config user.email t@t
+  git -C "$clone" config user.name t
+  echo init > "$clone/base.txt"
+  /usr/bin/git -C "$clone" add -A && git -C "$clone" commit -qm init
+  git -C "$clone" push -q origin "$default_branch"
+  git -C "$origin" symbolic-ref HEAD "refs/heads/$default_branch"
+  git -C "$clone" checkout -q -b "$ceo_branch"
+  echo feature > "$clone/feat.txt"
+  /usr/bin/git -C "$clone" add -A && git -C "$clone" commit -qm feature
+  git -C "$clone" checkout -q "$default_branch"
+  git -C "$clone" merge -q --no-ff "$ceo_branch" -m merge
+  git -C "$clone" push -q origin "$default_branch"
+  if [ "$mode" = "local_lag" ]; then
+    git -C "$clone" reset -q --hard HEAD~1
+  fi
+  echo "$clone"
+}
+
+mkmarker() { # <repo> <branch> -> echoes the ref name
+  local ref
+  ref="refs/ceo-loop/owned/$(branch_key "$2")"
+  git -C "$1" update-ref "$ref" "$(git -C "$1" rev-parse "$2")"
+  echo "$ref"
+}
+
+test_cleanup_reaps_a_merge_visible_only_through_the_remote() {
+  local repo; repo="$(mkclone_cleanup remote-only main ceo/remote-only local_lag)"
+  # Detach onto the remote's tip so `branch -d` agrees the branch is merged
+  # while local main still lags — isolating the remote ancestry arm.
+  git -C "$repo" checkout -q --detach origin/main
+  local ref; ref="$(mkmarker "$repo" ceo/remote-only)"
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "MERGED: ceo/remote-only" \
+    "a merge reachable only through origin/main must be seen as merged"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/remote-only 2>/dev/null || echo GONE)" "GONE" \
+    "the branch must actually be deleted"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" 2>/dev/null || echo GONE)" "GONE" \
+    "the ownership marker must be deleted alongside it"
+  assert_contains "$out" "MARKER_DELETED" "the marker deletion must be reported"
+}
+
+test_cleanup_keeps_the_marker_when_the_branch_delete_fails() {
+  # Local main lags origin/main, so the ancestry probe says merged and
+  # `git branch -d` refuses. Deleting the marker here would leave the branch
+  # standing with no ownership record and lock ceo-loop out of it forever.
+  local repo; repo="$(mkclone_cleanup lagging main ceo/lagging local_lag)"
+  local ref; ref="$(mkmarker "$repo" ceo/lagging)"
+  local before; before="$(git -C "$repo" rev-parse "$ref")"
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "BRANCH_DELETE_FAILED: ceo/lagging"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/lagging 2>/dev/null || echo GONE)" \
+    "$(git -C "$repo" rev-parse ceo/lagging)" "the branch must survive a failed delete"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" 2>/dev/null || echo GONE)" "$before" \
+    "the ownership marker must survive when its branch did"
+  assert_not_contains "$out" "MARKER_DELETED"
+}
+
+test_cleanup_keeps_the_marker_for_an_unmerged_branch() {
+  local repo; repo="$(mkrepo_cleanup unmerged-1 main)"
+  git -C "$repo" checkout -q -b ceo/never-merged
+  echo x > "$repo/x.txt"
+  /usr/bin/git -C "$repo" add -A && git -C "$repo" commit -qm x
+  local ref; ref="$(mkmarker "$repo" ceo/never-merged)"
+  local before; before="$(git -C "$repo" rev-parse "$ref")"
+  git -C "$repo" checkout -q main
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_not_contains "$out" "MERGED: ceo/never-merged"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" 2>/dev/null || echo GONE)" "$before" \
+    "an unmerged branch keeps its ownership marker"
+}
+
+test_cleanup_falls_through_a_stale_origin_head_symref() {
+  # The remote renamed its default branch; the clone's origin/HEAD still names
+  # the old one, which no longer resolves. Trusting it unchecked reproduces the
+  # very bug this reaper exists to fix.
+  local repo; repo="$(mkclone_cleanup renamed main ceo/renamed no_lag)"
+  git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+  local ref; ref="$(mkmarker "$repo" ceo/renamed)"
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH: main" \
+    "a stale origin/HEAD must fall through to the main/master chain"
+  assert_contains "$out" "MERGED: ceo/renamed"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/renamed 2>/dev/null || echo GONE)" "GONE" \
+    "the branch must be reaped despite the stale symref"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" 2>/dev/null || echo GONE)" "GONE" \
+    "the marker must be reaped with it"
+}
+
+test_cleanup_reports_an_unresolvable_default_branch() {
+  # No origin/HEAD, no main, no master. Inventing "main" here would hand both
+  # ancestry probes a dead ref and report the repo as all-active.
+  local repo; repo="$(mkrepo_cleanup trunk-only trunk)"
+  git -C "$repo" checkout -q -b ceo/orphaned
+  echo x > "$repo/x.txt"
+  /usr/bin/git -C "$repo" add -A && git -C "$repo" commit -qm x
+  git -C "$repo" checkout -q trunk
+  git -C "$repo" merge -q --no-ff ceo/orphaned -m merge
+  local ref; ref="$(mkmarker "$repo" ceo/orphaned)"
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH_UNRESOLVED" \
+    "an unresolvable default branch must be reported, not invented"
+  assert_not_contains "$out" "DEFAULT_BRANCH: main"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" 2>/dev/null || echo GONE)" \
+    "$(git -C "$repo" rev-parse ceo/orphaned)" "nothing is reaped when the default branch is unknown"
 }
 
 run_tests

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# ceo-cleanup.test.sh — tests for ceo-cleanup.sh merged branch reaping and default branch resolution.
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./test-harness.sh
+
+SCRIPT_DIR="$(pwd)"
+CLEANUP="$SCRIPT_DIR/ceo-cleanup.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+CEO_VAULT="$TMP/vault"
+export CEO_VAULT
+mkdir -p "$CEO_VAULT/CEO/log"
+
+mkrepo_cleanup() {
+  local name="$1" default_branch="$2"
+  local dir="$TMP/repos/$name"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b "$default_branch"
+  git -C "$dir" config user.email t@t
+  git -C "$dir" config user.name t
+  echo "init" > "$dir/base.txt"
+  git -C "$dir" add -A && git -C "$dir" commit -qm "init"
+  echo "$dir"
+}
+
+set_repos_md() { # <repo-path>...
+  local md="$CEO_VAULT/CEO/repos.md"
+  {
+    echo "| Repo | Local Path | Description |"
+    echo "|---|---|---|"
+    for p in "$@"; do
+      echo "| $(basename "$p") | $p | test repo |"
+    done
+  } > "$md"
+}
+
+test_cleanup_resolves_and_reaps_merged_branch_on_main_default() {
+  local repo; repo="$(mkrepo_cleanup repo-main-1 main)"
+  set_repos_md "$repo"
+
+  # Create a ceo branch with a commit
+  git -C "$repo" checkout -q -b ceo/test-feature
+  echo "feature" > "$repo/feat.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "add feature"
+
+  # Merge into main
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/test-feature -m "merge feature"
+
+  # Run cleanup
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH: main" "must report main as default branch"
+  assert_contains "$out" "MERGED: ceo/test-feature" "must identify branch as merged"
+  assert_contains "$out" "BRANCH_DELETED: ceo/test-feature" "must report branch deletion"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/test-feature 2>/dev/null || echo GONE)" "GONE" \
+    "merged branch must actually be deleted from git refs"
+}
+
+test_cleanup_resolves_and_reaps_merged_branch_on_master_default() {
+  local repo; repo="$(mkrepo_cleanup repo-master-1 master)"
+  set_repos_md "$repo"
+
+  # Create a ceo branch with a commit
+  git -C "$repo" checkout -q -b ceo/master-feature
+  echo "feature" > "$repo/feat.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "add feature"
+
+  # Merge into master
+  git -C "$repo" checkout -q master
+  git -C "$repo" merge -q --no-ff ceo/master-feature -m "merge feature"
+
+  # Run cleanup
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH: master" "must report master as default branch"
+  assert_contains "$out" "MERGED: ceo/master-feature" "must identify branch as merged"
+  assert_contains "$out" "BRANCH_DELETED: ceo/master-feature" "must report branch deletion"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/master-feature 2>/dev/null || echo GONE)" "GONE" \
+    "merged branch must actually be deleted from git refs"
+}
+
+test_cleanup_resolves_origin_head_symref() {
+  local origin="$TMP/repos/origin-trunk.git"
+  git init -q --bare -b trunk "$origin"
+  local seed="$TMP/repos/seed-trunk"
+  git clone -q "$origin" "$seed"
+  git -C "$seed" config user.email t@t
+  git -C "$seed" config user.name t
+  echo "init" > "$seed/base.txt"
+  git -C "$seed" add -A && git -C "$seed" commit -qm "init"
+  git -C "$seed" push -q origin trunk
+  git -C "$origin" symbolic-ref HEAD refs/heads/trunk
+  rm -rf "$seed"
+
+  local clone="$TMP/repos/clone-trunk"
+  git clone -q "$origin" "$clone"
+  git -C "$clone" config user.email t@t
+  git -C "$clone" config user.name t
+  set_repos_md "$clone"
+
+  # Create a ceo branch in clone
+  git -C "$clone" checkout -q -b ceo/trunk-feature
+  echo "feature" > "$clone/feat.txt"
+  git -C "$clone" add -A && git -C "$clone" commit -qm "add trunk feature"
+
+  # Merge into trunk and push to origin
+  git -C "$clone" checkout -q trunk
+  git -C "$clone" merge -q --no-ff ceo/trunk-feature -m "merge trunk feature"
+  git -C "$clone" push -q origin trunk
+
+  # Run cleanup
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH: trunk" "must resolve trunk from origin/HEAD symref"
+  assert_contains "$out" "MERGED: ceo/trunk-feature" "must identify branch as merged"
+  assert_eq "$(git -C "$clone" rev-parse --verify -q refs/heads/ceo/trunk-feature 2>/dev/null || echo GONE)" "GONE" \
+    "merged branch must actually be deleted from git refs"
+}
+
+test_cleanup_removes_worktree_for_merged_branch() {
+  local repo; repo="$(mkrepo_cleanup repo-wt-1 main)"
+  set_repos_md "$repo"
+
+  # Create a ceo branch and worktree
+  local wt="$TMP/wt/ceo-test-wt"
+  git -C "$repo" worktree add -q -b ceo/test-wt "$wt" main
+  echo "wt" > "$wt/wt.txt"
+  git -C "$wt" add -A && git -C "$wt" commit -qm "add wt feature"
+
+  # Merge branch into main
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/test-wt -m "merge wt feature"
+
+  # Verify worktree exists before cleanup
+  assert_eq "$(git -C "$repo" worktree list | grep -c "ceo/test-wt" || true)" "1"
+
+  # Run cleanup
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "WORKTREE_REMOVED"
+  assert_eq "$(git -C "$repo" worktree list | grep -c "ceo/test-wt" || true)" "0" \
+    "worktree must be deregistered"
+  assert_eq "$([ -d "$wt" ] && echo exists || echo gone)" "gone" "worktree directory must be removed"
+}
+
+run_tests

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 source ./test-harness.sh
+# shellcheck source=ceo-loop-lib.sh
+source ./ceo-loop-lib.sh
 
 SCRIPT_DIR="$(pwd)"
 CLEANUP="$SCRIPT_DIR/ceo-cleanup.sh"
@@ -149,6 +151,37 @@ test_cleanup_removes_worktree_for_merged_branch() {
   assert_eq "$(git -C "$repo" worktree list | grep -c "ceo/test-wt" || true)" "0" \
     "worktree must be deregistered"
   assert_eq "$([ -d "$wt" ] && echo exists || echo gone)" "gone" "worktree directory must be removed"
+}
+
+test_cleanup_deletes_owned_ref_for_merged_branch() {
+  local repo; repo="$(mkrepo_cleanup repo-owned-1 main)"
+  set_repos_md "$repo"
+
+  # Create a ceo branch with a commit
+  git -C "$repo" checkout -q -b ceo/owned-feature
+  echo "owned" > "$repo/owned.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "add owned feature"
+
+  # Create the loop ownership marker as ceo-loop would
+  local key; key="$(branch_key "ceo/owned-feature")"
+  local owned_ref="refs/ceo-loop/owned/$key"
+  git -C "$repo" update-ref "$owned_ref" "$(git -C "$repo" rev-parse ceo/owned-feature)"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$owned_ref" 2>/dev/null || echo GONE)" \
+    "$(git -C "$repo" rev-parse ceo/owned-feature)" "ownership marker must exist before cleanup"
+
+  # Merge branch into main
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/owned-feature -m "merge owned feature"
+
+  # Run cleanup
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "MERGED: ceo/owned-feature"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$owned_ref" 2>/dev/null || echo GONE)" "GONE" \
+    "ownership marker must be deleted when branch is reaped"
+  assert_eq "$(git -C "$repo" for-each-ref refs/ceo-loop/owned | wc -l | tr -d ' ')" "0" \
+    "for-each-ref refs/ceo-loop/owned must be empty"
 }
 
 run_tests

--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -371,3 +371,15 @@ jq -nc --arg fp "$CEO_FP" \
 echo "repair-$CEO_FP"
 TICKET_INNER
 }
+
+# ── branch key hashing (#338) ────────────────────────────────────────────────
+
+# branch_key <branch-name> -> stable hex, whichever hasher this host has
+branch_key() {
+  local h
+  h="$(printf '%s' "$1" | shasum 2>/dev/null | awk '{print $1}')"
+  [ -n "$h" ] || h="$(printf '%s' "$1" | sha1sum 2>/dev/null | awk '{print $1}')"
+  [ -n "$h" ] || h="$(printf '%s' "$1" | cksum | awk '{print $1"-"$2}')"
+  printf '%s' "$h"
+}
+

--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -374,12 +374,17 @@ TICKET_INNER
 
 # ── branch key hashing (#338) ────────────────────────────────────────────────
 
-# branch_key <branch-name> -> stable hex, whichever hasher this host has
+# branch_key <branch-name> -> 40-hex SHA-1
+#
+# One hasher, hard-required, matching ceo_finding_fingerprint and the repair
+# fingerprint above. This used to fall back sha1sum -> cksum, which bought
+# nothing — those callers already require shasum outright, so a shasum-free host
+# is broken regardless — and cost the property the key exists for. The key is an
+# identity: ceo-loop.sh writes refs/ceo-loop/owned/<key> and ceo-cleanup.sh
+# deletes it. Two PATHs resolving different tiers (cron vs. an interactive
+# login) yield different keys for one branch, and cleanup then reports a clean
+# reap while the marker leaks permanently (#341).
 branch_key() {
-  local h
-  h="$(printf '%s' "$1" | shasum 2>/dev/null | awk '{print $1}')"
-  [ -n "$h" ] || h="$(printf '%s' "$1" | sha1sum 2>/dev/null | awk '{print $1}')"
-  [ -n "$h" ] || h="$(printf '%s' "$1" | cksum | awk '{print $1"-"$2}')"
-  printf '%s' "$h"
+  printf '%s' "$(printf '%s' "$1" | shasum | awk '{print $1}')"
 }
 

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -239,7 +239,8 @@ test_branch_key_returns_deterministic_hash() {
   k3="$(branch_key "nh/other-test")"
   assert_eq "$k1" "$k2" "same branch produces identical key"
   assert_fails "different branches produce different keys" test "$k1" = "$k3"
-  assert_eq "${#k1}" "40" "sha1/shasum produces 40-character hex key"
+  assert_eq "${#k1}" "40" "the key is a 40-character SHA-1"
+  assert_fails "the key is lowercase hex only" test -n "$(printf '%s' "$k1" | tr -d '0-9a-f')"
 }
 
 run_tests

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -232,4 +232,14 @@ test_promotion_integration_branch_targets_always_promote() {
   assert_eq "$(ceo_promotion_gate high integration main "")" "promote"
 }
 
+test_branch_key_returns_deterministic_hash() {
+  local k1 k2 k3
+  k1="$(branch_key "nh/loop-test")"
+  k2="$(branch_key "nh/loop-test")"
+  k3="$(branch_key "nh/other-test")"
+  assert_eq "$k1" "$k2" "same branch produces identical key"
+  assert_fails "different branches produce different keys" test "$k1" = "$k3"
+  assert_eq "${#k1}" "40" "sha1/shasum produces 40-character hex key"
+}
+
 run_tests

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -101,20 +101,27 @@ require_field() { # <jq-path> <name>
   fi
   printf '%s' "$v"
 }
+valid_ref_name() { # <ref-name>
+  local r="$1"
+  # The branch name becomes both a git ref and a filesystem path, so it is
+  # validated before either is built from it. `check-ref-format` is the authority
+  # and covers the case that mattered: ".." reached the slash collapse below, WT
+  # resolved to $REPO_DIR, and the reclaim's `rm -rf` aimed at the repository root
+  # (#332). The one thing it accepts and should not is a leading dash — today only
+  # `checkout -b` happens to refuse that, and every other interpolation of the ref
+  # would read it as an option, so it is rejected here rather than left to luck.
+  if ! git check-ref-format "refs/heads/$r" 2>/dev/null \
+     || case "$r" in -*) true ;; *) false ;; esac; then
+    echo "ceo-loop: '$r' is not a valid git branch name — refusing to build a ref or a worktree path from it" >&2
+    exit 2
+  fi
+}
+valid_ref_name "$TARGET"
+valid_ref_name "$DEFAULT_BRANCH"
+
 REPO="$(require_field '.repo' 'repo' | tr '/' '-')" # keep state paths one level deep
 BRANCH="$(require_field '.branch' 'branch')"
-# The branch name becomes both a git ref and a filesystem path, so it is
-# validated before either is built from it. `check-ref-format` is the authority
-# and covers the case that mattered: ".." reached the slash collapse below, WT
-# resolved to $REPO_DIR, and the reclaim's `rm -rf` aimed at the repository root
-# (#332). The one thing it accepts and should not is a leading dash — today only
-# `checkout -b` happens to refuse that, and every other interpolation of $BRANCH
-# would read it as an option, so it is rejected here rather than left to luck.
-if ! git check-ref-format "refs/heads/$BRANCH" 2>/dev/null \
-   || case "$BRANCH" in -*) true ;; *) false ;; esac; then
-  echo "ceo-loop: '$BRANCH' is not a valid git branch name — refusing to build a ref or a worktree path from it" >&2
-  exit 2
-fi
+valid_ref_name "$BRANCH"
 SHAPE="$(jget '.shape // "bug-fix"')"
 VERIFY_CMD="$(require_field '.verify_cmd' 'verify_cmd')"
 

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -207,13 +207,6 @@ VERIFY_LOG=""
 # namespace cannot hold "topic" and "topic/sub" at once, and collapsing "/" to
 # "_" made nh/loop-x and the literal nh_loop-x share one worktree, so the second
 # run evicted the first run's checkout.
-branch_key() { # <branch-name> -> stable hex, whichever hasher this host has
-  local h
-  h="$(printf '%s' "$1" | shasum 2>/dev/null | awk '{print $1}')"
-  [ -n "$h" ] || h="$(printf '%s' "$1" | sha1sum 2>/dev/null | awk '{print $1}')"
-  [ -n "$h" ] || h="$(printf '%s' "$1" | cksum | awk '{print $1"-"$2}')"
-  printf '%s' "$h"
-}
 BRANCH_KEY="$(branch_key "$BRANCH")"
 
 if [ "$DRY_RUN" != "1" ]; then

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -669,7 +669,9 @@ test_rejects_a_target_name_with_leading_dash() {
   local out rc=0
   out=$(bash "$LOOP" run --spec "$TMP/tdash.json" --routes "$TMP/routes-tdash.json" --target -oProxyCommand=x 2>&1) || rc=$?
   assert_eq "$rc" "2" "a target branch name starting with - is rejected at argument validation"
-  assert_contains "$out" "not a valid git branch name"
+  # Name the value: valid_ref_name is called for BRANCH, TARGET and DEFAULT_BRANCH
+  # and emits one message shape, so a bare needle passes with TARGET unvalidated.
+  assert_contains "$out" "'-oProxyCommand=x' is not a valid git branch name"
 }
 
 test_rejects_a_target_name_git_would_not_accept() {
@@ -680,7 +682,7 @@ test_rejects_a_target_name_git_would_not_accept() {
   local out rc=0
   out=$(bash "$LOOP" run --spec "$TMP/tbad.json" --routes "$TMP/routes-tbad.json" --target "main^" 2>&1) || rc=$?
   assert_eq "$rc" "2" "an invalid target branch name is rejected at argument validation"
-  assert_contains "$out" "not a valid git branch name"
+  assert_contains "$out" "'main^' is not a valid git branch name"
 }
 
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -661,4 +661,26 @@ JSON
   assert_not_contains "$out" "unknown ticket"
 }
 
+test_rejects_a_target_name_with_leading_dash() {
+  local repo; repo="$(mkrepo targetdash)"
+  local wscript="${TMP}/w-tdash.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-tdash.json" "$wscript" true
+  mkspec "$TMP/tdash.json" "$repo" nh/loop-tdash "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/tdash.json" --routes "$TMP/routes-tdash.json" --target -oProxyCommand=x 2>&1) || rc=$?
+  assert_eq "$rc" "2" "a target branch name starting with - is rejected at argument validation"
+  assert_contains "$out" "not a valid git branch name"
+}
+
+test_rejects_a_target_name_git_would_not_accept() {
+  local repo; repo="$(mkrepo targetbadname)"
+  local wscript="${TMP}/w-tbad.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-tbad.json" "$wscript" true
+  mkspec "$TMP/tbad.json" "$repo" nh/loop-tbad "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/tbad.json" --routes "$TMP/routes-tbad.json" --target "main^" 2>&1) || rc=$?
+  assert_eq "$rc" "2" "an invalid target branch name is rejected at argument validation"
+  assert_contains "$out" "not a valid git branch name"
+}
+
 run_tests


### PR DESCRIPTION
Closes #338

## Description (Issue Fixed & New Behavior)

Three hygiene fixes in `scripts/ceo-cleanup.sh` and `scripts/ceo-loop.sh`, plus the defects a review panel found in the first pass at them.

**1. `ceo-cleanup.sh` reaped against the wrong default branch.** It compared merged branches to `origin/master` while `ceo-loop.sh` defaults `TARGET=main`, so on a `main` repo no loop branch was ever seen as merged and the reaper silently did nothing. It now resolves the default branch from `git symbolic-ref refs/remotes/origin/HEAD`, verifies that the resolved name actually resolves to a ref, falls back to `main` then `master`, and prints `DEFAULT_BRANCH: <name>`. When nothing resolves it prints `DEFAULT_BRANCH_UNRESOLVED` and skips the repo rather than inventing a name — an invented name hands both ancestry probes a dead ref and reports the repo as all-active.

Verifying the symref matters on its own: `symbolic-ref` does not check its target, so a remote that renames its default branch leaves a symref pointing at a ref that no longer exists. Trusting that reproduced the exact symptom this issue exists to fix.

**2. Ownership markers are reaped alongside merged branches.** `branch_key()` moved into `scripts/ceo-loop-lib.sh` so `ceo-cleanup.sh` and `ceo-loop.sh` share one implementation, and the `MERGED:` arm deletes the branch's `refs/ceo-loop/owned/<key>` marker.

The delete is gated on `git branch -d` actually succeeding. The two judgments disagree — the ancestry probe is answered by `origin/$DEFAULT_BRANCH`, `branch -d` by the local branch — so in any clone whose local default branch lags the remote the first says merged and the second refuses. Deleting the marker there left the branch standing with no ownership record, and `ceo-loop` then reads it as a stranger's branch and refuses it forever (exit 6). It now reports `MARKER_DELETED` / `MARKER_DELETE_FAILED`, matching every neighbouring operation.

`branch_key()` also lost its `shasum` → `sha1sum` → `cksum` fallback chain. The chain bought nothing (`ceo_finding_fingerprint` and the repair fingerprint in the same file already require `shasum` outright) and cost the property the key exists for: two PATHs resolving different tiers produce different keys for one branch, so cleanup reports a clean reap while the marker leaks. Output is byte-identical for every input tried, so no marker already on disk is orphaned.

**3. `$TARGET` reached a ref write unvalidated.** `ceo-loop.sh` hoisted its `check-ref-format` + leading-dash check into a shared `valid_ref_name()` and applies it to `$TARGET` and `$DEFAULT_BRANCH` alongside `$BRANCH`. The pre-existing `rev-parse --verify` at `:169` is gated on `[ -z "$CURRENT_BASE" ]`, so `--current-base <sha>` skipped it entirely.

Also restores `readlink -f "$0"` in `_CLEANUP_DIR`. Dropping it was unrelated to all three fixes and made this the one script that dies before it can source its own config when invoked through a symlink; thirteen sibling scripts keep that form.

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning $(find ./scripts -name '*.sh')` — 0 warnings.
3. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` — 10 pass. (bash 4+ required; macOS stock `/bin/bash` is 3.2 and fails every arm on `mapfile`.)
4. `… scripts/ceo-loop-lib.test.sh` — 33 pass.
5. `… scripts/ceo-loop.test.sh` — 32 pass. Several minutes; that is normal.
6. Mutation-check each guard individually. Reverting the remote ancestry arm to `origin/master` fails 5 assertions; ungating the marker delete fails 1; dropping the symref verification fails 4; re-inventing `main` instead of reporting unresolved fails 2; removing `valid_ref_name "\$TARGET"` fails 4. Every one asserts git ref state (`rev-parse`, `for-each-ref`, `worktree list`) rather than stderr text.

## Additional Notes

Reviewed by a three-lane panel (conventions, silent-failure, test quality) against a read-only worktree. The findings it produced are what the second and third commits fix — the marker-on-failed-reap bug was a regression this PR introduced, and the four original cleanup arms all stayed green when the remote half of fix 1 was reverted, because none of their fixtures had a merge visible only through the remote.

Two findings deferred with tickets rather than scope creep: #342 (`MERGED_TOTAL` counts detections rather than successful deletions, so a run that reaps nothing still reports `AI_NEEDED: no`) and #343 (`ceo-loop` reports `action=promote` and exits 0 after a failed fast-forward).