### PR TITLE
ceo-loop: serialize in-flight workers before reclaim and gate base tip claims

### DIFF
--- a/scripts/ceo-loop-lib.sh
+++ b/scripts/ceo-loop-lib.sh
@@ -221,12 +221,13 @@ ceo_review_gate() {
 
 # ceo_worker_register <state-dir> <branch> <base-sha> <file>... — records an
 # in-flight worker. Exits 6 on overlap with a registered worker sharing any
-# file, migration path, or declared dependency, naming the conflict.
+# file, migration path, or declared dependency, or if an in-flight worker is
+# already active on the same branch.
 ceo_worker_register() {
   local dir="$1" branch="$2" base="$3"; shift 3
   mkdir -p "$dir"
   touch "$dir/workers.jsonl"
-  CEO_LOCK_DIR="$dir" CEO_BRANCH="$branch" CEO_BASE="$base" \
+  CEO_LOCK_DIR="$dir" CEO_BRANCH="$branch" CEO_BASE="$base" CEO_PID="${CEO_PID:-$$}" \
     CEO_LOCK_WAIT="$CEO_LOCK_TIMEOUT_SECS" bash -s "$@" <<'REGISTER_INNER'
 set -euo pipefail
 lock="$CEO_LOCK_DIR/.lock"; waited=0
@@ -240,6 +241,7 @@ done
 trap 'rmdir "$lock" 2>/dev/null || true' EXIT
 file="$CEO_LOCK_DIR/workers.jsonl"
 lineno=0
+live_rows=()
 while IFS= read -r row; do
   lineno=$((lineno + 1))
   [ -n "$row" ] || continue
@@ -249,20 +251,50 @@ while IFS= read -r row; do
     echo "ceo-workers: corrupt row at line $lineno of $file — fix or remove it before registering" >&2
     exit 6
   fi
-  for f in "$@"; do
-    if echo "$row" | jq -e --arg f "$f" --arg b "$CEO_BRANCH" \
-      'select(.branch != $b) | (.files | index($f))' >/dev/null 2>&1; then
-      conflict="$(echo "$row" | jq -r .branch)"
-      echo "ceo-workers: '$CEO_BRANCH' overlaps in-flight worker '$conflict' on file $f — serialize or rebase" >&2
+  row_branch="$(echo "$row" | jq -r .branch)"
+  row_pid="$(echo "$row" | jq -r 'if .pid then (.pid | tostring) else empty end')"
+
+  # Prune registrations for dead processes
+  if [ -n "$row_pid" ] && ! kill -0 "$row_pid" 2>/dev/null; then
+    continue
+  fi
+
+  # In-flight worker on the same branch
+  if [ "$row_branch" = "$CEO_BRANCH" ]; then
+    if [ -n "$row_pid" ] && [ "$row_pid" != "$CEO_PID" ]; then
+      echo "ceo-workers: '$CEO_BRANCH' already has an in-flight worker (PID $row_pid) — serialize or choose another branch" >&2
       exit 6
     fi
-  done
+  else
+    for f in "$@"; do
+      if echo "$row" | jq -e --arg f "$f" '(.files | index($f))' >/dev/null 2>&1; then
+        conflict="$row_branch"
+        echo "ceo-workers: '$CEO_BRANCH' overlaps in-flight worker '$conflict' on file $f — serialize or rebase" >&2
+        exit 6
+      fi
+    done
+  fi
+  live_rows+=("$row")
 done < "$file"
+
+# Rewrite active rows without dead registrations
+if [ "${#live_rows[@]}" -gt 0 ]; then
+  printf '%s\n' "${live_rows[@]}" > "$file"
+else
+  : > "$file"
+fi
+
+files_json="[]"
+if [ "$#" -gt 0 ] && [ -n "${1:-}" ]; then
+  files_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+fi
+
 # Upsert: a branch registering twice replaces its own row instead of stacking
 # duplicates (a later release of one duplicate would orphan the other).
 jq -nc --arg b "$CEO_BRANCH" --arg base "$CEO_BASE" \
-  --argjson files "$(printf '%s\n' "$@" | jq -R . | jq -s .)" \
-  '{branch: $b, base: $base, files: $files}' >> "$file"
+  --arg pid "$CEO_PID" \
+  --argjson files "$files_json" \
+  '{branch: $b, base: $base, pid: ($pid | if . == "" then null else (tonumber? // .) end), files: $files}' >> "$file"
 # Keep exactly one row per branch: the upsert drops earlier rows for it.
 jq -cs 'sort_by(.branch) | group_by(.branch) | map(last) | .[]' "$file" \
   > "$file.dedup" && mv "$file.dedup" "$file"

--- a/scripts/ceo-loop-lib.test.sh
+++ b/scripts/ceo-loop-lib.test.sh
@@ -243,4 +243,37 @@ test_branch_key_returns_deterministic_hash() {
   assert_fails "the key is lowercase hex only" test -n "$(printf '%s' "$k1" | tr -d '0-9a-f')"
 }
 
+test_worker_register_records_pid_and_rejects_in_flight_same_branch() {
+  local dir="$TMP/state-reg"
+  mkdir -p "$dir"
+  ceo_worker_register "$dir" "nh/b1" "base1" "f1.txt"
+  assert_eq "$(jq -r .pid "$dir/workers.jsonl")" "$$" "worker row records process PID"
+
+  local out rc=0
+  out=$(CEO_PID="$PPID" ceo_worker_register "$dir" "nh/b1" "base1" "f2.txt" 2>&1) || rc=$?
+  assert_eq "$rc" "6" "registering an in-flight branch with different live PID exits 6"
+  assert_contains "$out" "already has an in-flight worker"
+}
+
+test_worker_register_prunes_dead_pid_registration() {
+  local dir="$TMP/state-prune"
+  mkdir -p "$dir"
+  printf '%s\n' '{"branch":"nh/dead","base":"b","pid":99999999,"files":["d.txt"]}' > "$dir/workers.jsonl"
+  ceo_worker_register "$dir" "nh/live" "b" "l.txt"
+  assert_eq "$(jq -r 'select(.branch == "nh/dead")' "$dir/workers.jsonl")" "" \
+    "dead PID worker row is pruned on subsequent registration"
+  assert_eq "$(jq -r .branch "$dir/workers.jsonl")" "nh/live" \
+    "live worker is registered"
+}
+
+test_worker_register_allows_same_process_to_update_file_list() {
+  local dir="$TMP/state-upsert"
+  mkdir -p "$dir"
+  ceo_worker_register "$dir" "nh/b1" "base1" "f1.txt"
+  ceo_worker_register "$dir" "nh/b1" "base1" "f1.txt" "f2.txt"
+  assert_eq "$(wc -l < "$dir/workers.jsonl" | tr -d ' ')" "1" "single row kept for branch"
+  assert_eq "$(jq -c .files "$dir/workers.jsonl")" '["f1.txt","f2.txt"]' \
+    "same process updates its own file list"
+}
+
 run_tests

--- a/scripts/ceo-loop.sh
+++ b/scripts/ceo-loop.sh
@@ -148,7 +148,7 @@ ceo_loop_cleanup() {
   # A dead or blocked run frees its serialization slot but LEAVES the worktree
   # and branch for inspection — deleting evidence of what a worker did would
   # hide the very state a repair ticket needs.
-  [ -n "$WT" ] && ceo_worker_release "$DIR" "$BRANCH" 2>/dev/null || true
+  ceo_worker_release "$DIR" "$BRANCH" 2>/dev/null || true
 }
 trap ceo_loop_cleanup EXIT
 START_TS="$(date +%s)"
@@ -217,6 +217,12 @@ VERIFY_LOG=""
 BRANCH_KEY="$(branch_key "$BRANCH")"
 
 if [ "$DRY_RUN" != "1" ]; then
+  # Early registration under state lock before any destructive reclaim or worktree
+  # creation: records the branch and PID so concurrent loops on the same branch or
+  # overlapping declared files refuse fast before touching the working directory.
+  mapfile -t DECLARED_FILES < <(jq -r '.files[]?' "$SPEC" 2>/dev/null || true)
+  ceo_worker_register "$DIR" "$BRANCH" "$CURRENT_BASE" "${DECLARED_FILES[@]}" || exit $?
+
   WT="$REPO_DIR/.ceo-loop/${BRANCH//\//_}-${BRANCH_KEY:0:12}"
   OWNED_REF="refs/ceo-loop/owned/$BRANCH_KEY"
   # The marker records the tip it vouches for, and is re-pointed every time the
@@ -344,16 +350,10 @@ if [ "$DRY_RUN" != "1" ]; then
     || { echo "ceo-loop: could not create isolated worktree at $WT" >&2; exit 6; }
   git -C "$WT" checkout -b "$BRANCH" "$CURRENT_BASE" >/dev/null 2>&1 \
     || { echo "ceo-loop: could not create branch $BRANCH" >&2; exit 6; }
-  # Claim it in the same step that creates it, so a run killed later still
-  # leaves a branch the next run is allowed to reclaim.
-  ceo_claim_branch
-fi
-
-# Early registration with declared intent (if any) so concurrent loops on the
-# same repo serialize before doing work; replaced by diff-derived files below.
-mapfile -t DECLARED_FILES < <(jq -r '.files[]?' "$SPEC" 2>/dev/null || true)
-if [ "${#DECLARED_FILES[@]}" -gt 0 ] && [ -n "${DECLARED_FILES[0]}" ]; then
-  ceo_worker_register "$DIR" "$BRANCH" "$CURRENT_BASE" "${DECLARED_FILES[@]}" || exit $?
+  # Note: do not claim ownership marker here. The loop only claims ownership
+  # when it actually commits worker output below. Claiming $CURRENT_BASE before
+  # committing aliases the target branch tip, which would match any human branch
+  # cut from main on a later run (#336).
 fi
 
 while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do

--- a/scripts/ceo-loop.test.sh
+++ b/scripts/ceo-loop.test.sh
@@ -1141,4 +1141,105 @@ test_reclaim_deletes_broken_symref_branch() {
     "broken symref is deleted by ceo_delete_branch"
 }
 
+test_in_flight_worker_on_same_branch_refuses_before_reclaim() {
+  # Issue #336: Reclaim must not destroy an in-flight worker on the same branch.
+  local repo; repo="$(mkrepo inflight)"
+  local wscript="${TMP}/w-inflight.sh"
+  write_script "$wscript" 'cd "$WT" && echo step1 > f.txt && sleep 2 && echo step2 >> f.txt'
+  mkroutes "$TMP/routes-inflight.json" "$wscript" true
+  mkspec "$TMP/inflight.json" "$repo" nh/loop-inflight "true"
+
+  # Launch Run 1 in the background
+  local out1_log="$TMP/run1.log"
+  bash "$LOOP" run --spec "$TMP/inflight.json" --routes "$TMP/routes-inflight.json" --target main > "$out1_log" 2>&1 &
+  local pid1=$!
+
+  # Wait for Run 1 to register and create its worktree
+  local wt1=""
+  for _ in $(seq 1 50); do
+    wt1="$(git -C "$repo" worktree list --porcelain | awk '/^worktree .*\.ceo-loop/{print $2}' | head -1)"
+    if [ -n "$wt1" ] && [ -d "$wt1" ]; then break; fi
+    sleep 0.1
+  done
+  [ -n "$wt1" ] || { fail_test "run 1 worktree must be registered"; wait "$pid1" || true; return 1; }
+
+  # Run 2 targeting the same branch while Run 1 is in-flight
+  local out2 rc2=0
+  out2=$(bash "$LOOP" run --spec "$TMP/inflight.json" --routes "$TMP/routes-inflight.json" --target main 2>&1) || rc2=$?
+  assert_eq "$rc2" "6" "concurrent run on same branch exits 6"
+  assert_contains "$out2" "already has an in-flight worker" \
+    "in-flight worker conflict is surfaced by name"
+
+  # Assert Run 1's worktree was NOT destroyed by Run 2
+  assert_eq "$([ -d "$wt1" ] && echo PRESENT || echo GONE)" "PRESENT" \
+    "in-flight worktree is not deleted by concurrent run"
+  assert_eq "$(git -C "$repo" worktree list --porcelain | grep -c "$wt1" || true)" "1" \
+    "in-flight worktree remains registered in git metadata"
+
+  # Wait for Run 1 to complete cleanly
+  local rc1=0
+  wait "$pid1" || rc1=$?
+  assert_eq "$rc1" "0" "in-flight run completes successfully without interruption"
+}
+
+test_uncommitted_run_does_not_authorize_deleting_human_branch_at_main() {
+  # Issue #336: A run that dies before committing leaves no marker pointing at
+  # the target tip, so a human branch at main is never matched and deleted.
+  local repo; repo="$(mkrepo humanguard)"
+  local wscript="${TMP}/w-fail.sh"
+  write_script "$wscript" 'exit 1'
+  mkroutes "$TMP/routes-fail.json" "$wscript" "$wscript"
+  mkspec "$TMP/fail.json" "$repo" nh/loop-humanguard "true"
+
+  local out1 rc1=0
+  out1=$(bash "$LOOP" run --spec "$TMP/fail.json" --routes "$TMP/routes-fail.json" --target main 2>&1) || rc1=$?
+  assert_eq "$rc1" "4" "worker failure exits 4 before committing"
+  assert_contains "$out1" "every routed candidate failed"
+
+  # Cleanup worktree and branch from the failed run
+  git -C "$repo" worktree list --porcelain | awk '/^worktree .*\.ceo-loop/{print $2}' \
+    | while read -r w; do git -C "$repo" worktree remove --force --force "$w" 2>/dev/null || true; done
+  git -C "$repo" branch -D nh/loop-humanguard >/dev/null 2>&1 || true
+
+  # A human now creates a branch from main with the same name
+  git -C "$repo" branch nh/loop-humanguard main
+  local human_sha; human_sha="$(git -C "$repo" rev-parse refs/heads/nh/loop-humanguard)"
+
+  local out2 rc2=0
+  out2=$(bash "$LOOP" run --spec "$TMP/fail.json" --routes "$TMP/routes-fail.json" --target main 2>&1) || rc2=$?
+  assert_eq "$rc2" "6" "loop refuses to delete human branch at base tip"
+  assert_contains "$out2" "already exists and was not created by ceo-loop"
+  assert_eq "$(git -C "$repo" rev-parse refs/heads/nh/loop-humanguard 2>/dev/null)" "$human_sha" \
+    "human branch remains untouched at its commit"
+}
+
+test_early_registration_without_declared_files_prevents_same_branch_collision() {
+  # Issue #336: Specs without declared files must still register under state lock
+  # to prevent same-branch concurrency races.
+  local repo; repo="$(mkrepo nofiles)"
+  local wscript="${TMP}/w-nofiles.sh"
+  write_script "$wscript" 'cd "$WT" && echo work > w.txt && sleep 2'
+  mkroutes "$TMP/routes-nofiles.json" "$wscript" true
+  # Spec explicitly omits .files
+  mkspec "$TMP/nofiles.json" "$repo" nh/loop-nofiles "true"
+
+  bash "$LOOP" run --spec "$TMP/nofiles.json" --routes "$TMP/routes-nofiles.json" --target main > "$TMP/nofiles1.log" 2>&1 &
+  local pid1=$!
+
+  local repo_slug; repo_slug="$(jq -r .repo "$TMP/nofiles.json" | tr '/' '-')"
+  local sdir; sdir="$(ceo_loop_state_dir "$repo_slug")"
+  for _ in $(seq 1 50); do
+    if [ -s "$sdir/workers.jsonl" ]; then break; fi
+    sleep 0.1
+  done
+
+  local out2 rc2=0
+  out2=$(bash "$LOOP" run --spec "$TMP/nofiles.json" --routes "$TMP/routes-nofiles.json" --target main 2>&1) || rc2=$?
+  assert_eq "$rc2" "6" "concurrent run without declared files exits 6 on same branch"
+  assert_contains "$out2" "already has an in-flight worker"
+
+  wait "$pid1" || true
+}
+
 run_tests
+


### PR DESCRIPTION
Closes #336

### Problem
1. **Liveness vs Authorship**: `refs/ceo-loop/owned/<key>` proves authorship, not liveness. The reclaim logic (`ceo_remove_worktree`, `rm -rf`, `branch -D`) ran before worker registration. Furthermore, `ceo_worker_register` checked conflict only on differing branches (`select(.branch != $b)`), allowing concurrent runs on the same spec/branch to overwrite rows and delete an active worker's worktree and branch mid-flight.
2. **Comment Inaccuracy**: The setup comment claimed early registration serialized before work, but registration was gated on `.files` being declared and ran fifteen lines after destructive reclaim.
3. **`$CURRENT_BASE` Aliasing on Initial Claim**: The first claim at branch creation recorded `$CURRENT_BASE` before any work was committed. A crashed run left an ownership marker pointing at `main`. A human subsequently running `git branch <same-name> main` matched the marker, and `ceo-loop` deleted the human's branch without refusal.

### Changes
1. **PID Tracking & Same-Branch Liveness Guard** (`scripts/ceo-loop-lib.sh`):
   - `ceo_worker_register` now records process PID (`$$`) in each row of `workers.jsonl`.
   - On registration, same-branch rows with active in-flight PIDs (`kill -0`) fail fast with exit 6 (`ceo-workers: '$CEO_BRANCH' already has an in-flight worker (PID $row_pid) — serialize or choose another branch`).
   - Stale rows with dead PIDs are automatically pruned during registration.
2. **Registration Hoisted Before Reclaim** (`scripts/ceo-loop.sh`):
   - Worker registration is moved before the ownership check and reclaim block.
   - Registration runs unconditionally (regardless of whether `.files` is declared), serializing setup under the state lock and rejecting same-branch collisions before touching working directories.
   - `ceo_worker_release` in `ceo_loop_cleanup` is called unconditionally on exit to ensure worker rows are freed even if setup failed before `$WT` was assigned.
3. **Eliminate Base Tip Ownership Aliasing** (`scripts/ceo-loop.sh`):
   - Removed `ceo_claim_branch` from branch creation. Ownership is only claimed when the worker output is committed.
   - An uncommitted or crashed run leaves no marker pointing at `$CURRENT_BASE`. A subsequent human branch at `main` does not match, and `ceo-loop` safely refuses with exit 6 instead of deleting the branch.
4. **Tests & Invariant Verification** (`scripts/ceo-loop-lib.test.sh`, `scripts/ceo-loop.test.sh`):
   - Added unit tests for PID tracking, same-branch in-flight rejection, same-process file list updating, and dead PID pruning.
   - Added integration test arms for in-flight same-branch refusal (asserting the active worker's worktree remains intact), human branch preservation at `main`, and early registration without declared files.
   - Verified each arm under mutation testing.

### Verification
- `shellcheck -S warning $(find ./scripts -name '*.sh')` -> 0 warnings
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh` -> 36 tests passed
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` -> 19 tests passed
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` -> 49 tests passed