### PR TITLE
Scope loop worktree reclaim to target branch and remove global prune (#345)

### DIFF
--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -244,10 +244,15 @@ if [ "$DRY_RUN" != "1" ]; then
     exit 6
   fi
   # Reclaim leftovers from prior attempts: deregister the worktree first
-  # (a branch checked out in a registered worktree cannot be deleted), prune,
-  # then drop the loop-owned branch.
+  # (a branch checked out in a registered worktree cannot be deleted), then drop
+  # the loop-owned branch. NOT `git worktree prune`: that is repo-wide and would
+  # deregister unrelated unreachable worktrees (#345). `worktree remove --force`
+  # handles stale registrations scoped strictly to this branch/worktree (#344).
+  WT_REGISTERED=$(git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null | awk -v target="branch refs/heads/$BRANCH" '/^worktree /{wt=substr($0, 10)} $0==target{print wt}')
+  if [ -n "$WT_REGISTERED" ]; then
+    git -C "$REPO_DIR" worktree remove --force --force "$WT_REGISTERED" 2>/dev/null || true
+  fi
   git -C "$REPO_DIR" worktree remove --force --force "$WT" 2>/dev/null || true
-  git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
   rm -rf "$WT"
   git -C "$REPO_DIR" branch -D "$BRANCH" 2>/dev/null || true
   git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -258,17 +258,27 @@ if [ "$DRY_RUN" != "1" ]; then
   # is registered `detached`, and a branch filter is structurally blind to it --
   # those then accumulate one admin dir per run, silently, at exit 0. The
   # directory name catches them: it is ${BRANCH//\//_}-${BRANCH_KEY:0:12},
-  # unique to this branch, so the match stays scoped to what we own. Removing by
-  # the path `worktree list` reports, rather than by $WT, also sidesteps
-  # /var vs /private/var on macOS -- git refuses the uncanonicalized form as
-  # "not a working tree" once the directory is gone.
+  # unique to this branch.
+  #
+  # Both tests are confined to $REPO_DIR/.ceo-loop/, and the branch one has to
+  # be. The loop owns the branch NAME, not every checkout of it: a person who
+  # checks the parked branch out somewhere of their own to read it leaves the
+  # tip unmoved, so the ownership guard above passes, and an unscoped branch
+  # match would hand their dirty worktree to `remove --force --force`. Outside
+  # .ceo-loop/ the right answer is the `checkout -b` refusal further down.
+  #
+  # Removing by the path `worktree list` reports, rather than by $WT, is also
+  # strictly more robust: where the path has a symlinked prefix and a missing
+  # ancestor directory -- /var -> /private/var under $TMPDIR, which is the test
+  # fixture rather than any real repo -- git refuses the uncanonicalized form as
+  # "not a working tree".
   WT_BASE="/$(basename "$WT")"
-  git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+  { git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null || true; } \
     | awk -v br="branch refs/heads/$BRANCH" -v base="$WT_BASE" '
         /^worktree / { if (own && p != "") print p
                        p = substr($0, 10)
                        own = (substr(p, length(p) - length(base) + 1) == base) }
-        $0 == br     { own = 1 }
+        $0 == br     { if (p ~ /\/\.ceo-loop\//) own = 1 }
         END          { if (own && p != "") print p }
       ' \
     | while IFS= read -r WT_OWNED; do

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -243,16 +243,37 @@ if [ "$DRY_RUN" != "1" ]; then
     echo "  Choose a different .branch in the spec, or delete the branch yourself if it is disposable." >&2
     exit 6
   fi
-  # Reclaim leftovers from prior attempts: deregister the worktree first
-  # (a branch checked out in a registered worktree cannot be deleted), then drop
-  # the loop-owned branch. NOT `git worktree prune`: that is repo-wide and would
-  # deregister unrelated unreachable worktrees (#345). `worktree remove --force`
-  # handles stale registrations scoped strictly to this branch/worktree (#344).
-  WT_REGISTERED=$(git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null | awk -v target="branch refs/heads/$BRANCH" '/^worktree /{wt=substr($0, 10)} $0==target{print wt}')
-  if [ -n "$WT_REGISTERED" ]; then
-    git -C "$REPO_DIR" worktree remove --force --force "$WT_REGISTERED" 2>/dev/null || true
-  fi
-  git -C "$REPO_DIR" worktree remove --force --force "$WT" 2>/dev/null || true
+  # Reclaim leftovers from prior attempts: deregister every worktree
+  # registration this branch owns (a branch checked out in a registered worktree
+  # cannot be deleted), then drop the loop-owned branch.
+  #
+  # NOT `git worktree prune` (#345). That is repo-wide, and "directory missing"
+  # is not "worktree dead" -- an unmounted volume looks identical, and prune
+  # deletes that worktree's admin dir along with its index and HEAD, which
+  # `git worktree repair` cannot undo.
+  #
+  # Ownership is two tests, because neither alone covers it. A leftover carries
+  # `branch refs/heads/$BRANCH` only if the run that made it reached the
+  # `checkout -b` below; killed between `worktree add --detach` and that line it
+  # is registered `detached`, and a branch filter is structurally blind to it --
+  # those then accumulate one admin dir per run, silently, at exit 0. The
+  # directory name catches them: it is ${BRANCH//\//_}-${BRANCH_KEY:0:12},
+  # unique to this branch, so the match stays scoped to what we own. Removing by
+  # the path `worktree list` reports, rather than by $WT, also sidesteps
+  # /var vs /private/var on macOS -- git refuses the uncanonicalized form as
+  # "not a working tree" once the directory is gone.
+  WT_BASE="/$(basename "$WT")"
+  git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+    | awk -v br="branch refs/heads/$BRANCH" -v base="$WT_BASE" '
+        /^worktree / { if (own && p != "") print p
+                       p = substr($0, 10)
+                       own = (substr(p, length(p) - length(base) + 1) == base) }
+        $0 == br     { own = 1 }
+        END          { if (own && p != "") print p }
+      ' \
+    | while IFS= read -r WT_OWNED; do
+        git -C "$REPO_DIR" worktree remove --force --force "$WT_OWNED" 2>/dev/null || true
+      done
   rm -rf "$WT"
   git -C "$REPO_DIR" branch -D "$BRANCH" 2>/dev/null || true
   git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -685,4 +685,51 @@ test_rejects_a_target_name_git_would_not_accept() {
   assert_contains "$out" "'main^' is not a valid git branch name"
 }
 
+test_loop_reclaim_leaves_an_unrelated_absent_worktree_registered() {
+  # The loop must clear only the worktree blocking the branch in front of it.
+  # `git worktree prune` is repo-wide and reads "directory missing" as "worktree
+  # dead", which an unmounted volume or offline path looks like — it deletes that
+  # worktree's admin dir, taking its index and HEAD with it, and `git worktree
+  # repair` cannot undo that (#345).
+  local repo; repo="$(mkrepo blastradius)"
+  local human_wt="$TMP/vol/blast-human"
+  mkdir -p "$TMP/vol"
+  git -C "$repo" worktree add -q -b nh/human-work "$human_wt" main
+  echo "human work" > "$human_wt/human.txt"
+  /usr/bin/git -C "$human_wt" add -A && git -C "$human_wt" commit -qm "human work"
+
+  # Initial loop run to create the branch, worktree, and ownership marker
+  local wscript="${TMP}/w-blast.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-blast.json" "$wscript" true
+  mkspec "$TMP/blast.json" "$repo" nh/loop-blast "false"
+  CEO_LOOP_MAX_RETRIES=0 bash "$LOOP" run --spec "$TMP/blast.json" --routes "$TMP/routes-blast.json" --target main >/dev/null 2>&1 || true
+
+  # Simulate the human worktree becoming unreachable (e.g. unmounted volume)
+  mv "$TMP/vol" "$TMP/vol-unmounted"
+
+  # Simulate loop worktree directory being removed (stale registration leftover)
+  rm -rf "$repo/.ceo-loop"
+
+  # Second loop run (reclaim path with successful verification)
+  mkspec "$TMP/blast.json" "$repo" nh/loop-blast "true"
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/blast.json" --routes "$TMP/routes-blast.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "0" "reclaim run must succeed"
+
+  # Verify the unreachable worktree was NOT deregistered
+  assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c 'blast-human' || true)" "1" \
+    "an unreachable worktree the loop was not asked about stays registered"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/human-work >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
+    "PRESENT" "and its branch is untouched"
+
+  # Remount and verify human worktree is functional
+  mv "$TMP/vol-unmounted" "$TMP/vol"
+  assert_eq "$(git -C "$human_wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo BROKEN)" "nh/human-work" \
+    "the remounted human worktree is still a working checkout"
+  assert_eq "$(git -C "$human_wt" status --porcelain 2>/dev/null && echo OK || echo BROKEN)" "OK" \
+    "remounted worktree status operates cleanly"
+  assert_eq "$(git -C "$human_wt" cat-file -e HEAD:human.txt 2>/dev/null && echo yes || echo no)" "yes" \
+    "human commit content is intact"
+}
+
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -766,4 +766,36 @@ test_loop_reclaim_clears_a_detached_leftover_registration() {
     "the leftover registration is cleared, not left to accumulate beside the new one"
 }
 
+test_loop_reclaim_leaves_a_human_checkout_of_its_branch_alone() {
+  # The loop owns the branch NAME, not every checkout of it. A person who checks
+  # the parked branch out to read it leaves the tip unmoved, so the ownership
+  # guard passes -- and an unscoped branch match would then hand their dirty
+  # worktree to `remove --force --force`, which deletes it without complaint.
+  local repo; repo="$(mkrepo humancheckout)"
+  local wscript="${TMP}/w-human.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-human.json" "$wscript" true
+  mkspec "$TMP/human.json" "$repo" nh/loop-human "true"
+
+  CEO_LOOP_MAX_RETRIES=0 bash "$LOOP" run --spec "$TMP/human.json" \
+    --routes "$TMP/routes-human.json" --target main >/dev/null 2>&1 || true
+
+  # The loop's own worktree goes away; the branch stays parked at the tip the
+  # loop recorded, which is what makes the ownership guard pass on the next run.
+  rm -rf "$repo/.ceo-loop"
+  git -C "$repo" worktree prune
+
+  # A person checks that branch out somewhere of their own, with uncommitted work.
+  local human_wt="$TMP/human-review-$$"
+  git -C "$repo" worktree add -q "$human_wt" nh/loop-human
+  echo "notes I have not committed" > "$human_wt/notes.txt"
+
+  bash "$LOOP" run --spec "$TMP/human.json" --routes "$TMP/routes-human.json" \
+    --target main >/dev/null 2>&1 || true
+
+  assert_eq "$([ -f "$human_wt/notes.txt" ] && echo PRESENT || echo DESTROYED)" "PRESENT" \
+    "uncommitted work in a human's checkout of the branch is not deleted"
+  assert_eq "$(git -C "$human_wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo BROKEN)" \
+    "nh/loop-human" "and their worktree is still a working checkout"
+}
+
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -719,17 +719,51 @@ test_loop_reclaim_leaves_an_unrelated_absent_worktree_registered() {
   # Verify the unreachable worktree was NOT deregistered
   assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c 'blast-human' || true)" "1" \
     "an unreachable worktree the loop was not asked about stays registered"
