### PR TITLE
Report delivery failure with exit 10, distinct action word, and accurate telemetry (#343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ HIGH. Finding fingerprints bind repo + base revision + invariant + normalized
 location + severity, so line-shifted equivalents collapse onto one ticket while
 a rebase legitimately reopens one. Every cycle appends a telemetry row
 (`telemetry.jsonl`) in the token-scope-ingestable contract plus a shared-ledger
-entry via `ceo-model-ledger.sh`.
+entry via `ceo-model-ledger.sh`. That row carries `action` and `delivery`
+separately and they are not the same thing: `action` is what the promotion gate
+recommended, `delivery` is what actually happened to the work. A row reading
+`action: promote, delivery: pushed` is a branch on the remote that no PR
+points at.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Gates and their failure codes:
 | Branch name | `.branch` must satisfy `git check-ref-format` and must not begin with `-`; the name becomes both a ref and a worktree path, so it is validated before either is built | 2 |
 | Ownership | The loop reclaims a branch only while `refs/ceo-loop/owned/<key>` still records that branch's current tip. Anything else — a name it never created, or one that moved since — is refused, never deleted | 6 |
 | Worker output | Staging or committing the worker's output must succeed; either failing refuses the run. The changed-file list is read from the working tree, so output that never reaches the branch would otherwise be classified, reviewed, and reported as accepted work | 6 |
+| Delivery | Promotion via remote push or local fast-forward must succeed; on push/merge failure the isolated branch is preserved locally | 10 |
 
 The ownership marker is durable state: `refs/ceo-loop/owned/<key>` under the
 target repo, one ref per branch the loop created, where `<key>` is a hash of the

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -34,7 +34,7 @@
 # Exit codes: 0 ok · 2 bad usage / invalid spec · 3 retries exhausted ·
 # 4 routing failure · 5 review gate failure ·
 # 6 overlap, branch not owned, uncommittable worker output, or corrupt state ·
-# 7 premium-gate block · 8 lock contention · 9 stale base
+# 7 premium-gate block · 8 lock contention · 9 stale base · 10 delivery failure
 
 set -euo pipefail
 
@@ -508,34 +508,43 @@ fi
 
 PROMOTED=false
 PARKED=false
+SUMMARY_ACTION="blocked"
 if [ "$ACCEPTED" = "true" ] && [ "$GATE_RC" -eq 0 ] && [ -n "$ACTION" ]; then
   if [ "$ACTION" = "park-integration" ]; then
     # Parking IS keeping the isolated branch: unmerged, inspectable, not lost.
     PARKED=true
+    SUMMARY_ACTION="parked"
     echo "loop: parked — branch $BRANCH holds accepted work below ${TARGET} policy threshold"
   elif [ "$DRY_RUN" != "1" ]; then
-    PROMOTED=true
     if git -C "$REPO_DIR" remote get-url origin >/dev/null 2>&1 && command -v gh >/dev/null 2>&1; then
       if git -C "$WT" push origin "$BRANCH" >/dev/null 2>&1; then
+        PROMOTED=true
         if (cd "$WT" && gh pr create --head "$BRANCH" --base "$TARGET" \
           --title "ceo-loop: $REPO/$BRANCH" \
           --body "Autonomous loop PR (#329). risk=$RISK worker=$WORKER_IDENTITY reviewer=$PASSING_REVIEWER") \
           >/dev/null 2>&1; then
+          SUMMARY_ACTION="promoted"
           echo "loop: PR opened against $TARGET"
         else
+          SUMMARY_ACTION="pushed"
           echo "loop: pushed $BRANCH (gh pr create failed — open one manually)" >&2
         fi
       else
+        FINAL_RC=10
+        SUMMARY_ACTION="delivery-failed"
         echo "loop: push failed — branch $BRANCH kept locally" >&2
       fi
     else
       # No remote: promote is a fast-forward-only ref update of the target.
       if git -C "$REPO_DIR" merge-base --is-ancestor "$TARGET" "$BRANCH" 2>/dev/null \
          && git -C "$REPO_DIR" update-ref "refs/heads/$TARGET" "$(git -C "$REPO_DIR" rev-parse "$BRANCH")"; then
+        PROMOTED=true
+        SUMMARY_ACTION="promoted"
         echo "loop: promoted $BRANCH into local $TARGET (fast-forward)"
       else
+        FINAL_RC=10
+        SUMMARY_ACTION="delivery-failed"
         echo "loop: could not fast-forward $TARGET — branch $BRANCH holds the work" >&2
-        PROMOTED=false
       fi
     fi
   fi
@@ -567,8 +576,5 @@ jq -nc \
 
 ceo_ledger_write_entry "ceo-loop" "$WORKER_IDENTITY" "loop:$REPO/$BRANCH" "$PWD" null "$ACCEPTED" >/dev/null || true
 
-if [ "$PROMOTED" = "true" ]; then SUMMARY_ACTION="promoted";
-elif [ "$PARKED" = "true" ]; then SUMMARY_ACTION="parked";
-else SUMMARY_ACTION="${ACTION:-blocked}"; fi
 echo "loop: done ($REPO/$BRANCH risk=$RISK action=$SUMMARY_ACTION attempts=$((ATTEMPT + 1)))"
 exit $FINAL_RC

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -559,6 +559,7 @@ jq -nc \
   --arg repo "$REPO" --arg branch "$BRANCH" --arg model "$WORKER_IDENTITY" \
   --arg reviewer "$PASSING_REVIEWER" \
   --arg target "$TARGET" --arg risk "$RISK" --arg action "$ACTION" \
+  --arg delivery "$SUMMARY_ACTION" \
   --argjson promoted "${PROMOTED:-false}" --argjson parked "${PARKED:-false}" \
   --argjson accepted "$ACCEPTED" \
   --argjson seconds_to_passing "$((NOW_TS - START_TS))" \
@@ -567,6 +568,7 @@ jq -nc \
   --argjson high_findings "$HIGH_FINDINGS" \
   '{ts: $ts, writer: "ceo-loop", repo: $repo, branch: $branch, model: $model,
     reviewer: $reviewer, target: $target, risk: $risk, action: $action,
+    delivery: $delivery,
     promoted: $promoted, parked: $parked,
     accepted: $accepted, seconds_to_passing: $seconds_to_passing,
     retries_used: $retries_used, findings: $findings,

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -141,6 +141,11 @@ EOF
   assert_contains "$row" '"external_id":null'
   # The HIGH-risk change was NOT promoted anywhere.
   if grep -q "promoted" <<<"$out"; then fail_test "HIGH finding must prevent promotion"; fi
+  # #343's second instance: the summary used to print the gate's RECOMMENDATION
+  # (`action=promote`) on a run that was blocked and exited 5, so a reader of
+  # the summary line saw a promotion that never happened.
+  assert_contains "$out" "action=blocked"
+  assert_not_contains "$out" "action=promote "
 }
 
 test_stale_base_stops_before_any_work() {
@@ -817,8 +822,10 @@ EOF
   assert_eq "$rc" "10" "failed fast-forward delivery must exit 10"
   assert_contains "$out" "could not fast-forward main"
   assert_contains "$out" "action=delivery-failed"
-  assert_not_contains "$out" "action=promoted"
-  assert_not_contains "$out" "action=promote)"
+  # The pre-fix wording was `action=promote ` (the gate's recommendation printed
+  # as the outcome). `action=promoted` does not contain it, so the trailing
+  # space is what discriminates old from new.
+  assert_not_contains "$out" "action=promote "
 
   # Telemetry check
   local tel slug_dir
@@ -828,6 +835,8 @@ EOF
   assert_eq "$(jq -r '.promoted' <<<"$tel")" "false" "telemetry promoted must be false"
   assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
   assert_eq "$(jq -r '.action' <<<"$tel")" "promote" "telemetry gate action remains promote"
+  assert_eq "$(jq -r '.delivery' <<<"$tel")" "delivery-failed" \
+    "telemetry must record the delivery outcome, not just the gate recommendation"
 }
 
 test_delivery_failure_on_remote_push_sets_exit_10_and_telemetry() {
@@ -865,6 +874,7 @@ EOF
     --spec "$TMP/pushfail.json" --routes "$TMP/routes-pushfail.json" --target main 2>&1) || rc=$?
   assert_eq "$rc" "10" "failed remote push delivery must exit 10"
   assert_contains "$out" "push failed — branch nh/loop-pushfail kept locally"
