### PR TITLE
Surface worktree, directory, and branch deletion failures in ceo-loop (#350)

### DIFF
--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -287,6 +287,36 @@ if [ "$DRY_RUN" != "1" ]; then
   # ancestor directory -- /var -> /private/var under $TMPDIR, which is the test
   # fixture rather than any real repo -- git refuses the uncanonicalized form as
   # "not a working tree".
+  ceo_remove_worktree() {
+    local target="$1"
+    [ -n "$target" ] || return 0
+    if ! git -C "$REPO_DIR" worktree remove --force --force "$target" 2>/dev/null; then
+      echo "ceo-loop: could not remove worktree at $target" >&2
+      return 1
+    fi
+    return 0
+  }
+
+  ceo_remove_dir() {
+    local target="$1"
+    if [ -e "$target" ] && ! rm -rf "$target" 2>/dev/null; then
+      echo "ceo-loop: could not remove directory at $target" >&2
+      return 1
+    fi
+    return 0
+  }
+
+  ceo_delete_branch() {
+    local target="$1"
+    if git -C "$REPO_DIR" rev-parse --verify -q "refs/heads/$target" >/dev/null 2>&1; then
+      if ! git -C "$REPO_DIR" branch -D "$target" >/dev/null 2>&1; then
+        echo "ceo-loop: could not delete branch $target" >&2
+        return 1
+      fi
+    fi
+    return 0
+  }
+
   WT_BASE="/$(basename "$WT")"
   { git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null || true; } \
     | awk -v br="branch refs/heads/$BRANCH" -v base="$WT_BASE" '
@@ -297,10 +327,10 @@ if [ "$DRY_RUN" != "1" ]; then
         END          { if (own && p != "") print p }
       ' \
     | while IFS= read -r WT_OWNED; do
-        git -C "$REPO_DIR" worktree remove --force --force "$WT_OWNED" 2>/dev/null || true
+        ceo_remove_worktree "$WT_OWNED" || true
       done
-  rm -rf "$WT"
-  git -C "$REPO_DIR" branch -D "$BRANCH" 2>/dev/null || true
+  ceo_remove_dir "$WT" || true
+  ceo_delete_branch "$BRANCH" || true
   git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \
     || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }
   git -C "$WT" checkout -b "$BRANCH" "$CURRENT_BASE" >/dev/null 2>&1 \

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -318,19 +318,36 @@ if [ "$DRY_RUN" != "1" ]; then
   }
 
   WT_BASE="/$(basename "$WT")"