-  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/human-work >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
-    "PRESENT" "and its branch is untouched"
 
   # Remount and verify human worktree is functional
   mv "$TMP/vol-unmounted" "$TMP/vol"
   assert_eq "$(git -C "$human_wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo BROKEN)" "nh/human-work" \
     "the remounted human worktree is still a working checkout"
-  assert_eq "$(git -C "$human_wt" status --porcelain 2>/dev/null && echo OK || echo BROKEN)" "OK" \
-    "remounted worktree status operates cleanly"
-  assert_eq "$(git -C "$human_wt" cat-file -e HEAD:human.txt 2>/dev/null && echo yes || echo no)" "yes" \
-    "human commit content is intact"
+  # Read the content through the repo, not through the worktree -- the two
+  # assertions this replaces both re-measured the line above from inside the
+  # broken checkout, so all three flipped together and none could flip alone.
+  assert_eq "$(git -C "$repo" cat-file -e refs/heads/nh/human-work:human.txt 2>/dev/null && echo yes || echo no)" \
+    "yes" "the human commit content survives"
+}
+
+test_loop_reclaim_clears_a_detached_leftover_registration() {
+  # `worktree add --detach` runs before `checkout -b`, so a run killed between
+  # them leaves a registration with no branch on it. Selecting leftovers by
+  # branch alone cannot see that one, and the repo-wide prune that used to
+  # absorb it is gone -- so each reclaim registers another admin dir, silently,
+  # at exit 0.
+  local repo; repo="$(mkrepo detachedleftover)"
+  local wscript="${TMP}/w-detached.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-detached.json" "$wscript" true
+  mkspec "$TMP/detached.json" "$repo" nh/loop-detached "true"
+
+  CEO_LOOP_MAX_RETRIES=0 bash "$LOOP" run --spec "$TMP/detached.json" \
+    --routes "$TMP/routes-detached.json" --target main >/dev/null 2>&1 || true
+
+  # Reduce the loop's own worktree to the state a kill between `worktree add
+  # --detach` and `checkout -b` leaves behind: registered, detached, directory
+  # unreachable.
+  local wt; wt="$(git -C "$repo" worktree list --porcelain \
+    | awk '/^worktree /{p=substr($0,10)} /^branch refs\/heads\/nh\/loop-detached$/{print p}')"
+  [ -n "$wt" ] || { echo "fixture: no loop worktree registered" >&2; return 1; }
+  git -C "$repo" -C "$wt" checkout -q --detach HEAD 2>/dev/null \
+    || git -C "$wt" checkout -q --detach HEAD
+  git -C "$repo" branch -D nh/loop-detached >/dev/null 2>&1 || true
+  rm -rf "$repo/.ceo-loop"
+  assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c '^detached$' || true)" "1" \
+    "fixture leaves exactly one detached registration"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/detached.json" \
+    --routes "$TMP/routes-detached.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "0" "the reclaim run must succeed"
+  assert_eq "$(ls "$repo/.git/worktrees" 2>/dev/null | wc -l | tr -d ' ')" "1" \
+    "the leftover registration is cleared, not left to accumulate beside the new one"
 }
 
 run_tests


