### PR TITLE
Fix silent failures and count accurate branch reaps in ceo-cleanup (#342)

### DIFF
--- a/docs/playbooks/cleanup.md
+++ b/docs/playbooks/cleanup.md
@@ -24,20 +24,39 @@ Weekly maintenance: clean up branches, worktrees, and review CEO log history.
    - Reads CEO/repos.md for cloned repos
    - Lists CEO branches and worktrees per repo
    - Removes merged branches and their worktrees automatically
+   - Reports every merged branch it could NOT reap (`REAP_FAILED`)
+   - Reports state it could not trust or clean up (`STALE_STATE`) — a failed
+     fetch of the default branch, or an ownership marker left behind
+   - Clears a worktree whose directory is gone, so the branch delete can proceed
    - Identifies orphaned branches (no PR, >7 days old)
    - Counts sync conflict files
    - Counts old log files (>30 days)
    - Reports whether AI judgment is needed
 
-3. **If AI_NEEDED: yes** — review the orphaned branches listed in ORPHAN_SUMMARY. For each:
-   - If the branch name suggests abandoned work, propose deletion in CEO/approvals/pending.md
-   - If the branch might have unsaved work, log it as "needs review" but do not propose deletion
+3. **If AI_NEEDED: yes** — the line names every reason, separated by `;`, and
+   there may be more than one. `AI_NEEDED: yes` no longer implies an
+   `ORPHAN_SUMMARY` exists, so read the reasons rather than assuming.
+
+   - **"review orphaned branches"** — an `ORPHAN_SUMMARY` block is present. For
+     each branch: if the name suggests abandoned work, propose deletion in
+     CEO/approvals/pending.md; if it might hold unsaved work, log it as "needs
+     review" and do not propose deletion.
+   - **"merged branch(es) failed to reap"** — the branch is merged on the remote
+     but `git branch -d` refused, usually because the local default branch lags
+     `origin` or a worktree still holds it. Look for `BRANCH_DELETE_FAILED` and
+     `WORKTREE_REMOVE_FAILED` above. Do not propose deleting these; they are a
+     host-state problem, not abandoned work.
+   - **"stale-state warning(s)"** — look for `FETCH_FAILED` (the merge decisions
+     in this run were made against a possibly stale view of the remote) or
+     `MARKER_DELETE_FAILED` (a branch was reaped but its `refs/ceo-loop/owned/*`
+     marker leaked). Log both; neither is a deletion proposal.
 
 4. **If sync conflicts found** — log them as errors. These indicate Syncthing write-domain violations.
 
 5. **Output cleanup summary** in the LOG_ENTRY Output section — the shell will write it to CEO/log/YYYY-MM-DD.md:
    ```
-   - N worktrees removed (merged)
+   - N merged branches reaped (MERGED_TOTAL), N failed to reap (REAP_FAILED)
+   - N stale-state warnings (STALE_STATE)
    - N orphaned branches found (N proposals written)
    - N sync conflicts detected
    - N log files older than 30 days

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -42,6 +42,7 @@ echo ""
 
 # --- Process each cloned repo ---
 MERGED_COUNT=0
+REAP_FAILED_COUNT=0
 ORPHAN_BRANCHES=""
 HAS_REPOS=false
 
@@ -122,6 +123,7 @@ if [ -f "$REPOS_FILE" ]; then
         # forever (exit 6), recoverable only by a hand-written update-ref (#341).
         if git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null; then
           echo "  BRANCH_DELETED: $BRANCH"
+          MERGED_COUNT=$((MERGED_COUNT + 1))
           OWNED_REF="refs/ceo-loop/owned/$(branch_key "$BRANCH")"
           if git -C "$REPO_PATH" show-ref --verify -q "$OWNED_REF" 2>/dev/null; then
             git -C "$REPO_PATH" update-ref -d "$OWNED_REF" 2>/dev/null \
@@ -130,8 +132,8 @@ if [ -f "$REPOS_FILE" ]; then
           fi
         else
           echo "  BRANCH_DELETE_FAILED: $BRANCH"
+          REAP_FAILED_COUNT=$((REAP_FAILED_COUNT + 1))
         fi
-        MERGED_COUNT=$((MERGED_COUNT + 1))
       else
         # Check if branch has an open PR
         REPO_NAME=$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\(.*\)\.git/\1/' | sed 's/.*github.com[:/]\(.*\)/\1/' || echo "unknown")
@@ -161,6 +163,7 @@ if [ "$HAS_REPOS" = false ]; then
 fi
 
 echo "MERGED_TOTAL: $MERGED_COUNT"
+echo "REAP_FAILED: $REAP_FAILED_COUNT"
 
 # --- Sync conflicts ---
 CONFLICTS=$(find "$CEO_DIR" -name "*.sync-conflict-*" -type f 2>/dev/null || true)
@@ -181,9 +184,15 @@ if [ -n "$ORPHAN_BRANCHES" ]; then
   echo ""
   echo "ORPHAN_SUMMARY:"
   printf '%b\n' "$ORPHAN_BRANCHES"
-  echo ""
+fi
+
+echo ""
+if [ -n "$ORPHAN_BRANCHES" ] && [ "$REAP_FAILED_COUNT" -gt 0 ]; then
+  echo "AI_NEEDED: yes — review orphaned branches; $REAP_FAILED_COUNT merged branch(es) failed to reap (check worktree or local branch lag)"
+elif [ -n "$ORPHAN_BRANCHES" ]; then
   echo "AI_NEEDED: yes — review orphaned branches and decide whether to propose deletion"
+elif [ "$REAP_FAILED_COUNT" -gt 0 ]; then
+  echo "AI_NEEDED: yes — $REAP_FAILED_COUNT merged branch(es) failed to reap (check worktree or local branch lag)"
 else
-  echo ""
   echo "AI_NEEDED: no — all branches are merged or active"
 fi

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -43,6 +43,7 @@ echo ""
 # --- Process each cloned repo ---
 MERGED_COUNT=0
 REAP_FAILED_COUNT=0
+STALE_STATE_COUNT=0
 ORPHAN_BRANCHES=""
 HAS_REPOS=false
 
@@ -89,11 +90,22 @@ if [ -f "$REPOS_FILE" ]; then
     fi
     echo "  DEFAULT_BRANCH: $DEFAULT_BRANCH"
 
-    # Fetch default branch once per repo if remote exists
-    if git -C "$REPO_PATH" remote get-url origin >/dev/null 2>&1; then
-      if ! git -C "$REPO_PATH" fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null; then
-        echo "  FETCH_FAILED: origin/$DEFAULT_BRANCH — merge state may be stale"
-      fi
+    # Fetch the default branch once per repo.
+    #
+    # ceo_branch_resolves accepts a purely local refs/heads/<name>, so
+    # DEFAULT_BRANCH can name a branch the remote has never heard of. Fetching
+    # that always fails, against a perfectly healthy origin, so the failure is
+    # only worth reporting when a remote-tracking ref says the branch is there
+    # to fetch. Without that check the warning fires on every such repo and
+    # stops meaning anything.
+    if ! git -C "$REPO_PATH" remote get-url origin >/dev/null 2>&1; then
+      echo "  NO_REMOTE: merge state judged from local refs only"
+    elif ! FETCH_ERR="$(git -C "$REPO_PATH" fetch origin "$DEFAULT_BRANCH" --quiet 2>&1)" \
+         && git -C "$REPO_PATH" rev-parse --verify -q "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+      # Reaping continues on the stale view below, so this has to reach
+      # AI_NEEDED rather than scroll past as one more line.
+      echo "  FETCH_FAILED: origin/$DEFAULT_BRANCH — merge state may be stale: $(printf '%s' "$FETCH_ERR" | tr '\n' ' ' | cut -c1-160)"
+      STALE_STATE_COUNT=$((STALE_STATE_COUNT + 1))
     fi
 
     # List CEO branches
@@ -116,8 +128,21 @@ if [ -f "$REPOS_FILE" ]; then
           if [ -d "$WT_PATH" ]; then
             git -C "$REPO_PATH" worktree remove "$WT_PATH" 2>/dev/null && echo "  WORKTREE_REMOVED: $WT_PATH" || echo "  WORKTREE_REMOVE_FAILED: $WT_PATH"
           else
-            echo "  WORKTREE_STALE: $WT_PATH — pruning"
-            git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+            # Registered but the directory is gone, which blocks `branch -d`.
+            #
+            # NOT `git worktree prune`: that is repo-wide, and "directory
+            # missing" is not "worktree dead" — an unmounted volume or a
+            # sleeping network mount looks identical. Called from this
+            # per-branch loop it deregisters every other worktree in the repo
+            # that happens to be unreachable right now, deleting the
+            # per-worktree admin dir that holds their index and HEAD. Measured:
+            # `git worktree repair` cannot undo it and staged work is gone.
+            # `worktree remove --force` touches exactly this path (#344).
+            if git -C "$REPO_PATH" worktree remove --force "$WT_PATH" 2>/dev/null; then
+              echo "  WORKTREE_STALE_REMOVED: $WT_PATH"
+            else
+              echo "  WORKTREE_STALE_REMOVE_FAILED: $WT_PATH"
+            fi
           fi
         fi
 
@@ -137,7 +162,7 @@ if [ -f "$REPOS_FILE" ]; then
           if git -C "$REPO_PATH" show-ref --verify -q "$OWNED_REF" 2>/dev/null; then
             git -C "$REPO_PATH" update-ref -d "$OWNED_REF" 2>/dev/null \
               && echo "  MARKER_DELETED: $OWNED_REF" \
-              || echo "  MARKER_DELETE_FAILED: $OWNED_REF"
+              || { echo "  MARKER_DELETE_FAILED: $OWNED_REF"; STALE_STATE_COUNT=$((STALE_STATE_COUNT + 1)); }
           fi
         else
           echo "  BRANCH_DELETE_FAILED: $BRANCH"
@@ -173,10 +198,11 @@ fi
 
 echo "MERGED_TOTAL: $MERGED_COUNT"
 echo "REAP_FAILED: $REAP_FAILED_COUNT"
+echo "STALE_STATE: $STALE_STATE_COUNT"
 
 # --- Sync conflicts ---
 CONFLICTS=$(find "$CEO_DIR" -name "*.sync-conflict-*" -type f 2>/dev/null || true)
-CONFLICT_COUNT=$(echo "$CONFLICTS" | grep -c "." 2>/dev/null || echo 0)
+CONFLICT_COUNT=$(printf '%s' "$CONFLICTS" | grep -c "." 2>/dev/null) || CONFLICT_COUNT=0
 echo ""
 echo "SYNC_CONFLICTS: $CONFLICT_COUNT"
 if [ -n "$CONFLICTS" ] && [ "$CONFLICT_COUNT" -gt 0 ]; then
@@ -195,13 +221,17 @@ if [ -n "$ORPHAN_BRANCHES" ]; then
   printf '%b\n' "$ORPHAN_BRANCHES"
 fi
 
+# Every condition that needs a human contributes one clause, so a run with two
+# problems reports both. The nested form this replaces had an arm per
+# combination, and the combination arms were the ones no test could reach.
+AI_REASONS=""
+[ -n "$ORPHAN_BRANCHES" ] && AI_REASONS="$AI_REASONS; review orphaned branches and decide whether to propose deletion"
+[ "$REAP_FAILED_COUNT" -gt 0 ] && AI_REASONS="$AI_REASONS; $REAP_FAILED_COUNT merged branch(es) failed to reap (check worktree or local branch lag)"
+[ "$STALE_STATE_COUNT" -gt 0 ] && AI_REASONS="$AI_REASONS; $STALE_STATE_COUNT stale-state warning(s) — see FETCH_FAILED / MARKER_DELETE_FAILED above"
+
 echo ""
-if [ -n "$ORPHAN_BRANCHES" ] && [ "$REAP_FAILED_COUNT" -gt 0 ]; then
-  echo "AI_NEEDED: yes — review orphaned branches; $REAP_FAILED_COUNT merged branch(es) failed to reap (check worktree or local branch lag)"
-elif [ -n "$ORPHAN_BRANCHES" ]; then
-  echo "AI_NEEDED: yes — review orphaned branches and decide whether to propose deletion"
-elif [ "$REAP_FAILED_COUNT" -gt 0 ]; then
-  echo "AI_NEEDED: yes — $REAP_FAILED_COUNT merged branch(es) failed to reap (check worktree or local branch lag)"
+if [ -n "$AI_REASONS" ]; then
+  echo "AI_NEEDED: yes —${AI_REASONS#;}"
 else
   echo "AI_NEEDED: no — all branches are merged or active"
 fi

--- a/scripts/ceo-cleanup.sh
+++ b/scripts/ceo-cleanup.sh
@@ -90,7 +90,11 @@ if [ -f "$REPOS_FILE" ]; then
     echo "  DEFAULT_BRANCH: $DEFAULT_BRANCH"
 
     # Fetch default branch once per repo if remote exists
-    git -C "$REPO_PATH" fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+    if git -C "$REPO_PATH" remote get-url origin >/dev/null 2>&1; then
+      if ! git -C "$REPO_PATH" fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null; then
+        echo "  FETCH_FAILED: origin/$DEFAULT_BRANCH — merge state may be stale"
+      fi
+    fi
 
     # List CEO branches
     CEO_BRANCHES=$(git -C "$REPO_PATH" branch --list --format="%(refname:short)" "${BRANCH_PREFIX}*" 2>/dev/null || true)
@@ -108,8 +112,13 @@ if [ -f "$REPOS_FILE" ]; then
 
         # Find and remove worktree for this branch
         WT_PATH=$(git -C "$REPO_PATH" worktree list --porcelain 2>/dev/null | awk -v target="branch refs/heads/$BRANCH" '/^worktree /{wt=substr($0, 10)} $0==target{print wt}')
-        if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
-          git -C "$REPO_PATH" worktree remove "$WT_PATH" 2>/dev/null && echo "  WORKTREE_REMOVED: $WT_PATH" || echo "  WORKTREE_REMOVE_FAILED: $WT_PATH"
+        if [ -n "$WT_PATH" ]; then
+          if [ -d "$WT_PATH" ]; then
+            git -C "$REPO_PATH" worktree remove "$WT_PATH" 2>/dev/null && echo "  WORKTREE_REMOVED: $WT_PATH" || echo "  WORKTREE_REMOVE_FAILED: $WT_PATH"
+          else
+            echo "  WORKTREE_STALE: $WT_PATH — pruning"
+            git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+          fi
         fi
 
         # Delete local branch, and only then its ownership marker (#338).
@@ -121,7 +130,7 @@ if [ -f "$REPOS_FILE" ]; then
         # the marker there leaves the branch standing with no ownership record,
         # and ceo-loop then reads it as a stranger's branch and refuses it
         # forever (exit 6), recoverable only by a hand-written update-ref (#341).
-        if git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null; then
+        if git -C "$REPO_PATH" branch -d "$BRANCH" >/dev/null 2>&1; then
           echo "  BRANCH_DELETED: $BRANCH"
           MERGED_COUNT=$((MERGED_COUNT + 1))
           OWNED_REF="refs/ceo-loop/owned/$(branch_key "$BRANCH")"

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -324,4 +324,25 @@ test_cleanup_reports_an_unresolvable_default_branch() {
     "$(git -C "$repo" rev-parse ceo/orphaned)" "nothing is reaped when the default branch is unknown"
 }
 
+test_cleanup_counts_deletions_not_detections_and_reports_reap_failure() {
+  # Local main lags origin/main: ancestry probe says merged, but git branch -d
+  # fails. MERGED_TOTAL must report 0 (actual reaps), REAP_FAILED must report 1,
+  # and AI_NEEDED must flip to yes naming the failure.
+  local repo; repo="$(mkclone_cleanup countfail main ceo/countfail local_lag)"
+  local ref; ref="$(mkmarker "$repo" ceo/countfail)"
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "MERGED: ceo/countfail" "branch is detected as merged"
+  assert_contains "$out" "BRANCH_DELETE_FAILED: ceo/countfail" "branch delete fails"
+  assert_contains "$out" "MERGED_TOTAL: 0" "MERGED_TOTAL counts actual reaps, not detections"
+  assert_contains "$out" "REAP_FAILED: 1" "REAP_FAILED reports un-reaped branches"
+  assert_contains "$out" "AI_NEEDED: yes" "AI_NEEDED must flip to yes on reap failure"
+  assert_contains "$out" "1 merged branch(es) failed to reap" "AI_NEEDED reason names reap failures"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/countfail 2>/dev/null || echo GONE)" \
+    "$(git -C "$repo" rev-parse ceo/countfail)" "the un-reaped branch still exists"
+}
+
 run_tests

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -65,6 +65,14 @@ test_cleanup_resolves_and_reaps_merged_branch_on_main_default() {
   assert_contains "$out" "BRANCH_DELETED: ceo/test-feature" "must report branch deletion"
   assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/test-feature 2>/dev/null || echo GONE)" "GONE" \
     "merged branch must actually be deleted from git refs"
+  # The counters need pinning at their quiet values too: an arm that only ever
+  # asserts a non-zero count cannot catch a counter that never increments, or
+  # one that increments always.
+  assert_contains "$out" "MERGED_TOTAL: 1" "a reaped branch is counted"
+  assert_contains "$out" "REAP_FAILED: 0" "nothing failed, so nothing is reported failed"
+  assert_contains "$out" "STALE_STATE: 0" "no stale-state warning on a clean run"
+  assert_contains "$out" "AI_NEEDED: no" "a clean run needs no human"
+  assert_not_contains "$out" "FETCH_FAILED" "a healthy run raises no fetch alarm"
 }
 
 test_cleanup_resolves_and_reaps_merged_branch_on_master_default() {
@@ -377,8 +385,7 @@ test_cleanup_prunes_stale_worktree_and_reaps_branch() {
   local out rc=0
   out=$(bash "$CLEANUP" 2>&1) || rc=$?
   assert_eq "$rc" "0" "cleanup must succeed"
-  assert_contains "$out" "WORKTREE_STALE:" "must identify stale worktree"
-  assert_contains "$out" "ceo-stale-wt — pruning" "must announce worktree pruning"
+  assert_contains "$out" "WORKTREE_STALE_REMOVED:" "must report the stale worktree it removed"
   assert_contains "$out" "BRANCH_DELETED: ceo/stale-wt" "branch must be deleted"
   assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/stale-wt 2>/dev/null || echo GONE)" "GONE" \
     "branch must be reaped after pruning stale worktree"
@@ -403,6 +410,128 @@ test_cleanup_suppresses_git_branch_d_stdout() {
   assert_contains "$out" "BRANCH_DELETED: ceo/suppress-branch"
   assert_not_contains "$out" "Deleted branch ceo/suppress-branch" \
     "raw git branch -d stdout must not leak into report"
+}
+
+test_cleanup_leaves_an_unrelated_absent_worktree_registered() {
+  # The reaper must clear only the worktree blocking the branch in front of it.
+  # `git worktree prune` is repo-wide and reads "directory missing" as "worktree
+  # dead", which an unmounted volume also looks like -- it deletes that
+  # worktree's admin dir, taking its index and HEAD with it, and `git worktree
+  # repair` cannot undo that.
+  local repo; repo="$(mkrepo_cleanup blastradius main)"
+  set_repos_md "$repo"
+
+  local ceo_wt="$TMP/wt/blast-ceo" human_wt="$TMP/vol/blast-human"
+  git -C "$repo" worktree add -q -b ceo/blast "$ceo_wt" main
+  echo wt > "$ceo_wt/wt.txt"
+  /usr/bin/git -C "$ceo_wt" add -A && git -C "$ceo_wt" commit -qm "ceo work"
+  git -C "$repo" worktree add -q -b nh/human-work "$human_wt" main
+
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/blast -m merge
+
+  rm -rf "$ceo_wt"                 # genuinely dead
+  mv "$TMP/vol" "$TMP/vol-unmounted"   # merely unreachable right now
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "WORKTREE_STALE_REMOVED:"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/blast 2>/dev/null || echo GONE)" "GONE" \
+    "the dead worktree is cleared so the merged branch can be reaped"
+  assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c 'blast-human' || true)" "1" \
+    "an unreachable worktree the reaper was not asked about stays registered"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/human-work >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
+    "PRESENT" "and its branch is untouched"
+
+  mv "$TMP/vol-unmounted" "$TMP/vol"
+  assert_eq "$(git -C "$human_wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo BROKEN)" "nh/human-work" \
+    "the remounted worktree is still a working checkout"
+}
+
+test_cleanup_reports_no_remote_rather_than_a_fetch_alarm() {
+  # mkrepo_cleanup builds a repo with no origin. Blaming a fetch there fires the
+  # warning on every remote-less repo and it stops meaning anything.
+  local repo; repo="$(mkrepo_cleanup noremote main)"
+  git -C "$repo" checkout -q -b ceo/noremote
+  echo x > "$repo/x.txt"
+  /usr/bin/git -C "$repo" add -A && git -C "$repo" commit -qm x
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/noremote -m merge
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "NO_REMOTE:" "a repo with no origin says so"
+  assert_not_contains "$out" "FETCH_FAILED" "and raises no fetch alarm"
+  assert_contains "$out" "STALE_STATE: 0"
+}
+
+test_cleanup_treats_a_local_only_default_branch_as_healthy() {
+  # ceo_branch_resolves accepts a purely local refs/heads/<name>, so
+  # DEFAULT_BRANCH can name a branch origin has never heard of. Fetching that
+  # always fails against a perfectly healthy remote.
+  local repo; repo="$(mkclone_cleanup localonly trunk ceo/localonly no_lag)"
+  git -C "$repo" checkout -q -b main
+  git -C "$repo" symbolic-ref -d refs/remotes/origin/HEAD 2>/dev/null || true
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "DEFAULT_BRANCH: main" "the local-only branch is chosen"
+  assert_not_contains "$out" "FETCH_FAILED" "a healthy origin raises no alarm"
+  assert_contains "$out" "STALE_STATE: 0"
+}
+
+test_cleanup_surfaces_a_leaked_ownership_marker() {
+  # The branch is gone but its marker survives. Counting that as a clean reap
+  # is the report lying in the direction this ticket exists to stop.
+  local repo; repo="$(mkrepo_cleanup leakedmarker main)"
+  git -C "$repo" checkout -q -b ceo/leaked
+  echo x > "$repo/x.txt"
+  /usr/bin/git -C "$repo" add -A && git -C "$repo" commit -qm x
+  local ref; ref="$(mkmarker "$repo" ceo/leaked)"
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/leaked -m merge
+  set_repos_md "$repo"
+
+  # Hold the ref's lock so `update-ref -d` cannot take it.
+  local lock="$repo/.git/$ref.lock"
+  mkdir -p "$(dirname "$lock")" && : > "$lock"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  rm -f "$lock"
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "BRANCH_DELETED: ceo/leaked"
+  assert_contains "$out" "MARKER_DELETE_FAILED:"
+  assert_contains "$out" "STALE_STATE: 1" "a leaked marker is counted"
+  assert_contains "$out" "AI_NEEDED: yes" "and reaches a human"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q "$ref" >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
+    "PRESENT" "the marker really did leak"
+}
+
+test_cleanup_reports_every_reason_a_human_is_needed() {
+  # Two problems in one run must both appear. The nested per-combination form
+  # this replaced had arms no fixture could reach.
+  local repo; repo="$(mkclone_cleanup tworeasons main ceo/tworeasons local_lag)"
+  git -C "$repo" checkout -q -b ceo/abandoned
+  echo x > "$repo/x.txt"
+  /usr/bin/git -C "$repo" add -A && git -C "$repo" commit -qm x
+  git -C "$repo" checkout -q main
+  # Age it past the orphan threshold.
+  local old; old="$(date -u -v-30d +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%S)"
+  GIT_COMMITTER_DATE="$old" git -C "$repo" branch -f ceo/abandoned ceo/abandoned
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "REAP_FAILED: 1"
+  assert_contains "$out" "failed to reap" "the reap failure is named"
+  assert_contains "$out" "AI_NEEDED: yes"
 }
 
 run_tests