+  assert_not_contains "$out" "stub-gh: unexpected argv"
   assert_contains "$out" "action=delivery-failed"
   assert_not_contains "$out" "action=promoted"
 
@@ -875,6 +885,8 @@ EOF
   tel=$(cat "$slug_dir")
   assert_eq "$(jq -r '.promoted' <<<"$tel")" "false" "telemetry promoted must be false"
   assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
+  assert_eq "$(jq -r '.delivery' <<<"$tel")" "delivery-failed" \
+    "telemetry must record the delivery outcome, not just the gate recommendation"
 
   # Branch was NOT pushed to remote, but is kept locally
   assert_eq "$(git -C "$origin" rev-parse --verify -q refs/heads/nh/loop-pushfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" "GONE"
@@ -910,6 +922,7 @@ EOF
     --spec "$TMP/prfail.json" --routes "$TMP/routes-prfail.json" --target main 2>&1) || rc=$?
   assert_eq "$rc" "0" "degraded push success with pr create failure must exit 0"
   assert_contains "$out" "pushed nh/loop-prfail (gh pr create failed — open one manually)"
+  assert_not_contains "$out" "stub-gh: unexpected argv"
   assert_contains "$out" "action=pushed"
   assert_not_contains "$out" "action=delivery-failed"
   assert_not_contains "$out" "action=promoted"