### PR DESCRIPTION
Closes #345

## Description (Issue Fixed & New Behavior)

`scripts/ceo-loop.sh` called repo-wide `git worktree prune` from the branch-reclaim path. That is scoped to the whole repository, and "directory missing" is not "worktree dead" — an unmounted volume or a sleeping network mount presents identically. One reclaim therefore deregistered every other worktree in the repo that happened to be unreachable at that moment, deleting the per-worktree admin dir holding its `index` and `HEAD`. `git worktree repair` cannot undo that.

**The prune is gone.** Leftovers are now selected by ownership and removed one at a time.

**Ownership is two tests, both confined to `$REPO_DIR/.ceo-loop/`.** Neither alone covers it:

- The **directory name** — `${BRANCH//\//_}-${BRANCH_KEY:0:12}`, unique to this branch. This is the arm that catches a *detached* leftover. `worktree add --detach` runs before `checkout -b`, so a run killed between them registers a worktree with no branch on it, and a branch-keyed filter is structurally blind to it. Those then accumulate one admin dir per run, silently, at exit 0 — measured four registrations for one path after four cycles. The prune had been absorbing them.
- The **branch line**, which covers a leftover at a pre-#335 path that still holds the branch.

The `.ceo-loop/` confinement on the branch arm is load-bearing, not tidiness. The loop owns the branch *name*, not every checkout of it. The ownership guard above compares the branch tip to `OWNED_REF` and passes whenever the tip is unmoved — exactly the state when a person checks the parked branch out to read it and has committed nothing. An unscoped branch match would then hand their dirty worktree to `remove --force --force`. Outside `.ceo-loop/` the correct answer is the `checkout -b` refusal further down, which is what happened before this branch.