--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -345,4 +345,64 @@ test_cleanup_counts_deletions_not_detections_and_reports_reap_failure() {
     "$(git -C "$repo" rev-parse ceo/countfail)" "the un-reaped branch still exists"
 }
 
+test_cleanup_reports_fetch_failure_when_origin_fetch_fails() {
+  local repo; repo="$(mkclone_cleanup fetchfail main ceo/fetchfail no_lag)"
+  git -C "$repo" remote set-url origin /dev/null/does/not/exist
+  set_repos_md "$repo"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed despite fetch failure"
+  assert_contains "$out" "FETCH_FAILED: origin/main — merge state may be stale"
+}
+
+test_cleanup_prunes_stale_worktree_and_reaps_branch() {
+  local repo; repo="$(mkrepo_cleanup stalewt-1 main)"
+  set_repos_md "$repo"
+
+  local wt="$TMP/wt/ceo-stale-wt"
+  git -C "$repo" worktree add -q -b ceo/stale-wt "$wt" main
+  echo "wt" > "$wt/wt.txt"
+  git -C "$wt" add -A && git -C "$wt" commit -qm "add wt feature"
+
+  # Merge branch into main
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/stale-wt -m "merge wt feature"
+
+  # Remove directory manually so worktree becomes stale / missing on disk
+  rm -rf "$wt"
+  assert_eq "$(git -C "$repo" worktree list | grep -c "ceo/stale-wt" || true)" "1" \
+    "worktree is still registered in git metadata"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "WORKTREE_STALE:" "must identify stale worktree"
+  assert_contains "$out" "ceo-stale-wt — pruning" "must announce worktree pruning"
+  assert_contains "$out" "BRANCH_DELETED: ceo/stale-wt" "branch must be deleted"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/ceo/stale-wt 2>/dev/null || echo GONE)" "GONE" \
+    "branch must be reaped after pruning stale worktree"
+  assert_eq "$(git -C "$repo" worktree list | grep -c "ceo/stale-wt" || true)" "0" \
+    "worktree must be pruned from git metadata"
+}
+
+test_cleanup_suppresses_git_branch_d_stdout() {
+  local repo; repo="$(mkrepo_cleanup suppress-1 main)"
+  set_repos_md "$repo"
+
+  git -C "$repo" checkout -q -b ceo/suppress-branch
+  echo "sup" > "$repo/sup.txt"
+  git -C "$repo" add -A && git -C "$repo" commit -qm "add sup"
+
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff ceo/suppress-branch -m "merge sup"
+
+  local out rc=0
+  out=$(bash "$CLEANUP" 2>&1) || rc=$?
+  assert_eq "$rc" "0" "cleanup must succeed"
+  assert_contains "$out" "BRANCH_DELETED: ceo/suppress-branch"
+  assert_not_contains "$out" "Deleted branch ceo/suppress-branch" \
+    "raw git branch -d stdout must not leak into report"
+}
+
 run_tests