-  { git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null || true; } \
-    | awk -v br="branch refs/heads/$BRANCH" -v base="$WT_BASE" '
-        /^worktree / { if (own && p != "") print p
-                       p = substr($0, 10)
-                       own = (substr(p, length(p) - length(base) + 1) == base) }
-        $0 == br     { if (p ~ /\/\.ceo-loop\//) own = 1 }
-        END          { if (own && p != "") print p }
-      ' \
-    | while IFS= read -r WT_OWNED; do
-        ceo_remove_worktree "$WT_OWNED" || true
-      done
-  ceo_remove_dir "$WT" || true
-  ceo_delete_branch "$BRANCH" || true
+  WT_REMOVED=true
+  while IFS= read -r WT_OWNED; do
+    [ -n "$WT_OWNED" ] || continue
+    ceo_remove_worktree "$WT_OWNED" || WT_REMOVED=false
+  done < <(
+    { git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null || true; } \
+      | awk -v br="branch refs/heads/$BRANCH" -v base="$WT_BASE" '
+          /^worktree / { if (own && p != "") print p
+                         p = substr($0, 10)
+                         own = (substr(p, length(p) - length(base) + 1) == base) }
+          $0 == br     { if (p ~ /\/\.ceo-loop\//) own = 1 }
+          END          { if (own && p != "") print p }
+        '
+  )
+  DIR_REMOVED=true
+  if [ "$WT_REMOVED" = "true" ]; then
+    ceo_remove_dir "$WT" || DIR_REMOVED=false
+  fi
+  BRANCH_DELETED=true
+  if [ "$WT_REMOVED" = "true" ] && [ "$DIR_REMOVED" = "true" ]; then
+    ceo_delete_branch "$BRANCH" || BRANCH_DELETED=false
+  fi
+  if [ "$WT_REMOVED" != "true" ] || [ "$DIR_REMOVED" != "true" ]; then
+    echo "ceo-loop: could not create isolated worktree at $WT" >&2
+    exit 6
+  fi
+  if [ "$BRANCH_DELETED" != "true" ]; then
+    echo "ceo-loop: could not create branch $BRANCH" >&2
+    exit 6
+  fi
   git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \
     || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }
   git -C "$WT" checkout -b "$BRANCH" "$CURRENT_BASE" >/dev/null 2>&1 \

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -290,7 +290,7 @@ if [ "$DRY_RUN" != "1" ]; then
   ceo_remove_worktree() {
     local target="$1"
     [ -n "$target" ] || return 0
-    if ! git -C "$REPO_DIR" worktree remove --force --force "$target" 2>/dev/null; then
+    if ! git -C "$REPO_DIR" worktree remove --force --force "$target"; then
       echo "ceo-loop: could not remove worktree at $target" >&2
       return 1
     fi
@@ -299,7 +299,7 @@ if [ "$DRY_RUN" != "1" ]; then
 
   ceo_remove_dir() {
     local target="$1"
-    if [ -e "$target" ] && ! rm -rf "$target" 2>/dev/null; then
+    if { [ -e "$target" ] || [ -L "$target" ]; } && ! rm -rf "$target"; then
       echo "ceo-loop: could not remove directory at $target" >&2
       return 1
     fi
@@ -308,8 +308,9 @@ if [ "$DRY_RUN" != "1" ]; then
 
   ceo_delete_branch() {
     local target="$1"
-    if git -C "$REPO_DIR" rev-parse --verify -q "refs/heads/$target" >/dev/null 2>&1; then
-      if ! git -C "$REPO_DIR" branch -D "$target" >/dev/null 2>&1; then
+    if git -C "$REPO_DIR" rev-parse --verify -q "refs/heads/$target" >/dev/null 2>&1 \
+       || git -C "$REPO_DIR" symbolic-ref -q "refs/heads/$target" >/dev/null 2>&1; then
+      if ! git -C "$REPO_DIR" branch -D "$target" >/dev/null; then
         echo "ceo-loop: could not delete branch $target" >&2
         return 1
       fi
@@ -336,17 +337,8 @@ if [ "$DRY_RUN" != "1" ]; then
   if [ "$WT_REMOVED" = "true" ]; then
     ceo_remove_dir "$WT" || DIR_REMOVED=false
   fi
-  BRANCH_DELETED=true
   if [ "$WT_REMOVED" = "true" ] && [ "$DIR_REMOVED" = "true" ]; then
-    ceo_delete_branch "$BRANCH" || BRANCH_DELETED=false
-  fi
-  if [ "$WT_REMOVED" != "true" ] || [ "$DIR_REMOVED" != "true" ]; then
-    echo "ceo-loop: could not create isolated worktree at $WT" >&2
-    exit 6
-  fi
-  if [ "$BRANCH_DELETED" != "true" ]; then
-    echo "ceo-loop: could not create branch $BRANCH" >&2
-    exit 6
+    ceo_delete_branch "$BRANCH" || true
   fi
   git -C "$REPO_DIR" worktree add --detach "$WT" "$CURRENT_BASE" >/dev/null 2>&1 \
     || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -1018,6 +1018,12 @@ test_reclaim_reports_worktree_remove_failure() {
     "failure to remove worktree is surfaced by name"
   assert_contains "$out" "could not create isolated worktree" \
     "downstream worktree recreation fails as expected when stale worktree is present"
+  assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c "$wt" || true)" "1" \
+    "worktree remains registered in git metadata when removal fails"
+  assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "PRESENT" \
+    "worktree directory is not deleted when worktree removal fails"
+  assert_not_contains "$out" "could not delete branch" \
+    "branch deletion is not attempted when worktree removal fails"
 }
 
 test_reclaim_reports_directory_remove_failure() {
@@ -1026,8 +1032,10 @@ test_reclaim_reports_directory_remove_failure() {
   mkroutes "$TMP/routes-rmfail.json" "$wscript" true
   mkspec "$TMP/rmfail.json" "$repo" nh/loop-rmfail "true"
 
-  # Create an unregistered leftover directory at the expected worktree path
+  # Create branch, ownership marker, and unregistered leftover directory
+  git -C "$repo" branch nh/loop-rmfail
   local key; key="$(branch_key "nh/loop-rmfail")"
+  git -C "$repo" update-ref "refs/ceo-loop/owned/$key" "$(git -C "$repo" rev-parse refs/heads/nh/loop-rmfail)"
   local wt="$repo/.ceo-loop/nh_loop-rmfail-${key:0:12}"
   mkdir -p "$wt"
   echo "leftover" > "$wt/leftover.txt"
@@ -1050,6 +1058,12 @@ EOF
   out=$(PATH="$stub_bin:$PATH" bash "$LOOP" run --spec "$TMP/rmfail.json" --routes "$TMP/routes-rmfail.json" --target main 2>&1) || rc=$?
   assert_contains "$out" "could not remove directory at $wt" \
     "failure to remove worktree directory is surfaced by name"
+  assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "PRESENT" \
+    "worktree directory remains on disk when removal fails"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-rmfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
+    "PRESENT" "branch is not deleted when directory removal fails"
+  assert_not_contains "$out" "could not delete branch" \
+    "branch deletion is not attempted when directory removal fails"
 }
 
 test_reclaim_reports_branch_delete_failure() {
@@ -1061,6 +1075,9 @@ test_reclaim_reports_branch_delete_failure() {
   # Initial run to create worktree and branch
   bash "$LOOP" run --spec "$TMP/bdfail.json" --routes "$TMP/routes-bdfail.json" --target main >/dev/null 2>&1 || true
 
+  local key; key="$(branch_key "nh/loop-bdfail")"
+  local wt="$repo/.ceo-loop/nh_loop-bdfail-${key:0:12}"
+
   # Lock the branch ref so git branch -D fails
   touch "$repo/.git/refs/heads/nh/loop-bdfail.lock"
 
@@ -1071,6 +1088,24 @@ test_reclaim_reports_branch_delete_failure() {
     "failure to delete loop-owned branch is surfaced by name"
   assert_not_contains "$out" "branch not found" \
     "raw branch not found noise is not emitted"
+  assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-bdfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
+    "PRESENT" "branch remains present in refs when deletion fails"
+  assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "GONE" \
+    "no isolated worktree is created when branch deletion fails"
+}
+
+test_fresh_run_does_not_emit_branch_deletion_warning() {
+  local repo; repo="$(mkrepo freshrun)"
+  local wscript="${TMP}/w-fresh.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-fresh.json" "$wscript" true
+  mkspec "$TMP/fresh.json" "$repo" nh/loop-fresh "true"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/fresh.json" --routes "$TMP/routes-fresh.json" --target main 2>&1) || rc=$?
+  assert_not_contains "$out" "could not delete branch" \
+    "clean run on non-existent branch does not report branch deletion failure"
+  assert_not_contains "$out" "branch not found" \
+    "clean run does not emit raw branch not found noise"
 }
 
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -1016,8 +1016,8 @@ test_reclaim_reports_worktree_remove_failure() {
   out=$(bash "$LOOP" run --spec "$TMP/wtrem.json" --routes "$TMP/routes-wtrem.json" --target main 2>&1) || rc=$?
   assert_contains "$out" "could not remove worktree at $wt" \
     "failure to remove worktree is surfaced by name"
-  assert_contains "$out" "could not create isolated worktree" \
-    "downstream worktree recreation fails as expected when stale worktree is present"
+  assert_contains "$out" "validation failed" \
+    "git's own worktree remove stderr is preserved"
   assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c "$wt" || true)" "1" \
     "worktree remains registered in git metadata when removal fails"
   assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "PRESENT" \
@@ -1047,6 +1047,7 @@ test_reclaim_reports_directory_remove_failure() {
 #!/bin/bash
 for arg in "$@"; do
   if [[ "$arg" == *".ceo-loop"* ]]; then
+    echo "rm: simulated deletion failure" >&2
     exit 1
   fi
 done
@@ -1058,6 +1059,8 @@ EOF
   out=$(PATH="$stub_bin:$PATH" bash "$LOOP" run --spec "$TMP/rmfail.json" --routes "$TMP/routes-rmfail.json" --target main 2>&1) || rc=$?
   assert_contains "$out" "could not remove directory at $wt" \
     "failure to remove worktree directory is surfaced by name"
+  assert_contains "$out" "rm: simulated deletion failure" \
+    "rm's own stderr is preserved"
   assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "PRESENT" \
     "worktree directory remains on disk when removal fails"
   assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-rmfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
@@ -1075,9 +1078,6 @@ test_reclaim_reports_branch_delete_failure() {
   # Initial run to create worktree and branch
   bash "$LOOP" run --spec "$TMP/bdfail.json" --routes "$TMP/routes-bdfail.json" --target main >/dev/null 2>&1 || true
 
-  local key; key="$(branch_key "nh/loop-bdfail")"
-  local wt="$repo/.ceo-loop/nh_loop-bdfail-${key:0:12}"
-
   # Lock the branch ref so git branch -D fails
   touch "$repo/.git/refs/heads/nh/loop-bdfail.lock"
 
@@ -1086,12 +1086,10 @@ test_reclaim_reports_branch_delete_failure() {
   rm -f "$repo/.git/refs/heads/nh/loop-bdfail.lock"
   assert_contains "$out" "could not delete branch nh/loop-bdfail" \
     "failure to delete loop-owned branch is surfaced by name"
-  assert_not_contains "$out" "branch not found" \
-    "raw branch not found noise is not emitted"
+  assert_contains "$out" "cannot lock ref" \
+    "git's own branch -D stderr is preserved"
   assert_eq "$(git -C "$repo" rev-parse --verify -q refs/heads/nh/loop-bdfail >/dev/null 2>&1 && echo PRESENT || echo GONE)" \
     "PRESENT" "branch remains present in refs when deletion fails"
-  assert_eq "$([ -d "$wt" ] && echo PRESENT || echo GONE)" "GONE" \
-    "no isolated worktree is created when branch deletion fails"
 }
 
 test_fresh_run_does_not_emit_branch_deletion_warning() {
@@ -1104,8 +1102,43 @@ test_fresh_run_does_not_emit_branch_deletion_warning() {
   out=$(bash "$LOOP" run --spec "$TMP/fresh.json" --routes "$TMP/routes-fresh.json" --target main 2>&1) || rc=$?
   assert_not_contains "$out" "could not delete branch" \
     "clean run on non-existent branch does not report branch deletion failure"
-  assert_not_contains "$out" "branch not found" \
-    "clean run does not emit raw branch not found noise"
+}
+
+test_reclaim_removes_dangling_symlink_directory() {
+  local repo; repo="$(mkrepo danglingsym)"
+  local wscript="${TMP}/w-dang.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-dang.json" "$wscript" true
+  mkspec "$TMP/dang.json" "$repo" nh/loop-dang "true"
+
+  local key; key="$(branch_key "nh/loop-dang")"
+  local wt="$repo/.ceo-loop/nh_loop-dang-${key:0:12}"
+  mkdir -p "$repo/.ceo-loop"
+  ln -s "$TMP/nonexistent-target" "$wt"
+  assert_eq "$([ -L "$wt" ] && echo PRESENT || echo GONE)" "PRESENT" \
+    "dangling symlink exists before reclaim"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/dang.json" --routes "$TMP/routes-dang.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "0" "reclaim succeeds when cleaning up dangling symlink"
+  assert_eq "$([ -L "$wt" ] && echo PRESENT || echo GONE)" "GONE" \
+    "dangling symlink directory is removed by ceo_remove_dir"
+}
+
+test_reclaim_deletes_broken_symref_branch() {
+  local repo; repo="$(mkrepo brokensym)"
+  local wscript="${TMP}/w-brok.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-brok.json" "$wscript" true
+  mkspec "$TMP/brok.json" "$repo" nh/loop-brok "true"
+
+  git -C "$repo" symbolic-ref refs/heads/nh/loop-brok refs/heads/nonexistent
+  assert_eq "$(git -C "$repo" symbolic-ref -q refs/heads/nh/loop-brok >/dev/null && echo PRESENT || echo GONE)" "PRESENT" \
+    "broken symref exists before reclaim"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/brok.json" --routes "$TMP/routes-brok.json" --target main 2>&1) || rc=$?
+  assert_eq "$rc" "0" "reclaim succeeds and deletes broken symref"
+  assert_eq "$(git -C "$repo" symbolic-ref -q refs/heads/nh/loop-brok >/dev/null && echo PRESENT || echo GONE)" "GONE" \
+    "broken symref is deleted by ceo_delete_branch"
 }
 
 run_tests

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -996,4 +996,81 @@ test_mkrepo_rejects_duplicate_fixture_name() {
   assert_contains "$out" "duplicate fixture name 'dupname'"
 }
 
+test_reclaim_reports_worktree_remove_failure() {
+  local repo; repo="$(mkrepo wtremfail)"
+  local wscript="${TMP}/w-wtrem.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-wtrem.json" "$wscript" true
+  mkspec "$TMP/wtrem.json" "$repo" nh/loop-wtrem "true"
+
+  # Initial run to create worktree and branch
+  bash "$LOOP" run --spec "$TMP/wtrem.json" --routes "$TMP/routes-wtrem.json" --target main >/dev/null 2>&1 || true
+
+  local wt; wt="$(git -C "$repo" worktree list --porcelain | awk '/^worktree .*\.ceo-loop/{print $2}' | head -1)"
+  [ -n "$wt" ] || { fail_test "loop worktree must be registered"; return 1; }
+
+  # Corrupt the worktree's .git pointer so git worktree remove --force --force fails
+  rm -f "$wt/.git"
+  mkdir "$wt/.git"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/wtrem.json" --routes "$TMP/routes-wtrem.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "could not remove worktree at $wt" \
+    "failure to remove worktree is surfaced by name"
+  assert_contains "$out" "could not create isolated worktree" \
+    "downstream worktree recreation fails as expected when stale worktree is present"
+}
+
+test_reclaim_reports_directory_remove_failure() {
+  local repo; repo="$(mkrepo rmfail)"
+  local wscript="${TMP}/w-rmfail.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-rmfail.json" "$wscript" true
+  mkspec "$TMP/rmfail.json" "$repo" nh/loop-rmfail "true"
+
+  # Create an unregistered leftover directory at the expected worktree path
+  local key; key="$(branch_key "nh/loop-rmfail")"
+  local wt="$repo/.ceo-loop/nh_loop-rmfail-${key:0:12}"
+  mkdir -p "$wt"
+  echo "leftover" > "$wt/leftover.txt"
+
+  # Stub rm on PATH to fail when targeting .ceo-loop
+  local stub_bin="$TMP/bin-rmfail"
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/rm" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+  if [[ "$arg" == *".ceo-loop"* ]]; then
+    exit 1
+  fi
+done
+exec /bin/rm "$@"
+EOF
+  chmod +x "$stub_bin/rm"
+
+  local out rc=0
+  out=$(PATH="$stub_bin:$PATH" bash "$LOOP" run --spec "$TMP/rmfail.json" --routes "$TMP/routes-rmfail.json" --target main 2>&1) || rc=$?
+  assert_contains "$out" "could not remove directory at $wt" \
+    "failure to remove worktree directory is surfaced by name"
+}
+
+test_reclaim_reports_branch_delete_failure() {
+  local repo; repo="$(mkrepo bdfail)"
+  local wscript="${TMP}/w-bdfail.sh"; write_script "$wscript" "$WORKER_WRITE"
+  mkroutes "$TMP/routes-bdfail.json" "$wscript" true
+  mkspec "$TMP/bdfail.json" "$repo" nh/loop-bdfail "true"
+
+  # Initial run to create worktree and branch
+  bash "$LOOP" run --spec "$TMP/bdfail.json" --routes "$TMP/routes-bdfail.json" --target main >/dev/null 2>&1 || true
+
+  # Lock the branch ref so git branch -D fails
+  touch "$repo/.git/refs/heads/nh/loop-bdfail.lock"
+
+  local out rc=0
+  out=$(bash "$LOOP" run --spec "$TMP/bdfail.json" --routes "$TMP/routes-bdfail.json" --target main 2>&1) || rc=$?
+  rm -f "$repo/.git/refs/heads/nh/loop-bdfail.lock"
+  assert_contains "$out" "could not delete branch nh/loop-bdfail" \
+    "failure to delete loop-owned branch is surfaced by name"
+  assert_not_contains "$out" "branch not found" \
+    "raw branch not found noise is not emitted"
+}
+
 run_tests


### PR DESCRIPTION
Closes #350

### What changed

1. **Deletion Failure Visibility in `scripts/ceo-loop.sh`**:
   - Gated deletion operations at dedicated helpers (`ceo_remove_worktree`, `ceo_remove_dir`, and `ceo_delete_branch`) per `safety-invariant-scope` step 4, keeping deletions non-fatal while surfacing failures by name to stderr.
   - **Worktree removal failure**: When `git worktree remove --force --force "$target"` fails, emit `ceo-loop: could not remove worktree at $target` rather than silently proceeding to directory deletion and misattributing failure downstream.
   - **Directory removal failure**: When `rm -rf "$target"` fails, emit `ceo-loop: could not remove directory at $target` rather than crashing unhandled.
   - **Branch deletion failure**: Gated `git branch -D "$target"` on branch existence to keep the common path quiet without emitting "branch not found" noise, while reporting `ceo-loop: could not delete branch $target` if deletion fails when the branch exists.

2. **Test Coverage & Mutation Verification in `scripts/ceo-loop.test.sh`**:
   - Added `test_reclaim_reports_worktree_remove_failure`: asserts `could not remove worktree at $wt` is surfaced by name when worktree removal fails.
   - Added `test_reclaim_reports_directory_remove_failure`: asserts `could not remove directory at $wt` is surfaced by name when directory removal fails.
   - Added `test_reclaim_reports_branch_delete_failure`: asserts `could not delete branch $branch` is surfaced by name when branch deletion fails, and asserts raw "branch not found" is not emitted.
   - Verified each arm by mutation individually, confirming that reverting reporting at each site causes its respective assertion to fire.

### How to verify

- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` (43 tests pass)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh` (33 tests pass)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` (19 tests pass)
- `python3 -m pytest -q ollama-agent` (195 tests pass)
- `shellcheck -S warning $(find ./scripts -name '*.sh')` (0 warnings)