Removing by the path `worktree list` reports, rather than by the literal `$WT`, is also strictly more robust. Where a path has a symlinked prefix *and* a missing ancestor directory (`/var` → `/private/var` under `$TMPDIR`, which is the test fixture rather than a real repo under `/Users`), git refuses the uncanonicalized form as "not a working tree".

## Testing Procedure

1. Check out this branch.
2. `shellcheck -S warning $(find ./scripts -name '*.sh')` — 0 warnings.
3. `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` — 35 pass. (bash 4+ for `mapfile`; several minutes is normal.)
4. `… scripts/ceo-loop-lib.test.sh` — 33 pass. `… scripts/ceo-cleanup.test.sh` — 19 pass.
5. Mutation-check each guard:
   - Restore `git worktree prune` → `test_loop_reclaim_leaves_an_unrelated_absent_worktree_registered` fails on the bystander's registration **and** on whether it is still a working checkout after its path returns.
   - Revert the selector to branch-only → `test_loop_reclaim_clears_a_detached_leftover_registration` fails on `.git/worktrees` holding two entries instead of one.
   - Unscope the branch arm from `.ceo-loop/` → `test_loop_reclaim_leaves_a_human_checkout_of_its_branch_alone` fails with the notes file `DESTROYED` and the worktree `BROKEN`.

## Additional Notes

Reviewed by a two-lane panel (correctness, test quality) against a read-only worktree. Both later commits are what their findings required.

The first pass replaced the prune with a branch-keyed filter, which the test lane showed could not see a detached leftover — trading a repo-wide hazard for silent unbounded accumulation. The ownership selector that fixed *that* was itself unbounded by path, and the correctness lane reproduced it deleting a human's uncommitted work where `origin/main` refuses and leaves everything intact. Both are fixed and pinned by arms that assert state in the victim's directory rather than a message.

Three assertions in the bystander arm were also collapsed: one could not fail (prune deletes admin dirs, never refs), and the content check ran `cat-file` inside the broken checkout, so it re-measured the assertion above it. It now reads through the repo.