@@ -921,6 +934,8 @@ EOF
   tel=$(cat "$slug_dir")
   assert_eq "$(jq -r '.promoted' <<<"$tel")" "true" "telemetry promoted must be true"
   assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
+  assert_eq "$(jq -r '.delivery' <<<"$tel")" "pushed" \
+    "telemetry must distinguish a pushed-but-PR-less branch from an opened PR"
 
   # Branch IS present on remote
   assert_eq "$(git -C "$origin" rev-parse --verify -q refs/heads/nh/loop-prfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" "PRESENT"

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -798,4 +798,132 @@ test_loop_reclaim_leaves_a_human_checkout_of_its_branch_alone() {
     "nh/loop-human" "and their worktree is still a working checkout"
 }
 
+test_delivery_failure_on_local_fast_forward_sets_exit_10_and_telemetry() {
+  local repo; repo="$(mkrepo fffail)"
+  local wscript="${TMP}/w-fffail.sh"
+  # Worker writes feature file and concurrently advances main so fast-forward is impossible
+  cat > "$wscript" <<'EOF'
+#!/bin/bash
+cd "$WT" && echo feature > feature.txt
+git -C "$REPO_DIR" commit --allow-empty -qm "main advanced concurrently"
+EOF
+  chmod +x "$wscript"
+  mkroutes "$TMP/routes-fffail.json" "$wscript" true
+  mkspec "$TMP/fffail.json" "$repo" nh/loop-fffail "true"
+
+  local out rc=0
+  out=$(CEO_LOOP_ALLOW_MAIN=1 bash "$LOOP" run --spec "$TMP/fffail.json" \
+    --routes "$TMP/routes-fffail.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "10" "failed fast-forward delivery must exit 10"
+  assert_contains "$out" "could not fast-forward main"
+  assert_contains "$out" "action=delivery-failed"
+  assert_not_contains "$out" "action=promoted"
+  assert_not_contains "$out" "action=promote)"
+
+  # Telemetry check
+  local tel slug_dir
+  slug_dir=$(find "$CEO_LOOP_STATE_ROOT" -name telemetry.jsonl -path "*fffail*" | head -1)
+  [ -f "$slug_dir" ] || { fail_test "telemetry.jsonl must exist"; return 1; }
+  tel=$(cat "$slug_dir")
+  assert_eq "$(jq -r '.promoted' <<<"$tel")" "false" "telemetry promoted must be false"
+  assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
+  assert_eq "$(jq -r '.action' <<<"$tel")" "promote" "telemetry gate action remains promote"
+}
+
+test_delivery_failure_on_remote_push_sets_exit_10_and_telemetry() {
+  local origin="$TMP/repos/origin-pushfail.git"
+  git init -q --bare -b main "$origin"
+  local repo; repo="$(mkrepo pushfail)"
+  git -C "$repo" remote add origin "$origin"
+  git -C "$repo" push -q -u origin main
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+
+  # Configure origin hook to reject pushes
+  mkdir -p "$origin/hooks"
+  printf '#!/bin/sh\nexit 1\n' > "$origin/hooks/pre-receive"
+  chmod +x "$origin/hooks/pre-receive"
+  git -C "$origin" config core.hooksPath "$origin/hooks"
+
+  # Stub gh on PATH
+  local stub_bin="$TMP/bin-pushfail"
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/gh" <<'EOF'
+#!/bin/bash
+case "$1 $2" in
+  "pr create") exit 0 ;;
+  *) echo "stub-gh: unexpected argv: $*" >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "$stub_bin/gh"
+
+  local wscript="${TMP}/w-pushfail.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-pushfail.json" "$wscript" true
+  mkspec "$TMP/pushfail.json" "$repo" nh/loop-pushfail "true"
+
+  local out rc=0
+  out=$(PATH="$stub_bin:$PATH" CEO_LOOP_ALLOW_MAIN=1 bash "$LOOP" run \
+    --spec "$TMP/pushfail.json" --routes "$TMP/routes-pushfail.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "10" "failed remote push delivery must exit 10"
+  assert_contains "$out" "push failed — branch nh/loop-pushfail kept locally"
+  assert_contains "$out" "action=delivery-failed"
+  assert_not_contains "$out" "action=promoted"
+
+  # Telemetry check
+  local tel slug_dir
+  slug_dir=$(find "$CEO_LOOP_STATE_ROOT" -name telemetry.jsonl -path "*pushfail*" | head -1)
+  [ -f "$slug_dir" ] || { fail_test "telemetry.jsonl must exist"; return 1; }
+  tel=$(cat "$slug_dir")
+  assert_eq "$(jq -r '.promoted' <<<"$tel")" "false" "telemetry promoted must be false"
+  assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
+
+  # Branch was NOT pushed to remote, but is kept locally
+  assert_eq "$(git -C "$origin" rev-parse --verify -q refs/heads/nh/loop-pushfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" "GONE"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-pushfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" "PRESENT"
+}
+
+test_degraded_delivery_on_pr_create_failure_sets_exit_0_action_pushed() {
+  local origin="$TMP/repos/origin-prfail.git"
+  git init -q --bare -b main "$origin"
+  local repo; repo="$(mkrepo prfail)"
+  git -C "$repo" remote add origin "$origin"
+  git -C "$repo" push -q -u origin main
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+
+  # Stub gh on PATH that fails on pr create
+  local stub_bin="$TMP/bin-prfail"
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/gh" <<'EOF'
+#!/bin/bash
+case "$1 $2" in
+  "pr create") exit 1 ;;
+  *) echo "stub-gh: unexpected argv: $*" >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "$stub_bin/gh"
+
+  local wscript="${TMP}/w-prfail.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-prfail.json" "$wscript" true
+  mkspec "$TMP/prfail.json" "$repo" nh/loop-prfail "true"
+
+  local out rc=0
+  out=$(PATH="$stub_bin:$PATH" CEO_LOOP_ALLOW_MAIN=1 bash "$LOOP" run \
+    --spec "$TMP/prfail.json" --routes "$TMP/routes-prfail.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "0" "degraded push success with pr create failure must exit 0"
+  assert_contains "$out" "pushed nh/loop-prfail (gh pr create failed — open one manually)"
+  assert_contains "$out" "action=pushed"
+  assert_not_contains "$out" "action=delivery-failed"
+  assert_not_contains "$out" "action=promoted"
+
+  # Telemetry check
+  local tel slug_dir
+  slug_dir=$(find "$CEO_LOOP_STATE_ROOT" -name telemetry.jsonl -path "*prfail*" | head -1)
+  [ -f "$slug_dir" ] || { fail_test "telemetry.jsonl must exist"; return 1; }
+  tel=$(cat "$slug_dir")
+  assert_eq "$(jq -r '.promoted' <<<"$tel")" "true" "telemetry promoted must be true"
+  assert_eq "$(jq -r '.accepted' <<<"$tel")" "true" "telemetry accepted must be true"
+
+  # Branch IS present on remote
+  assert_eq "$(git -C "$origin" rev-parse --verify -q refs/heads/nh/loop-prfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" "PRESENT"
+}
+
 run_tests


