### PR TITLE
test(cleanup): add test arms for duplicate fixture guards in ceo-cleanup.test.sh

### DIFF
--- a/scripts/ceo-cleanup.test.sh
+++ b/scripts/ceo-cleanup.test.sh
@@ -534,4 +534,23 @@ test_cleanup_reports_every_reason_a_human_is_needed() {
   assert_contains "$out" "AI_NEEDED: yes"
 }
 
+test_mkrepo_cleanup_rejects_duplicate_fixture_name() {
+  local repo; repo="$(mkrepo_cleanup dupname-mkrepo main)"
+  assert_file_exists "$repo/base.txt" "first mkrepo_cleanup call must succeed"
+  local out rc=0
+  out=$(mkrepo_cleanup dupname-mkrepo main 2>&1) || rc=$?
+  assert_eq "$rc" "1" "mkrepo_cleanup must return 1 on duplicate fixture name"
+  assert_contains "$out" "mkrepo_cleanup: duplicate fixture name 'dupname-mkrepo'"
+}
+
+test_mkclone_cleanup_rejects_duplicate_fixture_name() {
+  local repo; repo="$(mkclone_cleanup dupname-clone main ceo/dup no_lag)"
+  assert_file_exists "$repo/base.txt" "first mkclone_cleanup call must succeed"
+  local out rc=0
+  out=$(mkclone_cleanup dupname-clone main ceo/dup no_lag 2>&1) || rc=$?
+  assert_eq "$rc" "1" "mkclone_cleanup must return 1 on duplicate fixture name"
+  assert_contains "$out" "mkclone_cleanup: duplicate fixture name 'dupname-clone'"
+}
+
 run_tests
+


### PR DESCRIPTION
Closes #351

### Context & Architectural Decision
PR #348 added a duplicate-fixture-name guard and corresponding test arm (`test_mkrepo_rejects_duplicate_fixture_name`) to `mkrepo` in `scripts/ceo-loop.test.sh`. Identical guards already existed in `scripts/ceo-cleanup.test.sh` for `mkrepo_cleanup` (line 25) and `mkclone_cleanup` (line 206), but lacked test coverage.

Per the decision in #351, we adopt the convention that fixture-builder guards are tested beside the builder in the suite file where they are defined, rather than moving them into `scripts/test-harness.test.sh`. `mkrepo`, `mkrepo_cleanup`, and `mkclone_cleanup` are suite-local helpers with distinct signatures and topologies, while `test-harness.sh` is an assertion/runner framework agnostic of git fixtures. Colocating each test arm with its builder keeps the suites decoupled and ensures regression tests directly execute the production helpers.

### Changes
- In `scripts/ceo-cleanup.test.sh`:
  - Added `test_mkrepo_cleanup_rejects_duplicate_fixture_name`: verifies `mkrepo_cleanup` returns 1 and prints `mkrepo_cleanup: duplicate fixture name '<name>'` on duplicate invocations.
  - Added `test_mkclone_cleanup_rejects_duplicate_fixture_name`: verifies `mkclone_cleanup` returns 1 and prints `mkclone_cleanup: duplicate fixture name '<name>'` on duplicate invocations.

### Verification
- `shellcheck -S warning $(find ./scripts -name '*.sh')` -> 0 warnings
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-cleanup.test.sh` -> 21 tests passed
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop-lib.test.sh` -> 33 tests passed
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/bash scripts/ceo-loop.test.sh` -> 46 tests passed

### Mutation Proofs
1. Commented out guard line 25 in `scripts/ceo-cleanup.test.sh` (`[ ! -e "$dir" ] || ...`):
   `test_mkrepo_cleanup_rejects_duplicate_fixture_name` failed (got rc 0 with stdout output, want rc 1).
2. Commented out guard line 206 in `scripts/ceo-cleanup.test.sh` (`[ ! -e "$clone" ] || ...`):
   `test_mkclone_cleanup_rejects_duplicate_fixture_name` failed (got rc 0 with stdout output, want rc 1).
3. Commented out guard line 31 in `scripts/ceo-loop.test.sh` (`[ ! -e "$dir" ] || ...`):
   `test_mkrepo_rejects_duplicate_fixture_name` failed (got rc 0 with stdout output, want rc 1).