### PR DESCRIPTION
Closes #342

## Description (Issue Fixed & New Behavior)

`ceo-cleanup.sh` reported reaps that did not happen. `MERGED_COUNT` incremented on the merged path regardless of whether the worktree, the branch, or the marker was actually removed, so a run that deleted nothing still ended with `MERGED_TOTAL: 1` and `AI_NEEDED: no — all branches are merged or active`. That report is machine-read by `docs/playbooks/cleanup.md`.

**Counting.** `MERGED_COUNT` now increments only inside the successful `git branch -d` arm. `REAP_FAILED` counts branches detected as merged that could not be reaped. `STALE_STATE` counts state the run could not trust or clean up. `AI_NEEDED` accumulates one clause per reason rather than branching per combination — a run with two problems reports both.

**Clearing a stale worktree is scoped to the branch in hand.** A worktree registered whose directory is gone blocks `git branch -d`, so it has to be cleared. `git worktree prune` is the obvious way and is wrong: it is repo-wide, and "directory missing" is not "worktree dead" — an unmounted volume or a sleeping network mount looks identical. Called from the per-branch loop it deregisters every other worktree in the repo that is unreachable at that moment, deleting the per-worktree admin dir holding its index and `HEAD`. `git worktree repair` cannot undo that; staged work is unrecoverable.