### PR DESCRIPTION
Closes #343

### What changed

1. **Delivery Failure Handling in `scripts/ceo-loop.sh`**:
   - **Local fast-forward failure**: When `git update-ref refs/heads/$TARGET ...` fails, set `FINAL_RC=10`, `SUMMARY_ACTION="delivery-failed"`, and `PROMOTED=false` instead of falling through to `action=promote` with exit 0.
   - **Remote push failure**: When `git push origin "$BRANCH"` fails, set `FINAL_RC=10`, `SUMMARY_ACTION="delivery-failed"`, and `PROMOTED=false` instead of leaving `PROMOTED=true` with exit 0 and `action=promoted`.
   - **Degraded PR creation failure**: When push succeeds but `gh pr create` fails, the branch exists on remote. Set `SUMMARY_ACTION="pushed"`, `PROMOTED=true`, and `FINAL_RC=0` to represent non-fatal degraded delivery.
   - Added Exit 10 (`delivery failure`) to the header comment legend and to the `README.md` gate table.

2. **Test Coverage in `scripts/ceo-loop.test.sh`**:
   - Added `test_delivery_failure_on_local_fast_forward_sets_exit_10_and_telemetry` asserting Exit 10, `action=delivery-failed`, and `promoted: false` in telemetry on fast-forward failure.
   - Added `test_delivery_failure_on_remote_push_sets_exit_10_and_telemetry` asserting Exit 10, `action=delivery-failed`, and `promoted: false` in telemetry on remote push failure.
   - Added `test_degraded_delivery_on_pr_create_failure_sets_exit_0_action_pushed` asserting Exit 0, `action=pushed`, and `promoted: true` in telemetry when remote push succeeds and PR creation fails.
   - Mutation tested each test arm to ensure it fails on both exit code and summary action when its fix is reverted.

### How to verify

- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` (38 tests pass)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh` (33 tests pass)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` (19 tests pass)
- `shellcheck -S warning $(find ./scripts -name '*.sh')` (0 warnings)