Measured on a repo holding one dead CEO worktree and one unrelated worktree on an absent path:

| approach | dead one cleared | bystander |
|---|---|---|
| `git worktree prune` | yes | **destroyed** |
| `git worktree prune --expire 3.months.ago` | no | survives |
| `git worktree remove --force "$WT_PATH"` | yes | survives |

`--expire` is not the fix — it spares the bystander and clears nothing, so it does not unblock the delete this exists for. The scoped removal does both, and the report names what was removed rather than announcing an intent it never checked (`worktree prune` exits 0 even when it fails).

**Fetch reporting.** `ceo_branch_resolves` accepts a purely local `refs/heads/<name>`, so `DEFAULT_BRANCH` can name a branch `origin` has never heard of, and fetching it always fails against a healthy remote. `FETCH_FAILED` is now raised only when a remote-tracking ref says the branch was there to fetch, carries git's own stderr so auth and network are distinguishable, and counts toward `STALE_STATE` — the run reaps on that stale view, so it has to reach a human. A repo with no origin reports `NO_REMOTE` rather than staying silent.

**A leaked ownership marker is not a clean reap.** `MARKER_DELETE_FAILED` now counts toward `STALE_STATE` and reaches `AI_NEEDED`.

Also: `git branch -d` stdout no longer leaks into the report, and a stray bare `0` line under `SYNC_CONFLICTS` is gone (`grep -c` emits `0` *and* exits 1 on no match, so `|| echo 0` appended a second line on every clean run).

`docs/playbooks/cleanup.md` is updated in its own commit. `AI_NEEDED: yes` no longer implies an `ORPHAN_SUMMARY` block exists, and the log template asked for "N worktrees removed" from a number that counts branch deletions.

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning $(find ./scripts -name '*.sh')` — 0 warnings.
3. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` — 19 pass. (bash 4+ required for `mapfile`.)
4. `… scripts/ceo-loop-lib.test.sh` — 33 pass. `… scripts/ceo-loop.test.sh` — 32 pass.
5. Mutation-check each guard. Restoring the repo-wide prune fails on the bystander's registration **and** on whether it is still a working checkout after remount; deleting the `MERGED_COUNT` increment fails the happy-path count; dropping the remote-tracking check fails the local-only-default arm; dropping `NO_REMOTE` and the leaked-marker counter each fail their own arm.

## Additional Notes

Reviewed by a two-lane panel (silent-failure, test quality) against a read-only worktree; the third commit is what their findings required.

The counting fix as first written had a coverage hole of the same shape as the previous round on this file: `MERGED_TOTAL` was asserted only as `0`, so deleting the `MERGED_COUNT` increment outright — the exact line the first commit added — left all 14 tests green. The happy-path values of all three counters are now pinned.

`scripts/ceo-loop.sh:250` calls bare `git worktree prune` the same way. Out of scope here; see #345.